### PR TITLE
Prevent legacy service loads, cleanup legacy plists

### DIFF
--- a/Conf/install_services.sh
+++ b/Conf/install_services.sh
@@ -23,12 +23,14 @@ function die {
 /bin/launchctl remove com.google.santa.bundleservice || true
 /bin/launchctl remove com.google.santa.metricservice || true
 /bin/launchctl remove com.google.santa.syncservice || true
+/bin/launchctl remove com.google.santad || true
 GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 [[ -n "${GUI_USER}" ]] && /bin/launchctl asuser "${GUI_USER}" /bin/launchctl remove com.google.santa || true
 /bin/rm /Library/LaunchAgents/com.google.santa.plist
 /bin/rm /Library/LaunchDaemons/com.google.santa.bundleservice.plist
 /bin/rm /Library/LaunchDaemons/com.google.santa.metricservice.plist
 /bin/rm /Library/LaunchDaemons/com.google.santa.syncservice.plist
+/bin/rm /Library/LaunchDaemons/com.google.santad.plist
 
 ################################################################################
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -17,8 +17,14 @@
 
 #include <EndpointSecurity/ESTypes.h>
 #include <bsm/libbsm.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/errno.h>
+#include <unistd.h>
+
 #include <algorithm>
+#include <tuple>
+#include <unordered_set>
 
 #import "Source/common/SNTLogging.h"
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
@@ -40,6 +46,74 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
   {"/Library/LaunchAgents/com.northpolesec.santa.", WatchItemPathType::kPrefix},
   {"/Library/LaunchDaemons/com.northpolesec.santa.", WatchItemPathType::kPrefix},
 };
+
+void RemoveLegacyLaunchdPlists() {
+  constexpr std::string_view legacyPlists[] = {
+    "/Library/LaunchDaemons/com.google.santad.plist",
+    "/Library/LaunchDaemons/com.google.santa.bundleservice.plist",
+    "/Library/LaunchDaemons/com.google.santa.metricservice.plist",
+    "/Library/LaunchDaemons/com.google.santa.syncservice.plist",
+    "/Library/LaunchAgents/com.google.santa.plist",
+  };
+
+  for (const auto &plist : legacyPlists) {
+    // Note: As currently written, all legacy plists will be removed when any of the individual plists
+    // are attempted to be loaded. This is a bit overkill in that each plist will be removed 5 times, but
+    // not a big deal. If the unlink error is that the file doesn't exist, the log warning is suppressed.
+    if (unlinkat(AT_FDCWD, plist.data(), AT_SYMLINK_NOFOLLOW_ANY) != 0 && errno != ENOENT) {
+      LOGW(@"Unable to remove legacy plist \"%s\": %d: %s", plist.data(), errno, strerror(errno));
+    }
+  }
+}
+
+/// Return a pair of whether or not to allow the exec and whether or not the ES response should be cached.
+/// If the exec is not launchctl, the response can be cached, otherwise the response should not be cached.
+std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
+  es_string_token_t exec_path = esMsg->event.exec.target->executable->path;
+  if (strncmp(exec_path.data, "/bin/launchctl", exec_path.length) != 0) {
+    return {ES_AUTH_RESULT_ALLOW, true};
+  }
+
+  // Ensure there are at least 2 arguments after the command
+  std::shared_ptr<EndpointSecurityAPI> esApi = esMsg.ESAPI();
+  uint32_t argCount = esApi->ExecArgCount(&esMsg->event.exec);
+  if (argCount < 2) {
+    return {ES_AUTH_RESULT_ALLOW, false};
+  }
+
+  // Check for some allowed subcommands
+  es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, 1);
+  static const std::unordered_set<std::string> safe_commands{
+    "blame", "help", "hostinfo", "list", "plist", "print", "procinfo",
+  };
+  if (safe_commands.find(std::string(arg.data, arg.length)) != safe_commands.end()) {
+    return {ES_AUTH_RESULT_ALLOW, false};
+  }
+
+
+
+  for (int i = 2; i < argCount; i++) {
+    es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, i);
+#ifndef DEBUG
+    // Allow launchctl actions on the daemon in debug builds
+    if (strnstr(arg.data, "com.northpolesec.santa.daemon", arg.length) != NULL) {
+      LOGW(@"Preventing attempt to kill Santa daemon");
+      return {ES_AUTH_RESULT_DENY, false};
+    }
+#endif
+
+    // If legacy plists paths are found, assume a load is being attempted. Block the exec and
+    // delete all of the plists.
+    if (strnstr(arg.data, "/Library/LaunchDaemons/com.google.santa", arg.length) != NULL ||
+        strnstr(arg.data, "/Library/LaunchAgents/com.google.santa.plist", arg.length) != NULL) {
+      LOGW(@"Preventing load of legacy Santa component");
+      RemoveLegacyLaunchdPlists();
+      return {ES_AUTH_RESULT_DENY, false};
+    }
+  }
+
+  return {ES_AUTH_RESULT_ALLOW, false};
+}
 
 @implementation SNTEndpointSecurityTamperResistance {
   std::shared_ptr<Logger> _logger;
@@ -66,6 +140,7 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
 - (void)handleMessage:(Message &&)esMsg
    recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {
   es_auth_result_t result = ES_AUTH_RESULT_ALLOW;
+  BOOL cacheable = YES;
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_AUTH_UNLINK: {
       if ([SNTEndpointSecurityTamperResistance
@@ -104,6 +179,10 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
         break;
       }
       result = ES_AUTH_RESULT_ALLOW;
+      // OPEN events are not currently cacheable because we haven't yet implemented a method to respond
+      // with a subset of allowed flags. This could be changed in the future if desired, but currently
+      // this is not a hot enough path to worry about.
+      cacheable = NO;
       break;
     }
 
@@ -118,12 +197,7 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
     }
 
     case ES_EVENT_TYPE_AUTH_EXEC: {
-      // When not running a debug build, prevent attempts to kill Santa
-      // by launchctl commands.
-#ifndef DEBUG
-      result = ValidateLaunchctlExec(esMsg);
-      if (result == ES_AUTH_RESULT_DENY) LOGW(@"Preventing attempt to kill Santa daemon");
-#endif
+      std::tie(result, cacheable) = ValidateLaunchctlExec(esMsg);
       break;
     }
 
@@ -137,8 +211,7 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
   // Do not cache ES_EVENT_TYPE_AUTH_OPEN events.
   [self respondToMessage:esMsg
           withAuthResult:result
-               cacheable:(esMsg->event_type != ES_EVENT_TYPE_AUTH_OPEN &&
-                          result == ES_AUTH_RESULT_ALLOW)];
+               cacheable:cacheable];
 
   // For this client, a processed event is one that was found to be violating anti-tamper policy
   recordEventMetrics(result == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
@@ -164,40 +237,6 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
                                   ES_EVENT_TYPE_AUTH_RENAME,
                                   ES_EVENT_TYPE_AUTH_OPEN,
                                 }];
-}
-
-es_auth_result_t ValidateLaunchctlExec(const Message &esMsg) {
-  es_string_token_t exec_path = esMsg->event.exec.target->executable->path;
-  if (strncmp(exec_path.data, "/bin/launchctl", exec_path.length) != 0) {
-    return ES_AUTH_RESULT_ALLOW;
-  }
-
-  // Ensure there are at least 2 arguments after the command
-  std::shared_ptr<EndpointSecurityAPI> esApi = esMsg.ESAPI();
-  uint32_t argCount = esApi->ExecArgCount(&esMsg->event.exec);
-  if (argCount < 2) {
-    return ES_AUTH_RESULT_ALLOW;
-  }
-
-  // Check for some allowed subcommands
-  es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, 1);
-  static const std::unordered_set<std::string> safe_commands{
-    "blame", "help", "hostinfo", "list", "plist", "print", "procinfo",
-  };
-  if (safe_commands.find(std::string(arg.data, arg.length)) != safe_commands.end()) {
-    return ES_AUTH_RESULT_ALLOW;
-  }
-
-  // Check whether com.northpolesec.santa.daemon is in the argument list.
-  // launchctl no longer accepts PIDs to operate on.
-  for (int i = 2; i < argCount; i++) {
-    es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, i);
-    if (strnstr(arg.data, "com.northpolesec.santa.daemon", arg.length) != NULL) {
-      return ES_AUTH_RESULT_DENY;
-    }
-  }
-
-  return ES_AUTH_RESULT_ALLOW;
 }
 
 + (std::vector<std::pair<std::string, WatchItemPathType>>)getProtectedPaths {

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -57,17 +57,19 @@ void RemoveLegacyLaunchdPlists() {
   };
 
   for (const auto &plist : legacyPlists) {
-    // Note: As currently written, all legacy plists will be removed when any of the individual plists
-    // are attempted to be loaded. This is a bit overkill in that each plist will be removed 5 times, but
-    // not a big deal. If the unlink error is that the file doesn't exist, the log warning is suppressed.
+    // Note: As currently written, all legacy plists will be removed when any of the individual
+    // plists are attempted to be loaded. This is a bit overkill in that each plist will be removed
+    // 5 times, but not a big deal. If the unlink error is that the file doesn't exist, the log
+    // warning is suppressed.
     if (unlinkat(AT_FDCWD, plist.data(), AT_SYMLINK_NOFOLLOW_ANY) != 0 && errno != ENOENT) {
       LOGW(@"Unable to remove legacy plist \"%s\": %d: %s", plist.data(), errno, strerror(errno));
     }
   }
 }
 
-/// Return a pair of whether or not to allow the exec and whether or not the ES response should be cached.
-/// If the exec is not launchctl, the response can be cached, otherwise the response should not be cached.
+/// Return a pair of whether or not to allow the exec and whether or not the ES response should be
+/// cached. If the exec is not launchctl, the response can be cached, otherwise the response should
+/// not be cached.
 std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
   es_string_token_t exec_path = esMsg->event.exec.target->executable->path;
   if (strncmp(exec_path.data, "/bin/launchctl", exec_path.length) != 0) {
@@ -89,8 +91,6 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
   if (safe_commands.find(std::string(arg.data, arg.length)) != safe_commands.end()) {
     return {ES_AUTH_RESULT_ALLOW, false};
   }
-
-
 
   for (int i = 2; i < argCount; i++) {
     es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, i);
@@ -179,9 +179,9 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
         break;
       }
       result = ES_AUTH_RESULT_ALLOW;
-      // OPEN events are not currently cacheable because we haven't yet implemented a method to respond
-      // with a subset of allowed flags. This could be changed in the future if desired, but currently
-      // this is not a hot enough path to worry about.
+      // OPEN events are not currently cacheable because we haven't yet implemented a method to
+      // respond with a subset of allowed flags. This could be changed in the future if desired, but
+      // currently this is not a hot enough path to worry about.
       cacheable = NO;
       break;
     }
@@ -209,9 +209,7 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
 
   // Do not cache denied operations so that each tamper attempt is logged.
   // Do not cache ES_EVENT_TYPE_AUTH_OPEN events.
-  [self respondToMessage:esMsg
-          withAuthResult:result
-               cacheable:cacheable];
+  [self respondToMessage:esMsg withAuthResult:result cacheable:cacheable];
 
   // For this client, a processed event is one that was found to be violating anti-tamper policy
   recordEventMetrics(result == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -208,8 +208,9 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
   }
 
   // Do not cache denied operations so that each tamper attempt is logged.
-  // Do not cache ES_EVENT_TYPE_AUTH_OPEN events.
-  [self respondToMessage:esMsg withAuthResult:result cacheable:cacheable];
+  [self respondToMessage:esMsg
+          withAuthResult:result
+               cacheable:(cacheable && result == ES_AUTH_RESULT_ALLOW)];
 
   // For this client, a processed event is one that was found to be violating anti-tamper policy
   recordEventMetrics(result == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -140,7 +140,7 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
 - (void)handleMessage:(Message &&)esMsg
    recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {
   es_auth_result_t result = ES_AUTH_RESULT_ALLOW;
-  BOOL cacheable = YES;
+  bool cacheable = true;
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_AUTH_UNLINK: {
       if ([SNTEndpointSecurityTamperResistance
@@ -182,7 +182,7 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
       // OPEN events are not currently cacheable because we haven't yet implemented a method to
       // respond with a subset of allowed flags. This could be changed in the future if desired, but
       // currently this is not a hot enough path to worry about.
-      cacheable = NO;
+      cacheable = false;
       break;
     }
 


### PR DESCRIPTION
This PR adds additional protections to the Tamper Resistance client to prevent launchd loads of legacy Santa plists. When these loads are attempted, the legacy plists are also removed from the filesystem if they exist.

Some additional install_services.sh cleanup of legacy components was also added.