### PR TITLE
Add RuleType FAA config to replace InvertProcessExceptions

### DIFF
--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -39,7 +39,8 @@ enum class WatchItemRuleType {
 static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType = WatchItemPathType::kLiteral;
 static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
-static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType = WatchItemRuleType::kPathsWithAllowedProcesses;
+static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType =
+  WatchItemRuleType::kPathsWithAllowedProcesses;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 
@@ -101,9 +102,8 @@ struct WatchItemPolicy {
     // for equality purposes
     return name == other.name && version == other.version && path == other.path &&
            path_type == other.path_type && allow_read_access == other.allow_read_access &&
-           audit_only == other.audit_only &&
-           rule_type == other.rule_type && silent == other.silent &&
-           silent_tty == other.silent_tty && processes == other.processes;
+           audit_only == other.audit_only && rule_type == other.rule_type &&
+           silent == other.silent && silent_tty == other.silent_tty && processes == other.processes;
   }
 
   bool operator!=(const WatchItemPolicy &other) const { return !(*this == other); }

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -32,15 +32,14 @@ enum class WatchItemPathType {
 };
 
 enum class WatchItemRuleType {
-  kFileWithProcessExceptions,
-  kFileWithTargetedProcesses,
+  kPathsWithAllowedProcesses,
+  kPathsWithDeniedProcesses,
 };
 
 static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType = WatchItemPathType::kLiteral;
 static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
-static constexpr bool kWatchItemPolicyDefaultInvertProcessExceptions = false;
-static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType = WatchItemRuleType::kFileWithProcessExceptions;
+static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType = WatchItemRuleType::kPathsWithAllowedProcesses;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -30,10 +31,16 @@ enum class WatchItemPathType {
   kLiteral,
 };
 
+enum class WatchItemRuleType {
+  kFileWithProcessExceptions,
+  kFileWithTargetedProcesses,
+};
+
 static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType = WatchItemPathType::kLiteral;
 static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
 static constexpr bool kWatchItemPolicyDefaultInvertProcessExceptions = false;
+static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType = WatchItemRuleType::kFileWithProcessExceptions;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 
@@ -70,7 +77,7 @@ struct WatchItemPolicy {
                   WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
                   bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                   bool ao = kWatchItemPolicyDefaultAuditOnly,
-                  bool ipe = kWatchItemPolicyDefaultInvertProcessExceptions,
+                  WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
                   bool esm = kWatchItemPolicyDefaultEnableSilentMode,
                   bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode, std::string_view cm = "",
                   NSString *edu = nil, NSString *edt = nil, std::vector<Process> procs = {})
@@ -80,7 +87,7 @@ struct WatchItemPolicy {
         path_type(pt),
         allow_read_access(ara),
         audit_only(ao),
-        invert_process_exceptions(ipe),
+        rule_type(rt),
         silent(esm),
         silent_tty(estm),
         custom_message(cm.length() == 0 ? std::nullopt : std::make_optional<std::string>(cm)),
@@ -96,7 +103,7 @@ struct WatchItemPolicy {
     return name == other.name && version == other.version && path == other.path &&
            path_type == other.path_type && allow_read_access == other.allow_read_access &&
            audit_only == other.audit_only &&
-           invert_process_exceptions == other.invert_process_exceptions && silent == other.silent &&
+           rule_type == other.rule_type && silent == other.silent &&
            silent_tty == other.silent_tty && processes == other.processes;
   }
 
@@ -108,7 +115,7 @@ struct WatchItemPolicy {
   WatchItemPathType path_type;
   bool allow_read_access;
   bool audit_only;
-  bool invert_process_exceptions;
+  WatchItemRuleType rule_type;
   bool silent;
   bool silent_tty;
   std::optional<std::string> custom_message;

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -40,6 +40,7 @@ extern NSString *const kWatchItemConfigKeyOptions;
 extern NSString *const kWatchItemConfigKeyOptionsAllowReadAccess;
 extern NSString *const kWatchItemConfigKeyOptionsAuditOnly;
 extern NSString *const kWatchItemConfigKeyOptionsInvertProcessExceptions;
+extern NSString *const kWatchItemConfigKeyOptionsRuleType;
 extern NSString *const kWatchItemConfigKeyOptionsEnableSilentMode;
 extern NSString *const kWatchItemConfigKeyOptionsEnableSilentTTYMode;
 extern NSString *const kWatchItemConfigKeyOptionsCustomMessage;

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -524,7 +524,8 @@ bool ParseConfigSingleWatchItem(NSString *name, std::string_view policy_version,
 
   WatchItemRuleType rule_type = kWatchItemPolicyDefaultRuleType;
   if (options[kWatchItemConfigKeyOptionsRuleType]) {
-    rule_type = GetRuleType(options[kWatchItemConfigKeyOptionsRuleType]).value_or(kWatchItemPolicyDefaultRuleType);
+    rule_type = GetRuleType(options[kWatchItemConfigKeyOptionsRuleType])
+                  .value_or(kWatchItemPolicyDefaultRuleType);
   } else if (options[kWatchItemConfigKeyOptionsInvertProcessExceptions]) {
     // Convert deprecated config option to the new WatchItemRuleType option
     if ([options[kWatchItemConfigKeyOptionsInvertProcessExceptions] boolValue]) {
@@ -537,8 +538,7 @@ bool ParseConfigSingleWatchItem(NSString *name, std::string_view policy_version,
   for (const PathAndTypePair &path_type_pair : std::get<PathAndTypeVec>(path_list)) {
     policies.push_back(std::make_shared<WatchItemPolicy>(
       NSStringToUTF8StringView(name), policy_version, path_type_pair.first, path_type_pair.second,
-      allow_read_access, audit_only, rule_type, enable_silent_mode,
-      enable_silent_tty_mode,
+      allow_read_access, audit_only, rule_type, enable_silent_mode, enable_silent_tty_mode,
       NSStringToUTF8StringView(options[kWatchItemConfigKeyOptionsCustomMessage]),
       options[kWatchItemConfigKeyOptionsEventDetailURL],
       options[kWatchItemConfigKeyOptionsEventDetailText], std::get<PolicyProcessVec>(proc_list)));

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -37,8 +37,8 @@
 
 using santa::kWatchItemPolicyDefaultAllowReadAccess;
 using santa::kWatchItemPolicyDefaultAuditOnly;
-using santa::kWatchItemPolicyDefaultRuleType;
 using santa::kWatchItemPolicyDefaultPathType;
+using santa::kWatchItemPolicyDefaultRuleType;
 using santa::Unit;
 using santa::WatchItemPathType;
 using santa::WatchItemPolicy;
@@ -80,12 +80,12 @@ class WatchItemsPeer : public WatchItems {
 
 }  // namespace santa
 
+using santa::GetRuleType;
 using santa::IsWatchItemNameValid;
 using santa::ParseConfig;
 using santa::ParseConfigSingleWatchItem;
 using santa::VerifyConfigWatchItemPaths;
 using santa::VerifyConfigWatchItemProcesses;
-using santa::GetRuleType;
 using santa::WatchItemsPeer;
 
 static constexpr std::string_view kBadPolicyName("__BAD_NAME__");
@@ -811,38 +811,49 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     // Check other option keys
 
     // kWatchItemConfigKeyOptionsRuleType - Invalid type
-    XCTAssertFalse(ParseConfigSingleWatchItem(@"", "", @{
-      kWatchItemConfigKeyPaths : @[ @"a" ],
-      kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @[]}
-    },
-    policies, &err));
+    XCTAssertFalse(ParseConfigSingleWatchItem(
+      @"", "", @{
+        kWatchItemConfigKeyPaths : @[ @"a" ],
+        kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @[]}
+      },
+      policies, &err));
 
     // kWatchItemConfigKeyOptionsRuleType - Invalid RuleType value
-    XCTAssertFalse(ParseConfigSingleWatchItem(@"", "", @{
-      kWatchItemConfigKeyPaths : @[ @"a" ],
-      kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @"InvalidValue"}
-    },
-    policies, &err));
+    XCTAssertFalse(ParseConfigSingleWatchItem(
+      @"", "", @{
+        kWatchItemConfigKeyPaths : @[ @"a" ],
+        kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @"InvalidValue"}
+      },
+      policies, &err));
 
-    // kWatchItemConfigKeyOptionsRuleType - Override kWatchItemConfigKeyOptionsInvertProcessExceptions
+    // kWatchItemConfigKeyOptionsRuleType - Override
+    // kWatchItemConfigKeyOptionsInvertProcessExceptions
     policies.clear();
-    XCTAssertTrue(ParseConfigSingleWatchItem(@"", "", @{
-      kWatchItemConfigKeyPaths : @[ @"a" ],
-      kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @"PathsWithAllowedProcesses", kWatchItemConfigKeyOptionsInvertProcessExceptions: @(YES)}
-    },
-    policies, &err));
+    XCTAssertTrue(ParseConfigSingleWatchItem(
+      @"", "", @{
+        kWatchItemConfigKeyPaths : @[ @"a" ],
+        kWatchItemConfigKeyOptions : @{
+          kWatchItemConfigKeyOptionsRuleType : @"PathsWithAllowedProcesses",
+          kWatchItemConfigKeyOptionsInvertProcessExceptions : @(YES)
+        }
+      },
+      policies, &err));
     XCTAssertEqual(policies.size(), 1);
-    XCTAssertEqual(policies[0].get()->rule_type, santa::WatchItemRuleType::kPathsWithAllowedProcesses);
+    XCTAssertEqual(policies[0].get()->rule_type,
+                   santa::WatchItemRuleType::kPathsWithAllowedProcesses);
 
-    // kWatchItemConfigKeyOptionsRuleType - kWatchItemConfigKeyOptionsInvertProcessExceptions used as fallback
+    // kWatchItemConfigKeyOptionsRuleType - kWatchItemConfigKeyOptionsInvertProcessExceptions used
+    // as fallback
     policies.clear();
-    XCTAssertTrue(ParseConfigSingleWatchItem(@"", "", @{
-      kWatchItemConfigKeyPaths : @[ @"a" ],
-      kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsInvertProcessExceptions: @(YES)}
-    },
-    policies, &err));
+    XCTAssertTrue(ParseConfigSingleWatchItem(
+      @"", "", @{
+        kWatchItemConfigKeyPaths : @[ @"a" ],
+        kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsInvertProcessExceptions : @(YES)}
+      },
+      policies, &err));
     XCTAssertEqual(policies.size(), 1);
-    XCTAssertEqual(policies[0].get()->rule_type, santa::WatchItemRuleType::kPathsWithDeniedProcesses);
+    XCTAssertEqual(policies[0].get()->rule_type,
+                   santa::WatchItemRuleType::kPathsWithDeniedProcesses);
 
     // kWatchItemConfigKeyOptionsCustomMessage - Invalid type
     XCTAssertFalse(ParseConfigSingleWatchItem(
@@ -926,10 +937,12 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   XCTAssertEqual(policies.size(), 2);
   XCTAssertEqual(*policies[0].get(),
                  WatchItemPolicy("rule", kVersion, "a", kWatchItemPolicyDefaultPathType, true,
-                                 false, santa::WatchItemRuleType::kPathsWithDeniedProcesses, true, false, "", nil, nil, procs));
+                                 false, santa::WatchItemRuleType::kPathsWithDeniedProcesses, true,
+                                 false, "", nil, nil, procs));
   XCTAssertEqual(*policies[1].get(),
                  WatchItemPolicy("rule", kVersion, "b", WatchItemPathType::kPrefix, true, false,
-                                 santa::WatchItemRuleType::kPathsWithDeniedProcesses, true, false, "", nil, nil, procs));
+                                 santa::WatchItemRuleType::kPathsWithDeniedProcesses, true, false,
+                                 "", nil, nil, procs));
 }
 
 - (void)testState {

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -817,10 +817,10 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     },
     policies, &err));
 
-    // kWatchItemConfigKeyOptionsRuleType - Invalid rule type
+    // kWatchItemConfigKeyOptionsRuleType - Invalid RuleType value
     XCTAssertFalse(ParseConfigSingleWatchItem(@"", "", @{
       kWatchItemConfigKeyPaths : @[ @"a" ],
-      kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @"InvalidRule"}
+      kWatchItemConfigKeyOptions : @{kWatchItemConfigKeyOptionsRuleType : @"InvalidValue"}
     },
     policies, &err));
 
@@ -843,7 +843,6 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     policies, &err));
     XCTAssertEqual(policies.size(), 1);
     XCTAssertEqual(policies[0].get()->rule_type, santa::WatchItemRuleType::kPathsWithDeniedProcesses);
-    NSLog(@"got err: %@", err);
 
     // kWatchItemConfigKeyOptionsCustomMessage - Invalid type
     XCTAssertFalse(ParseConfigSingleWatchItem(

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -635,10 +635,10 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
     }
   }
 
-  // If the `invert_process_exceptions` option is set, the decision should be
+  // If the `RuleType` option is set, the decision should be
   // inverted from allowed to denied or vice versa. Note that this inversion
   // must be made prior to checking the policy's audit-only flag.
-  if (policy->invert_process_exceptions) {
+  if (policy->rule_type == santa::WatchItemRuleType::kFileWithTargetedProcesses) {
     if (decision == FileAccessPolicyDecision::kAllowed) {
       decision = FileAccessPolicyDecision::kDenied;
     } else {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -635,10 +635,11 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
     }
   }
 
-  // If the `RuleType` option is set, the decision should be
-  // inverted from allowed to denied or vice versa. Note that this inversion
-  // must be made prior to checking the policy's audit-only flag.
-  if (policy->rule_type == santa::WatchItemRuleType::kFileWithTargetedProcesses) {
+  // If the RuleType option was configured to contain a list of denied processes,
+  // the decision should be inverted from allowed to denied or vice versa.
+  // Note that this inversion must be made prior to checking the policy's
+  // audit-only flag.
+  if (policy->rule_type == santa::WatchItemRuleType::kPathsWithDeniedProcesses) {
     if (decision == FileAccessPolicyDecision::kAllowed) {
       decision = FileAccessPolicyDecision::kDenied;
     } else {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -683,10 +683,12 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
                    FileAccessPolicyDecision::kAllowedAuditOnly);
   }
 
-  // The remainder of the tests set the policy's `invert_process_exceptions` option
-  policy->invert_process_exceptions = true;
+  // The remainder of the tests set the policy's `rule_type` option to
+  // invert process exceptions
+  policy->rule_type = santa::WatchItemRuleType::kPathsWithDeniedProcesses;
 
-  // If no exceptions for inverted policy, operations are allowed
+  // If the policy wasn't matched, but the rule type specifies denied processes,
+  // then the operation should be allowed.
   {
     OCMExpect([accessClientMock policyProcess:policyProc matchesESProcess:&esProc])
       .ignoringNonObjectArgs()
@@ -698,8 +700,8 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
                    FileAccessPolicyDecision::kAllowed);
   }
 
-  // For audit only policies with no exception matches and inverted exceptions, operations are
-  // allowed
+  // For audit only policies with no process match and the rule type specifies
+  // denied processes, operations are allowed.
   {
     OCMExpect([accessClientMock policyProcess:policyProc matchesESProcess:&esProc])
       .ignoringNonObjectArgs()
@@ -711,8 +713,8 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
                    FileAccessPolicyDecision::kAllowed);
   }
 
-  // For audit only policies with exception match and inverted exceptions, operations are allowed
-  // audit only
+  // For audit only policies with matched process details and the rule type specifies
+  // denied processes, operations are allowed audit only.
   {
     OCMExpect([accessClientMock policyProcess:policyProc matchesESProcess:&esProc])
       .ignoringNonObjectArgs()
@@ -722,6 +724,19 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
                                    forTarget:target
                                    toMessage:Message(mockESApi, &esMsg)],
                    FileAccessPolicyDecision::kAllowedAuditOnly);
+  }
+
+  // For policies with matched process details and the rule type specifies
+  // denied processes, operations are denied.
+  {
+    OCMExpect([accessClientMock policyProcess:policyProc matchesESProcess:&esProc])
+      .ignoringNonObjectArgs()
+      .andReturn(true);
+    policy->audit_only = false;
+    XCTAssertEqual([accessClient applyPolicy:optionalPolicy
+                                   forTarget:target
+                                   toMessage:Message(mockESApi, &esMsg)],
+                   FileAccessPolicyDecision::kDenied);
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -16,31 +16,32 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 
 ## Configuration
 
-| Key                       | Parent       | Type       | Required | Santa Version | Description |
-| :------------------------ | :----------- | :--------- | :------- | :------------ | :---------- |
-| `Version`                 | `<Root>`     | String     | Yes      | v2023.1+      | Version of the configuration. Will be reported in events. |
-| `EventDetailURL`          | `<Root>`     | String     | No       | v2023.8+      | When the user gets a block notification, a button can be displayed which will take them to a web page with more information about that event. This URL will be used for all rules unless overridden by a rule-specific option. See the [EventDetailURL](#eventdetailurl) section below.  |
-| `EventDetailText`         | `<Root>`     | String     | No       | v2023.8+      | Related to `EventDetailURL`, controls the button text that will be displayed. (max length = 48 chars) |
-| `WatchItems`              | `<Root>`     | Dictionary | No       | v2023.1+      | The set of configuration items that will be monitored by Santa. |
-| `<Name>`                  | `WatchItems` | Dictionary | No       | v2023.1+      | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (i.e., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
-| `Paths`                   | `<Name>`     | Array      | Yes      | v2023.1+      | A list of either String or Dictionary types that contain path globs to monitor. String type entires will have default values applied for the attributes that can be manually set with the Dictionary type. |
-| `Path`                    | `Paths`      | String     | Yes      | v2023.1+      | The path glob to monitor. |
-| `IsPrefix`                | `Paths`      | Boolean    | No       | v2023.1+      | Whether or not the path glob represents a prefix path. (Default = `false`) |
-| `Options`                 | `<Name>`     | Dictionary | No       | v2023.1+      | Customizes the actions for a given rule. |
-| `AllowReadAccess`         | `Options`    | Boolean    | No       | v2023.1+      | If true, indicates the rule will **not** be applied to actions that are read-only access (e.g., opening a watched path for reading, or cloning a watched path). If false, the rule will apply both to read-only access and access that could modify the watched path. (Default = `false`) |
-| `AuditOnly`               | `Options`    | Boolean    | No       | v2023.1+      | If true, operations violating the rule will only be logged. If false, operations violating the rule will be denied and logged. (Default = `true`) |
-| `InvertProcessExceptions` | `Options`    | Boolean    | No       | v2023.5+      | If true, logic is inverted for the list of processes defined by the `Processes` key such that the list becomes the set of processes that will be denied or allowed but audited. (Default = `false`) |
-| `EnableSilentMode`        | `Options`    | String     | No       | v2023.7+      | If true, Santa will not display a GUI dialog when this rule is violated. |
-| `EnableSilentTTYMode`     | `Options`    | String     | No       | v2023.7+      | If true, Santa will not post a message to the controlling TTY when this rule is violated. |
-| `EventDetailURL`          | `Options`    | String     | No       | v2023.8+      | Rule-specific URL that overrides the top-level `EventDetailURL`. |
-| `EventDetailText`         | `Options`    | String     | No       | v2023.8+      | Rule-specific button text that overrides the top-level `EventDetailText`. |
-| `Processes`               | `<Name>`     | Array      | No       | v2023.1+      | A list of dictionaries defining processes that are allowed to access paths matching the globs defined with the `Paths` key. For a process performing the operation to be considered a match, it must match all defined attributes of at least one entry in the list. |
-| `BinaryPath`              | `Processes`  | String     | No       | v2023.1+      | A path literal that an instigating process must be executed from. |
-| `TeamID`                  | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
-| `CertificateSha256`       | `Processes`  | String     | No       | v2023.1+      | SHA256 of the leaf certificate of the instigating process. |
-| `CDHash`                  | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
-| `SigningID`               | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. |
-| `PlatformBinary`          | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
+| Key                           | Parent       | Type       | Required | Santa Version | Description |
+| :---------------------------- | :----------- | :--------- | :------- | :------------ | :---------- |
+| `Version`                     | `<Root>`     | String     | Yes      | v2023.1+      | Version of the configuration. Will be reported in events. |
+| `EventDetailURL`              | `<Root>`     | String     | No       | v2023.8+      | When the user gets a block notification, a button can be displayed which will take them to a web page with more information about that event. This URL will be used for all rules unless overridden by a rule-specific option. See the [EventDetailURL](#eventdetailurl) section below.  |
+| `EventDetailText`             | `<Root>`     | String     | No       | v2023.8+      | Related to `EventDetailURL`, controls the button text that will be displayed. (max length = 48 chars) |
+| `WatchItems`                  | `<Root>`     | Dictionary | No       | v2023.1+      | The set of configuration items that will be monitored by Santa. |
+| `<Name>`                      | `WatchItems` | Dictionary | No       | v2023.1+      | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (i.e., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
+| `Paths`                       | `<Name>`     | Array      | Yes      | v2023.1+      | A list of either String or Dictionary types that contain path globs to monitor. String type entires will have default values applied for the attributes that can be manually set with the Dictionary type. |
+| `Path`                        | `Paths`      | String     | Yes      | v2023.1+      | The path glob to monitor. |
+| `IsPrefix`                    | `Paths`      | Boolean    | No       | v2023.1+      | Whether or not the path glob represents a prefix path. (Default = `false`) |
+| `Options`                     | `<Name>`     | Dictionary | No       | v2023.1+      | Customizes the actions for a given rule. |
+| `AllowReadAccess`             | `Options`    | Boolean    | No       | v2023.1+      | If true, indicates the rule will **not** be applied to actions that are read-only access (e.g., opening a watched path for reading, or cloning a watched path). If false, the rule will apply both to read-only access and access that could modify the watched path. (Default = `false`) |
+| `AuditOnly`                   | `Options`    | Boolean    | No       | v2023.1+      | If true, operations violating the rule will only be logged. If false, operations violating the rule will be denied and logged. (Default = `true`) |
+| ~~`InvertProcessExceptions`~~ | `Options`    | Boolean    | No       | v2023.5+      | DEPRECATED. Please use `RuleType` instead. If false, behaves like `RuleType` `PathsWithAllowedProcesses`. If true, behaves like `RuleType` `PathsWithDeniedProcesses`. This setting is overriden if `RuleType` is set. |
+| `RuleType`                    | `Options`    | String     | No       | v2024.11      | Defines how `Paths` and `Processes` are interpreted.<br />`PathsWithAllowedProcesses`: Default. Access to the defined `Paths` will be denied (or audited) for all processes that **don't match** items in the `Processes` array.<br />`PathsWithDeniedProcesses`: Access to the defined `Paths` will be denied (or audited) for all processes that **match** items in the `Processes` array. |
+| `EnableSilentMode`            | `Options`    | Boolean    | No       | v2023.7+      | If true, Santa will not display a GUI dialog when this rule is violated. |
+| `EnableSilentTTYMode`         | `Options`    | Boolean    | No       | v2023.7+      | If true, Santa will not post a message to the controlling TTY when this rule is violated. |
+| `EventDetailURL`              | `Options`    | String     | No       | v2023.8+      | Rule-specific URL that overrides the top-level `EventDetailURL`. |
+| `EventDetailText`             | `Options`    | String     | No       | v2023.8+      | Rule-specific button text that overrides the top-level `EventDetailText`. |
+| `Processes`                   | `<Name>`     | Array      | No       | v2023.1+      | A list of dictionaries defining processes that are allowed to access paths matching the globs defined with the `Paths` key. For a process performing the operation to be considered a match, it must match all defined attributes of at least one entry in the list. |
+| `BinaryPath`                  | `Processes`  | String     | No       | v2023.1+      | A path literal that an instigating process must be executed from. |
+| `TeamID`                      | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
+| `CertificateSha256`           | `Processes`  | String     | No       | v2023.1+      | SHA256 of the leaf certificate of the instigating process. |
+| `CDHash`                      | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
+| `SigningID`                   | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. |
+| `PlatformBinary`              | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
 
 ### EventDetailURL
 When the user gets a file access block notification, a button can be displayed


### PR DESCRIPTION
`InvertProcessExceptions` is being deprecated in favor of a new `RuleType` config option. This PR defines two RuleType values to keep parity with previous configs:

* `PathsWithAllowedProcesses`: Equates to `InvertProcessExceptions` being set to `false`
* `PathsWithDeniedProcesses`: Equates to `InvertProcessExceptions` being set to `true`

This new configuration is being introduced to support upcoming process-centric FAA rules.