### PR TITLE
GUI: Prevent publisher from expanding UI too much

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ bazel_dep(name = "abseil-cpp", version = "20240116.2", repo_name = "com_google_a
 bazel_dep(name = "rules_python", version = "0.33.2")
 bazel_dep(name = "rules_cc", version = "0.0.13")
 bazel_dep(name = "rules_apple", version = "3.8.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "2.0.0-rc1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "2.1.1", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
 bazel_dep(name = "protobuf", version = "29.0-rc1", repo_name = "com_google_protobuf")
 bazel_dep(name = "googletest", version = "1.14.0.bcr.1", repo_name = "com_google_googletest")

--- a/Source/common/CertificateHelpers.m
+++ b/Source/common/CertificateHelpers.m
@@ -22,12 +22,14 @@ NSString *Publisher(NSArray<MOLCertificate *> *certs, NSString *teamID) {
 
   if ([leafCert.commonName isEqualToString:@"Apple Mac OS Application Signing"]) {
     return [NSString stringWithFormat:@"App Store (Team ID: %@)", teamID];
+  } else if ([leafCert.commonName hasPrefix:@"Developer ID Application"]) {
+    // Developer ID Application certs have the company name in the OrgName field
+    // but also include it in the CommonName and we don't want to print it twice.
+    return [NSString stringWithFormat:@"%@ (%@)", leafCert.orgName, teamID];
   } else if (leafCert.commonName && leafCert.orgName) {
     return [NSString stringWithFormat:@"%@ - %@", leafCert.orgName, leafCert.commonName];
   } else if (leafCert.commonName) {
     return leafCert.commonName;
-  } else if (leafCert.orgName) {
-    return leafCert.orgName;
   } else {
     return nil;
   }

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -8,10 +8,6 @@ package(
     default_visibility = ["//:santa_package_group"],
 )
 
-exports_files([
-    "Resources/Images.xcassets/AppIcon.appiconset/santa-hat-icon-256.png",
-])
-
 swift_library(
     name = "SNTMessageView",
     srcs = ["SNTMessageView.swift"],

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -199,7 +199,7 @@ struct SNTBinaryMessageEventView: View {
           Text("Filename").bold().font(Font.system(size: 12.0))
         }
 
-        if e?.publisherInfo != "" {
+        if e?.publisherInfo ?? "" != "" {
           Text("Publisher").bold().font(Font.system(size: 12.0))
         }
 
@@ -210,17 +210,27 @@ struct SNTBinaryMessageEventView: View {
 
       VStack(alignment: .leading, spacing: 10.0) {
         if let bundleName = e?.fileBundleName {
-          Text(bundleName).textSelection(.enabled)
+          Text(bundleName)
         } else if let filePath = e?.filePath {
-          Text((filePath as NSString).lastPathComponent).textSelection(.enabled)
+          Text((filePath as NSString).lastPathComponent)
         }
 
         if let publisher = e?.publisherInfo {
-          Text(publisher).textSelection(.enabled)
+          // The publisher field can be quite long, so limit its size and add the full
+          // string as s tooltip so hovering over the field will show the full label.
+          //
+          // This /could/ be done by setting the frame(maxWidth:), truncationMode(.head) and
+          // lineLimit(1) BUT there is what appears to be a bug in that once the text is
+          // selected it grows to the full size of the window.
+          if publisher.count > 50 {
+            Text(publisher.prefix(50)+"…").help(publisher)
+          } else {
+            Text(publisher)
+          }
         }
 
-        Text(e?.executingUser ?? "").textSelection(.enabled)
-      }
+        Text(e?.executingUser ?? "")
+      }.textSelection(.enabled)
     }.sheet(isPresented: $isShowingDetails) {
       MoreDetailsView(e: e, customURL: customURL, bundleProgress: bundleProgress)
     }

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -223,7 +223,7 @@ struct SNTBinaryMessageEventView: View {
           // lineLimit(1) BUT there is what appears to be a bug in that once the text is
           // selected it grows to the full size of the window.
           if publisher.count > 50 {
-            Text(publisher.prefix(50) + "…").help(publisher)
+            Text(verbatim: publisher.prefix(50) + "…").help(publisher)
           } else {
             Text(publisher)
           }

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -223,7 +223,7 @@ struct SNTBinaryMessageEventView: View {
           // lineLimit(1) BUT there is what appears to be a bug in that once the text is
           // selected it grows to the full size of the window.
           if publisher.count > 50 {
-            Text(publisher.prefix(50)+"…").help(publisher)
+            Text(publisher.prefix(50) + "…").help(publisher)
           } else {
             Text(publisher)
           }


### PR DESCRIPTION
Firstly, limit the width of the publisher field so it can only grow to a max size and add the full text in a tooltop to allow the full string to be seen if needed.

![image](https://github.com/user-attachments/assets/332dd695-3878-4ec3-a89a-d0f4d21a48d7)
![image](https://github.com/user-attachments/assets/acde7204-8ac3-4ad3-8e0b-a8de86dd9262)

Secondly, if the publisher field is a 'Developer ID Application' cert, don't show the OrgName and CommonName fields as the OrgName is really the useful part

![image](https://github.com/user-attachments/assets/8b0b515e-0fb1-4621-93d7-801f09ec8d2c)