### PR TITLE
installer: support side-by-side install of NPS Santa [1/2]

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -186,14 +186,13 @@ genrule(
 )
 
 genrule(
-  name = "package-dev",
-  srcs = [ ":release" ],
-  outs = ["santa-dev.pkg"],
-  cmd = """
+    name = "package-dev",
+    srcs = [":release"],
+    outs = ["santa-dev.pkg"],
+    cmd = """
   tar -xzvf $(<)
-  RELEASE_ROOT=. SCRATCH=. BUILD_DEV_DISTRIBUTION_PKG=1 \
+  RELEASE_ROOT=. PKG_OUT_DIR=$(@D) BUILD_DEV_DISTRIBUTION_PKG=1 \
     ./conf/package.sh
-  mv santa-dev.pkg $(@)
   """,
 )
 

--- a/BUILD
+++ b/BUILD
@@ -108,6 +108,7 @@ genrule(
         "Conf/com.northpolesec.santa.newsyslog.conf",
         "Conf/Package/Distribution.xml",
         "Conf/Package/notarization_tool.sh",
+        "Conf/Package/package.sh",
         "Conf/Package/package_and_sign.sh",
         "Conf/Package/postinstall",
         "Conf/Package/preinstall",
@@ -182,6 +183,19 @@ genrule(
     """,
     }),
     heuristic_label_expansion = 0,
+)
+
+genrule(
+  name = "package-dev",
+  srcs = [ ":release" ],
+  outs = ["santa-dev.pkg"],
+  cmd = """
+  tar -xzvf $(<)
+  # chmod a+x conf/package.sh
+  RELEASE_ROOT=. SCRATCH=. BUILD_DEV_DISTRIBUTION_PKG=1 \
+    ./conf/package.sh
+  mv santa-dev.pkg $(@)
+  """,
 )
 
 test_suite(

--- a/BUILD
+++ b/BUILD
@@ -191,7 +191,6 @@ genrule(
   outs = ["santa-dev.pkg"],
   cmd = """
   tar -xzvf $(<)
-  # chmod a+x conf/package.sh
   RELEASE_ROOT=. SCRATCH=. BUILD_DEV_DISTRIBUTION_PKG=1 \
     ./conf/package.sh
   mv santa-dev.pkg $(@)

--- a/Conf/Package/package.sh
+++ b/Conf/Package/package.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# This script packages up Santa and its configs.
+# The output is "${SCRATCH}/app.pkg".
+#
+# If BUILD_DEV_DISTRIBUTION_PKG is set, "santa-dev.pkg" will also be produced.
+# The dev package is helpful when testing installer behavior for dev builds.
+#
+# All of the following environment variables are required.
+
+# RELEASE_ROOT is a required environment variable that points to the root
+# of an extracted release tarball produced with the :release and :release_driver
+# rules in Santa's main BUILD file.
+[[ -n "${RELEASE_ROOT}" ]] || die "RELEASE_ROOT unset"
+
+[[ -n "${SCRATCH}" ]] || die "SCRATCH unset"
+
+################################################################################
+
+function die {
+  echo "${@}"
+  exit 2
+}
+
+readonly APP_PKG_ROOT="${SCRATCH}/app_pkg_root"
+readonly APP_PKG_SCRIPTS="${SCRATCH}/pkg_scripts"
+
+readonly SCRIPT_PATH="$(/usr/bin/dirname -- ${BASH_SOURCE[0]})"
+
+/bin/mkdir -p "${APP_PKG_ROOT}" "${APP_PKG_SCRIPTS}"
+
+# Ensure _CodeSignature/CodeResources files have 0644 permissions so they can
+# be verified without using sudo.
+/usr/bin/find "binaries" -type f -name CodeResources -exec chmod 0644 {} \;
+/usr/bin/find "binaries" -type d -exec chmod 0755 {} \;
+/usr/bin/find "conf" -type f -name "com.northpolesec.santa*" -exec chmod 0644 {} \;
+
+echo "creating app pkg"
+/bin/mkdir -p "${APP_PKG_ROOT}/Applications" \
+  "${APP_PKG_ROOT}/Library/LaunchAgents" \
+  "${APP_PKG_ROOT}/Library/LaunchDaemons" \
+  "${APP_PKG_ROOT}/private/etc/asl" \
+  "${APP_PKG_ROOT}/private/etc/newsyslog.d"
+/bin/cp -vXR "binaries/Santa.app" "${APP_PKG_ROOT}/Applications/Santa_NPS.app"
+/bin/cp -vX "conf/com.northpolesec.santa.plist" "${APP_PKG_ROOT}/Library/LaunchAgents/"
+/bin/cp -vX "conf/com.northpolesec.santa.bundleservice.plist" "${APP_PKG_ROOT}/Library/LaunchDaemons/"
+/bin/cp -vX "conf/com.northpolesec.santa.metricservice.plist" "${APP_PKG_ROOT}/Library/LaunchDaemons/"
+/bin/cp -vX "conf/com.northpolesec.santa.syncservice.plist" "${APP_PKG_ROOT}/Library/LaunchDaemons/"
+/bin/cp -vX "conf/com.northpolesec.santa.newsyslog.conf" "${APP_PKG_ROOT}/private/etc/newsyslog.d/"
+/bin/cp -vXL "${SCRIPT_PATH}/preinstall" "${APP_PKG_SCRIPTS}/"
+/bin/cp -vXL "${SCRIPT_PATH}/postinstall" "${APP_PKG_SCRIPTS}/"
+/bin/chmod +x "${APP_PKG_SCRIPTS}/"*
+
+# Disable bundle relocation.
+/usr/bin/pkgbuild --analyze --root "${APP_PKG_ROOT}" "${SCRATCH}/component.plist"
+/usr/bin/plutil -replace BundleIsRelocatable -bool NO "${SCRATCH}/component.plist"
+/usr/bin/plutil -replace BundleIsVersionChecked -bool NO "${SCRATCH}/component.plist"
+/usr/bin/plutil -replace BundleOverwriteAction -string upgrade "${SCRATCH}/component.plist"
+/usr/bin/plutil -replace ChildBundles -json "[]" "${SCRATCH}/component.plist"
+
+# Build app package
+/usr/bin/pkgbuild --identifier "com.northpolesec.santa" \
+  --version 9999.1.1 \
+  --root "${APP_PKG_ROOT}" \
+  --component-plist "${SCRATCH}/component.plist" \
+  --scripts "${APP_PKG_SCRIPTS}" \
+  "${SCRATCH}/app.pkg"
+
+# Build dev distribution package if instructed.
+if [ -n "${BUILD_DEV_DISTRIBUTION_PKG}" ]; then
+  echo "productbuild pkg"
+  /usr/bin/productbuild \
+    --distribution "${SCRIPT_PATH}/Distribution.xml" \
+    --package-path "${SCRATCH}" \
+    "santa-dev.pkg"
+fi

--- a/Conf/Package/postinstall
+++ b/Conf/Package/postinstall
@@ -13,8 +13,21 @@
 mkdir -p /usr/local/bin
 /bin/ln -sf /Applications/Santa.app/Contents/MacOS/santactl /usr/local/bin/santactl
 
-# Load com.northpolesec.santa.daemon
-/Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
+if /bin/launchctl list EQHXZ8M8AV.com.google.santa.daemon > /dev/null 2>&1; then
+    echo "com.google.santa.daemon is running"
+
+    # Load com.northpolesec.santa.daemon from Santa_NPS.app. While com.google.santa.daemon
+    # is running, com.northpolesec.santa.daemon will idle. When com.google.santa.daemon is unloaded
+    # by the user or MDM, com.northpolesec.santa.daemon will finish installing itself. 
+    /Applications/Santa_NPS.app/Contents/MacOS/Santa --load-system-extension
+else
+    echo "install / update com.northpolesec.santa.daemon"
+
+    Load com.northpolesec.santa.daemon
+    mv /Applications/Santa_NPS.app /Applications/Santa.app
+    /Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
+fi
+
 
 # Load com.northpolesec.santa.bundleservice
 /bin/launchctl load -w /Library/LaunchDaemons/com.northpolesec.santa.bundleservice.plist

--- a/Conf/Package/postinstall
+++ b/Conf/Package/postinstall
@@ -14,20 +14,15 @@ mkdir -p /usr/local/bin
 /bin/ln -sf /Applications/Santa.app/Contents/MacOS/santactl /usr/local/bin/santactl
 
 if /bin/launchctl list EQHXZ8M8AV.com.google.santa.daemon > /dev/null 2>&1; then
-    echo "com.google.santa.daemon is running"
-
     # Load com.northpolesec.santa.daemon from Santa_NPS.app. While com.google.santa.daemon
     # is running, com.northpolesec.santa.daemon will idle. When com.google.santa.daemon is unloaded
     # by the user or MDM, com.northpolesec.santa.daemon will finish installing itself. 
     /Applications/Santa_NPS.app/Contents/MacOS/Santa --load-system-extension
 else
-    echo "install / update com.northpolesec.santa.daemon"
-
-    Load com.northpolesec.santa.daemon
+    # Finish installing, and load com.northpolesec.santa.daemon
     mv /Applications/Santa_NPS.app /Applications/Santa.app
     /Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
 fi
-
 
 # Load com.northpolesec.santa.bundleservice
 /bin/launchctl load -w /Library/LaunchDaemons/com.northpolesec.santa.bundleservice.plist

--- a/Conf/Package/preinstall
+++ b/Conf/Package/preinstall
@@ -10,7 +10,9 @@
 /bin/launchctl remove com.northpolesec.santa.metricservice || true
 /bin/launchctl remove com.northpolesec.santa.syncservice || true
 
-/bin/rm -rf /Applications/Santa.app
+# NPS Santa.app is installed by the installer as Santa_NPS.app. The postinstall,
+# or com.northpolesec.santa.daemon will rename it to Santa.app when safe to do so.
+/bin/rm -rf /Applications/Santa_NPS.app
 
 GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 [[ -z "${GUI_USER}" ]] && exit 0


### PR DESCRIPTION
This CL changes the installer to lay down Santa on disk as Santa_NPS.app. The post install or daemon will rename Santa_NPS.app to Santa.app when it is safe to do so.

A follow up CL will add logic in the daemon to idle while another install of Santa is running.

To test the installer behavior as new label has been added `package-dev`, which will package up a dev build. To support this, `package.sh` is now a separate script that can be called for both release and dev builds.

```
bazel build :package-dev -c opt
```
