### PR TITLE
Standalone Mode (beta)

### DIFF
--- a/Conf/Package/preinstall
+++ b/Conf/Package/preinstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Unload the supporting services. 
+# Unload the supporting services.
 # If a user is logged in, also unload the GUI agent.
 # If the target volume is not /, do nothing
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -1,4 +1,5 @@
 /// Copyright 2015-2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -318,7 +318,6 @@
 ///
 @property(readonly, nonatomic) BOOL enableStandaloneMode;
 
-
 ///
 /// The text to display when opening Santa.app.
 /// If unset, the default text will be displayed.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -311,6 +311,15 @@
 @property(readonly, nonatomic) BOOL enableSilentTTYMode;
 
 ///
+///  When standalonemode is enabled, Santa will let a user allow a
+///  binary using biometric authentication.
+///
+///  Defaults to NO.
+///
+@property(readonly, nonatomic) BOOL enableStandaloneMode;
+
+
+///
 /// The text to display when opening Santa.app.
 /// If unset, the default text will be displayed.
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1,4 +1,5 @@
 /// Copyright 2014-2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -93,6 +93,7 @@ static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
 static NSString *const kEnableSilentModeKey = @"EnableSilentMode";
 static NSString *const kEnableSilentTTYModeKey = @"EnableSilentTTYMode";
+static NSString *const kEnableStandaloneMode = @"EnableStandaloneMode";
 static NSString *const kAboutTextKey = @"AboutText";
 static NSString *const kMoreInfoURLKey = @"MoreInfoURL";
 static NSString *const kEventDetailURLKey = @"EventDetailURL";
@@ -224,6 +225,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
       kEnableBadSignatureProtectionKey : number,
       kEnableSilentModeKey : number,
       kEnableSilentTTYModeKey : number,
+      kEnableStandaloneMode : number,
       kAboutTextKey : string,
       kMoreInfoURLKey : string,
       kEventDetailURLKey : string,
@@ -766,6 +768,11 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 
 - (BOOL)enableSilentTTYMode {
   NSNumber *number = self.configState[kEnableSilentTTYModeKey];
+  return number ? [number boolValue] : NO;
+}
+
+- (BOOL)enableStandaloneMode {
+  NSNumber *number = self.configState[kEnableStandaloneMode];
   return number ? [number boolValue] : NO;
 }
 

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -126,6 +126,11 @@
 @property SNTEventState decision;
 
 ///
+///  Was this approval made as a result of a standalone mode authentication.
+///
+@property BOOL standaloneApproval;
+
+///
 ///  NSArray of logged in users when the decision was made.
 ///
 @property NSArray *loggedInUsers;

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -67,6 +67,7 @@
   ENCODE(self.quarantineRefererURL, @"quarantineRefererURL");
   ENCODE(self.quarantineTimestamp, @"quarantineTimestamp");
   ENCODE(self.quarantineAgentBundleID, @"quarantineAgentBundleID");
+  ENCODE([NSNumber numberWithBool:self.standaloneApproval], @"standaloneApproval");
 }
 
 - (instancetype)init {
@@ -114,6 +115,7 @@
     _quarantineRefererURL = DECODE(NSString, @"quarantineRefererURL");
     _quarantineTimestamp = DECODE(NSDate, @"quarantineTimestamp");
     _quarantineAgentBundleID = DECODE(NSString, @"quarantineAgentBundleID");
+    _standaloneApproval = [DECODE(NSNumber, @"standaloneApproval") boolValue];
   }
   return self;
 }

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -26,7 +26,7 @@
 - (void)postBlockNotification:(SNTStoredEvent *)event
             withCustomMessage:(NSString *)message
                  andCustomURL:(NSString *)url
-                 andReply:(void (^)(BOOL authenticated))reply;
+                     andReply:(void (^)(BOOL authenticated))reply;
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message;
 - (void)postFileAccessBlockNotification:(SNTFileAccessEvent *)event
                           customMessage:(NSString *)message

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -1,4 +1,5 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -25,7 +25,8 @@
 @protocol SNTNotifierXPC
 - (void)postBlockNotification:(SNTStoredEvent *)event
             withCustomMessage:(NSString *)message
-                 andCustomURL:(NSString *)url;
+                 andCustomURL:(NSString *)url
+                 andReply:(void (^)(BOOL authenticated))reply;
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message;
 - (void)postFileAccessBlockNotification:(SNTFileAccessEvent *)event
                           customMessage:(NSString *)message

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -51,6 +51,11 @@ struct RuleCounts {
 - (void)databaseEventCount:(void (^)(int64_t count))reply;
 - (void)staticRuleCount:(void (^)(int64_t count))reply;
 
+/// 
+/// Standalone rules
+///
+- (void)addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply;
+
 ///
 ///  Decision ops
 ///

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -51,7 +51,7 @@ struct RuleCounts {
 - (void)databaseEventCount:(void (^)(int64_t count))reply;
 - (void)staticRuleCount:(void (^)(int64_t count))reply;
 
-/// 
+///
 /// Standalone rules
 ///
 - (void)addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply;

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -52,11 +52,6 @@ struct RuleCounts {
 - (void)staticRuleCount:(void (^)(int64_t count))reply;
 
 ///
-/// Standalone rules
-///
-- (void)addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply;
-
-///
 ///  Decision ops
 ///
 

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -74,6 +74,7 @@ objc_library(
         "SecurityInterface",
         "SystemExtensions",
         "UserNotifications",
+        "LocalAuthentication",
     ],
     deps = [
         ":SNTAboutWindowView",

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -26,7 +26,7 @@
 - (instancetype)initWithEvent:(SNTStoredEvent *)event
                     customMsg:(NSString *)message
                     customURL:(NSString *)url
-                    reply:(void (^)(BOOL authenticated))replyBlock;
+                        reply:(void (^)(BOOL authenticated))replyBlock;
 
 - (IBAction)showCertInfo:(id)sender;
 - (void)updateBlockNotification:(SNTStoredEvent *)event withBundleHash:(NSString *)bundleHash;
@@ -66,9 +66,8 @@
 @property(readonly) SNTStoredEvent *event;
 
 ///
-/// TODO(PLM) Fix comment
-/// The reply block to call when the user has authenticated via touch ID in standalone mode.
-///
+///  The reply block to call when the user has made a decision in standalone
+///  mode.
 @property(readonly, nonatomic) void (^replyBlock)(BOOL authenticated);
 
 ///

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -60,12 +60,6 @@
 @property(weak) IBOutlet NSButton *dismissEventButton;
 
 ///
-///   Reference to the "Check Event" button in the XIB. Used to help the user
-///   check the binary.
-///
-@property(weak) IBOutlet NSButton *checkEventButton;
-
-///
 ///  The execution event that this window is for
 ///
 @property(readonly) SNTStoredEvent *event;

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -66,6 +66,17 @@
 @property(readonly) SNTStoredEvent *event;
 
 ///
+/// TODO(PLM) Fix comment
+/// The reply block to call when the user has authenticated via touch ID in standalone mode.
+///
+@property(readonly, nonatomic) void (^replyBlock)(BOOL authenticated);
+
+///
+/// TODO(PLM) Fix this comment
+///
+//@property dispatch_semaphore_t replyBlockSemaphore;
+
+///
 ///  The root progress object. Child nodes are vended to santad to report on work being done.
 ///
 @property NSProgress *progress;

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -1,4 +1,5 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -71,11 +71,6 @@
 @property(readonly, nonatomic) void (^replyBlock)(BOOL authenticated);
 
 ///
-/// TODO(PLM) Fix this comment
-///
-//@property dispatch_semaphore_t replyBlockSemaphore;
-
-///
 ///  The root progress object. Child nodes are vended to santad to report on work being done.
 ///
 @property NSProgress *progress;

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -25,7 +25,8 @@
 
 - (instancetype)initWithEvent:(SNTStoredEvent *)event
                     customMsg:(NSString *)message
-                    customURL:(NSString *)url;
+                    customURL:(NSString *)url
+                    reply:(void (^)(BOOL authenticated))replyBlock;
 
 - (IBAction)showCertInfo:(id)sender;
 - (void)updateBlockNotification:(SNTStoredEvent *)event withBundleHash:(NSString *)bundleHash;

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -60,6 +60,12 @@
 @property(weak) IBOutlet NSButton *dismissEventButton;
 
 ///
+///   Reference to the "Check Event" button in the XIB. Used to help the user
+///   check the binary.
+///
+@property(weak) IBOutlet NSButton *checkEventButton;
+
+///
 ///  The execution event that this window is for
 ///
 @property(readonly) SNTStoredEvent *event;

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -184,7 +184,7 @@
 - (void)approveBinaryForStandaloneMode {
   LAContext *context = [[LAContext alloc] init];
 
-  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  //dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
   LOGE(@"PLM -- Attempting to authenticate user for standalone mode");
 
@@ -193,7 +193,7 @@
                     reply:^(BOOL success, NSError *error) {
                       if (self.replyBlock == nil) {
                         LOGE(@"PLM -- replyBlock is nil");
-                        dispatch_semaphore_signal(sema); 
+   //                     dispatch_semaphore_signal(sema); 
                         return;
                       }
 
@@ -205,11 +205,11 @@
                           LOGE(@"PLM -- User failed to authenticate for standalone mode");
                           self.replyBlock(NO);
                       }
-                      dispatch_semaphore_signal(sema); 
+    //                  dispatch_semaphore_signal(sema); 
                     }];
 
   //TODO do we need to use a semaphore here?
-  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+  //dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
   //dispatch_semaphore_signal(self.replyBlockSemaphore);
 }
 
@@ -217,8 +217,8 @@
   BOOL isInStandaloneMode = [[SNTConfigurator configurator] enableStandaloneMode];
 
   if (isInStandaloneMode) {
-    [self closeWindow:sender];
     [self approveBinaryForStandaloneMode];
+    [self closeWindow:sender];
 
     return;
   }

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -1,4 +1,5 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -152,17 +152,17 @@
 
 // When running in standalone mode, the user is prompted to approve the binary.
 - (void)approveBinaryForStandaloneMode {
-  LAContext *context;
   NSError *err;
 
-  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-  context = [[LAContext alloc] init];
+  LAContext *context = [[LAContext alloc] init];
 
   if (![context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&err]) {
     // TODO: handle error
     LOGE(@"Unable to process Touch ID error: %@", err);
     return;
   }
+
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
   [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
           localizedReason:[NSString stringWithFormat:@"Approve %@", self.event.signingID]

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -92,9 +92,6 @@
 
   if (!url && !isStandalone) {
     [self.openEventButton removeFromSuperview];
-  }
-  if (!isStandalone) {
-    [self.checkEventButton removeFromSuperview];
   } else if (isStandalone) {
     [self.openEventButton setTitle:@"Approve"];
     // Require the button keyEquivalent set to be CMD + Return
@@ -229,14 +226,6 @@
   NSURL *url = [SNTBlockMessage eventDetailURLForEvent:self.event customURL:self.customURL];
 
   [self closeWindow:sender];
-  [[NSWorkspace sharedWorkspace] openURL:url];
-}
-
-- (IBAction)checkEventDetails:(id)sender {
-  NSString *eventCheckURL =
-    [NSString stringWithFormat:@"https://www.virustotal.com/gui/search/%@", self.event.fileSHA256];
-  NSURL *url = [[NSURL alloc] initWithString:eventCheckURL];
-
   [[NSWorkspace sharedWorkspace] openURL:url];
 }
 

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -63,7 +63,6 @@
     _customMessage = message;
     _customURL = url;
     _replyBlock = replyBlock;
-    //    _replyBlockSemaphore = dispatch_semaphore_create(0);
     _progress = [NSProgress discreteProgressWithTotalUnitCount:1];
     [_progress addObserver:self
                 forKeyPath:@"fractionCompleted"
@@ -181,7 +180,7 @@
 - (void)approveBinaryForStandaloneMode {
   LAContext *context = [[LAContext alloc] init];
 
-  LOGE(@"PLM -- Attempting to authenticate user for standalone mode");
+  LOGD(@"Attempting to authenticate user for standalone mode");
 
   [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
           localizedReason:[NSString stringWithFormat:@"Approve %@", self.event.signingID]

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -104,20 +104,13 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
   // this message, don't do anything else.
   if ([SNTConfigurator configurator].enableSilentMode) return;
 
-  /*
-  LOGE(@"PLM -- Calling reply block with YES from queueMessage");
-  if ([pendingMsg isKindOfClass:[SNTBinaryMessageWindowController class]]) {
-    SNTBinaryMessageWindowController *controller = (SNTBinaryMessageWindowController *)pendingMsg;
-    if (controller.replyBlock) {
-      LOGE(@"PLM -- Calling reply block with YES from queueMessage");
-      controller.replyBlock(YES);
-    }
-  }*/
-
   dispatch_async(dispatch_get_main_queue(), ^{
     if ([self notificationAlreadyQueued:pendingMsg]) {
-   //   pendingMsg.replyBlock(NO);
-      LOGE(@"PLM -- Notification already queued, dropping");
+      if ([pendingMsg isKindOfClass:[SNTBinaryMessageWindowController class]]) {
+        SNTBinaryMessageWindowController *bmwc = (SNTBinaryMessageWindowController *)pendingMsg;
+        LOGE(@"PLM -- Notification already queued, dropping");
+        bmwc.replyBlock(NO);
+      }
       return;
     }
 
@@ -360,17 +353,6 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 
   LOGE(@"PLM -- queueing message");
   [self queueMessage:pendingMsg];
-/*
-  if ([[SNTConfigurator configurator] enableStandaloneMode]) {
-    if ([pendingMsg isKindOfClass:[SNTBinaryMessageWindowController class]]) {
-      SNTBinaryMessageWindowController *controller = (SNTBinaryMessageWindowController *)pendingMsg;
-      LOGE(@"PLM -- waiting for the user to approve the binary");
-     // dispatch_wait(controller.replyBlockSemaphore, DISPATCH_TIME_FOREVER);
-    }
-  }
-  */
-  NSRunLoop *runLoop = [NSRunLoop mainRunLoop];
-  [runLoop run];
 }
 
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message {

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -1,4 +1,5 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -108,7 +108,6 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
     if ([self notificationAlreadyQueued:pendingMsg]) {
       if ([pendingMsg isKindOfClass:[SNTBinaryMessageWindowController class]]) {
         SNTBinaryMessageWindowController *bmwc = (SNTBinaryMessageWindowController *)pendingMsg;
-        LOGE(@"PLM -- Notification already queued, dropping");
         bmwc.replyBlock(NO);
       }
       return;
@@ -351,7 +350,6 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
     [[SNTBinaryMessageWindowController alloc] initWithEvent:event customMsg:message 
                                               customURL:url reply:reply];
 
-  LOGE(@"PLM -- queueing message");
   [self queueMessage:pendingMsg];
 }
 

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -332,14 +332,15 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 
 - (void)postBlockNotification:(SNTStoredEvent *)event
             withCustomMessage:(NSString *)message
-                 andCustomURL:(NSString *)url {
+                 andCustomURL:(NSString *)url 
+                 andReply:(void (^)(BOOL))reply {
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;
   }
 
   SNTBinaryMessageWindowController *pendingMsg =
-    [[SNTBinaryMessageWindowController alloc] initWithEvent:event customMsg:message customURL:url];
+    [[SNTBinaryMessageWindowController alloc] initWithEvent:event customMsg:message customURL:url reply:reply];
 
   [self queueMessage:pendingMsg];
 }

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -339,16 +339,18 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 // XPC entrypoint for posting a block notification.
 - (void)postBlockNotification:(SNTStoredEvent *)event
             withCustomMessage:(NSString *)message
-                 andCustomURL:(NSString *)url 
-                 andReply:(void (^)(BOOL))reply {
+                 andCustomURL:(NSString *)url
+                     andReply:(void (^)(BOOL))reply {
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;
   }
 
   SNTBinaryMessageWindowController *pendingMsg =
-    [[SNTBinaryMessageWindowController alloc] initWithEvent:event customMsg:message 
-                                              customURL:url reply:reply];
+    [[SNTBinaryMessageWindowController alloc] initWithEvent:event
+                                                  customMsg:message
+                                                  customURL:url
+                                                      reply:reply];
 
   [self queueMessage:pendingMsg];
 }

--- a/Source/gui/SNTNotificationManagerTest.m
+++ b/Source/gui/SNTNotificationManagerTest.m
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -58,7 +59,7 @@
   id dncMock = OCMClassMock([NSDistributedNotificationCenter class]);
   OCMStub([dncMock defaultCenter]).andReturn(dncMock);
 
-  [sut postBlockNotification:ev withCustomMessage:@"" andCustomURL:@""];
+  [sut postBlockNotification:ev withCustomMessage:@"" andCustomURL:@"" andReply:^(BOOL authenticated){}];
 
   OCMVerify([dncMock postNotificationName:@"com.northpolesec.santa.notification.blockedeexecution"
                                    object:@"com.northpolesec.santa"

--- a/Source/gui/SNTNotificationManagerTest.m
+++ b/Source/gui/SNTNotificationManagerTest.m
@@ -59,7 +59,11 @@
   id dncMock = OCMClassMock([NSDistributedNotificationCenter class]);
   OCMStub([dncMock defaultCenter]).andReturn(dncMock);
 
-  [sut postBlockNotification:ev withCustomMessage:@"" andCustomURL:@"" andReply:^(BOOL authenticated){}];
+  [sut postBlockNotification:ev
+           withCustomMessage:@""
+                andCustomURL:@""
+                    andReply:^(BOOL authenticated){
+                    }];
 
   OCMVerify([dncMock postNotificationName:@"com.northpolesec.santa.notification.blockedeexecution"
                                    object:@"com.northpolesec.santa"

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -1,4 +1,5 @@
 /// Copyright 2015-2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -150,6 +150,9 @@ REGISTER_COMMAND_NAME(@"status")
     enableTransitiveRules = response;
   }];
 
+  // TODO make a proper RPC call for this.
+  BOOL enableStandAloneMode = [[SNTConfigurator configurator] enableStandaloneMode];
+
   __block BOOL watchItemsEnabled = NO;
   __block uint64_t watchItemsRuleCount = 0;
   __block NSString *watchItemsPolicyVersion = nil;
@@ -199,6 +202,7 @@ REGISTER_COMMAND_NAME(@"status")
         @"driver_connected" : @(YES),
         @"mode" : clientMode ?: @"null",
         @"transitive_rules" : @(enableTransitiveRules),
+        @"standalone_mode" : @(configurator.enableStandaloneMode),
         @"log_type" : eventLogType,
         @"file_logging" : @(fileLogging),
         @"watchdog_cpu_events" : @(cpuEvents),
@@ -264,6 +268,9 @@ REGISTER_COMMAND_NAME(@"status")
 
     if (enableTransitiveRules) {
       printf("  %-25s | %s\n", "Transitive Rules", (enableTransitiveRules ? "Yes" : "No"));
+    }
+    if (enableStandAloneMode) {
+      printf("  %-25s | %s\n", "Standalone Mode", (enableStandAloneMode ? "Yes" : "No"));
     }
 
     printf("  %-25s | %s\n", "Log Type", [eventLogType UTF8String]);

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -160,6 +160,18 @@ double watchdogRAMPeak = 0;
   reply([SNTConfigurator configurator].staticRules.count);
 }
 
+- (void) addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply {
+  NSError *error;
+
+  if (![[SNTConfigurator configurator] enableStandaloneMode]) {
+    reply(nil);
+  }
+  // only add rules if standalone mode is enabled
+
+  [[SNTDatabaseController ruleTable] addRules:@[rule] ruleCleanup:SNTRuleCleanupNone error: &error];
+  reply(error);
+}
+
 - (void)retrieveAllRules:(void (^)(NSArray<SNTRule *> *, NSError *))reply {
   SNTConfigurator *config = [SNTConfigurator configurator];
 

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -160,20 +160,6 @@ double watchdogRAMPeak = 0;
   reply([SNTConfigurator configurator].staticRules.count);
 }
 
-- (void)addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply {
-  NSError *error;
-
-  if (![[SNTConfigurator configurator] enableStandaloneMode]) {
-    reply(nil);
-  }
-  // only add rules if standalone mode is enabled
-
-  [[SNTDatabaseController ruleTable] addRules:@[ rule ]
-                                  ruleCleanup:SNTRuleCleanupNone
-                                        error:&error];
-  reply(error);
-}
-
 - (void)retrieveAllRules:(void (^)(NSArray<SNTRule *> *, NSError *))reply {
   SNTConfigurator *config = [SNTConfigurator configurator];
 

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -160,7 +160,7 @@ double watchdogRAMPeak = 0;
   reply([SNTConfigurator configurator].staticRules.count);
 }
 
-- (void) addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply {
+- (void)addStandaloneRule:(SNTRule *)rule reply:(void (^)(NSError *))reply {
   NSError *error;
 
   if (![[SNTConfigurator configurator] enableStandaloneMode]) {
@@ -168,7 +168,9 @@ double watchdogRAMPeak = 0;
   }
   // only add rules if standalone mode is enabled
 
-  [[SNTDatabaseController ruleTable] addRules:@[rule] ruleCleanup:SNTRuleCleanupNone error: &error];
+  [[SNTDatabaseController ruleTable] addRules:@[ rule ]
+                                  ruleCleanup:SNTRuleCleanupNone
+                                        error:&error];
   reply(error);
 }
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -404,8 +404,20 @@ static NSString *const kPrinterProxyPostMonterey =
           self->_ttyWriter->Write(targetProc, msg);
         }
 
+
+        void (^replyBlock)(BOOL) = nil;
+
+        // Check if we're in standalone mode and create the rule wrapping it in a block. 
+        if ([[SNTConfigurator configurator] enableStandaloneMode]) {
+          replyBlock = ^void(BOOL authenticated) {
+            if (authenticated) {
+              [self createRuleForStandaloneMode:YES event:se];
+            }
+          };
+        } 
+
         // Let the user know what happened in the GUI.
-        [self.notifierQueue addEvent:se withCustomMessage:cd.customMsg andCustomURL:cd.customURL];
+        [self.notifierQueue addEvent:se withCustomMessage:cd.customMsg andCustomURL:cd.customURL andReply:replyBlock];
       }
     }
   }
@@ -478,6 +490,33 @@ static NSString *const kPrinterProxyPostMonterey =
 
   *users = [loggedInUsers allObjects];
   *sessions = [loggedInHosts copy];
+}
+
+- (void) createRuleForStandaloneMode:(BOOL) authenticated event:(SNTStoredEvent *)se {
+      SNTRuleType ruleType = SNTRuleTypeSigningID;
+      NSString *ruleIdentifier = se.signingID;
+
+      // Check here to see if the binary is validly signed if not
+      // then use a hash rule instead of a signing ID
+      if (se.signingChain.count == 0) {
+          LOGD(@"No certificate chain found for %@", se.filePath);
+          ruleType = SNTRuleTypeBinary;
+          ruleIdentifier = se.fileSHA256;
+      }
+
+      // Add rule to allow binary same as santactl rule.
+      SNTRule *newRule = [[SNTRule alloc] initWithIdentifier:ruleIdentifier
+                                                        state:SNTRuleStateAllow
+                                                         type:ruleType
+                                                    customMsg:@"Approved by user in standalone mode"
+                                                    timestamp:[[NSDate now] timeIntervalSince1970]];
+      NSError *err;
+      [self.ruleTable addRules:@[newRule] 
+                      ruleCleanup:SNTRuleCleanupNone 
+                      error:&err];
+      if (err) {
+          LOGE(@"Failed to add rule in standalone mode for %@: %@", se.filePath, err.localizedDescription);
+      }
 }
 
 @end

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -410,7 +410,8 @@ static NSString *const kPrinterProxyPostMonterey =
         // Check if we're in standalone mode and create the rule wrapping it in a block. 
         if ([[SNTConfigurator configurator] enableStandaloneMode]) {
           replyBlock = ^void(BOOL authenticated) {
-            LOGE(@"User responded to block event for %@ with authenticated: %d", se.filePath, authenticated);
+            LOGE(@"PLM -- User responded to block event for %@ with authenticated: %d", se.filePath, authenticated);
+            LOGE(@"PLM -- %@", NSThread.callStackSymbols);
             if (authenticated) {
               [self createRuleForStandaloneMode:YES event:se];
             }

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -523,7 +523,6 @@ static NSString *const kPrinterProxyPostMonterey =
          err.localizedDescription);
   }
 
-
   if ([[SNTConfigurator configurator] syncBaseURL]) {
     // Log an event so that if Santa is configured to use a sync service
     // it knows this was approved by the user in standalone mode.

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -405,11 +405,12 @@ static NSString *const kPrinterProxyPostMonterey =
         }
 
 
-        void (^replyBlock)(BOOL) = nil;
+        void (^replyBlock)(BOOL) = ^void(BOOL authenticated) {};
 
         // Check if we're in standalone mode and create the rule wrapping it in a block. 
         if ([[SNTConfigurator configurator] enableStandaloneMode]) {
           replyBlock = ^void(BOOL authenticated) {
+            LOGE(@"User responded to block event for %@ with authenticated: %d", se.filePath, authenticated);
             if (authenticated) {
               [self createRuleForStandaloneMode:YES event:se];
             }

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -1,5 +1,6 @@
 
 /// Copyright 2015-2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -522,6 +522,19 @@ static NSString *const kPrinterProxyPostMonterey =
     LOGE(@"Failed to add rule in standalone mode for %@: %@", se.filePath,
          err.localizedDescription);
   }
+
+
+  if ([[SNTConfigurator configurator] syncBaseURL]) {
+    // Log an event so that if Santa is configured to use a sync service
+    // it knows this was approved by the user in standalone mode.
+    SNTStoredEvent *newEvent = [se copy];
+    newEvent.decision = SNTEventStateAllow;
+    newEvent.standaloneApproval = YES;
+
+    dispatch_async(_eventQueue, ^{
+      [self.syncdQueue addEvents:@[ se ] isFromBundle:NO];
+    });
+  }
 }
 
 @end

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -376,7 +376,7 @@ static NSString *const kPrinterProxyPostMonterey =
         // message to santad to perform the upload logic for bundles.
         // See syncBundleEvent:relatedEvents: for more info.
         se.needsBundleHash = YES;
-      } else if (config.syncBaseURL) {
+      } else if (config.syncBaseURL && !config.enableStandaloneMode) {
         // So the server has something to show the user straight away, initiate an event
         // upload for the blocked binary rather than waiting for the next sync.
         dispatch_async(_eventQueue, ^{
@@ -526,9 +526,10 @@ static NSString *const kPrinterProxyPostMonterey =
   if ([[SNTConfigurator configurator] syncBaseURL]) {
     // Log an event so that if Santa is configured to use a sync service
     // it knows this was approved by the user in standalone mode.
-    SNTStoredEvent *newEvent = [se copy];
-    newEvent.decision = SNTEventStateAllow;
-    newEvent.standaloneApproval = YES;
+    if (authenticated) {
+      se.decision = SNTEventStateAllow;
+      se.standaloneApproval = YES;
+    }
 
     dispatch_async(_eventQueue, ^{
       [self.syncdQueue addEvents:@[ se ] isFromBundle:NO];

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -23,6 +23,7 @@
 
 - (void)addEvent:(SNTStoredEvent *)event
   withCustomMessage:(NSString *)message
-       andCustomURL:(NSString *)url;
+       andCustomURL:(NSString *)url
+       andReply:(void (^)(BOOL authenticated))reply;
 
 @end

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -1,4 +1,5 @@
 /// Copyright 2016 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -24,6 +24,6 @@
 - (void)addEvent:(SNTStoredEvent *)event
   withCustomMessage:(NSString *)message
        andCustomURL:(NSString *)url
-       andReply:(void (^)(BOOL authenticated))reply;
+           andReply:(void (^)(BOOL authenticated))reply;
 
 @end

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -38,8 +38,10 @@ static const int kMaximumNotifications = 10;
 
 - (void)addEvent:(SNTStoredEvent *)event
   withCustomMessage:(NSString *)message
-       andCustomURL:(NSString *)url {
+       andCustomURL:(NSString *)url 
+       andReply:(void (^)(BOOL authenticated))reply {
   if (!event) return;
+
   if (self.pendingNotifications.count > kMaximumNotifications) {
     LOGI(@"Pending GUI notification count is over %d, dropping.", kMaximumNotifications);
     return;
@@ -52,6 +54,12 @@ static const int kMaximumNotifications = 10;
   if (url) {
     d[@"url"] = url;
   }
+
+  if (reply) {
+    // Copy the block
+    d[@"reply"] = [reply copy];
+  }
+
   @synchronized(self.pendingNotifications) {
     [self.pendingNotifications addObject:d];
   }
@@ -67,7 +75,8 @@ static const int kMaximumNotifications = 10;
     for (NSDictionary *d in self.pendingNotifications) {
       [rop postBlockNotification:d[@"event"]
                withCustomMessage:d[@"message"]
-                    andCustomURL:d[@"url"]];
+                    andCustomURL:d[@"url"]
+                    andReply:d[@"reply"]];
       // TODO if running in standalone mode, add the rules to the database
       [postedNotifications addObject:d];
     }

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -57,7 +57,7 @@ static const int kMaximumNotifications = 10;
 
   if (reply) {
     // Copy the block
-    d[@"reply"] = reply; //[reply copy];
+    d[@"reply"] = [reply copy];
   }
 
   @synchronized(self.pendingNotifications) {

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -68,7 +68,7 @@ static const int kMaximumNotifications = 10;
       [rop postBlockNotification:d[@"event"]
                withCustomMessage:d[@"message"]
                     andCustomURL:d[@"url"]];
-      //TODO if running in standalone mode, add the rules to the database
+      // TODO if running in standalone mode, add the rules to the database
       [postedNotifications addObject:d];
     }
     [self.pendingNotifications removeObjectsInArray:postedNotifications];

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -57,7 +57,7 @@ static const int kMaximumNotifications = 10;
 
   if (reply) {
     // Copy the block
-    d[@"reply"] = [reply copy];
+    d[@"reply"] = reply; //[reply copy];
   }
 
   @synchronized(self.pendingNotifications) {

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -1,4 +1,5 @@
 /// Copyright 2016 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -68,6 +68,7 @@ static const int kMaximumNotifications = 10;
       [rop postBlockNotification:d[@"event"]
                withCustomMessage:d[@"message"]
                     andCustomURL:d[@"url"]];
+      //TODO if running in standalone mode, add the rules to the database
       [postedNotifications addObject:d];
     }
     [self.pendingNotifications removeObjectsInArray:postedNotifications];

--- a/Source/santad/SNTNotificationQueue.m
+++ b/Source/santad/SNTNotificationQueue.m
@@ -38,8 +38,8 @@ static const int kMaximumNotifications = 10;
 
 - (void)addEvent:(SNTStoredEvent *)event
   withCustomMessage:(NSString *)message
-       andCustomURL:(NSString *)url 
-       andReply:(void (^)(BOOL authenticated))reply {
+       andCustomURL:(NSString *)url
+           andReply:(void (^)(BOOL authenticated))reply {
   if (!event) return;
 
   if (self.pendingNotifications.count > kMaximumNotifications) {
@@ -56,7 +56,6 @@ static const int kMaximumNotifications = 10;
   }
 
   if (reply) {
-    // Copy the block
     d[@"reply"] = [reply copy];
   }
 
@@ -76,7 +75,7 @@ static const int kMaximumNotifications = 10;
       [rop postBlockNotification:d[@"event"]
                withCustomMessage:d[@"message"]
                     andCustomURL:d[@"url"]
-                    andReply:d[@"reply"]];
+                        andReply:d[@"reply"]];
       // TODO if running in standalone mode, add the rules to the database
       [postedNotifications addObject:d];
     }

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -176,6 +176,11 @@ using santa::NSStringToUTF8String;
     c->set_valid_until([cert.validUntil timeIntervalSince1970]);
   }
 
+  // Only send this field if this event is a standalone approval.
+  if (event.standaloneApproval) {
+    e->set_standalone_approval(event.standaloneApproval);
+  }
+
   return *e;
 }
 

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -234,6 +234,7 @@ message Event {
   string quarantine_agent_bundle_id = 27        [json_name="quarantine_agent_bundle_id"];
 
   repeated Certificate signing_chain = 28       [json_name="signing_chain"];
+  bool standalone_approval = 29                 [json_name="standalone_approval"];
 }
 
 message EventUploadRequest {

--- a/Testing/lint.sh
+++ b/Testing/lint.sh
@@ -11,7 +11,7 @@ go install github.com/bazelbuild/buildtools/buildifier@latest
 ~/go/bin/buildifier --lint=warn -r ${GIT_ROOT}
 
 if [ -d "./santa-venv" ]; then
- echo "santa-venv already exists reusing".  
+ echo "santa-venv already exists reusing"
 else
  echo "Creating virtual environment ./santa-venv..."
     python3 -m venv ./santa-venv

--- a/docs/concepts/mode.md
+++ b/docs/concepts/mode.md
@@ -27,6 +27,14 @@ Running Santa in Lockdown Mode will stop all blocked binaries and additionally
 will prevent all unknown binaries from running. This means that if the binary
 has no rules or scopes that apply, then it will be blocked.
 
+##### Standalone mode
+
+There is an optional setting called `Standalone Mode` that can be enabled via the `EnableStandaloneMode` key in the configuration profile.
+
+When Santa is in Standalone Mode it will allow the user to approve their own binaries provided they authenticate biometrically with Touch ID. Upon a successful authentication Santa will then add a `SigningID` rule for the binary if it is validly signed and a `BINARY` if it is not signed at all.
+
+When paired with Lockdown, it allows a user to quickly self approve in lieu of using a sync service. If one is using a sync service Events will still be sent up to that sync service.
+
 ##### Changing Modes
 
 There are two ways to change the running mode: changing the configuration

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -31,6 +31,7 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | EnableBadSignatureProtection       | Bool       | If true, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. Defaults to false. |
 | EnablePageZeroProtection           | Bool       | If true, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. Defaults to true. |
 | EnableSilentMode                   | Bool       | If true, Santa will not post any GUI notifications. This can be a very confusing experience for users, use with caution. Defaults to false. |
+| EnableStandaloneMode                   | Bool       | If true, Santa will allow the local user to approve binaries provided they successfully authenticate with TouchID. Use with caution. Defaults to false. |
 | EnableTransitiveRules              | Bool       | If true, Santa will respect compiler rule types and create allow rules for the executables they produce. Defaults to false. |
 | EnableSilentTTYMode                | Bool       | If true, Santa will not post any TTY notifications. This can be a very confusing experience for users, use with caution. Defaults to false. |
 | EnableForkAndExitLogging           | Bool       | If true, Santa will log FORK and EXIT event types. Defaults to false. |

--- a/docs/development/sync-protocol.md
+++ b/docs/development/sync-protocol.md
@@ -236,6 +236,7 @@ sequenceDiagram
 | signing_id | NO | string | Signing ID of the binary that was executed | "EQHXZ8M8AV:com.google.Chrome" |
 | team_id | NO | string | Team ID of the binary that was executed | "EQHXZ8M8AV" |
 | cdhash | NO | string | CDHash of the binary that was executed | "dbe8c39801f93e05fc7bc53a02af5b4d3cfc670a" |
+| standalone_approval | NO | bool | Indicates that this approval was the result of a standalone authentication by the user. | true |
 
 #### Signing Chain Objects
 


### PR DESCRIPTION
This PR creates a new Santa operating mode -- *standalone*
    
This adds a new operating mode to Santa called standalone mode.
    
When running in standalone mode TouchID can be used to approved binaries. If a
binary is properly signed a SigningID rule is generated otherwise a SHA256 rule
is generated. Note this lacks a GUI for browsing rules in the local rule db.

Example video of behavior attached (has the wrong logo):

[![Standalone Santa Operation](https://img.youtube.com/vi/ja5mylENUro/0.jpg)](https://www.youtube.com/watch?v=ja5mylENUro)

This PR is marked draft until the following things are added

1. [x] Comments are cleaned up
2. [ ] Documentation is updated (Mostly done -- sync updated, mode updated)
3. [ ] Tests are updated
4. [x] We decide if this is the right place to put the auth (move to reply block)
5. [x] We decide if Events need to have a new flag on them that informs the sync service that a binary was approved via Standalone mode. (Added standaloneApproval flag to events.
6. [ ] Rebase changes for the Swift UI

---
Aside I've been running with this mode for a month+.