### PR TITLE
Move away from /Library/Caches for migration

### DIFF
--- a/Conf/Package/migration.sh
+++ b/Conf/Package/migration.sh
@@ -28,11 +28,11 @@ GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 /bin/mv -f /private/etc/newsyslog.d/com.google.santa.newsyslog.conf /private/etc/newsyslog.d/com.northpolesec.santa.newsyslog.conf || true
 
 # Install NPS Santa.
-/bin/mv /Library/Caches/com.northpolesec.santa/Santa.app /Applications/Santa.app
+/bin/mv /var/db/santa/migration/Santa.app /Applications/Santa.app
 /Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
 
 # Cleanup migration service and on-disk artifacts.
-/bin/rm -rf /Library/Caches/com.northpolesec.santa/
+/bin/rm -rf /var/db/santa/migration/
 /bin/rm /Library/LaunchDaemons/com.northpolesec.santa.migration.plist
 /bin/launchctl remove com.northpolesec.santa.migration
 

--- a/Conf/Package/package.sh
+++ b/Conf/Package/package.sh
@@ -39,11 +39,11 @@ readonly APP_PKG_SCRIPTS="${SCRATCH}/pkg_scripts"
 /usr/bin/find "${RELEASE_ROOT}/conf" -type f -name "com.northpolesec.santa*" -exec chmod 0644 {} \;
 
 echo "creating app pkg"
-/bin/mkdir -p "${APP_PKG_ROOT}/Library/Caches/com.northpolesec.santa" \
+/bin/mkdir -p "${APP_PKG_ROOT}/var/db/santa/migration" \
   "${APP_PKG_ROOT}/Library/LaunchDaemons" \
   "${APP_PKG_ROOT}/private/etc/newsyslog.d"
-/bin/cp -vXR "${RELEASE_ROOT}/binaries/Santa.app" "${APP_PKG_ROOT}/Library/Caches/com.northpolesec.santa/"
-/bin/cp -vX "${RELEASE_ROOT}/conf/migration.sh" "${APP_PKG_ROOT}/Library/Caches/com.northpolesec.santa/"
+/bin/cp -vXR "${RELEASE_ROOT}/binaries/Santa.app" "${APP_PKG_ROOT}/var/db/santa/migration/"
+/bin/cp -vX "${RELEASE_ROOT}/conf/migration.sh" "${APP_PKG_ROOT}/var/db/santa/migration/"
 /bin/cp -vX "${RELEASE_ROOT}/conf/com.northpolesec.santa.migration.plist" "${APP_PKG_ROOT}/Library/LaunchDaemons/"
 /bin/cp -vX "${RELEASE_ROOT}/conf/com.northpolesec.santa.newsyslog.conf" "${APP_PKG_ROOT}/private/etc/newsyslog.d/"
 /bin/cp -vXL "${RELEASE_ROOT}/conf/preinstall" "${APP_PKG_SCRIPTS}/"

--- a/Conf/Package/postinstall
+++ b/Conf/Package/postinstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Santa is installed to /Library/Caches/com.northpolesec.santa/Santa.app. This
+# Santa is installed to /var/db/santa/migration/Santa.app. This
 # postinstall script moves it to /Applications/Santa.app, if Santa is not
 # running, or asks com.northpolesec.santa.daemon to finish the install.
 
@@ -26,7 +26,7 @@ if [ -z "${GOOGLE_SANTA_ACTIVATED}" ]; then
     # Removal was successful.
     # Install Santa and load the system extension. The system extension will
     # finish loading the rest of Santa's configs and helper services.
-    /bin/mv /Library/Caches/com.northpolesec.santa/Santa.app /Applications/Santa.app
+    /bin/mv /var/db/santa/migration/Santa.app /Applications/Santa.app
     /Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
   else
     # Tamper protections are enabled, ask Santa to install the update. If the
@@ -41,7 +41,7 @@ if [ -z "${GOOGLE_SANTA_ACTIVATED}" ]; then
   /bin/mv -f /private/etc/newsyslog.d/com.google.santa.newsyslog.conf /private/etc/newsyslog.d/com.northpolesec.santa.newsyslog.conf || true
 
   # Cleanup cache dir.
-  /bin/rm -rf /Library/Caches/com.northpolesec.santa
+  /bin/rm -rf /var/db/santa/migration
 
   # Create a symlink for santactl.
   /bin/mkdir -p /usr/local/bin

--- a/Conf/Package/preinstall
+++ b/Conf/Package/preinstall
@@ -4,6 +4,6 @@
 [[ $3 != "/" ]] && exit 0
 
 /bin/launchctl remove com.northpolesec.santa.migration || true
-/bin/rm -rf /Library/Caches/com.northpolesec.santa
+/bin/rm -rf /var/db/santa/migration
 
 exit 0

--- a/Conf/com.northpolesec.santa.migration.plist
+++ b/Conf/com.northpolesec.santa.migration.plist
@@ -6,7 +6,7 @@
 	<string>com.northpolesec.santa.migration</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Library/Caches/com.northpolesec.santa/migration.sh</string>
+		<string>/var/db/santa/migration/migration.sh</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/Conf/install.sh
+++ b/Conf/install.sh
@@ -33,11 +33,11 @@ else
   # Tamper protections are enabled, ask Santa to install the update. If the
   # update is valid, the system extension will take care of finishing the
   # install.
-  /bin/mkdir -p /Library/Caches/com.northpolesec.santa
-  /bin/cp -r ${BINARIES}/Santa.app /Library/Caches/com.northpolesec.santa/
+  /bin/mkdir -p /var/db/santa/migration
+  /bin/cp -r ${BINARIES}/Santa.app /var/db/santa/migration/
   /Applications/Santa.app/Contents/MacOS/santactl install
   # Cleanup cache dir.
-  /bin/rm -rf /Library/Caches/com.northpolesec.santa
+  /bin/rm -rf /var/db/santa/migration
 fi
 
 exit 0

--- a/Source/santactl/Commands/SNTCommandInstall.mm
+++ b/Source/santactl/Commands/SNTCommandInstall.mm
@@ -48,7 +48,7 @@ REGISTER_COMMAND_NAME(@"install")
 }
 
 - (void)runWithArguments:(NSArray *)arguments {
-  NSString *installFromPath = @"/Library/Caches/com.northpolesec.santa/Santa.app";
+  NSString *installFromPath = @"/var/db/santa/migration/Santa.app";
   int64_t secondsToWait = 15;
 
   LOGI(@"Asking daemon to install: %@", installFromPath);


### PR DESCRIPTION
This change only moves the scratch dir used for migration out of /Library/Caches due to external factors that can cause that directory to be blown away (such as OS upgrades).