### PR TITLE
Address findings from migration testing

### DIFF
--- a/Conf/Package/migration.sh
+++ b/Conf/Package/migration.sh
@@ -23,7 +23,9 @@ GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 /bin/rm -f /Library/LaunchDaemons/com.google.santa.metricservice.plist
 /bin/rm -f /Library/LaunchDaemons/com.google.santa.syncservice.plist
 /bin/rm -f /private/etc/asl/com.google.santa.asl.conf
-/bin/rm -f /private/etc/newsyslog.d/com.google.santa.newsyslog.conf
+# Move Google's newsyslog config file in case any changes were made so that the
+# same configuration continues to apply.
+/bin/mv -f /private/etc/newsyslog.d/com.google.santa.newsyslog.conf /private/etc/newsyslog.d/com.northpolesec.santa.newsyslog.conf || true
 
 # Install NPS Santa.
 /bin/mv /Library/Caches/com.northpolesec.santa/Santa.app /Applications/Santa.app

--- a/Conf/Package/postinstall
+++ b/Conf/Package/postinstall
@@ -35,6 +35,11 @@ if [ -z "${GOOGLE_SANTA_ACTIVATED}" ]; then
     /Applications/Santa.app/Contents/MacOS/santactl install
   fi
 
+  # Although Santa isn't running, we still try to move any lingering newsyslog
+  # config that might exist. If any changes had been made to a previous Santa
+  # deployment, that same config will continue to be used here.
+  /bin/mv -f /private/etc/newsyslog.d/com.google.santa.newsyslog.conf /private/etc/newsyslog.d/com.northpolesec.santa.newsyslog.conf || true
+
   # Cleanup cache dir.
   /bin/rm -rf /Library/Caches/com.northpolesec.santa
 

--- a/Conf/install_services.sh
+++ b/Conf/install_services.sh
@@ -31,8 +31,17 @@ GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 /bin/rm /Library/LaunchDaemons/com.google.santa.metricservice.plist
 /bin/rm /Library/LaunchDaemons/com.google.santa.syncservice.plist
 /bin/rm /Library/LaunchDaemons/com.google.santad.plist
+# Move Google's newsyslog config file in case any changes were made so that the
+# same configuration continues to apply.
+/bin/mv -f /private/etc/newsyslog.d/com.google.santa.newsyslog.conf /private/etc/newsyslog.d/com.northpolesec.santa.newsyslog.conf || true
 
 ################################################################################
+
+# Remove lingering migration launchd plist. This can stick around when upgrading
+# NPS Santa due to tamper protections of the previous version of NPS preventing
+# the deletion. While this is benign, we can take the opportunity to remove the
+# artifact here.
+/bin/rm -f /Library/LaunchDaemons/com.northpolesec.santa.migration.plist
 
 # Unload NPS Santa services in preparation for installation / update.
 /bin/launchctl remove com.northpolesec.santa.bundleservice || true
@@ -51,5 +60,3 @@ GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 /bin/launchctl load -w /Library/LaunchDaemons/com.northpolesec.santa.metricservice.plist
 /bin/launchctl load -w /Library/LaunchDaemons/com.northpolesec.santa.syncservice.plist
 [[ -n "${GUI_USER}" ]] && /bin/launchctl asuser "${GUI_USER}" /bin/launchctl load /Library/LaunchAgents/com.northpolesec.santa.plist
-
-exit 0

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -54,6 +54,10 @@ void RemoveLegacyLaunchdPlists() {
     "/Library/LaunchDaemons/com.google.santa.metricservice.plist",
     "/Library/LaunchDaemons/com.google.santa.syncservice.plist",
     "/Library/LaunchAgents/com.google.santa.plist",
+    // Assume that NPS Santa has already migrated any existing Google newsyslog
+    // config and we can simply remove a new config file that was just laid
+    // down as part of a Google Santa install that is being prevented from running.
+    "/private/etc/newsyslog.d/com.google.santa.newsyslog.conf",
   };
 
   for (const auto &plist : legacyPlists) {


### PR DESCRIPTION
This PR adds additional cleanup for two cases:

1. Upgrading from NPS Santa to NPS Santa
The `com.northpolesec.santa.migration.plist` launch daemon artifact was being left on disk. This was due to tamper protections preventing the deletion on installation of the upgraded version. While benign, it's not ideal to leave the artifact on disk. This file is now removed.

2. When Google Santa is attempted to be installed over NPS Santa, the `com.google.santa.newsyslog.conf` artifact was not cleaned up.
During discussion, we decided it would be best that instead of always attempting to remove this file, we should instead mv the contents to the new `com.northpolesec.santa.newsyslog.conf` path. This will help NPS deployments maintain the same configuration as the previous deployments in the rare event any changes to this file were made.