### PR TITLE
GUI: Localization support

### DIFF
--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -25,6 +25,8 @@
 
 @interface SNTBlockMessage : NSObject
 
+NS_ASSUME_NONNULL_BEGIN
+
 ///
 ///  Return a message suitable for presenting to the user.
 ///
@@ -38,8 +40,8 @@
 ///  if the rule that blocked this file included one, formatted using
 ///  +[SNTBlockMessage formatMessage].
 ///
-+ (NSAttributedString *)attributedBlockMessageForEvent:(SNTStoredEvent *)event
-                                         customMessage:(NSString *)customMessage;
++ (NSAttributedString *)attributedBlockMessageForEvent:(nullable SNTStoredEvent *)event
+                                         customMessage:(nullable NSString *)customMessage;
 
 + (NSAttributedString *)attributedBlockMessageForFileAccessEvent:(SNTFileAccessEvent *)event
                                                    customMessage:(NSString *)customMessage;
@@ -48,12 +50,16 @@
 ///  Return a URL generated from the EventDetailURL configuration key
 ///  after replacing templates in the URL with values from the event.
 ///
-+ (NSURL *)eventDetailURLForEvent:(SNTStoredEvent *)event customURL:(NSString *)url;
-+ (NSURL *)eventDetailURLForFileAccessEvent:(SNTFileAccessEvent *)event customURL:(NSString *)url;
++ (nullable NSURL *)eventDetailURLForEvent:(nullable SNTStoredEvent *)event
+                                 customURL:(nullable NSString *)url;
++ (nullable NSURL *)eventDetailURLForFileAccessEvent:(nullable SNTFileAccessEvent *)event
+                                           customURL:(nullable NSString *)url;
 
 ///
 ///  Strip HTML from a string, replacing <br /> with newline.
 ///
 + (NSString *)stringFromHTML:(NSString *)html;
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -78,14 +78,16 @@ static id ValueOrNull(id value) {
   } else if (event.decision == SNTEventStateBlockUnknown) {
     message = [[SNTConfigurator configurator] unknownBlockMessage];
     if (!message) {
-      message = @"The following application has been blocked from executing<br />"
-                @"because its trustworthiness cannot be determined.";
+      message = NSLocalizedString(
+        @"DefaultApplicationBlockedUnknownMessage",
+        @"The default message to show the user when an unknown application is blocked");
     }
   } else {
     message = [[SNTConfigurator configurator] bannedBlockMessage];
     if (!message) {
-      message = @"The following application has been blocked from executing<br />"
-                @"because it has been deemed malicious.";
+      message = NSLocalizedString(
+        @"DefaultApplicationBlockedBannedMessage",
+        @"The default message to show the user when a banned application is blocked");
     }
   }
   return [SNTBlockMessage formatMessage:message];
@@ -97,7 +99,9 @@ static id ValueOrNull(id value) {
   if (!message.length) {
     message = [[SNTConfigurator configurator] fileAccessBlockMessage];
     if (!message.length) {
-      message = @"Access to a file has been denied.";
+      message =
+        NSLocalizedString(@"DefaultFileBlockedMessage",
+                          @"The default message to show the user when access to a file is blocked");
     }
   }
   return [SNTBlockMessage formatMessage:message];

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -131,6 +131,7 @@ macos_application(
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",
     }),
+    strings = glob(["Resources/**/*.strings"]),
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":SantaGUI_lib"],

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,87 @@
+/* No comment provided by engineer. */
+"Access to a protected resource was denied." = "Access to a protected resource was denied.";
+
+/* No comment provided by engineer. */
+"Application" = "Application";
+
+/* No comment provided by engineer. */
+"Bundle Hash" = "Bundle Hash";
+
+/* No comment provided by engineer. */
+"CDHash" = "CDHash";
+
+/* Copy Details button in more details dialog */
+"Copy Details" = "Copy Details";
+
+/* The default message to show the user when a banned application is blocked */
+"DefaultApplicationBlockedBannedMessage" = "The following application has been blocked from<br />executing because it has been deemed malicious";
+
+/* The default message to show the user when an unknown application is blocked */
+"DefaultApplicationBlockedUnknownMessage" = "The following application has been blocked from executing<br />because its trustworthiness cannot be determined";
+
+/* The default message to show the user when access to a file is blocked */
+"DefaultFileBlockedMessage" = "Access to a file has been denied";
+
+/* No comment provided by engineer. */
+"Device BSD Path" = "Device BSD Path";
+
+/* No comment provided by engineer. */
+"Device Name" = "Device Name";
+
+/* Dismiss button in more details dialog */
+"Dismiss" = "Dismiss";
+
+/* No comment provided by engineer. */
+"Dismiss & Silence" = "Dismiss & Silence";
+
+/* No comment provided by engineer. */
+"Filename" = "Filename";
+
+/* More Details button in binary block dialog */
+"More Details" = "More Details";
+
+/* No comment provided by engineer. */
+"More Info..." = "More Info...";
+
+/* No comment provided by engineer. */
+"Mounting devices is blocked" = "Mounting devices is blocked";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
+
+/* No comment provided by engineer. */
+"Open Event..." = "Open Event...";
+
+/* No comment provided by engineer. */
+"Open..." = "Open...";
+
+/* No comment provided by engineer. */
+"Parent" = "Parent";
+
+/* No comment provided by engineer. */
+"Path" = "Path";
+
+/* No comment provided by engineer. */
+"Prevent future notifications for this application for " = "Prevent future notifications for this application for ";
+
+/* No comment provided by engineer. */
+"Publisher" = "Publisher";
+
+/* No comment provided by engineer. */
+"Remount Mode" = "Remount Mode";
+
+/* Explanation in About view */
+"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa is an application control system for macOS.\n\nThere are no user-configurable settings.";
+
+/* No comment provided by engineer. */
+"SHA-256" = "SHA-256";
+
+/* No comment provided by engineer. */
+"Signing ID" = "Signing ID";
+
+/* No comment provided by engineer. */
+"unknown" = "unknown";
+
+/* No comment provided by engineer. */
+"User" = "User";
+

--- a/Source/gui/Resources/en.lproj/regen.sh
+++ b/Source/gui/Resources/en.lproj/regen.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Script to re-generate the base en.lproj localizable strings based on the
+# SwiftUI code used to generate the UI, and any helper classes used. After
+# generation, it will be necessary to diff the result to see which strings
+# need to be added to other localizations.
+#
+# The output of genstrings is UTF-16, which many tools treat as binary
+# (including git), so the output is converted to UTF-8 with iconv.
+#
+
+cd "$(dirname "$0")"
+genstrings -SwiftUI -u -o $PWD ../../*.swift ../../../common/SNTBlockMessage.m
+iconv -f UTF-16 -t UTF-8 $PWD/Localizable.strings > $PWD/Localizable.strings.utf8
+mv $PWD/Localizable.strings.utf8 $PWD/Localizable.strings

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -1,0 +1,87 @@
+/* No comment provided by engineer. */
+"Access to a protected resource was denied." = "Доступ к защищенному ресурсу был запрещен.";
+
+/* No comment provided by engineer. */
+"Application" = "Приложение";
+
+/* No comment provided by engineer. */
+"Bundle Hash" = "Бандл-хэш";
+
+/* No comment provided by engineer. */
+"CDHash" = "CDHash";
+
+/* Copy Details button in binary block dialog */
+"Copy Details" = "Копия Подробности";
+
+/* The default message to show the user when a banned application is blocked */
+"DefaultApplicationBlockedBannedMessage" = "Следующее приложение было заблокировано для выполнения,<br />поскольку оно было признано вредоносным";
+
+/* The default message to show the user when an unknown application is blocked */
+"DefaultApplicationBlockedUnknownMessage" = "Следующее приложение было заблокировано для выполнения,<br />поскольку его надежность не может быть определена";
+
+/* The default message to show the user when access to a file is blocked */
+"DefaultFileBlockedMessage" = "Доступ к файлу был запрещен";
+
+/* No comment provided by engineer. */
+"Device BSD Path" = "Устройство BSD Path";
+
+/* No comment provided by engineer. */
+"Device Name" = "Имя устройства";
+
+/* No comment provided by engineer. */
+"Dismiss" = "Увольте";
+
+/* No comment provided by engineer. */
+"Dismiss & Silence" = "Отказ и молчание";
+
+/* No comment provided by engineer. */
+"Filename" = "Имя файла";
+
+/* More Details button in binary block dialog */
+"More Details" = "Подробнее";
+
+/* No comment provided by engineer. */
+"More Info..." = "Дополнительная информация...";
+
+/* No comment provided by engineer. */
+"Mounting devices is blocked" = "Монтажные устройства заблокированы";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
+
+/* No comment provided by engineer. */
+"Open Event..." = "Открытое мероприятие...";
+
+/* No comment provided by engineer. */
+"Open..." = "Открыть...";
+
+/* No comment provided by engineer. */
+"Parent" = "Родитель";
+
+/* No comment provided by engineer. */
+"Path" = "Путь";
+
+/* No comment provided by engineer. */
+"Prevent future notifications for this application for " = "Предотвращение будущих уведомлений для этого приложения для ";
+
+/* No comment provided by engineer. */
+"Publisher" = "Издатель";
+
+/* No comment provided by engineer. */
+"Remount Mode" = "Режим демонтажа";
+
+/* Explanation in About view */
+"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa - это система управления приложениями для macOS.\n\nНет никаких настраиваемых пользователем параметров.";
+
+/* No comment provided by engineer. */
+"SHA-256" = "SHA-256";
+
+/* No comment provided by engineer. */
+"Signing ID" = "Signing ID";
+
+/* No comment provided by engineer. */
+"unknown" = "неизвестно";
+
+/* No comment provided by engineer. */
+"User" = "Пользователь";
+

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,87 @@
+/* No comment provided by engineer. */
+"Access to a protected resource was denied." = "Відмовлено в доступі до захищеного ресурсу.";
+
+/* No comment provided by engineer. */
+"Application" = "Заявка";
+
+/* No comment provided by engineer. */
+"Bundle Hash" = "Пакетний хеш";
+
+/* No comment provided by engineer. */
+"CDHash" = "CDHash";
+
+/* Copy Details button in binary block dialog */
+"Copy Details" = "Деталі копіювання";
+
+/* The default message to show the user when a banned application is blocked */
+"DefaultApplicationBlockedBannedMessage" = "Наступну програму було заблоковано для виконання,<br />оскільки її було визнано шкідливою";
+
+/* The default message to show the user when an unknown application is blocked */
+"DefaultApplicationBlockedUnknownMessage" = "Наступна програма була заблокована для виконання,<br />оскільки не може бути визначена її достовірність";
+
+/* The default message to show the user when access to a file is blocked */
+"DefaultFileBlockedMessage" = "Відмовлено у доступі до файлу";
+
+/* No comment provided by engineer. */
+"Device BSD Path" = "Шлях BSD пристрою";
+
+/* No comment provided by engineer. */
+"Device Name" = "Назва пристрою";
+
+/* No comment provided by engineer. */
+"Dismiss" = "Звільнити";
+
+/* No comment provided by engineer. */
+"Dismiss & Silence" = "Звільнити і замовкнути";
+
+/* No comment provided by engineer. */
+"Filename" = "Ім'я файлу";
+
+/* More Details button in binary block dialog */
+"More Details" = "Детальніше";
+
+/* No comment provided by engineer. */
+"More Info..." = "Більше інформації...";
+
+/* No comment provided by engineer. */
+"Mounting devices is blocked" = "Монтажные устройства заблокированы";
+
+/* No comment provided by engineer. */
+"OK" = "Окей";
+
+/* No comment provided by engineer. */
+"Open Event..." = "Відкрита подія...";
+
+/* No comment provided by engineer. */
+"Open..." = "Відкрито...";
+
+/* No comment provided by engineer. */
+"Parent" = "Батько";
+
+/* No comment provided by engineer. */
+"Path" = "Шлях";
+
+/* No comment provided by engineer. */
+"Prevent future notifications for this application for " = "Запобігти майбутнім сповіщенням для цієї заявки для ";
+
+/* No comment provided by engineer. */
+"Publisher" = "Видавець";
+
+/* No comment provided by engineer. */
+"Remount Mode" = "Режим перевстановлення";
+
+/* Explanation in About view */
+"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa - система управління додатками для macOS.\n\nНемає налаштувань, що налаштовуються користувачем.";
+
+/* No comment provided by engineer. */
+"SHA-256" = "SHA-256";
+
+/* No comment provided by engineer. */
+"Signing ID" = "Signing ID";
+
+/* No comment provided by engineer. */
+"unknown" = "невідомо";
+
+/* No comment provided by engineer. */
+"User" = "Користувач";
+

--- a/Source/gui/SNTAboutWindowView.swift
+++ b/Source/gui/SNTAboutWindowView.swift
@@ -14,7 +14,7 @@ struct SNTAboutWindowView: View {
 
   var body: some View {
     VStack(spacing:20.0) {
-      Text("Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
+      Text(verbatim:"Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
 
       if let t = c.aboutText {
         Text(t).multilineTextAlignment(.center)
@@ -23,7 +23,7 @@ struct SNTAboutWindowView: View {
         Santa is an application control system for macOS.
 
         There are no user-configurable settings.
-        """).multilineTextAlignment(.center)
+        """, comment:"Explanation in About view").multilineTextAlignment(.center)
       }
 
       HStack {

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -129,7 +129,7 @@ struct SNTBinaryMessageEventExpandedView: View {
 
         addLabel {
             Text("Parent").bold().font(Font.system(size:12.0))
-            Text("\(e?.parentName ?? "") (\(String(format: "%d", e?.ppid.intValue ?? 0)))").textSelection(.enabled)
+            Text(verbatim: "\(e?.parentName ?? "") (\(String(format: "%d", e?.ppid.intValue ?? 0)))").textSelection(.enabled)
         }
 
         Spacer()
@@ -138,7 +138,7 @@ struct SNTBinaryMessageEventExpandedView: View {
       HStack {
         Button(action: { copyDetailsToClipboard(e:e, customURL:customURL as String?) }) {
           HStack(spacing:2.0) {
-            Text("Copy Details").foregroundColor(.blue)
+            Text("Copy Details", comment:"Copy Details button in more details dialog").foregroundColor(.blue)
             Image(systemName:"pencil.and.list.clipboard").foregroundColor(.blue)
           }
         }
@@ -149,7 +149,7 @@ struct SNTBinaryMessageEventExpandedView: View {
 
         Button(action: { presentationMode.wrappedValue.dismiss() }) {
           HStack(spacing:2.0) {
-            Text("Dismiss").foregroundColor(.blue)
+            Text("Dismiss", comment:"Dismiss button in more details dialog").foregroundColor(.blue)
             Image(systemName:"xmark.circle").foregroundColor(.blue)
           }
         }
@@ -175,9 +175,11 @@ struct SNTBinaryMessageEventView: View {
 
     HStack(spacing: 20.0) {
       VStack(alignment:.trailing, spacing:10.0) {
+        /*
         if e?.needsBundleHash ?? false {
           Text("Bundle Hash")
         }
+        */
 
         if e?.fileBundleName != "" {
           Text("Application").bold().font(Font.system(size:12.0))
@@ -195,6 +197,7 @@ struct SNTBinaryMessageEventView: View {
       Divider()
 
       VStack(alignment:.leading, spacing:10.0) {
+        /*
         if e?.needsBundleHash ?? false {
           // TODO: Implement bundle hashing
           ProgressView()
@@ -215,6 +218,7 @@ struct SNTBinaryMessageEventView: View {
             }
           */
         }
+        */
 
         if let bundleName = e?.fileBundleName {
           Text(bundleName).textSelection(.enabled)
@@ -235,7 +239,7 @@ struct SNTBinaryMessageEventView: View {
     ZStack {
       Button(action: { isShowingDetails = true }) {
         HStack(spacing:2.0) {
-          Text("More Details").foregroundColor(.blue)
+          Text("More Details", comment:"More Details button in binary block dialog").foregroundColor(.blue)
           Image(systemName:"info.circle").foregroundColor(.blue)
         }
       }
@@ -245,7 +249,7 @@ struct SNTBinaryMessageEventView: View {
 
       // This button is hidden and exists only to allow using the Cmd+D keyboard shortcut
       // to copy the event details to the clipboard even if the "More Details" button hasn't been pressed.
-      Button(action: { copyDetailsToClipboard(e:e, customURL:customURL as String?) }) { Text("Copy Details") }
+      Button(action: { copyDetailsToClipboard(e:e, customURL:customURL as String?) }) { Text(verbatim:"Copy Details") }
       .buttonStyle(ScalingButtonStyle())
       .opacity(0.0) // Invisible!
       .keyboardShortcut("d", modifiers: .command)
@@ -290,11 +294,14 @@ struct SNTBinaryMessageWindowView: View {
               .frame(maxWidth:32, maxHeight:32)
               .offset(x:-75)
               .saturation(0.5)
-          Text("Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
+          Text(verbatim: "Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
         }
       }
 
-      Text(AttributedString(SNTBlockMessage.attributedBlockMessage(for:event, customMessage:customMsg as String?))).multilineTextAlignment(.center)
+      Spacer()
+
+      let blockMessage = SNTBlockMessage.attributedBlockMessage(for:event, customMessage:customMsg as String?)
+      Text(AttributedString(blockMessage)).multilineTextAlignment(.center).frame(maxWidth:MAX_OUTER_VIEW_WIDTH - 60).fixedSize()
 
       SNTBinaryMessageEventView(e: event!, customURL: customURL)
 
@@ -327,7 +334,7 @@ struct SNTBinaryMessageWindowView: View {
             }
           })
           .buttonStyle(.borderedProminent)
-          .keyboardShortcut(KeyboardShortcut("\r", modifiers:.command))
+          .keyboardShortcut("\r", modifiers:.command)
           .help("⌘ ⏎")
         }
 
@@ -342,7 +349,7 @@ struct SNTBinaryMessageWindowView: View {
             }
           }
         })
-        .keyboardShortcut(KeyboardShortcut(.escape, modifiers:.command))
+        .keyboardShortcut(.escape, modifiers:.command)
         .help("⌘ Esc")
       }.frame(maxWidth:MAX_BUTTON_AREA_WIDTH)
 

--- a/Source/gui/SNTDeviceMessageWindowView.swift
+++ b/Source/gui/SNTDeviceMessageWindowView.swift
@@ -33,7 +33,7 @@ struct SNTDeviceMessageWindowView: View {
 
   var body: some View {
     VStack(spacing:20.0) {
-      Text("Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
+      Text(verbatim: "Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
 
       if let t = customMsg {
         if #available(macOS 12.0, *) {

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -53,7 +53,7 @@ struct Property : View {
             Image(systemName: "info.circle.fill")
           }.buttonStyle(BorderlessButtonStyle())
         }
-        Text(lbl + ":")
+        Text(verbatim: lbl + ":")
           .frame(alignment: .trailing)
           .lineLimit(1)
           .font(.system(size: 12, weight: .bold))
@@ -121,7 +121,7 @@ struct SNTFileAccessMessageWindowView: View {
   var body: some View {
     VStack(spacing:20.0) {
       Spacer()
-      Text("Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
+      Text(verbatim: "Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
 
       if let msg = customMessage {
         Text(AttributedString(msg)).multilineTextAlignment(.center).padding(15.0)


### PR DESCRIPTION
I've included basic translations in Russian and Ukrainian as examples; these translations were generated with a translation tool and checked by a fluent speaker of both so they're good but likely not perfect (improvements welcome!)

There's also a basic shell script included to help generate the base English localization files but manual work will be necessary to merge the output with the checked-in English file and to add/update any missing/changed strings in the other languages.

Before anyone asks: we can't use the newer xcstrings format because:
a) Bazel doesn't support it yet
b) I can't find a tool like genstrings to generate it automatically

Part of #14 and #53 