### PR TITLE
Update copyright statements for all binaries.

### DIFF
--- a/.pyink-config
+++ b/.pyink-config
@@ -3,3 +3,4 @@ pyink = true
 line-length = 80
 pyink-indentation = 2
 pyink-use-majority-quotes = true
+extend_skip = ["santa-venv"]

--- a/.pyink-config
+++ b/.pyink-config
@@ -3,4 +3,8 @@ pyink = true
 line-length = 80
 pyink-indentation = 2
 pyink-use-majority-quotes = true
-extend_skip = ["santa-venv"]
+exclude = '''
+/(
+    santa-venv
+)/
+'''

--- a/Source/gui/Info.plist
+++ b/Source/gui/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Google LLC.</string>
+	<string>North Pole Security, Inc.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/Source/santabundleservice/Info.plist
+++ b/Source/santabundleservice/Info.plist
@@ -21,6 +21,6 @@
 	<key>CFBundleVersion</key>
 	<string>${SANTA_VERSION}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Google LLC.</string>
+	<string>North Pole Security, Inc.</string>
 </dict>
 </plist>

--- a/Source/santactl/Info.plist
+++ b/Source/santactl/Info.plist
@@ -13,6 +13,6 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Google, LLC.</string>
+	<string>North Pole Security, Inc.</string>
 </dict>
 </plist>

--- a/Source/santad/Info.plist
+++ b/Source/santad/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Google, LLC.</string>
+	<string>North Pole Security, Inc.</string>
 	<key>NSSystemExtensionUsageDescription</key>
 	<string>Santa knows who is naughty and nice.</string>
-        <key>NSEndpointSecurityEarlyBoot</key>
-        <true/>
+    <key>NSEndpointSecurityEarlyBoot</key>
+    <true/>
 	<key>CFBundleExecutable</key>
 	<string>com.northpolesec.santa.daemon</string>
 </dict>

--- a/Source/santametricservice/Info.plist
+++ b/Source/santametricservice/Info.plist
@@ -21,6 +21,6 @@
 	<key>CFBundleVersion</key>
 	<string>${SANTA_VERSION}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Google LLC.</string>
+	<string>North Pole Security, Inc.</string>
 </dict>
 </plist>

--- a/Source/santasyncservice/Info.plist
+++ b/Source/santasyncservice/Info.plist
@@ -21,6 +21,6 @@
 	<key>CFBundleVersion</key>
 	<string>${SANTA_VERSION}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Google LLC.</string>
+	<string>North Pole Security, Inc.</string>
 </dict>
 </plist>

--- a/Testing/lint.sh
+++ b/Testing/lint.sh
@@ -10,6 +10,20 @@ find ${GIT_ROOT} \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \
 go install github.com/bazelbuild/buildtools/buildifier@latest
 ~/go/bin/buildifier --lint=warn -r ${GIT_ROOT}
 
+if command -v virtualenv &> /dev/null
+then
+    echo ""
+else
+    echo "virtualenv not found. Installing..."
+    sudo pip3 install virtualenv
+    if [ $? -eq 0 ]; then
+        echo "virtualenv has been successfully installed"
+    else
+        echo "Failed to install virtualenv"
+        exit 1
+    fi
+fi
+
 virtualenv ./venv
 source ./venv/bin/activate
 python3 -m pip install -q pyink

--- a/Testing/lint.sh
+++ b/Testing/lint.sh
@@ -10,5 +10,7 @@ find ${GIT_ROOT} \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \
 go install github.com/bazelbuild/buildtools/buildifier@latest
 ~/go/bin/buildifier --lint=warn -r ${GIT_ROOT}
 
+virtualenv ./venv
+source ./venv/bin/activate
 python3 -m pip install -q pyink
 python3 -m pyink --config ${GIT_ROOT}/.pyink-config --check ${GIT_ROOT}

--- a/Testing/lint.sh
+++ b/Testing/lint.sh
@@ -10,21 +10,19 @@ find ${GIT_ROOT} \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \
 go install github.com/bazelbuild/buildtools/buildifier@latest
 ~/go/bin/buildifier --lint=warn -r ${GIT_ROOT}
 
-if command -v virtualenv &> /dev/null
-then
-    echo ""
+if [ -d "./santa-venv" ]; then
+ echo "santa-venv already exists reusing".  
 else
-    echo "virtualenv not found. Installing..."
-    sudo pip3 install virtualenv
+ echo "Creating virtual environment ./santa-venv..."
+    python3 -m venv ./santa-venv
     if [ $? -eq 0 ]; then
-        echo "virtualenv has been successfully installed"
+        echo "Virtual environment ./santa-venv has been successfully created"
     else
-        echo "Failed to install virtualenv"
+        echo "Failed to create virtual environment ./santa-venv"
         exit 1
     fi
 fi
 
-virtualenv ./venv
-source ./venv/bin/activate
+source ./santa-venv/bin/activate
 python3 -m pip install -q pyink
 python3 -m pyink --config ${GIT_ROOT}/.pyink-config --check ${GIT_ROOT}


### PR DESCRIPTION
This PR updates the copyright statement in the Info.plist of all of the binaries in Santa.

This also updates the `Testing/lint.sh` script to use a virtual environment for python3 and updates the pyink config file to exclude the virtual env directory `./santa-venv`.