### PR TITLE
Add mirroring workflow for code signing repository

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,44 @@
+name: Mirror Main 
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'  # Runs every 10 minutes
+  workflow_dispatch:  # Allows manual triggering
+
+env:
+  SOURCE_REPO: 'northpolesec/santa'  
+  TARGET_BRANCH: 'main'
+
+jobs:
+  mirror_repository:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Check repository name
+      id: check_repo
+      run: |
+        REPO_NAME="${GITHUB_REPOSITORY#*/}"
+        SOURCE_NAME="${SOURCE_REPO#*/}"
+        if [ "$REPO_NAME" = "$SOURCE_NAME" ]; then
+          echo "Repository name matches SOURCE repo. Skipping mirroring."
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "Repository names do not match. Proceeding with mirroring."
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Checkout
+      if: steps.check_repo.outputs.skip == 'false'
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Mirror repository
+      if: steps.check_repo.outputs.skip == 'false'
+      run: |
+        git remote add source https://github.com/${{ env.SOURCE_REPO }}.git
+        git fetch source ${{ env.TARGET_BRANCH }}
+        git reset --hard source/${{ env.TARGET_BRANCH }}
+        git push -f origin ${{ env.TARGET_BRANCH }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,44 +1,42 @@
-name: Mirror Main 
+name: Mirror Main
 
 on:
   schedule:
-    - cron: '*/10 * * * *'  # Runs every 10 minutes
-  workflow_dispatch:  # Allows manual triggering
+    - cron: '*/10 * * * *' # Runs every 10 minutes
+  workflow_dispatch: # Allows manual triggering
 
 env:
-  SOURCE_REPO: 'northpolesec/santa'  
+  SOURCE_REPO: 'northpolesec/santa'
   TARGET_BRANCH: 'main'
 
 jobs:
   mirror_repository:
     runs-on: macos-latest
-    
+      - name: Should Mirror
     steps:
-    - name: Check repository name
-      id: check_repo
-      run: |
-        REPO_NAME="${GITHUB_REPOSITORY#*/}"
-        SOURCE_NAME="${SOURCE_REPO#*/}"
-        if [ "$REPO_NAME" = "$SOURCE_NAME" ]; then
-          echo "Repository name matches SOURCE repo. Skipping mirroring."
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "Repository names do not match. Proceeding with mirroring."
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
+        id: should_mirror
+        run: |
+          if [ "${{ secrets.ENABLE_MIRRORING }}" = "true" ]; then
+            echo "Mirroring $SOURCE_REPO"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "Secret gate not passed. Skipping mirroring."
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Checkout
 
-    - name: Checkout
-      if: steps.check_repo.outputs.skip == 'false'
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+        if: steps.should_mirror.outputs.enabled == 'true'
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Update Commits
 
-    - name: Mirror repository
-      if: steps.check_repo.outputs.skip == 'false'
-      run: |
-        git remote add source https://github.com/${{ env.SOURCE_REPO }}.git
-        git fetch source ${{ env.TARGET_BRANCH }}
-        git reset --hard source/${{ env.TARGET_BRANCH }}
-        git push -f origin ${{ env.TARGET_BRANCH }}
-      env:
+        if: steps.should_mirror.outputs.enabled == 'true'
+        run: |
+          git remote add source https://github.com/${{ env.SOURCE_REPO }}.git
+          git fetch source ${{ env.TARGET_BRANCH }}
+          git reset --hard source/${{ env.TARGET_BRANCH }}
+          git push -f origin ${{ env.TARGET_BRANCH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,7 +12,6 @@ env:
 jobs:
   mirror_repository:
     runs-on: macos-latest
-      - name: Should Mirror
     steps:
         id: should_mirror
         run: |
@@ -30,7 +29,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update Commits
-
         if: steps.should_mirror.outputs.enabled == 'true'
         run: |
           git remote add source https://github.com/${{ env.SOURCE_REPO }}.git

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -13,6 +13,7 @@ jobs:
   mirror_repository:
     runs-on: macos-latest
     steps:
+      - name: Should Mirror 
         id: should_mirror
         run: |
           if [ "${{ secrets.ENABLE_MIRRORING }}" = "true" ]; then
@@ -23,7 +24,6 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-
         if: steps.should_mirror.outputs.enabled == 'true'
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:


### PR DESCRIPTION
This PR adds a mirroring workflow that runs every 10 minutes. This is useful for our codesigning repository.

The mirror workflow is gated by a GitHub secret `ENABLE_MIRRORING` which must be equal to `"true"` for the workflow to start.