### PR TITLE
Set associated BundleIDs in launchd plists

### DIFF
--- a/Conf/com.northpolesec.santa.bundleservice.plist
+++ b/Conf/com.northpolesec.santa.bundleservice.plist
@@ -22,5 +22,9 @@
 	<string>Interactive</string>
 	<key>ThrottleInterval</key>
 	<integer>0</integer>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.northpolesec.santa</string>
+	</array>
 </dict>
 </plist>

--- a/Conf/com.northpolesec.santa.metricservice.plist
+++ b/Conf/com.northpolesec.santa.metricservice.plist
@@ -18,5 +18,9 @@
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.northpolesec.santa</string>
+	</array>
 </dict>
 </plist>

--- a/Conf/com.northpolesec.santa.migration.plist
+++ b/Conf/com.northpolesec.santa.migration.plist
@@ -12,5 +12,9 @@
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.northpolesec.santa</string>
+	</array>
 </dict>
 </plist>

--- a/Conf/com.northpolesec.santa.plist
+++ b/Conf/com.northpolesec.santa.plist
@@ -2,16 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-				<key>Label</key>
-				<string>com.northpolesec.santa</string>
-				<key>ProgramArguments</key>
-				<array>
-					<string>/Applications/Santa.app/Contents/MacOS/Santa</string>
-					<string>--syslog</string>
-				</array>
-				<key>RunAtLoad</key>
-				<true/>
-				<key>KeepAlive</key>
-				<true/>
+	<key>Label</key>
+	<string>com.northpolesec.santa</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/Santa.app/Contents/MacOS/Santa</string>
+		<string>--syslog</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.northpolesec.santa</string>
+	</array>
 </dict>
 </plist>

--- a/Conf/com.northpolesec.santa.syncservice.plist
+++ b/Conf/com.northpolesec.santa.syncservice.plist
@@ -18,5 +18,9 @@
 	<false/>
 	<key>KeepAlive</key>
 	<false/>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.northpolesec.santa</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This change allows the icon for Santa to be properly displayed in the "Login Items & Extensions" settings page for "Allow in Background" items.