### PR TITLE
Localization: Don't use keys in strings in SNTBlockMessage.

### DIFF
--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -79,14 +79,14 @@ static id ValueOrNull(id value) {
     message = [[SNTConfigurator configurator] unknownBlockMessage];
     if (!message) {
       message = NSLocalizedString(
-        @"DefaultApplicationBlockedUnknownMessage",
+        @"The following application has been blocked from executing<br />because its trustworthiness cannot be determined",
         @"The default message to show the user when an unknown application is blocked");
     }
   } else {
     message = [[SNTConfigurator configurator] bannedBlockMessage];
     if (!message) {
       message = NSLocalizedString(
-        @"DefaultApplicationBlockedBannedMessage",
+        @"The following application has been blocked from<br />executing because it has been deemed malicious",
         @"The default message to show the user when a banned application is blocked");
     }
   }
@@ -100,7 +100,7 @@ static id ValueOrNull(id value) {
     message = [[SNTConfigurator configurator] fileAccessBlockMessage];
     if (!message.length) {
       message =
-        NSLocalizedString(@"DefaultFileBlockedMessage",
+        NSLocalizedString(@"Access to a file has been denied",
                           @"The default message to show the user when access to a file is blocked");
     }
   }

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -79,14 +79,16 @@ static id ValueOrNull(id value) {
     message = [[SNTConfigurator configurator] unknownBlockMessage];
     if (!message) {
       message = NSLocalizedString(
-        @"The following application has been blocked from executing<br />because its trustworthiness cannot be determined",
+        @"The following application has been blocked from executing<br />because its "
+        @"trustworthiness cannot be determined",
         @"The default message to show the user when an unknown application is blocked");
     }
   } else {
     message = [[SNTConfigurator configurator] bannedBlockMessage];
     if (!message) {
       message = NSLocalizedString(
-        @"The following application has been blocked from<br />executing because it has been deemed malicious",
+        @"The following application has been blocked from<br />executing because it has been "
+        @"deemed malicious",
         @"The default message to show the user when a banned application is blocked");
     }
   }

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -14,13 +14,13 @@
 "Copy Details" = "Details kopieren";
 
 /* The default message to show the user when a banned application is blocked */
-"DefaultApplicationBlockedBannedMessage" = "Die folgende Applikation wurde blockiert,<br />da sie als schädlich eingestuft wurde";
+"The following application has been blocked from<br />executing because it has been deemed malicious" = "Die folgende Applikation wurde blockiert,<br />da sie als schädlich eingestuft wurde";
 
 /* The default message to show the user when an unknown application is blocked */
-"DefaultApplicationBlockedUnknownMessage" = "Die folgende Applikation wurde blockiert,<br />da ihre Vertrauenswürdigkeit nicht überprüft werden kann";
+"The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Die folgende Applikation wurde blockiert,<br />da ihre Vertrauenswürdigkeit nicht überprüft werden kann";
 
 /* The default message to show the user when access to a file is blocked */
-"DefaultFileBlockedMessage" = "Der Zugriff auf die Datei wurde verweigert";
+"Access to a file has been denied" = "Der Zugriff auf die Datei wurde verweigert";
 
 /* No comment provided by engineer. */
 "Device BSD Path" = "Device BSD-Pfad";

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -14,13 +14,13 @@
 "Copy Details" = "Copy Details";
 
 /* The default message to show the user when a banned application is blocked */
-"DefaultApplicationBlockedBannedMessage" = "The following application has been blocked from<br />executing because it has been deemed malicious";
+"The following application has been blocked from<br />executing because it has been deemed malicious" = "The following application has been blocked from<br />executing because it has been deemed malicious";
 
 /* The default message to show the user when an unknown application is blocked */
-"DefaultApplicationBlockedUnknownMessage" = "The following application has been blocked from executing<br />because its trustworthiness cannot be determined";
+"The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "The following application has been blocked from executing<br />because its trustworthiness cannot be determined";
 
 /* The default message to show the user when access to a file is blocked */
-"DefaultFileBlockedMessage" = "Access to a file has been denied";
+"Access to a file has been denied" = "Access to a file has been denied";
 
 /* No comment provided by engineer. */
 "Device BSD Path" = "Device BSD Path";

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -14,13 +14,13 @@
 "Copy Details" = "Копия Подробности";
 
 /* The default message to show the user when a banned application is blocked */
-"DefaultApplicationBlockedBannedMessage" = "Следующее приложение было заблокировано для выполнения,<br />поскольку оно было признано вредоносным";
+"The following application has been blocked from<br />executing because it has been deemed malicious" = "Следующее приложение было заблокировано для выполнения,<br />поскольку оно было признано вредоносным";
 
 /* The default message to show the user when an unknown application is blocked */
-"DefaultApplicationBlockedUnknownMessage" = "Следующее приложение было заблокировано для выполнения,<br />поскольку его надежность не может быть определена";
+"The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Следующее приложение было заблокировано для выполнения,<br />поскольку его надежность не может быть определена";
 
 /* The default message to show the user when access to a file is blocked */
-"DefaultFileBlockedMessage" = "Доступ к файлу был запрещен";
+"Access to a file has been denied" = "Доступ к файлу был запрещен";
 
 /* No comment provided by engineer. */
 "Device BSD Path" = "Устройство BSD Path";

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 "DefaultApplicationBlockedUnknownMessage" = "Наступна програма була заблокована для виконання,<br />оскільки не може бути визначена її достовірність";
 
 /* The default message to show the user when access to a file is blocked */
-"DefaultFileBlockedMessage" = "Відмовлено у доступі до файлу";
+"Access to a file has been denied" = "Відмовлено у доступі до файлу";
 
 /* No comment provided by engineer. */
 "Device BSD Path" = "Шлях BSD пристрою";


### PR DESCRIPTION
SNTBlockMessage is used to generate messages in the TTY, where localization won't be applied, so the English version of these strings need to remain the 'key'