### PR TITLE
Workflows: Use the runner OS as the key for disk caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
       - main
     paths:
       - 'Source/**'
-  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
 jobs:
   lint:
@@ -31,7 +30,7 @@ jobs:
         uses: bazel-contrib/setup-bazel@90b352333885f9fb6bf262d8e659f01b6219cc25 # ratchet:bazel-contrib/setup-bazel@0.9.0
         with:
           bazelisk-cache: true
-          disk-cache: true
+          disk-cache: ${{ runner.os }}
           repository-cache: true
       - name: Build Userspace
         run: bazel build --apple_generate_dsym -c opt :release --define=SANTA_BUILD_TYPE=adhoc


### PR DESCRIPTION
Also remove the workflow_dispatch option, being able to manually trigger the CI workflow isn't useful, continuous can be used for that instead.