### PR TITLE
[DRAFT] Add codesigning information to the ProcessInfoLight message

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -1,4 +1,17 @@
-// Important: This schema is currently in BETA
+/// Copyright 2024 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 syntax = "proto3";
 
@@ -206,7 +219,11 @@ message ProcessInfoLight {
   // File information for the executable backing this process
   optional FileInfoLight executable = 10;
 
+  // Tags added by configured annotators
   optional process_tree.Annotations annotations = 11;
+
+  // Code signature information for the process
+  optional CodeSignature code_signature = 12;
 }
 
 // Certificate information

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -248,6 +248,10 @@ void SerializeAndCheck(es_event_type_t eventType,
     es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(12, 34), MakeAuditToken(56, 78));
     es_message_t esMsg = MakeESMessage(eventType, &proc);
     esMsg.process->tty = &ttyFile;
+    esMsg.process->codesigning_flags = CS_SIGNED | CS_HARD | CS_KILL;
+    esMsg.process->signing_id = MakeESStringToken("my_signing_id");
+    esMsg.process->team_id = MakeESStringToken("my_team_id");
+    memset(esMsg.process->cdhash, 'A', sizeof(esMsg.process->cdhash));
     esMsg.version = cur_version;
 
     mockESApi->SetExpectationsRetainReleaseMessage();
@@ -334,6 +338,10 @@ void SerializeAndCheckNonESEvents(
     es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(12, 34), MakeAuditToken(56, 78));
     es_message_t esMsg = MakeESMessage(eventType, &proc);
     esMsg.process->tty = &ttyFile;
+    esMsg.process->codesigning_flags = CS_SIGNED | CS_HARD | CS_KILL;
+    esMsg.process->signing_id = MakeESStringToken("my_signing_id");
+    esMsg.process->team_id = MakeESStringToken("my_team_id");
+    memset(esMsg.process->cdhash, 'A', sizeof(esMsg.process->cdhash));
     esMsg.version = cur_version;
 
     messageSetup(mockESApi, &esMsg);

--- a/Source/santad/testdata/protobuf/v1/allowlist.json
+++ b/Source/santad/testdata/protobuf/v1/allowlist.json
@@ -26,6 +26,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v1/close.json
+++ b/Source/santad/testdata/protobuf/v1/close.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v1/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v1/exchangedata.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "file1": {

--- a/Source/santad/testdata/protobuf/v1/exec.json
+++ b/Source/santad/testdata/protobuf/v1/exec.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v1/exit.json
+++ b/Source/santad/testdata/protobuf/v1/exit.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "exited": {

--- a/Source/santad/testdata/protobuf/v1/fork.json
+++ b/Source/santad/testdata/protobuf/v1/fork.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "child": {

--- a/Source/santad/testdata/protobuf/v1/link.json
+++ b/Source/santad/testdata/protobuf/v1/link.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v1/rename.json
+++ b/Source/santad/testdata/protobuf/v1/rename.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v1/unlink.json
+++ b/Source/santad/testdata/protobuf/v1/unlink.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v2/allowlist.json
+++ b/Source/santad/testdata/protobuf/v2/allowlist.json
@@ -26,6 +26,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v2/close.json
+++ b/Source/santad/testdata/protobuf/v2/close.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v2/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v2/exchangedata.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "file1": {

--- a/Source/santad/testdata/protobuf/v2/exec.json
+++ b/Source/santad/testdata/protobuf/v2/exec.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v2/exit.json
+++ b/Source/santad/testdata/protobuf/v2/exit.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "exited": {

--- a/Source/santad/testdata/protobuf/v2/fork.json
+++ b/Source/santad/testdata/protobuf/v2/fork.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "child": {

--- a/Source/santad/testdata/protobuf/v2/link.json
+++ b/Source/santad/testdata/protobuf/v2/link.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v2/rename.json
+++ b/Source/santad/testdata/protobuf/v2/rename.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v2/unlink.json
+++ b/Source/santad/testdata/protobuf/v2/unlink.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v4/allowlist.json
+++ b/Source/santad/testdata/protobuf/v4/allowlist.json
@@ -26,6 +26,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v4/close.json
+++ b/Source/santad/testdata/protobuf/v4/close.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v4/cs_invalidated.json
+++ b/Source/santad/testdata/protobuf/v4/cs_invalidated.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  }
 }

--- a/Source/santad/testdata/protobuf/v4/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v4/exchangedata.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "file1": {

--- a/Source/santad/testdata/protobuf/v4/exec.json
+++ b/Source/santad/testdata/protobuf/v4/exec.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v4/exit.json
+++ b/Source/santad/testdata/protobuf/v4/exit.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "exited": {

--- a/Source/santad/testdata/protobuf/v4/fork.json
+++ b/Source/santad/testdata/protobuf/v4/fork.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "child": {

--- a/Source/santad/testdata/protobuf/v4/link.json
+++ b/Source/santad/testdata/protobuf/v4/link.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v4/rename.json
+++ b/Source/santad/testdata/protobuf/v4/rename.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v4/unlink.json
+++ b/Source/santad/testdata/protobuf/v4/unlink.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v5/allowlist.json
+++ b/Source/santad/testdata/protobuf/v5/allowlist.json
@@ -26,6 +26,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v5/close.json
+++ b/Source/santad/testdata/protobuf/v5/close.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v5/cs_invalidated.json
+++ b/Source/santad/testdata/protobuf/v5/cs_invalidated.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  }
 }

--- a/Source/santad/testdata/protobuf/v5/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v5/exchangedata.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "file1": {

--- a/Source/santad/testdata/protobuf/v5/exec.json
+++ b/Source/santad/testdata/protobuf/v5/exec.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v5/exit.json
+++ b/Source/santad/testdata/protobuf/v5/exit.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "exited": {

--- a/Source/santad/testdata/protobuf/v5/fork.json
+++ b/Source/santad/testdata/protobuf/v5/fork.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "child": {

--- a/Source/santad/testdata/protobuf/v5/link.json
+++ b/Source/santad/testdata/protobuf/v5/link.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v5/rename.json
+++ b/Source/santad/testdata/protobuf/v5/rename.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v5/unlink.json
+++ b/Source/santad/testdata/protobuf/v5/unlink.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v6/allowlist.json
+++ b/Source/santad/testdata/protobuf/v6/allowlist.json
@@ -26,6 +26,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v6/close.json
+++ b/Source/santad/testdata/protobuf/v6/close.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v6/cs_invalidated.json
+++ b/Source/santad/testdata/protobuf/v6/cs_invalidated.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  }
 }

--- a/Source/santad/testdata/protobuf/v6/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v6/exchangedata.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "file1": {

--- a/Source/santad/testdata/protobuf/v6/exec.json
+++ b/Source/santad/testdata/protobuf/v6/exec.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {

--- a/Source/santad/testdata/protobuf/v6/exit.json
+++ b/Source/santad/testdata/protobuf/v6/exit.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "exited": {

--- a/Source/santad/testdata/protobuf/v6/file_access.json
+++ b/Source/santad/testdata/protobuf/v6/file_access.json
@@ -33,7 +33,12 @@
   },
   "is_platform_binary": true,
   "is_es_client": true,
-  "cs_flags": 0,
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
+  },
+  "cs_flags": 536871680,
   "executable": {
    "path": "foo",
    "truncated": false,

--- a/Source/santad/testdata/protobuf/v6/fork.json
+++ b/Source/santad/testdata/protobuf/v6/fork.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "child": {

--- a/Source/santad/testdata/protobuf/v6/link.json
+++ b/Source/santad/testdata/protobuf/v6/link.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v6/login_login.json
+++ b/Source/santad/testdata/protobuf/v6/login_login.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "success": true,

--- a/Source/santad/testdata/protobuf/v6/login_login_failed_attempt.json
+++ b/Source/santad/testdata/protobuf/v6/login_login_failed_attempt.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "success": false,

--- a/Source/santad/testdata/protobuf/v6/lw_session_lock.json
+++ b/Source/santad/testdata/protobuf/v6/lw_session_lock.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "user": {

--- a/Source/santad/testdata/protobuf/v6/lw_session_login.json
+++ b/Source/santad/testdata/protobuf/v6/lw_session_login.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "user": {

--- a/Source/santad/testdata/protobuf/v6/lw_session_logout.json
+++ b/Source/santad/testdata/protobuf/v6/lw_session_logout.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "user": {

--- a/Source/santad/testdata/protobuf/v6/lw_session_unlock.json
+++ b/Source/santad/testdata/protobuf/v6/lw_session_unlock.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "user": {

--- a/Source/santad/testdata/protobuf/v6/openssh_login.json
+++ b/Source/santad/testdata/protobuf/v6/openssh_login.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "result": "RESULT_AUTH_SUCCESS",

--- a/Source/santad/testdata/protobuf/v6/openssh_login_failed_attempt.json
+++ b/Source/santad/testdata/protobuf/v6/openssh_login_failed_attempt.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "result": "RESULT_AUTH_FAIL_HOSTBASED",

--- a/Source/santad/testdata/protobuf/v6/openssh_logout.json
+++ b/Source/santad/testdata/protobuf/v6/openssh_logout.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "source": {

--- a/Source/santad/testdata/protobuf/v6/rename.json
+++ b/Source/santad/testdata/protobuf/v6/rename.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "source": {

--- a/Source/santad/testdata/protobuf/v6/screensharing_attach.json
+++ b/Source/santad/testdata/protobuf/v6/screensharing_attach.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "success": true,

--- a/Source/santad/testdata/protobuf/v6/screensharing_attach_unset_fields.json
+++ b/Source/santad/testdata/protobuf/v6/screensharing_attach_unset_fields.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "success": true,

--- a/Source/santad/testdata/protobuf/v6/screensharing_detach.json
+++ b/Source/santad/testdata/protobuf/v6/screensharing_detach.json
@@ -31,6 +31,11 @@
    "executable": {
     "path": "foo",
     "truncated": false
+   },
+   "code_signature": {
+    "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+    "signing_id": "my_signing_id",
+    "team_id": "my_team_id"
    }
   },
   "source": {

--- a/Source/santad/testdata/protobuf/v6/unlink.json
+++ b/Source/santad/testdata/protobuf/v6/unlink.json
@@ -30,6 +30,11 @@
   "executable": {
    "path": "foo",
    "truncated": false
+  },
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
   }
  },
  "target": {


### PR DESCRIPTION
This adds the `CodeSignature` message ([proto](https://github.com/northpolesec/santa/blob/e43219f07437ca558e6defc2aff37d3f8bcf40e1/Source/common/santa.proto#L32)) to the `ProcessInfoLight` message ([proto](https://github.com/northpolesec/santa/blob/e43219f07437ca558e6defc2aff37d3f8bcf40e1/Source/common/santa.proto#L182)).

Currently there are no good identifiers (except for path) when looking at a telemetry log to understand what the process might be. The `CodeSignature` message exists in the larger `ProcessInfo` message, but that is only used by EXEC and FAA events.

Pros: Adding the SID and TID will make processes more recognizable. The cdhash will also help make queries easier.
Cons: It does add overhead small overhead to event sizes. Also, while using cdhash to look for execs would be easier to get more information about a given process (e.g. the hash), you'd still need to run sub queries looking for pid/pidver and parent pid/pidver to find the exact EXEC for a process (e.g. to see args).