### PR TITLE
GUI: Update DeviceMessage to new UI

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -167,6 +167,7 @@ objc_library(
     hdrs = ["SNTBlockMessage.h"],
     deps = [
         ":SNTConfigurator",
+        ":SNTDeviceEvent",
         ":SNTFileAccessEvent",
         ":SNTLogging",
         ":SNTStoredEvent",
@@ -182,6 +183,7 @@ objc_library(
     module_name = "santa_common_SNTBlockMessage",
     deps = [
         ":SNTConfigurator",
+        ":SNTDeviceEvent",
         ":SNTFileAccessEvent",
         ":SNTLogging",
         ":SNTStoredEvent",

--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -19,9 +19,8 @@
 #import <Foundation/Foundation.h>
 #endif
 
-#import "Source/common/SNTFileAccessEvent.h"
-#import "Source/common/SNTStoredEvent.h"
-
+@class SNTFileAccessEvent;
+@class SNTDeviceEvent;
 @class SNTStoredEvent;
 
 @interface SNTBlockMessage : NSObject
@@ -47,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSAttributedString *)attributedBlockMessageForFileAccessEvent:
                           (nullable SNTFileAccessEvent *)event
                                                    customMessage:(nullable NSString *)customMessage;
+
++ (NSAttributedString *)attributedBlockMessageForDeviceEvent:(nullable SNTDeviceEvent *)event;
 
 ///
 ///  Return a URL generated from the EventDetailURL configuration key

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -15,6 +15,7 @@
 #import "Source/common/SNTBlockMessage.h"
 
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTDeviceEvent.h"
 #import "Source/common/SNTFileAccessEvent.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
@@ -104,6 +105,28 @@ static id ValueOrNull(id value) {
       message =
         NSLocalizedString(@"Access to a file has been denied",
                           @"The default message to show the user when access to a file is blocked");
+    }
+  }
+  return [SNTBlockMessage formatMessage:message];
+}
+
++ (NSAttributedString *)attributedBlockMessageForDeviceEvent:(SNTDeviceEvent *)event {
+  SNTConfigurator *c = [SNTConfigurator configurator];
+  NSString *message;
+  if ([c remountUSBMode]) {
+    message = [c remountUSBBlockMessage];
+    if (!message.length) {
+      message =
+        NSLocalizedString(@"The following device has been remounted with reduced permissions",
+                          @"The default message to show the user when a USB device is remounted "
+                          @"with reduced permissions");
+    }
+  } else {
+    message = [c bannedUSBBlockMessage];
+    if (!message.length) {
+      message = NSLocalizedString(
+        @"The following device has been blocked from mounting",
+        @"The default message to show the user when a USB device is blocked from mounting");
     }
   }
   return [SNTBlockMessage formatMessage:message];

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -798,17 +798,10 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 }
 
 - (NSString *)bannedUSBBlockMessage {
-  if (!self.configState[kBannedUSBBlockMessage]) {
-    return @"The following device has been blocked from mounting.";
-  }
-
   return self.configState[kBannedUSBBlockMessage];
 }
 
 - (NSString *)remountUSBBlockMessage {
-  if (!self.configState[kRemountUSBBlockMessage]) {
-    return @"The following device has been remounted with reduced permissions.";
-  }
   return self.configState[kRemountUSBBlockMessage];
 }
 

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -26,7 +26,7 @@
 - (void)postBlockNotification:(SNTStoredEvent *)event
             withCustomMessage:(NSString *)message
                  andCustomURL:(NSString *)url;
-- (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message;
+- (void)postUSBBlockNotification:(SNTDeviceEvent *)event;
 - (void)postFileAccessBlockNotification:(SNTFileAccessEvent *)event
                           customMessage:(NSString *)message
                               customURL:(NSString *)url

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -44,6 +44,8 @@ swift_library(
     ],
     generates_header = 1,
     deps = [
+        ":SNTMessageView",
+        "//Source/common:SNTBlockMessage_SantaGUI",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTDeviceEvent",
     ],

--- a/Source/gui/SNTDeviceMessageWindowController.h
+++ b/Source/gui/SNTDeviceMessageWindowController.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 // The device event this window is for.
 @property(readonly) SNTDeviceEvent *event;
 
-- (instancetype)initWithEvent:(SNTDeviceEvent *)event message:(nullable NSString *)message;
+- (instancetype)initWithEvent:(SNTDeviceEvent *)event;
 
 @end
 

--- a/Source/gui/SNTDeviceMessageWindowController.m
+++ b/Source/gui/SNTDeviceMessageWindowController.m
@@ -21,19 +21,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SNTDeviceMessageWindowController ()
-@property(copy, nullable) NSString *customMessage;
-@end
-
 @implementation SNTDeviceMessageWindowController
 
-- (instancetype)initWithEvent:(SNTDeviceEvent *)event message:(nullable NSString *)message {
+- (instancetype)initWithEvent:(SNTDeviceEvent *)event {
   self = [super init];
   if (self) {
     _event = event;
-    _customMessage = message;
   }
   return self;
+}
+
+- (void)windowDidResize:(NSNotification *)notification {
+  [self.window center];
 }
 
 - (void)showWindow:(id)sender {
@@ -41,20 +40,21 @@ NS_ASSUME_NONNULL_BEGIN
 
   self.window =
     [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 0, 0)
-                                styleMask:NSWindowStyleMaskClosable | NSWindowStyleMaskTitled
+                                styleMask:NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
+                                          NSWindowStyleMaskTitled
                                   backing:NSBackingStoreBuffered
                                     defer:NO];
+  self.window.titlebarAppearsTransparent = YES;
+  self.window.movableByWindowBackground = YES;
+  [self.window standardWindowButton:NSWindowZoomButton].hidden = YES;
+  [self.window standardWindowButton:NSWindowCloseButton].hidden = YES;
+  [self.window standardWindowButton:NSWindowMiniaturizeButton].hidden = YES;
+
   self.window.contentViewController =
-    [SNTDeviceMessageWindowViewFactory createWithWindow:self.window
-                                                  event:self.event
-                                              customMsg:self.attributedCustomMessage];
+    [SNTDeviceMessageWindowViewFactory createWithWindow:self.window event:self.event];
   self.window.delegate = self;
 
   [super showWindow:sender];
-}
-
-- (NSAttributedString *)attributedCustomMessage {
-  return [SNTBlockMessage formatMessage:self.customMessage];
 }
 
 - (NSString *)messageHash {

--- a/Source/gui/SNTDeviceMessageWindowView.swift
+++ b/Source/gui/SNTDeviceMessageWindowView.swift
@@ -27,16 +27,15 @@ import santa_gui_SNTMessageView
 
 struct SNTDeviceMessageWindowView: View {
   let window: NSWindow?
-  let event: SNTDeviceEvent?
+  let event: SNTDeviceEvent
 
   var body: some View {
     SNTMessageView(SNTBlockMessage.attributedBlockMessage(for:event)) {
       HStack(spacing: 20.0) {
         VStack(alignment:.trailing, spacing:10.0) {
-          Text("Device Name").bold().font(Font.system(size:12.0))
-          Text("Device BSD Path").bold().font(Font.system(size:12.0))
+          Text("Path").bold().font(Font.system(size:12.0))
 
-          if event!.remountArgs?.count ?? 0 > 0 {
+          if event.remountArgs?.count ?? 0 > 0 {
             Text("Remount Mode").bold().font(Font.system(size:12.0))
           }
         }
@@ -44,11 +43,10 @@ struct SNTDeviceMessageWindowView: View {
         Divider()
 
         VStack(alignment:.leading, spacing:10.0) {
-          Text(event!.mntonname)
-          Text(event!.mntfromname)
+          Text(event.mntonname)
 
-          if event!.remountArgs?.count ?? 0 > 0 {
-            Text(event!.readableRemountArgs())
+          if event.remountArgs?.count ?? 0 > 0 {
+            Text(event.readableRemountArgs())
           }
         }
       }

--- a/Source/gui/SNTDeviceMessageWindowView.swift
+++ b/Source/gui/SNTDeviceMessageWindowView.swift
@@ -14,49 +14,36 @@
 
 import SwiftUI
 
+import santa_common_SNTBlockMessage
 import santa_common_SNTConfigurator
 import santa_common_SNTDeviceEvent
+import santa_gui_SNTMessageView
 
 @objc public class SNTDeviceMessageWindowViewFactory : NSObject {
-  @objc public static func createWith(window: NSWindow, event: SNTDeviceEvent, customMsg: NSAttributedString?) -> NSViewController {
-    return NSHostingController(rootView:SNTDeviceMessageWindowView(window:window, event:event, customMsg:customMsg).frame(width:450, height:300))
+  @objc public static func createWith(window: NSWindow, event: SNTDeviceEvent) -> NSViewController {
+    return NSHostingController(rootView:SNTDeviceMessageWindowView(window:window, event:event).fixedSize())
   }
 }
 
 struct SNTDeviceMessageWindowView: View {
   let window: NSWindow?
   let event: SNTDeviceEvent?
-  let customMsg: NSAttributedString?
-
-  let c = SNTConfigurator()
-
 
   var body: some View {
-    VStack(spacing:20.0) {
-      Text(verbatim: "Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
-
-      if let t = customMsg {
-        if #available(macOS 12.0, *) {
-          let a = AttributedString(t)
-          Text(a).multilineTextAlignment(.center).padding(15.0)
-        } else {
-          Text(t.description).multilineTextAlignment(.center).padding(15.0)
-        }
-      } else {
-        Text("Mounting devices is blocked")
-      }
-
-      HStack(spacing:5.0) {
-        VStack(alignment: .trailing, spacing: 8.0) {
-          Text("Device Name").bold()
-          Text("Device BSD Path").bold()
+    SNTMessageView(SNTBlockMessage.attributedBlockMessage(for:event)) {
+      HStack(spacing: 20.0) {
+        VStack(alignment:.trailing, spacing:10.0) {
+          Text("Device Name").bold().font(Font.system(size:12.0))
+          Text("Device BSD Path").bold().font(Font.system(size:12.0))
 
           if event!.remountArgs?.count ?? 0 > 0 {
-            Text("Remount Mode").bold()
+            Text("Remount Mode").bold().font(Font.system(size:12.0))
           }
         }
-        Spacer().frame(width: 10.0)
-        VStack(alignment: .leading, spacing: 8.0) {
+
+        Divider()
+
+        VStack(alignment:.leading, spacing:10.0) {
           Text(event!.mntonname)
           Text(event!.mntfromname)
 
@@ -66,25 +53,17 @@ struct SNTDeviceMessageWindowView: View {
         }
       }
 
-      HStack {
-        Button(action: dismissButton) {
-          Text("OK").frame(width: 90.0)
-        }
-        .keyboardShortcut(.defaultAction)
+      Spacer()
 
-      }.padding(10.0)
-    }
+      HStack(spacing:15.0) {
+        DismissButton(customText: nil, silence: nil, action: dismissButton)
+      }
+
+      Spacer()
+    }.fixedSize()
   }
 
   func dismissButton() {
     window?.close()
   }
 }
-
-// Enable previews in Xcode.
-struct SNTDeviceMessageWindowView_Previews: PreviewProvider {
-  static var previews: some View {
-    SNTDeviceMessageWindowView(window: nil, event: nil, customMsg: nil)
-  }
-}
-

--- a/Source/gui/SNTMessageView.swift
+++ b/Source/gui/SNTMessageView.swift
@@ -113,9 +113,9 @@ public func OpenEventButton(customText: String? = nil, action: @escaping () -> V
   .help("⌘ Return")
 }
 
-public func DismissButton(customText: String? = nil, silence: Bool, action: @escaping () -> Void) -> some View {
+public func DismissButton(customText: String? = nil, silence: Bool?, action: @escaping () -> Void) -> some View {
   Button(action: action, label: {
-    let t = customText ?? (silence ? String(localized:"Dismiss & Silence") : String(localized:"Dismiss"))
+    let t = customText ?? (silence ?? false ? String(localized:"Dismiss & Silence") : String(localized:"Dismiss"))
     Text(t).frame(minWidth:150.0)
   })
   .keyboardShortcut(.escape, modifiers:.command)

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -347,13 +347,13 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
   [self queueMessage:pendingMsg];
 }
 
-- (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message {
+- (void)postUSBBlockNotification:(SNTDeviceEvent *)event {
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;
   }
   SNTDeviceMessageWindowController *pendingMsg =
-    [[SNTDeviceMessageWindowController alloc] initWithEvent:event message:message];
+    [[SNTDeviceMessageWindowController alloc] initWithEvent:event];
 
   [self queueMessage:pendingMsg];
 }

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -109,11 +109,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                          startupPreferences:[configurator onStartUSBOptions]];
 
   device_client.deviceBlockCallback = ^(SNTDeviceEvent *event) {
-    [[notifier_queue.notifierConnection remoteObjectProxy]
-      postUSBBlockNotification:event
-             withCustomMessage:([configurator remountUSBMode]
-                                  ? [configurator remountUSBBlockMessage]
-                                  : [configurator bannedUSBBlockMessage])];
+    [[notifier_queue.notifierConnection remoteObjectProxy] postUSBBlockNotification:event];
   };
 
   SNTEndpointSecurityRecorder *monitor_client =


### PR DESCRIPTION
This involved a lot of non-UI changes around how the block message is generated because this was previously handled partially in santad and partially in the configurator, which made the message un-localizable

![image](https://github.com/user-attachments/assets/0878b5f1-9e25-43fb-9338-a494cbe7e49b)

![image](https://github.com/user-attachments/assets/7eb2538e-e678-4921-805e-418d67bbef68)
