### PR TITLE
Fix tree aware clients handleContextMessage default return

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1458,6 +1458,7 @@ test_suite(
         ":SNTEndpointSecurityFileAccessAuthorizerTest",
         ":SNTEndpointSecurityRecorderTest",
         ":SNTEndpointSecurityTamperResistanceTest",
+        ":SNTEndpointSecurityTreeAwareClientTest",
         ":SNTEventTableTest",
         ":SNTExecutionControllerTest",
         ":SNTPolicyProcessorTest",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -320,6 +320,22 @@ objc_library(
     ],
 )
 
+santa_unit_test(
+    name = "SNTEndpointSecurityTreeAwareClientTest",
+    srcs = ["EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
+    deps = [
+        ":EndpointSecurityMessage",
+        ":Metrics",
+        ":MockEndpointSecurityAPI",
+        ":SNTEndpointSecurityTreeAwareClient",
+        "//Source/common:TestUtils",
+        "@OCMock",
+    ],
+)
+
 objc_library(
     name = "SNTEndpointSecurityRecorder",
     srcs = ["EventProviders/SNTEndpointSecurityRecorder.mm"],

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -78,6 +79,8 @@
                handler:(void (^)(const santa::Message &))messageHandler;
 
 - (bool)clearCache;
+
+- (bool)handleContextMessage:(santa::Message &)esMsg;
 
 + (std::set<std::string>)getProtectedPaths;
 + (bool)isProtectedPath:(const std::string_view)path;

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
@@ -1,4 +1,5 @@
 /// Copyright 2024 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -73,9 +74,13 @@ using santa::Processor;
   return [super subscribe:eventsWithLifecycle];
 }
 
+- (bool)eventWasAdded:(es_event_type_t)eventType {
+  return _addedEvents[eventType];
+}
+
 - (bool)handleContextMessage:(Message &)esMsg {
   if (!_processTree) {
-    return false;
+    return [self eventWasAdded:esMsg->event_type];
   }
 
   // Inform the tree
@@ -108,7 +113,7 @@ using santa::Processor;
   // ...and create the token for those.
   esMsg.SetProcessToken(santa::santad::process_tree::ProcessToken(_processTree, std::move(pids)));
 
-  return _addedEvents[esMsg->event_type];
+  return [self eventWasAdded:esMsg->event_type];
 }
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm
@@ -41,7 +41,11 @@ using santa::Processor;
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   EXPECT_CALL(*mockESApi, Subscribe).WillRepeatedly(testing::Return(true));
 
-  SNTEndpointSecurityTreeAwareClient *treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+  SNTEndpointSecurityTreeAwareClient *treeClient =
+    [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi
+                                                      metrics:nullptr
+                                                    processor:Processor::kUnknown
+                                                  processTree:nullptr];
 
   // Ensure no forced events initially set
   XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
@@ -56,7 +60,10 @@ using santa::Processor;
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
 
   // Subscribing to one of the forced events results in that event not being tracked
-  treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+  treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi
+                                                                 metrics:nullptr
+                                                               processor:Processor::kUnknown
+                                                             processTree:nullptr];
   [treeClient subscribe:{ES_EVENT_TYPE_NOTIFY_EXEC}];
 
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
@@ -64,7 +71,10 @@ using santa::Processor;
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
 
   // EXEC event is not forced for both AUTH and NOTIFY variants
-  treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+  treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi
+                                                                 metrics:nullptr
+                                                               processor:Processor::kUnknown
+                                                             processTree:nullptr];
   [treeClient subscribe:{ES_EVENT_TYPE_AUTH_EXEC}];
 
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
@@ -81,7 +91,11 @@ using santa::Processor;
 
   // Check that tree aware clients that only subscribe to a subset of forced events
   // return appropriately from handleContextMessage based on which events for force-added.
-  SNTEndpointSecurityTreeAwareClient *treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+  SNTEndpointSecurityTreeAwareClient *treeClient =
+    [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi
+                                                      metrics:nullptr
+                                                    processor:Processor::kUnknown
+                                                  processTree:nullptr];
 
   [treeClient subscribe:{ES_EVENT_TYPE_NOTIFY_FORK}];
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm
@@ -1,0 +1,100 @@
+/// Copyright 2024 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.h"
+
+#include <EndpointSecurity/ESTypes.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "Source/common/TestUtils.h"
+#include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
+#include "Source/santad/Metrics.h"
+
+using santa::Message;
+using santa::Processor;
+
+@interface SNTEndpointSecurityTreeAwareClient (Testing)
+- (bool)eventWasAdded:(es_event_type_t)eventType;
+@end
+
+@interface SNTEndpointSecurityTreeAwareClientTest : XCTestCase
+@end
+
+@implementation SNTEndpointSecurityTreeAwareClientTest
+
+- (void)testSubscribe {
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  EXPECT_CALL(*mockESApi, Subscribe).WillRepeatedly(testing::Return(true));
+
+  SNTEndpointSecurityTreeAwareClient *treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+
+  // Ensure no forced events initially set
+  XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
+  XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
+  XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
+
+  // Subscribe with no events to trigger forced events added
+  [treeClient subscribe:{}];
+
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
+
+  // Subscribing to one of the forced events results in that event not being tracked
+  treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+  [treeClient subscribe:{ES_EVENT_TYPE_NOTIFY_EXEC}];
+
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
+  XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
+
+  // EXEC event is not forced for both AUTH and NOTIFY variants
+  treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+  [treeClient subscribe:{ES_EVENT_TYPE_AUTH_EXEC}];
+
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
+  XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
+- (void)testHandleContextMessageExpectedReturnNullTree {
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+  EXPECT_CALL(*mockESApi, Subscribe).WillRepeatedly(testing::Return(true));
+
+  // Check that tree aware clients that only subscribe to a subset of forced events
+  // return appropriately from handleContextMessage based on which events for force-added.
+  SNTEndpointSecurityTreeAwareClient *treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi metrics:nullptr processor:Processor::kUnknown processTree:nullptr];
+
+  [treeClient subscribe:{ES_EVENT_TYPE_NOTIFY_FORK}];
+
+  {
+    es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXEC, NULL);
+    Message msg(mockESApi, &esMsg);
+    XCTAssertTrue([treeClient handleContextMessage:msg]);
+  }
+  {
+    es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_FORK, NULL);
+    Message msg(mockESApi, &esMsg);
+    XCTAssertFalse([treeClient handleContextMessage:msg]);
+  }
+}
+
+@end


### PR DESCRIPTION
This fixes an issue for tree aware clients that have not enabled any process tree annotations but also do no subscribe to the set of force-enabled tree aware client event types (fork/exec/exit).

Before this change, `handleContextMessage` would always return false when process trees weren't in use. Instead it should return whether or not the event type was force added.

This bug does not currently affect Santa's current implementation as the only tree aware client (the recorder) subscribes to the full set of force-enabled events. But it does affect various debug routines where event subscriptions are manipulated.

This PR also begins including tree aware client tests.