### PR TITLE
docs: Fix formatting in migration doc

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,3 +14,18 @@ gh_edit_branch: "main"
 plugins:
     - jekyll-redirect-from
 
+callouts:
+  warning:
+    title: Warning
+    color: red
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple

--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -7,27 +7,35 @@ nav_order: 7
 # Migrating from Google Santa to NPS Santa
 
 ## Overview
-This guide outlines the migration process from Google Santa to NPS Santa, designed to ensure a smooth transition with minimal security coverage gaps.
+This guide outlines the migration process from Google Santa to NPS Santa,
+designed to ensure a smooth transition with minimal security coverage gaps.
 
-If you are not currently running Google Santa, you can skip this doc and go straight to [Getting Started](getting-started.md).
+If you are not currently running Google Santa, you can skip this doc and go
+straight to [Getting Started](getting-started.md).
 
 ## Prerequisites
 - Active Google Santa installation
-- MDM (Mobile Device Management) - If you do not use an MDM jump to [2. Install NPS Santa](#2-install-nps-santa)
+- MDM (Mobile Device Management) - If you do not use an MDM jump to
+[Installing NPS Santa](#2-install-nps-santa)
 - NPS Santa installer package
 
 ## Migration Steps
 
 ### 1. Configure System Extensions
-- First, update your MDM configuration to allow both Google and NPS system extensions simultaneously. This dual-authorization is temporary but necessary for a seamless transition.
+- First, update your MDM configuration to allow both Google and NPS system
+extensions simultaneously. This dual-authorization is temporary but necessary
+for a seamless transition.
 - Also deploy a TCC full disk access MDM configuration for NPS Santa
-- See [Getting Started](./getting-started.md) for examples of the system extention and TCC MDM configurations for NPS Santa.
+- See [Getting Started](./getting-started.md) for examples of the system
+extention and TCC MDM configurations for NPS Santa.
 
 ### 2. Install NPS Santa
-Deploy the lastest NPS Santa [release](https://github.com/northpolesec/santa/releases) to your systems. The installer is designed with built-in migration support:
+Deploy the lastest NPS Santa [release](https://github.com/northpolesec/santa/releases)
+to your systems. The installer is designed with built-in migration support:
 - NPS Santa will remain dormant after installation
 - It will automatically monitor for Google Santa removal
-- At this point NPS Santa will NOT apear in `systemextensionsctl list`
+- At this point NPS Santa will **not** apear in `systemextensionsctl list`
+
 ```
 % systemextensionsctl list
 1 extension(s)
@@ -36,8 +44,9 @@ enabled	active	teamID	bundleID (version)	name	[state]
 *	*	EQHXZ8M8AV	com.google.santa.daemon (2024.9/2024.9.674285143)	santad	[activated enabled]
 ```
 
->[!WARNING]
->To avoid system extension authorization popups, ensure the MDM has applied configurations from #1 before deploying the NPS Santa installer.
+{: .warning }
+To avoid system extension authorization popups, ensure the MDM has applied
+configurations from #1 before deploying the NPS Santa installer.
 
 ### 3. Remove Google Santa Authorization
 Through your MDM:
@@ -45,15 +54,17 @@ Through your MDM:
 - This will trigger the automatic unloading of Google Santa
 - NPS Santa will detect the removal and will finish loading itself within second
 
->[!WARNING]
->To minimize security coverage downtime, ensure the NPS Santa installer has run before removing Google Santa from the allowed system extensions list
+{: .warning }
+To minimize security coverage downtime, ensure the NPS Santa installer has run
+before removing Google Santa from the allowed system extensions list
 
 If you do not use an MDM:
 - Remove Google Santa by dragging `/Applications/Santa.app` to the trash
 - Respond to the admin authentication popup dialog
 
 ### 4. Verification
-- NPS Santa should now installed and running.
+NPS Santa should now installed and running:
+
 ```
 % systemextensionsctl list
 2 extension(s)
@@ -64,5 +75,6 @@ enabled	active	teamID	bundleID (version)	name	[state]
 ```
 
 ## Notes
-- The terminated Google Santa entry will be cleared on the next reboot. In a terminated state, Google Santa does not affect NPS Santa.
+- The terminated Google Santa entry will be cleared on the next reboot. In a
+terminated state, Google Santa does not affect NPS Santa.
 - Security coverage downtime is kept to a minimum throughout the transition


### PR DESCRIPTION
* Fix the formatting of code blocks - as the blocks didn't have a newline in between they were not being parsed correctly
* Move the "warning" messages into callouts

To preview, run `bundle install && bundle exec jekyll serve` inside the docs folder.

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/1dc70908-0ca2-4731-98bd-bd9e9cdb90ac">
