### PR TITLE
config: services now watch for config changes

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1308,9 +1308,9 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 }
 
 - (void)startWatchingDefaults {
-  // Only com.northpolesec.santa.daemon should listen.
+  // santactl is not a long running daemon, it does not need to watch for config changes.
   NSString *processName = [[NSProcessInfo processInfo] processName];
-  if (![processName isEqualToString:@"com.northpolesec.santa.daemon"]) return;
+  if ([processName isEqualToString:@"santactl"]) return;
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(defaultsChanged:)
                                                name:NSUserDefaultsDidChangeNotification

--- a/Source/santasyncservice/SNTSyncService.m
+++ b/Source/santasyncservice/SNTSyncService.m
@@ -16,6 +16,7 @@
 
 #import <MOLXPCConnection/MOLXPCConnection.h>
 
+#import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTDropRootPrivs.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTXPCControlInterface.h"
@@ -48,6 +49,11 @@
       LOGE(@"Failed to drop root privileges. Exiting.");
       exit(1);
     }
+
+    // Initialize SNTConfigurator ONLY after privileges have been dropped.
+    [SNTConfigurator configurator];
+    NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
+    LOGI(@"Started, version %@", infoDict[@"CFBundleVersion"]);
 
     // Dropping root privileges to the 'nobody' user causes the default NSURLCache to throw
     // sandbox errors, which are benign but annoying. This line disables the cache entirely.

--- a/Source/santasyncservice/main.m
+++ b/Source/santasyncservice/main.m
@@ -16,14 +16,16 @@
 
 #import <MOLXPCConnection/MOLXPCConnection.h>
 
-#import "Source/common/SNTLogging.h"
 #import "Source/common/SNTXPCSyncServiceInterface.h"
 #import "Source/santasyncservice/SNTSyncService.h"
 
 int main(int argc, const char *argv[]) {
   @autoreleasepool {
-    NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
-    LOGI(@"Started, version %@", infoDict[@"CFBundleVersion"]);
+    // The LOG* functions make use of SNTConfigurator, which if initialized now will fail to update
+    // values after SNTSyncService drops privileges. Since SNTConfigurator is a singleton, we need
+    // to initialize it after privileges are dropped. To that end, don't log until after privileges
+    // are dropped.
+
     MOLXPCConnection *c =
       [[MOLXPCConnection alloc] initServerWithName:[SNTXPCSyncServiceInterface serviceID]];
     c.privilegedInterface = c.unprivilegedInterface =


### PR DESCRIPTION
Previously we had limited watching for config changes to only `com.northpolesec.santa.daemon`. This was because the other major consumer, `santasyncservice`, received an empty config when the config changed. It turns out this was due to the `NSUserDefaults`, by way of the `SNTConfigurator` singleton, being initialized before `santasyncservice` drops its root privileges.

This CL enables `santasyncservice`, and the other services, to watch for config changes.

It also fixes the bug described above in `santasyncservice`, `SNTConfigurator` is now initialized after dropping privileges.