### PR TITLE
gui: display bundle hashing progress

### DIFF
--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -18,6 +18,7 @@
 #import "Source/gui/SNTMessageWindowController.h"
 
 @class SNTStoredEvent;
+@class SNTBundleProgress;
 
 ///
 ///  Controller for a single message window.
@@ -41,12 +42,7 @@
 ///
 /// Is displayed if calculating the bundle hash is taking a bit.
 ///
-@property(weak) IBOutlet NSProgressIndicator *hashingIndicator;
-
-///
-/// Is displayed if calculating the bundle hash is taking a bit.
-///
-@property(weak) IBOutlet NSTextField *foundFileCountLabel;
+@property(readonly) SNTBundleProgress *bundleProgress;
 
 ///
 ///  The execution event that this window is for

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -50,6 +50,7 @@
                 forKeyPath:@"fractionCompleted"
                    options:NSKeyValueObservingOptionNew
                    context:NULL];
+    _bundleProgress = [[SNTBundleProgress alloc] init];
   }
   return self;
 }
@@ -65,10 +66,7 @@
   if ([keyPath isEqualToString:@"fractionCompleted"]) {
     dispatch_async(dispatch_get_main_queue(), ^{
       NSProgress *progress = object;
-      if (progress.fractionCompleted != 0.0) {
-        self.hashingIndicator.indeterminate = NO;
-      }
-      self.hashingIndicator.doubleValue = progress.fractionCompleted;
+      self.bundleProgress.fractionCompleted = progress.fractionCompleted;
     });
   }
 }
@@ -96,6 +94,7 @@
                event:self.event
            customMsg:self.customMessage
            customURL:self.customURL
+      bundleProgress:self.bundleProgress
      uiStateCallback:^(NSTimeInterval preventNotificationsPeriod) {
        self.silenceFutureNotificationsPeriod = preventNotificationsPeriod;
      }];
@@ -115,16 +114,8 @@
   // UI updates must happen on the main thread.
   dispatch_async(dispatch_get_main_queue(), ^{
     if ([self.event.idx isEqual:event.idx]) {
-      if (bundleHash) {
-        [self.bundleHashLabel setHidden:NO];
-      } else {
-        [self.bundleHashLabel removeFromSuperview];
-        [self.bundleHashTitle removeFromSuperview];
-      }
       self.event.fileBundleHash = bundleHash;
-      [self.foundFileCountLabel removeFromSuperview];
-      [self.hashingIndicator setHidden:YES];
-      // [self.openEventButton setEnabled:YES];
+      self.bundleProgress.isFinished = YES;
     }
   });
 }

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -174,7 +174,6 @@ struct MoreDetailsView: View {
 }
 
 struct SNTBinaryMessageEventView: View {
-  let window: NSWindow?
   let e: SNTStoredEvent? 
   let customURL: NSString?
   @StateObject var bundleProgress: SNTBundleProgress
@@ -184,12 +183,6 @@ struct SNTBinaryMessageEventView: View {
   var body: some View {
     HStack(spacing: 20.0) {
       VStack(alignment:.trailing, spacing:10.0) {
-        /*
-        if e?.needsBundleHash ?? false {
-          Text("Bundle Hash")
-        }
-        */
-
         if e?.fileBundleName != "" {
           Text("Application").bold().font(Font.system(size:12.0))
         } else if e?.filePath != "" {
@@ -253,7 +246,7 @@ struct SNTBinaryMessageWindowView: View {
 
   var body: some View {
     SNTMessageView(SNTBlockMessage.attributedBlockMessage(for:event, customMessage:customMsg as String?)) {
-      SNTBinaryMessageEventView(window: window, e: event!, customURL: customURL, bundleProgress: bundleProgress)
+      SNTBinaryMessageEventView(e: event!, customURL: customURL, bundleProgress: bundleProgress)
 
       SNTNotificationSilenceView(silence: $preventFutureNotifications, period: $preventFutureNotificationPeriod)
 
@@ -270,8 +263,7 @@ struct SNTBinaryMessageWindowView: View {
       }
 
       HStack(spacing:15.0) {
-        if event?.needsBundleHash ?? false && !bundleProgress.isFinished {
-        } else if c.eventDetailURL != nil {
+        if c.eventDetailURL != nil && !(event?.needsBundleHash ?? false && !bundleProgress.isFinished) {
           OpenEventButton(customText:c.eventDetailText, action:openButton)
         }
         DismissButton(customText: c.dismissText, silence: preventFutureNotifications, action: dismissButton)

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -28,6 +28,7 @@
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/gui/SNTBinaryMessageWindowController.h"
+#import "Source/gui/SNTBinaryMessageWindowView-Swift.h"
 #import "Source/gui/SNTDeviceMessageWindowController.h"
 #import "Source/gui/SNTFileAccessMessageWindowController.h"
 #import "Source/gui/SNTMessageWindowController.h"
@@ -210,7 +211,7 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 
 - (void)hashBundleBinariesForEvent:(SNTStoredEvent *)event
                     withController:(SNTBinaryMessageWindowController *)withController {
-  withController.foundFileCountLabel.stringValue = @"Searching for files...";
+  withController.bundleProgress.label = @"Searching for files...";
 
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
   MOLXPCConnection *bc = [SNTXPCBundleServiceInterface configuredConnection];
@@ -388,9 +389,11 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 
     if ([controller.event.idx isEqual:event.idx]) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        controller.foundFileCountLabel.stringValue =
-          [NSString stringWithFormat:@"%llu binaries / %llu %@", binaryCount,
-                                     hashedCount ?: fileCount, hashedCount ? @"hashed" : @"files"];
+        NSString *fileLabel =
+          [NSString stringWithFormat:@"%llu binaries / %llu files", binaryCount, fileCount];
+        NSString *hashedLabel =
+          [NSString stringWithFormat:@"%llu hashed / %llu binaries", hashedCount, binaryCount];
+        controller.bundleProgress.label = hashedCount ? hashedLabel : fileLabel;
       });
     }
   }

--- a/Source/santabundleservice/SNTBundleService.m
+++ b/Source/santabundleservice/SNTBundleService.m
@@ -143,7 +143,7 @@
 
   // Counts used as additional progress information in SantaGUI
   __block atomic_llong binaryCount = 0;
-  __block volatile int64_t sentBinaryCount = 0;
+  __block volatile int64_t completedUnits = 0;
 
   // Account for 80% of the work
   NSProgress *p;
@@ -158,9 +158,11 @@
       if (progress.isCancelled) return;
 
       dispatch_sync(dispatch_get_main_queue(), ^{
-        p.completedUnitCount++;
-        if (progress && ((i % 500) == 0 || binaryCount > sentBinaryCount)) {
-          sentBinaryCount = binaryCount;
+        // Update the UI for every 1% of work completed.
+        ++completedUnits;
+        if ((((double)completedUnits / subpaths.count) -
+             ((double)p.completedUnitCount / subpaths.count)) > 0.01) {
+          p.completedUnitCount = completedUnits;
           [[self.notifierConnection remoteObjectProxy] updateCountsForEvent:event
                                                                 binaryCount:binaryCount
                                                                   fileCount:i


### PR DESCRIPTION
This CL displays progress while bundle hashing.

While hashing:
<img width="592" alt="Screenshot 2024-10-24 at 4 49 08 PM" src="https://github.com/user-attachments/assets/d7c068d7-76ca-46fa-bd0a-749c94298e85">

More details once complete:
<img width="652" alt="Screenshot 2024-10-24 at 4 50 16 PM" src="https://github.com/user-attachments/assets/0b92f701-c44c-43ec-8542-10e31a8b656b">



https://github.com/user-attachments/assets/d6556049-0c6f-4311-8c47-d82b2030609d


