### PR TITLE
Support protobuf tests up to ES message version 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ tulsigen-*
 compile_commands.json
 .cache/
 .vscode/*
-.zed/*
+.zed**

--- a/Source/common/TestUtils.mm
+++ b/Source/common/TestUtils.mm
@@ -119,12 +119,7 @@ void SleepMS(long ms) {
 }
 
 uint32_t MaxSupportedESMessageVersionForCurrentOS() {
-  // Note 1: This function only returns a subset of versions. This is due to the
-  // minimum supported OS build version as well as features in latest versions
-  // not currently being used. Capping the max means unnecessary duuplicate test
-  // JSON files are not needed.
-  //
-  // Note 2: The following table maps ES message versions to lmin macOS version:
+  // Note: The following table maps ES message versions to min macOS version:
   //   ES Version | macOS Version
   //            1 | 10.15.0
   //            2 | 10.15.4
@@ -132,9 +127,13 @@ uint32_t MaxSupportedESMessageVersionForCurrentOS() {
   //            4 | 11.0
   //            5 | 12.3
   //            6 | 13.0
-  //            7 | 14.0
+  //            7 | 13.3
   //            8 | 15.0
-  if (@available(macOS 13.0, *)) {
+  if (@available(macOS 15.0, *)) {
+    return 8;
+  } else if (@available(macOS 13.3, *)) {
+    return 7;
+  } else if (@available(macOS 13.0, *)) {
     return 6;
   } else if (@available(macOS 12.3, *)) {
     return 5;

--- a/Source/santad/testdata/protobuf/v7/allowlist.json
+++ b/Source/santad/testdata/protobuf/v7/allowlist.json
@@ -1,0 +1,61 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2
+  },
+  "effective_group": {
+   "gid": -1
+  },
+  "real_user": {
+   "uid": -2
+  },
+  "real_group": {
+   "gid": -1
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "path": "close_file",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2
+   },
+   "group": {
+    "gid": -1
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  },
+  "hash": {
+   "type": "HASH_ALGO_SHA256",
+   "hash": "hash_value"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/close.json
+++ b/Source/santad/testdata/protobuf/v7/close.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "path": "close_file",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "modified": true
+}

--- a/Source/santad/testdata/protobuf/v7/cs_invalidated.json
+++ b/Source/santad/testdata/protobuf/v7/cs_invalidated.json
@@ -1,0 +1,35 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v7/exchangedata.json
@@ -1,0 +1,91 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "file1": {
+  "path": "exchange_file_1",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "file2": {
+  "path": "exchange_file_1",
+  "truncated": false,
+  "stat": {
+   "dev": 401,
+   "mode": 402,
+   "nlink": 403,
+   "ino": "404",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 405,
+   "access_time": "1970-01-01T00:08:20.000000600Z",
+   "modification_time": "1970-01-01T00:08:21.000000421Z",
+   "change_time": "1970-01-01T00:08:22.000000602Z",
+   "birth_time": "1970-01-01T00:08:23.000000603Z",
+   "size": "406",
+   "blocks": "407",
+   "blksize": 408,
+   "flags": 409,
+   "gen": 410
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/exec.json
+++ b/Source/santad/testdata/protobuf/v7/exec.json
@@ -1,0 +1,242 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "id": {
+   "pid": 23,
+   "pidversion": 45
+  },
+  "parent_id": {
+   "pid": 67,
+   "pidversion": 89
+  },
+  "responsible_id": {
+   "pid": 0,
+   "pidversion": 0
+  },
+  "original_parent_pid": 67,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "is_platform_binary": true,
+  "is_es_client": true,
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
+  },
+  "cs_flags": 536871680,
+  "executable": {
+   "path": "fooexec",
+   "truncated": false,
+   "stat": {
+    "dev": 301,
+    "mode": 302,
+    "nlink": 303,
+    "ino": "304",
+    "user": {
+     "uid": -2,
+     "name": "nobody"
+    },
+    "group": {
+     "gid": -1,
+     "name": "nogroup"
+    },
+    "rdev": 305,
+    "access_time": "1970-01-01T00:06:40.000000500Z",
+    "modification_time": "1970-01-01T00:06:41.000000321Z",
+    "change_time": "1970-01-01T00:06:42.000000502Z",
+    "birth_time": "1970-01-01T00:06:43.000000503Z",
+    "size": "306",
+    "blocks": "307",
+    "blksize": 308,
+    "flags": 309,
+    "gen": 310
+   },
+   "hash": {
+    "type": "HASH_ALGO_SHA256",
+    "hash": "1234_file_hash"
+   }
+  },
+  "start_time": "1970-01-01T00:00:00Z"
+ },
+ "script": {
+  "path": "script.sh",
+  "truncated": false,
+  "stat": {
+   "dev": 501,
+   "mode": 502,
+   "nlink": 503,
+   "ino": "504",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 505,
+   "access_time": "1970-01-01T00:10:00.000000700Z",
+   "modification_time": "1970-01-01T00:10:01.000000521Z",
+   "change_time": "1970-01-01T00:10:02.000000702Z",
+   "birth_time": "1970-01-01T00:10:03.000000703Z",
+   "size": "506",
+   "blocks": "507",
+   "blksize": 508,
+   "flags": 509,
+   "gen": 510
+  }
+ },
+ "working_directory": {
+  "path": "cwd",
+  "truncated": false,
+  "stat": {
+   "dev": 401,
+   "mode": 402,
+   "nlink": 403,
+   "ino": "404",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 405,
+   "access_time": "1970-01-01T00:08:20.000000600Z",
+   "modification_time": "1970-01-01T00:08:21.000000421Z",
+   "change_time": "1970-01-01T00:08:22.000000602Z",
+   "birth_time": "1970-01-01T00:08:23.000000603Z",
+   "size": "406",
+   "blocks": "407",
+   "blksize": 408,
+   "flags": 409,
+   "gen": 410
+  }
+ },
+ "args": [
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
+ ],
+ "envs": [
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
+ ],
+ "fds": [
+  {
+   "fd": 1,
+   "fd_type": "FD_TYPE_VNODE"
+  },
+  {
+   "fd": 2,
+   "fd_type": "FD_TYPE_SOCKET"
+  },
+  {
+   "fd": 3,
+   "fd_type": "FD_TYPE_PIPE",
+   "pipe_id": "123"
+  }
+ ],
+ "fd_list_truncated": false,
+ "decision": "DECISION_ALLOW",
+ "reason": "REASON_BINARY",
+ "mode": "MODE_LOCKDOWN",
+ "certificate_info": {
+  "hash": {
+   "type": "HASH_ALGO_SHA256",
+   "hash": "5678_cert_hash"
+  }
+ },
+ "explain": "extra!",
+ "quarantine_url": "google.com",
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/exit.json
+++ b/Source/santad/testdata/protobuf/v7/exit.json
@@ -1,0 +1,38 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "exited": {
+  "exit_status": 1
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/file_access.json
+++ b/Source/santad/testdata/protobuf/v7/file_access.json
@@ -1,0 +1,79 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "responsible_id": {
+   "pid": 0,
+   "pidversion": 0
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "is_platform_binary": true,
+  "is_es_client": true,
+  "cs_flags": 0,
+  "executable": {
+   "path": "foo",
+   "truncated": false,
+   "stat": {
+    "dev": 101,
+    "mode": 102,
+    "nlink": 103,
+    "ino": "104",
+    "user": {
+     "uid": -2,
+     "name": "nobody"
+    },
+    "group": {
+     "gid": -1,
+     "name": "nogroup"
+    },
+    "rdev": 105,
+    "access_time": "1970-01-01T00:03:20.000000300Z",
+    "modification_time": "1970-01-01T00:03:21.000000121Z",
+    "change_time": "1970-01-01T00:03:22.000000302Z",
+    "birth_time": "1970-01-01T00:03:23.000000303Z",
+    "size": "106",
+    "blocks": "107",
+    "blksize": 108,
+    "flags": 109,
+    "gen": 110
+   }
+  },
+  "tty": {
+   "path": "footty",
+   "truncated": false
+  },
+  "start_time": "1970-01-01T00:00:00Z"
+ },
+ "target": {
+  "path": "target",
+  "truncated": false
+ },
+ "policy_version": "policy_version",
+ "policy_name": "policy_name",
+ "access_type": "ACCESS_TYPE_OPEN",
+ "policy_decision": "POLICY_DECISION_DENIED"
+}

--- a/Source/santad/testdata/protobuf/v7/fork.json
+++ b/Source/santad/testdata/protobuf/v7/fork.json
@@ -1,0 +1,68 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "child": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo_child",
+   "truncated": false
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/link.json
+++ b/Source/santad/testdata/protobuf/v7/link.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v7/login_login.json
+++ b/Source/santad/testdata/protobuf/v7/login_login.json
@@ -1,0 +1,42 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": true,
+  "user": {
+   "uid": 321,
+   "name": "asdf"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/login_login_failed_attempt.json
+++ b/Source/santad/testdata/protobuf/v7/login_login_failed_attempt.json
@@ -1,0 +1,42 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": false,
+  "failure_message": "bXl8ZmFpbHVyZQ==",
+  "user": {
+   "name": "asdf"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/lw_session_lock.json
+++ b/Source/santad/testdata/protobuf/v7/lw_session_lock.json
@@ -1,0 +1,44 @@
+{
+ "lock": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/lw_session_login.json
+++ b/Source/santad/testdata/protobuf/v7/lw_session_login.json
@@ -1,0 +1,44 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/lw_session_logout.json
+++ b/Source/santad/testdata/protobuf/v7/lw_session_logout.json
@@ -1,0 +1,44 @@
+{
+ "logout": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/lw_session_unlock.json
+++ b/Source/santad/testdata/protobuf/v7/lw_session_unlock.json
@@ -1,0 +1,44 @@
+{
+ "unlock": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/openssh_login.json
+++ b/Source/santad/testdata/protobuf/v7/openssh_login.json
@@ -1,0 +1,46 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "result": "RESULT_AUTH_SUCCESS",
+  "source": {
+   "address": "MS4yLjMuNA==",
+   "type": "TYPE_IPV4"
+  },
+  "user": {
+   "uid": 12345,
+   "name": "foo_user"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/openssh_login_failed_attempt.json
+++ b/Source/santad/testdata/protobuf/v7/openssh_login_failed_attempt.json
@@ -1,0 +1,42 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "result": "RESULT_AUTH_FAIL_HOSTBASED",
+  "source": {
+   "address": "Ojox",
+   "type": "TYPE_IPV6"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/openssh_logout.json
+++ b/Source/santad/testdata/protobuf/v7/openssh_logout.json
@@ -1,0 +1,45 @@
+{
+ "logout": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "source": {
+   "address": "MS4yLjMuNA==",
+   "type": "TYPE_IPV4"
+  },
+  "user": {
+   "uid": 12345,
+   "name": "foo_user"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/rename.json
+++ b/Source/santad/testdata/protobuf/v7/rename.json
@@ -1,0 +1,65 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": false
+}

--- a/Source/santad/testdata/protobuf/v7/screensharing_attach.json
+++ b/Source/santad/testdata/protobuf/v7/screensharing_attach.json
@@ -1,0 +1,54 @@
+{
+ "attach": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": true,
+  "source": {
+   "address": "Ojox",
+   "type": "TYPE_IPV6"
+  },
+  "viewer": "Zm9vQGV4YW1wbGUuY29t",
+  "authentication_type": "aWRr",
+  "authentication_user": {
+   "name": "my_auth_user"
+  },
+  "session_user": {
+   "name": "my_session_user"
+  },
+  "existing_session": true,
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/screensharing_attach_unset_fields.json
+++ b/Source/santad/testdata/protobuf/v7/screensharing_attach_unset_fields.json
@@ -1,0 +1,45 @@
+{
+ "attach": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": true,
+  "source": {
+   "type": "TYPE_UNKNOWN"
+  },
+  "existing_session": true,
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/screensharing_detach.json
+++ b/Source/santad/testdata/protobuf/v7/screensharing_detach.json
@@ -1,0 +1,45 @@
+{
+ "detach": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "source": {
+   "address": "MS4yLjMuNA==",
+   "type": "TYPE_IPV4"
+  },
+  "viewer": "Zm9vQGV4YW1wbGUuY29t",
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v7/unlink.json
+++ b/Source/santad/testdata/protobuf/v7/unlink.json
@@ -1,0 +1,63 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "path": "unlink_file",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/allowlist.json
+++ b/Source/santad/testdata/protobuf/v8/allowlist.json
@@ -1,0 +1,61 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2
+  },
+  "effective_group": {
+   "gid": -1
+  },
+  "real_user": {
+   "uid": -2
+  },
+  "real_group": {
+   "gid": -1
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "path": "close_file",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2
+   },
+   "group": {
+    "gid": -1
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  },
+  "hash": {
+   "type": "HASH_ALGO_SHA256",
+   "hash": "hash_value"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/close.json
+++ b/Source/santad/testdata/protobuf/v8/close.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "path": "close_file",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "modified": true
+}

--- a/Source/santad/testdata/protobuf/v8/cs_invalidated.json
+++ b/Source/santad/testdata/protobuf/v8/cs_invalidated.json
@@ -1,0 +1,35 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/exchangedata.json
+++ b/Source/santad/testdata/protobuf/v8/exchangedata.json
@@ -1,0 +1,91 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "file1": {
+  "path": "exchange_file_1",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "file2": {
+  "path": "exchange_file_1",
+  "truncated": false,
+  "stat": {
+   "dev": 401,
+   "mode": 402,
+   "nlink": 403,
+   "ino": "404",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 405,
+   "access_time": "1970-01-01T00:08:20.000000600Z",
+   "modification_time": "1970-01-01T00:08:21.000000421Z",
+   "change_time": "1970-01-01T00:08:22.000000602Z",
+   "birth_time": "1970-01-01T00:08:23.000000603Z",
+   "size": "406",
+   "blocks": "407",
+   "blksize": 408,
+   "flags": 409,
+   "gen": 410
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/exec.json
+++ b/Source/santad/testdata/protobuf/v8/exec.json
@@ -1,0 +1,242 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "id": {
+   "pid": 23,
+   "pidversion": 45
+  },
+  "parent_id": {
+   "pid": 67,
+   "pidversion": 89
+  },
+  "responsible_id": {
+   "pid": 0,
+   "pidversion": 0
+  },
+  "original_parent_pid": 67,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "is_platform_binary": true,
+  "is_es_client": true,
+  "code_signature": {
+   "cdhash": "QUFBQUFBQUFBQUFBQUFBQUFBQUE=",
+   "signing_id": "my_signing_id",
+   "team_id": "my_team_id"
+  },
+  "cs_flags": 536871680,
+  "executable": {
+   "path": "fooexec",
+   "truncated": false,
+   "stat": {
+    "dev": 301,
+    "mode": 302,
+    "nlink": 303,
+    "ino": "304",
+    "user": {
+     "uid": -2,
+     "name": "nobody"
+    },
+    "group": {
+     "gid": -1,
+     "name": "nogroup"
+    },
+    "rdev": 305,
+    "access_time": "1970-01-01T00:06:40.000000500Z",
+    "modification_time": "1970-01-01T00:06:41.000000321Z",
+    "change_time": "1970-01-01T00:06:42.000000502Z",
+    "birth_time": "1970-01-01T00:06:43.000000503Z",
+    "size": "306",
+    "blocks": "307",
+    "blksize": 308,
+    "flags": 309,
+    "gen": 310
+   },
+   "hash": {
+    "type": "HASH_ALGO_SHA256",
+    "hash": "1234_file_hash"
+   }
+  },
+  "start_time": "1970-01-01T00:00:00Z"
+ },
+ "script": {
+  "path": "script.sh",
+  "truncated": false,
+  "stat": {
+   "dev": 501,
+   "mode": 502,
+   "nlink": 503,
+   "ino": "504",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 505,
+   "access_time": "1970-01-01T00:10:00.000000700Z",
+   "modification_time": "1970-01-01T00:10:01.000000521Z",
+   "change_time": "1970-01-01T00:10:02.000000702Z",
+   "birth_time": "1970-01-01T00:10:03.000000703Z",
+   "size": "506",
+   "blocks": "507",
+   "blksize": 508,
+   "flags": 509,
+   "gen": 510
+  }
+ },
+ "working_directory": {
+  "path": "cwd",
+  "truncated": false,
+  "stat": {
+   "dev": 401,
+   "mode": 402,
+   "nlink": 403,
+   "ino": "404",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 405,
+   "access_time": "1970-01-01T00:08:20.000000600Z",
+   "modification_time": "1970-01-01T00:08:21.000000421Z",
+   "change_time": "1970-01-01T00:08:22.000000602Z",
+   "birth_time": "1970-01-01T00:08:23.000000603Z",
+   "size": "406",
+   "blocks": "407",
+   "blksize": 408,
+   "flags": 409,
+   "gen": 410
+  }
+ },
+ "args": [
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
+ ],
+ "envs": [
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
+ ],
+ "fds": [
+  {
+   "fd": 1,
+   "fd_type": "FD_TYPE_VNODE"
+  },
+  {
+   "fd": 2,
+   "fd_type": "FD_TYPE_SOCKET"
+  },
+  {
+   "fd": 3,
+   "fd_type": "FD_TYPE_PIPE",
+   "pipe_id": "123"
+  }
+ ],
+ "fd_list_truncated": false,
+ "decision": "DECISION_ALLOW",
+ "reason": "REASON_BINARY",
+ "mode": "MODE_LOCKDOWN",
+ "certificate_info": {
+  "hash": {
+   "type": "HASH_ALGO_SHA256",
+   "hash": "5678_cert_hash"
+  }
+ },
+ "explain": "extra!",
+ "quarantine_url": "google.com",
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/exit.json
+++ b/Source/santad/testdata/protobuf/v8/exit.json
@@ -1,0 +1,38 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "exited": {
+  "exit_status": 1
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/file_access.json
+++ b/Source/santad/testdata/protobuf/v8/file_access.json
@@ -1,0 +1,79 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "responsible_id": {
+   "pid": 0,
+   "pidversion": 0
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "is_platform_binary": true,
+  "is_es_client": true,
+  "cs_flags": 0,
+  "executable": {
+   "path": "foo",
+   "truncated": false,
+   "stat": {
+    "dev": 101,
+    "mode": 102,
+    "nlink": 103,
+    "ino": "104",
+    "user": {
+     "uid": -2,
+     "name": "nobody"
+    },
+    "group": {
+     "gid": -1,
+     "name": "nogroup"
+    },
+    "rdev": 105,
+    "access_time": "1970-01-01T00:03:20.000000300Z",
+    "modification_time": "1970-01-01T00:03:21.000000121Z",
+    "change_time": "1970-01-01T00:03:22.000000302Z",
+    "birth_time": "1970-01-01T00:03:23.000000303Z",
+    "size": "106",
+    "blocks": "107",
+    "blksize": 108,
+    "flags": 109,
+    "gen": 110
+   }
+  },
+  "tty": {
+   "path": "footty",
+   "truncated": false
+  },
+  "start_time": "1970-01-01T00:00:00Z"
+ },
+ "target": {
+  "path": "target",
+  "truncated": false
+ },
+ "policy_version": "policy_version",
+ "policy_name": "policy_name",
+ "access_type": "ACCESS_TYPE_OPEN",
+ "policy_decision": "POLICY_DECISION_DENIED"
+}

--- a/Source/santad/testdata/protobuf/v8/fork.json
+++ b/Source/santad/testdata/protobuf/v8/fork.json
@@ -1,0 +1,68 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "child": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo_child",
+   "truncated": false
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/link.json
+++ b/Source/santad/testdata/protobuf/v8/link.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v8/login_login.json
+++ b/Source/santad/testdata/protobuf/v8/login_login.json
@@ -1,0 +1,42 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": true,
+  "user": {
+   "uid": 321,
+   "name": "asdf"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/login_login_failed_attempt.json
+++ b/Source/santad/testdata/protobuf/v8/login_login_failed_attempt.json
@@ -1,0 +1,42 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": false,
+  "failure_message": "bXl8ZmFpbHVyZQ==",
+  "user": {
+   "name": "asdf"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/lw_session_lock.json
+++ b/Source/santad/testdata/protobuf/v8/lw_session_lock.json
@@ -1,0 +1,44 @@
+{
+ "lock": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/lw_session_login.json
+++ b/Source/santad/testdata/protobuf/v8/lw_session_login.json
@@ -1,0 +1,44 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/lw_session_logout.json
+++ b/Source/santad/testdata/protobuf/v8/lw_session_logout.json
@@ -1,0 +1,44 @@
+{
+ "logout": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/lw_session_unlock.json
+++ b/Source/santad/testdata/protobuf/v8/lw_session_unlock.json
@@ -1,0 +1,44 @@
+{
+ "unlock": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "user": {
+   "uid": 1,
+   "name": "daemon"
+  },
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/openssh_login.json
+++ b/Source/santad/testdata/protobuf/v8/openssh_login.json
@@ -1,0 +1,46 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "result": "RESULT_AUTH_SUCCESS",
+  "source": {
+   "address": "MS4yLjMuNA==",
+   "type": "TYPE_IPV4"
+  },
+  "user": {
+   "uid": 12345,
+   "name": "foo_user"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/openssh_login_failed_attempt.json
+++ b/Source/santad/testdata/protobuf/v8/openssh_login_failed_attempt.json
@@ -1,0 +1,42 @@
+{
+ "login": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "result": "RESULT_AUTH_FAIL_HOSTBASED",
+  "source": {
+   "address": "Ojox",
+   "type": "TYPE_IPV6"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/openssh_logout.json
+++ b/Source/santad/testdata/protobuf/v8/openssh_logout.json
@@ -1,0 +1,45 @@
+{
+ "logout": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "source": {
+   "address": "MS4yLjMuNA==",
+   "type": "TYPE_IPV4"
+  },
+  "user": {
+   "uid": 12345,
+   "name": "foo_user"
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/rename.json
+++ b/Source/santad/testdata/protobuf/v8/rename.json
@@ -1,0 +1,65 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": false
+}

--- a/Source/santad/testdata/protobuf/v8/screensharing_attach.json
+++ b/Source/santad/testdata/protobuf/v8/screensharing_attach.json
@@ -1,0 +1,54 @@
+{
+ "attach": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": true,
+  "source": {
+   "address": "Ojox",
+   "type": "TYPE_IPV6"
+  },
+  "viewer": "Zm9vQGV4YW1wbGUuY29t",
+  "authentication_type": "aWRr",
+  "authentication_user": {
+   "name": "my_auth_user"
+  },
+  "session_user": {
+   "name": "my_session_user"
+  },
+  "existing_session": true,
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/screensharing_attach_unset_fields.json
+++ b/Source/santad/testdata/protobuf/v8/screensharing_attach_unset_fields.json
@@ -1,0 +1,45 @@
+{
+ "attach": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "success": true,
+  "source": {
+   "type": "TYPE_UNKNOWN"
+  },
+  "existing_session": true,
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/screensharing_detach.json
+++ b/Source/santad/testdata/protobuf/v8/screensharing_detach.json
@@ -1,0 +1,45 @@
+{
+ "detach": {
+  "instigator": {
+   "id": {
+    "pid": 12,
+    "pidversion": 34
+   },
+   "parent_id": {
+    "pid": 56,
+    "pidversion": 78
+   },
+   "original_parent_pid": 56,
+   "group_id": 111,
+   "session_id": 222,
+   "effective_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "effective_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "real_user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "real_group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "executable": {
+    "path": "foo",
+    "truncated": false
+   }
+  },
+  "source": {
+   "address": "MS4yLjMuNA==",
+   "type": "TYPE_IPV4"
+  },
+  "viewer": "Zm9vQGV4YW1wbGUuY29t",
+  "graphical_session": {
+   "id": 123
+  }
+ }
+}

--- a/Source/santad/testdata/protobuf/v8/unlink.json
+++ b/Source/santad/testdata/protobuf/v8/unlink.json
@@ -1,0 +1,63 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "target": {
+  "path": "unlink_file",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ }
+}


### PR DESCRIPTION
We previously intentionally capped the max ES version supported to not need several duplicated golden test files. However the new authentication event types types have special cases on the latest ES version.

This PR bumps the max supported OS for tests and adds the golden test files for existing event types.