### PR TITLE
Subscribe to authentication event types and handle enrichment

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -503,6 +503,7 @@ objc_library(
     hdrs = ["EventProviders/EndpointSecurity/EnrichedTypes.h"],
     deps = [
         ":EndpointSecurityMessage",
+        "//Source/common:Platform",
         "//Source/santad/ProcessTree:process_tree_cc_proto",
     ],
 )
@@ -1223,6 +1224,7 @@ santa_unit_test(
         ":EndpointSecurityMessage",
         ":Metrics",
         ":MockEndpointSecurityAPI",
+        "//Source/common:Platform",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTMetricSet",
         "//Source/common:TestUtils",

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.h
@@ -41,6 +41,9 @@ class Enricher {
   virtual EnrichedProcess Enrich(
       const es_process_t &es_proc,
       EnrichOptions options = EnrichOptions::kDefault);
+  virtual std::optional<EnrichedProcess> Enrich(
+      const es_process_t *es_proc,
+      EnrichOptions options = EnrichOptions::kDefault);
   virtual EnrichedFile Enrich(const es_file_t &es_file,
                               EnrichOptions options = EnrichOptions::kDefault);
 

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -110,11 +110,10 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
             UIDForUsername(
               StringTokenToStringView(es_msg->event.authentication->data.auto_unlock->username))));
 
-        // Note: return nullptr here rather than exit. Unlike the programmer error case
-        // below which results in an exit, here we have a case of potentially new
-        // authentication types being added in the future for this one event type. If
-        // that happens, we don't want versions of Santa compiled for an older SDK to
-        // start exiting due to an unknown type.
+        // Note: There is a case here where future OS versions could add new authentication types that
+        // did not exist in the SDK used to build the current running version of Santa. Return nullptr
+        // here to signal to the caller that event processing should not continue. Santa would have to
+        // be updated and rebuilt with the new SDK in order to properly handle the new types.
         default: return nullptr;
       }
     case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN:

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -110,10 +110,11 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
             UIDForUsername(
               StringTokenToStringView(es_msg->event.authentication->data.auto_unlock->username))));
 
-        // Note: There is a case here where future OS versions could add new authentication types that
-        // did not exist in the SDK used to build the current running version of Santa. Return nullptr
-        // here to signal to the caller that event processing should not continue. Santa would have to
-        // be updated and rebuilt with the new SDK in order to properly handle the new types.
+        // Note: There is a case here where future OS versions could add new authentication types
+        // that did not exist in the SDK used to build the current running version of Santa. Return
+        // nullptr here to signal to the caller that event processing should not continue. Santa
+        // would have to be updated and rebuilt with the new SDK in order to properly handle the new
+        // types.
         default: return nullptr;
       }
     case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN:

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include "Source/santad/EventProviders/EndpointSecurity/Enricher.h"
 
@@ -86,6 +87,36 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
       return std::make_unique<EnrichedMessage>(
         EnrichedCSInvalidated(std::move(es_msg), Enrich(*es_msg->process)));
 #if HAVE_MACOS_13
+    case ES_EVENT_TYPE_NOTIFY_AUTHENTICATION:
+      switch (es_msg->event.authentication->type) {
+        case ES_AUTHENTICATION_TYPE_OD:
+          return std::make_unique<EnrichedMessage>(
+            EnrichedAuthenticationOD(std::move(es_msg), Enrich(*es_msg->process),
+                                     Enrich(es_msg->event.authentication->data.od->instigator)));
+        case ES_AUTHENTICATION_TYPE_TOUCHID:
+          return std::make_unique<EnrichedMessage>(EnrichedAuthenticationTouchID(
+            std::move(es_msg), Enrich(*es_msg->process),
+            Enrich(es_msg->event.authentication->data.touchid->instigator),
+            es_msg->event.authentication->data.touchid->has_uid
+              ? UsernameForUID(es_msg->event.authentication->data.touchid->uid.uid)
+              : std::nullopt));
+        case ES_AUTHENTICATION_TYPE_TOKEN:
+          return std::make_unique<EnrichedMessage>(EnrichedAuthenticationToken(
+            std::move(es_msg), Enrich(*es_msg->process),
+            Enrich(es_msg->event.authentication->data.token->instigator)));
+        case ES_AUTHENTICATION_TYPE_AUTO_UNLOCK:
+          return std::make_unique<EnrichedMessage>(EnrichedAuthenticationAutoUnlock(
+            std::move(es_msg), Enrich(*es_msg->process),
+            UIDForUsername(
+              StringTokenToStringView(es_msg->event.authentication->data.auto_unlock->username))));
+
+        // Note: return nullptr here rather than exit. Unlike the programmer error case
+        // below which results in an exit, here we have a case of potentially new
+        // authentication types being added in the future for this one event type. If
+        // that happens, we don't want versions of Santa compiled for an older SDK to
+        // start exiting due to an unknown type.
+        default: return nullptr;
+      }
     case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN:
       return std::make_unique<EnrichedMessage>(EnrichedLoginWindowSessionLogin(
         std::move(es_msg), Enrich(*es_msg->process),
@@ -126,6 +157,11 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
       LOGE(@"Attempting to enrich an unhandled event type: %d", es_msg->event_type);
       exit(EXIT_FAILURE);
   }
+}
+
+std::optional<EnrichedProcess> Enricher::Enrich(const es_process_t *es_proc,
+                                                EnrichOptions options) {
+  return es_proc ? std::make_optional<EnrichedProcess>(Enrich(*es_proc, options)) : std::nullopt;
 }
 
 EnrichedProcess Enricher::Enrich(const es_process_t &es_proc, EnrichOptions options) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import "Source/santad/EventProviders/SNTEndpointSecurityRecorder.h"
 #include <os/base.h>
@@ -178,6 +179,11 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
   // data as close to the source event as possible.
   std::unique_ptr<EnrichedMessage> enrichedMessage = _enricher->Enrich(std::move(esMsg));
 
+  if (!enrichedMessage) {
+    recordEventMetrics(EventDisposition::kDropped);
+    return;
+  }
+
   // Asynchronously log the message
   [self processEnrichedMessage:std::move(enrichedMessage)
                        handler:^(std::unique_ptr<EnrichedMessage> msg) {
@@ -203,6 +209,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
 #if HAVE_MACOS_13
   if (@available(macOS 13.0, *)) {
     events.insert({
+      ES_EVENT_TYPE_NOTIFY_AUTHENTICATION,
       ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN,
       ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT,
       ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN,

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include <EndpointSecurity/ESTypes.h>
 #import <OCMock/OCMock.h>
@@ -97,6 +98,7 @@ class MockLogger : public Logger {
 #if HAVE_MACOS_13
   if (@available(macOS 13.0, *)) {
     expectedEventSubs.insert({
+      ES_EVENT_TYPE_NOTIFY_AUTHENTICATION,
       ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN,
       ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT,
       ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK,
@@ -148,7 +150,12 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  std::unique_ptr<EnrichedMessage> enrichedMsg = std::unique_ptr<EnrichedMessage>(nullptr);
+  // Create a fake enriched message. It isn't used other than to inject a valid
+  // returned object from a mocked Enrich method. The purpose is to ensure the
+  // check in the recorder that a message is enriched always succeeds.
+  es_message_t fakeEnrichedMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXIT, NULL);
+  std::unique_ptr<EnrichedMessage> enrichedMsg = std::make_unique<EnrichedMessage>(EnrichedMessage(
+    santa::EnrichedExit(Message(mockESApi, &fakeEnrichedMsg), santa::EnrichedProcess())));
 
   auto mockEnricher = std::make_shared<MockEnricher>();
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #ifndef SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_BASICSTRING_H
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_BASICSTRING_H
@@ -58,6 +59,10 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedOpenSSHLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogout &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationOD &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationAutoUnlock &) override;
 #endif
 
   std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include "Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h"
 
@@ -34,36 +35,6 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 #import "Source/santad/SNTDecisionCache.h"
-
-using santa::EndpointSecurityAPI;
-using santa::EnrichedClose;
-using santa::EnrichedCSInvalidated;
-using santa::EnrichedEventType;
-using santa::EnrichedExchange;
-using santa::EnrichedExec;
-using santa::EnrichedExit;
-using santa::EnrichedFork;
-using santa::EnrichedLink;
-using santa::EnrichedLoginLogin;
-using santa::EnrichedLoginLogout;
-using santa::EnrichedLoginWindowSessionLock;
-using santa::EnrichedLoginWindowSessionLogin;
-using santa::EnrichedLoginWindowSessionLogout;
-using santa::EnrichedLoginWindowSessionUnlock;
-using santa::EnrichedOpenSSHLogin;
-using santa::EnrichedOpenSSHLogout;
-using santa::EnrichedProcess;
-using santa::EnrichedRename;
-using santa::EnrichedScreenSharingAttach;
-using santa::EnrichedScreenSharingDetach;
-using santa::EnrichedUnlink;
-using santa::Message;
-using santa::MountFromName;
-using santa::NonNull;
-using santa::Pid;
-using santa::Pidversion;
-using santa::RealGroup;
-using santa::RealUser;
 
 namespace santa {
 
@@ -644,6 +615,38 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedLoginLogout &ms
   AppendInstigator(str, msg);
   AppendEventUser(str, msg->event.login_logout->username,
                   std::make_optional<uid_t>(msg->event.login_logout->uid));
+
+  return FinalizeString(str);
+}
+
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedAuthenticationOD &msg) {
+  std::string str = CreateDefaultString();
+
+  str.append("action=AUTHENTICATION_OD");
+
+  return FinalizeString(str);
+}
+
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedAuthenticationTouchID &msg) {
+  std::string str = CreateDefaultString();
+
+  str.append("action=AUTHENTICATION_TOUCHID");
+
+  return FinalizeString(str);
+}
+
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedAuthenticationToken &msg) {
+  std::string str = CreateDefaultString();
+
+  str.append("action=AUTHENTICATION_TOKEN");
+
+  return FinalizeString(str);
+}
+
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedAuthenticationAutoUnlock &msg) {
+  std::string str = CreateDefaultString();
+
+  str.append("action=AUTHENTICATION_AUTO_UNLOCK");
 
   return FinalizeString(str);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #ifndef SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_EMPTY_H
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_EMPTY_H
@@ -49,6 +50,10 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedOpenSSHLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogout &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationOD &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationAutoUnlock &) override;
 
   std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                            const std::string &policy_name,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -1,40 +1,19 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Empty.h"
-
-using santa::EnrichedClose;
-using santa::EnrichedCSInvalidated;
-using santa::EnrichedExchange;
-using santa::EnrichedExec;
-using santa::EnrichedExit;
-using santa::EnrichedFork;
-using santa::EnrichedLink;
-using santa::EnrichedLoginLogin;
-using santa::EnrichedLoginLogout;
-using santa::EnrichedLoginWindowSessionLock;
-using santa::EnrichedLoginWindowSessionLogin;
-using santa::EnrichedLoginWindowSessionLogout;
-using santa::EnrichedLoginWindowSessionUnlock;
-using santa::EnrichedOpenSSHLogin;
-using santa::EnrichedOpenSSHLogout;
-using santa::EnrichedProcess;
-using santa::EnrichedRename;
-using santa::EnrichedScreenSharingAttach;
-using santa::EnrichedScreenSharingDetach;
-using santa::EnrichedUnlink;
-using santa::Message;
 
 namespace santa {
 
@@ -117,6 +96,22 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedLoginLogin &) {
 }
 
 std::vector<uint8_t> Empty::SerializeMessage(const EnrichedLoginLogout &) {
+  return {};
+}
+
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedAuthenticationOD &) {
+  return {};
+}
+
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedAuthenticationTouchID &) {
+  return {};
+}
+
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedAuthenticationToken &) {
+  return {};
+}
+
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedAuthenticationAutoUnlock &) {
   return {};
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -58,6 +59,10 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedOpenSSHLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogout &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationOD &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) override;
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationAutoUnlock &) override;
 #endif
 
   std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -42,41 +43,6 @@ using google::protobuf::Arena;
 using google::protobuf::Timestamp;
 using JsonPrintOptions = google::protobuf::json::PrintOptions;
 using google::protobuf::json::MessageToJsonString;
-
-using santa::EffectiveGroup;
-using santa::EffectiveUser;
-using santa::EndpointSecurityAPI;
-using santa::EnrichedClose;
-using santa::EnrichedCSInvalidated;
-using santa::EnrichedEventType;
-using santa::EnrichedExchange;
-using santa::EnrichedExec;
-using santa::EnrichedExit;
-using santa::EnrichedFile;
-using santa::EnrichedFork;
-using santa::EnrichedLink;
-using santa::EnrichedLoginLogin;
-using santa::EnrichedLoginLogout;
-using santa::EnrichedLoginWindowSessionLock;
-using santa::EnrichedLoginWindowSessionLogin;
-using santa::EnrichedLoginWindowSessionLogout;
-using santa::EnrichedLoginWindowSessionUnlock;
-using santa::EnrichedOpenSSHLogin;
-using santa::EnrichedOpenSSHLogout;
-using santa::EnrichedProcess;
-using santa::EnrichedRename;
-using santa::EnrichedScreenSharingAttach;
-using santa::EnrichedScreenSharingDetach;
-using santa::EnrichedUnlink;
-using santa::Message;
-using santa::MountFromName;
-using santa::NonNull;
-using santa::NSStringToUTF8StringView;
-using santa::Pid;
-using santa::Pidversion;
-using santa::RealGroup;
-using santa::RealUser;
-using santa::StringTokenToStringView;
 
 namespace pbv1 = ::santa::pb::v1;
 
@@ -978,6 +944,22 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedLoginLogout &msg) 
                  msg->event.login_logout->username);
 
   return FinalizeProto(santa_msg);
+}
+
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedAuthenticationOD &msg) {
+  return {};
+}
+
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedAuthenticationTouchID &msg) {
+  return {};
+}
+
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedAuthenticationToken &msg) {
+  return {};
+}
+
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedAuthenticationAutoUnlock &msg) {
+  return {};
 }
 
 #endif  // HAVE_MACOS_13

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #ifndef SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_SERIALIZER_H
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_SERIALIZER_H
@@ -65,6 +66,11 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedOpenSSHLogout &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogin &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginLogout &) = 0;
+  virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationOD &) = 0;
+  virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) = 0;
+  virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) = 0;
+  virtual std::vector<uint8_t> SerializeMessage(
+    const santa::EnrichedAuthenticationAutoUnlock &) = 0;
 
   virtual std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                                    const std::string &policy_name,

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include "Source/santad/Metrics.h"
 
@@ -55,6 +56,7 @@ static NSString *const kEventTypeNotifyUnlink = @"NotifyUnlink";
 static NSString *const kEventTypeNotifyUnmount = @"NotifyUnmount";
 static NSString *const kPseudoEventTypeGlobal = @"Global";
 #if HAVE_MACOS_13
+static NSString *const kEventTypeNotifyAuthentication = @"NotifyAuthentication";
 static NSString *const kEventTypeNotifyLoginLogin = @"NotifyLoginLogin";
 static NSString *const kEventTypeNotifyLoginLogout = @"NotifyLoginLogout";
 static NSString *const kEventTypeNotifyLWSessionLogin = @"NotifyLWSessionLogin";
@@ -131,6 +133,7 @@ NSString *const EventTypeToString(es_event_type_t eventType) {
     case ES_EVENT_TYPE_NOTIFY_UNLINK: return kEventTypeNotifyUnlink;
     case ES_EVENT_TYPE_NOTIFY_UNMOUNT: return kEventTypeNotifyUnmount;
 #if HAVE_MACOS_13
+    case ES_EVENT_TYPE_NOTIFY_AUTHENTICATION: return kEventTypeNotifyAuthentication;
     case ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN: return kEventTypeNotifyLoginLogin;
     case ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT: return kEventTypeNotifyLoginLogout;
     case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN: return kEventTypeNotifyLWSessionLogin;

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include "Source/santad/Metrics.h"
 
@@ -23,6 +24,7 @@
 #include <map>
 #include <memory>
 
+#include "Source/common/Platform.h"
 #import "Source/common/SNTCommonEnums.h"
 #include "Source/common/SNTMetricSet.h"
 #include "Source/common/TestUtils.h"
@@ -197,6 +199,19 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
     {ES_EVENT_TYPE_NOTIFY_RENAME, @"NotifyRename"},
     {ES_EVENT_TYPE_NOTIFY_UNLINK, @"NotifyUnlink"},
     {ES_EVENT_TYPE_NOTIFY_UNMOUNT, @"NotifyUnmount"},
+#if HAVE_MACOS_13
+    {ES_EVENT_TYPE_NOTIFY_AUTHENTICATION, @"NotifyAuthentication"},
+    {ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN, @"NotifyLoginLogin"},
+    {ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT, @"NotifyLoginLogout"},
+    {ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN, @"NotifyLWSessionLogin"},
+    {ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT, @"NotifyLWSessionLogout"},
+    {ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK, @"NotifyLWSessionLock"},
+    {ES_EVENT_TYPE_NOTIFY_LW_SESSION_UNLOCK, @"NotifyLWSessionUnlock"},
+    {ES_EVENT_TYPE_NOTIFY_SCREENSHARING_ATTACH, @"NotifyScreensharingAttach"},
+    {ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH, @"NotifyScreensharingDetach"},
+    {ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN, @"NotifyOpenSSHLogin"},
+    {ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT, @"NotifyOpenSSHLogout"},
+#endif
     {ES_EVENT_TYPE_LAST, @"Global"},
   };
 


### PR DESCRIPTION
This PR starts adding in support for new authentication event types. Protobuf/string serialization will come in future PRs.

The main goal is to define the new enriched types and handle them in the enricher.