### PR TITLE
GUI: Add SNTTestGUI for doing manual testing of the UI

### DIFF
--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -78,7 +78,7 @@ static id ValueOrNull(id value) {
     message = customMessage;
   } else if (event.decision == SNTEventStateBlockUnknown) {
     message = [[SNTConfigurator configurator] unknownBlockMessage];
-    if (!message) {
+    if (!message.length) {
       message = NSLocalizedString(
         @"The following application has been blocked from executing<br />because its "
         @"trustworthiness cannot be determined",
@@ -86,7 +86,7 @@ static id ValueOrNull(id value) {
     }
   } else {
     message = [[SNTConfigurator configurator] bannedBlockMessage];
-    if (!message) {
+    if (!message.length) {
       message = NSLocalizedString(
         @"The following application has been blocked from<br />executing because it has been "
         @"deemed malicious",

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -683,6 +683,13 @@
 + (instancetype)configurator NS_SWIFT_NAME(configurator());
 
 ///
+///  Replace the shared configurator with a custom one using a static config.
+///
+#ifdef DEBUG
++ (void)overrideConfig:(NSDictionary *)config;
+#endif
+
+///
 ///  Clear the sync server configuration from the effective configuration.
 ///
 - (void)clearSyncState;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -312,7 +312,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 // The object returned is guaranteed to exist for the lifetime of the process so there's no need
 // to do this handling.
 static SNTConfigurator *sharedConfigurator = nil;
-+ (instancetype)configurator {
++ (__unsafe_unretained instancetype)configurator {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     sharedConfigurator = [[SNTConfigurator alloc] init];

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -311,14 +311,30 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 // The returned value is marked unsafe_unretained to avoid unnecessary retain/release handling.
 // The object returned is guaranteed to exist for the lifetime of the process so there's no need
 // to do this handling.
-+ (__unsafe_unretained instancetype)configurator {
-  static SNTConfigurator *sharedConfigurator;
+static SNTConfigurator *sharedConfigurator = nil;
++ (instancetype)configurator {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     sharedConfigurator = [[SNTConfigurator alloc] init];
   });
   return sharedConfigurator;
 }
+
+#ifdef DEBUG
+- (instancetype)initWithStaticConfig:(NSDictionary *)config {
+  self = [super init];
+  if (self) {
+    _configState = [config mutableCopy];
+    _syncState = [config mutableCopy];
+  }
+  return self;
+}
+
++ (void)overrideConfig:(NSDictionary *)config {
+  (void)[SNTConfigurator configurator];  // burn the onceToken
+  sharedConfigurator = [[SNTConfigurator alloc] initWithStaticConfig:config];
+}
+#endif
 
 + (NSSet *)syncAndConfigStateSet {
   static NSSet *set;

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -149,6 +149,30 @@ macos_application(
     deps = [":SantaGUI_lib"],
 )
 
+swift_library(
+    name = "SNTTestGUI_lib",
+    srcs = ["SNTTestGUI.swift"],
+    deps = [
+        ":SNTBinaryMessageWindowView",
+        ":SNTDeviceMessageWindowView",
+        ":SNTFileAccessMessageWindowView",
+        ":SNTMessageView",
+        "//Source/common:SNTDeviceEvent",
+    ],
+)
+
+macos_application(
+    name = "SNTTestGUI",
+    app_icons = glob(["Resources/Images.xcassets/**"]),
+    bundle_id = "com.northpolesec.santatestgui",
+    bundle_name = "SantaTestGUI",
+    infoplists = ["Info.plist"],
+    minimum_os_version = "14.0",
+    strings = glob(["Resources/**/*.strings"]),
+    version = "//:version",
+    deps = [":SNTTestGUI_lib"],
+)
+
 santa_unit_test(
     name = "SNTNotificationManagerTest",
     srcs = [

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -288,7 +288,7 @@ struct SNTBinaryMessageWindowView: View {
         }
 
         HStack(spacing: 15.0) {
-          if c.eventDetailURL != nil
+          if c.eventDetailURL.count > 0
             && !(event?.needsBundleHash ?? false && !bundleProgress.isFinished)
           {
             OpenEventButton(customText: c.eventDetailText, action: openButton)

--- a/Source/gui/SNTTestGUI.swift
+++ b/Source/gui/SNTTestGUI.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+import santa_common_SNTConfigurator
+import santa_common_SNTDeviceEvent
+import santa_common_SNTStoredEvent
+import Source_gui_SNTDeviceMessageWindowView
+import Source_gui_SNTBinaryMessageWindowView
+
+func ShowWindow(_ vc: NSViewController, _ window: NSWindow) {
+  window.contentRect(forFrameRect: NSMakeRect(0, 0, 0, 0))
+  window.styleMask = [.closable, .resizable, .titled]
+  window.backingType = .buffered
+  window.titlebarAppearsTransparent = true
+  window.isMovableByWindowBackground = true
+  window.standardWindowButton(.zoomButton)?.isHidden = true
+  window.standardWindowButton(.closeButton)?.isHidden = true
+  window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+  window.contentViewController = vc
+  window.makeKeyAndOrderFront(nil)
+  window.setFrame(window.frame, display: true)
+  window.center()
+}
+
+class SNTDebugStoredEvent: SNTStoredEvent {
+  let staticPublisher: String
+
+  override var publisherInfo: String {
+    get {
+      return self.staticPublisher
+    }
+  }
+
+  init(staticPublisher: String) {
+    self.staticPublisher = staticPublisher
+    super.init()
+  }
+
+  required init(coder: NSCoder) {
+    self.staticPublisher = ""
+    super.init(coder: coder)!
+  }
+}
+
+struct BinaryView: View {
+  @State var application: String = "Bad Malware"
+  @State var publisher: String = "Developer ID: Cozy Bear (X4P54F4992)"
+  @State var sha256: String = "60055b1f6fb276bfacf61f91505a72201987f20ad8b6867cce3058f4c0f0f5e5"
+  @State var cdhash: String = "e38e71023d09c2e8e78a0e382669d1338ee8876a"
+  @State var teamID: String = "9X9633G7QW"
+  @State var path: String = "/Applications/Malware.app/Contents/MacOS"
+  @State var parent: String = "launchd"
+  @State var ppid: String = "1"
+
+  @State var bannedBlockMessage: String = ""
+  @State var eventDetailURL: String = "http://sync-server-hostname/blockables/%bundle_or_file_identifier%"
+
+  @State var customMsg: String = ""
+  @State var customURL: String = ""
+
+  var body: some View {
+    VStack(spacing: 15.0) {
+      GroupBox(label: Label("Event Properties", systemImage: "")) {
+        Form {
+          TextField(text: $application, label: { Text("Application") })
+          TextField(text: $publisher, label: { Text("Publisher") })
+          TextField(text: $sha256, label: { Text("SHA-256") })
+          TextField(text: $cdhash, label: { Text("CDHash") })
+          TextField(text: $teamID, label: { Text("TeamID") })
+          TextField(text: $path, label: { Text("Path") })
+          TextField(text: $parent, label: { Text("Parent") })
+          TextField(text: $ppid, label: { Text("PPID") })
+        }
+      }
+
+      Spacer()
+
+      GroupBox(label: Label("Config Overrides", systemImage: "")) {
+        Form {
+          HStack {
+            TextField(text: $bannedBlockMessage, label: { Text("Banned Block Message") })
+            Button(action: {
+              bannedBlockMessage =
+                "<img src='https://static.wikia.nocookie.net/villains/images/8/8a/Robot_Santa.png/revision/latest?cb=20200520230856' /><br /><br />Isn't Santa fun?"
+            }) {
+              Text("Populate (With Image)").font(Font.subheadline)
+            }
+            Button(action: { bannedBlockMessage = "You may not run this thing" }) {
+              Text("Populate (1-line)").font(Font.subheadline)
+            }
+            Button(action: { bannedBlockMessage = "" }) { Text("Clear").font(Font.subheadline) }
+          }
+
+          HStack {
+            TextField(text: $eventDetailURL, label: { Text("Event Detail URL") })
+            Button(action: { eventDetailURL = "http://sync-server-hostname/blockables/%bundle_or_file_identifier%" }) {
+              Text("Populate").font(Font.subheadline)
+            }
+            Button(action: { eventDetailURL = "" }) { Text("Clear").font(Font.subheadline) }
+          }
+        }
+      }
+
+      Button("Display") {
+        SNTConfigurator.overrideConfig([
+          "BannedBlockMessage": bannedBlockMessage,
+          "EventDetailURL": eventDetailURL,
+        ])
+
+        let event = SNTDebugStoredEvent(staticPublisher: publisher)
+        event.fileBundleName = application
+        event.fileSHA256 = sha256
+        event.cdhash = cdhash
+        event.teamID = teamID
+        event.filePath = path
+        event.parentName = parent
+        event.pid = 12345
+        event.ppid = NSNumber(value: Int(ppid) ?? 1)
+        event.executingUser = NSUserName()
+
+        let window = NSWindow()
+        ShowWindow(
+          SNTBinaryMessageWindowViewFactory.createWith(
+            window: window,
+            event: event,
+            customMsg: customMsg as NSString?,
+            customURL: customURL as NSString?,
+            bundleProgress: SNTBundleProgress(),
+            uiStateCallback: { interval in print("Silence interval was set to \(interval)") }
+          ),
+          window
+        )
+      }
+    }
+  }
+}
+
+struct FAAView: View {
+  var body: some View {
+    VStack {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundStyle(.tint)
+      Text("Hello, world!")
+    }
+  }
+}
+
+struct DeviceView: View {
+  @State private var device: String = "SANDISK CRUZER"
+  @State private var remountArgs: String = "rdonly"
+
+  @State private var remountUSBMode: String = "rdonly,noexec"
+  @State private var remountUSBBlockMessage: String = ""
+  @State private var bannedUSBBlockMessage: String = ""
+
+  var body: some View {
+    VStack {
+      GroupBox(label: Label("Event Properties", systemImage: "")) {
+        TextField(text: $device, label: { Text("Device") })
+        TextField(text: $remountArgs, label: { Text("Remount Args (comma-separated)") })
+
+      }
+      GroupBox(label: Label("Config Overrides", systemImage: "")) {
+        TextField(text: $remountUSBMode, label: { Text("RemountUSBMode (comma-separated)") })
+        TextField(text: $remountUSBBlockMessage, label: { Text("RemountUSB Block Message") })
+        TextField(text: $bannedUSBBlockMessage, label: { Text("Banned Block Message") })
+      }
+
+      Button("Display") {
+        let event = SNTDeviceEvent()
+        event.mntonname = device
+        event.remountArgs = remountArgs.components(separatedBy: ",")
+
+        SNTConfigurator.overrideConfig([
+          "RemountUSBBlockMessage": remountUSBBlockMessage,
+          "BannedUSBBlockMessage": bannedUSBBlockMessage,
+        ])
+
+        let window = NSWindow()
+        ShowWindow(SNTDeviceMessageWindowViewFactory.createWith(window: window, event: event), window)
+      }
+    }
+  }
+}
+
+struct ContentView: View {
+  var body: some View {
+    TabView {
+      BinaryView().padding(15.0).tabItem({ Text("Binary") })
+      FAAView().padding(15.0).tabItem({ Text("FAA") })
+      DeviceView().padding(15.0).tabItem({ Text("Device") })
+    }
+  }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate()
+  }
+}
+
+@main
+struct testApp: App {
+  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+  var body: some Scene {
+    Window("Main Window", id: "main") {
+      ContentView()
+    }
+  }
+}
+

--- a/Source/gui/SNTTestGUI.swift
+++ b/Source/gui/SNTTestGUI.swift
@@ -210,4 +210,3 @@ struct testApp: App {
     }
   }
 }
-

--- a/Testing/localization.py
+++ b/Testing/localization.py
@@ -11,6 +11,7 @@ def regen_base_localization():
   """Re-generation the English localization file using genstrings."""
   files_to_localize = [
       f.as_posix() for f in pathlib.Path('Source/gui').glob('*.swift')
+      if f.name not in ['SNTTestGUI.swift']
   ]
   files_to_localize.append('Source/common/SNTBlockMessage.m')
 


### PR DESCRIPTION
So far this is mostly useful for the Binary message window, though there is some rudimentary support for Device messages too. Before I finish that I wanted to get something up.

Run with `bazel run //Source/gui:SNTTestGUI`