### PR TITLE
partial revert: installer: support side-by-side install of NPS Santa [1/2] 

### DIFF
--- a/Conf/Package/package.sh
+++ b/Conf/Package/package.sh
@@ -44,7 +44,7 @@ echo "creating app pkg"
   "${APP_PKG_ROOT}/Library/LaunchDaemons" \
   "${APP_PKG_ROOT}/private/etc/asl" \
   "${APP_PKG_ROOT}/private/etc/newsyslog.d"
-/bin/cp -vXR "binaries/Santa.app" "${APP_PKG_ROOT}/Applications/Santa_NPS.app"
+/bin/cp -vXR "binaries/Santa.app" "${APP_PKG_ROOT}/Applications/Santa.app"
 /bin/cp -vX "conf/com.northpolesec.santa.plist" "${APP_PKG_ROOT}/Library/LaunchAgents/"
 /bin/cp -vX "conf/com.northpolesec.santa.bundleservice.plist" "${APP_PKG_ROOT}/Library/LaunchDaemons/"
 /bin/cp -vX "conf/com.northpolesec.santa.metricservice.plist" "${APP_PKG_ROOT}/Library/LaunchDaemons/"

--- a/Conf/Package/postinstall
+++ b/Conf/Package/postinstall
@@ -13,16 +13,8 @@
 mkdir -p /usr/local/bin
 /bin/ln -sf /Applications/Santa.app/Contents/MacOS/santactl /usr/local/bin/santactl
 
-if /bin/launchctl list EQHXZ8M8AV.com.google.santa.daemon > /dev/null 2>&1; then
-    # Load com.northpolesec.santa.daemon from Santa_NPS.app. While com.google.santa.daemon
-    # is running, com.northpolesec.santa.daemon will idle. When com.google.santa.daemon is unloaded
-    # by the user or MDM, com.northpolesec.santa.daemon will finish installing itself. 
-    /Applications/Santa_NPS.app/Contents/MacOS/Santa --load-system-extension
-else
-    # Finish installing, and load com.northpolesec.santa.daemon
-    mv /Applications/Santa_NPS.app /Applications/Santa.app
-    /Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
-fi
+# Load com.northpolesec.santa.daemon
+/Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
 
 # Load com.northpolesec.santa.bundleservice
 /bin/launchctl load -w /Library/LaunchDaemons/com.northpolesec.santa.bundleservice.plist

--- a/Conf/Package/preinstall
+++ b/Conf/Package/preinstall
@@ -10,9 +10,7 @@
 /bin/launchctl remove com.northpolesec.santa.metricservice || true
 /bin/launchctl remove com.northpolesec.santa.syncservice || true
 
-# NPS Santa.app is installed by the installer as Santa_NPS.app. The postinstall,
-# or com.northpolesec.santa.daemon will rename it to Santa.app when safe to do so.
-/bin/rm -rf /Applications/Santa_NPS.app
+/bin/rm -rf /Applications/Santa.app
 
 GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 [[ -z "${GUI_USER}" ]] && exit 0


### PR DESCRIPTION
This is a partial revert of 338da35. It keeps the `:package-dev` rule, but reverts installing as Santa_NPS.app.

Rebase once https://github.com/northpolesec/santa/pull/26 lands.