### PR TITLE
Fix: Database Rule Table Version number

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("//:helper.bzl", "santa_unit_test")
 

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -166,8 +166,8 @@ objc_library(
     srcs = ["TelemetryEventMap.mm"],
     hdrs = ["TelemetryEventMap.h"],
     deps = [
-      ":String",
-      "@com_google_absl//absl/container:flat_hash_map",
+        ":String",
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -49,6 +49,6 @@
 ///
 /// @return The current version of the table schema.
 ///
-@property(atomic, readonly) uint32_t currentVersion;
+- (uint32_t)currentVersion;
 
 @end

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -41,6 +41,12 @@
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
 ///
+///  Current supported version of the table schema. This should be overriden in
+///  subclasses.
+///
+- (uint32_t)currentSupportedVersion;
+
+///
 /// @return The current version of the table schema.
 ///
 @property(atomic, readonly) uint32_t currentVersion;

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -40,4 +40,9 @@
 - (void)inDatabase:(void (^)(FMDatabase *db))block;
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
+///
+/// @return The current version of the table schema.
+///
+@property(atomic) uint32_t currentSchemaVersion;
+
 @end

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -43,6 +43,6 @@
 ///
 /// @return The current version of the table schema.
 ///
-@property(atomic) uint32_t currentSchemaVersion;
+@property(atomic, readonly) uint32_t currentVersion;
 
 @end

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import "Source/santad/DataLayer/SNTDatabaseTable.h"
+#include <stdint.h>
 
 #include <sqlite3.h>
 
@@ -86,6 +87,7 @@
     LOGI(@"Updated %@ from version %d to %d", [self className], currentVersion, newVersion);
 
     [db setUserVersion:newVersion];
+    _currentSchemaVersion = newVersion;
   }];
 }
 

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -87,7 +87,7 @@
     LOGI(@"Updated %@ from version %d to %d", [self className], currentVersion, newVersion);
 
     [db setUserVersion:newVersion];
-    _currentSchemaVersion = newVersion;
+    _currentVersion = newVersion;
   }];
 }
 

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -76,6 +76,15 @@
   return 0;
 }
 
+- (uint32_t)currentVersion {
+  __block uint32_t curVersion = 0;
+  [self.dbQ inDatabase:^(FMDatabase *db) {
+    curVersion = [db userVersion];
+  }];
+
+  return curVersion;
+}
+
 /// Called at the end of initialization to ensure the table in the
 /// database exists and uses the latest schema.
 - (void)updateTableSchema {
@@ -87,7 +96,6 @@
     LOGI(@"Updated %@ from version %d to %d", [self className], currentVersion, newVersion);
 
     [db setUserVersion:newVersion];
-    _currentVersion = newVersion;
   }];
 }
 

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -122,4 +122,9 @@
 ///
 - (uint32_t)currentSupportedVersion;
 
+///
+/// The current version of the rule table schema.
+///
+@property(readonly, nonatomic) uint32_t currentVersion;
+
 @end

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -117,9 +117,4 @@
 @property(readonly, nonatomic)
   NSDictionary<NSString *, SNTCachedDecision *> *criticalSystemBinaries;
 
-///
-///  Current supported version of the rule table schema.
-///
-- (uint32_t)currentSupportedVersion;
-
 @end

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -122,9 +122,4 @@
 ///
 - (uint32_t)currentSupportedVersion;
 
-///
-/// The current version of the rule table schema.
-///
-@property(readonly, nonatomic) uint32_t currentVersion;
-
 @end

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -117,4 +117,9 @@
 @property(readonly, nonatomic)
   NSDictionary<NSString *, SNTCachedDecision *> *criticalSystemBinaries;
 
+///
+///  Current supported version of the rule table schema.
+///
+- (uint32_t)currentSupportedVersion;
+
 @end

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -26,7 +26,7 @@
 #import "Source/common/SNTRule.h"
 #import "Source/common/SigningIDHelpers.h"
 
-static const uint32_t kRuleTableCurrentVersion = 7;
+static const uint32_t kRuleTableCurrentVersion = 8;
 
 // TODO(nguyenphillip): this should be configurable.
 // How many rules must be in database before we start trying to remove transitive rules.

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -537,7 +537,11 @@
 // This test ensures that we bump the constant on updates to the rule table
 // schema.
 - (void)testConstantVersionIsUpdated {
-  XCTAssertEqual([self.sut currentSupportedVersion], 8);
+  uint32_t expectedValue = 8;
+  uint32_t constantVersion = [self.sut currentSupportedVersion];
+  XCTAssertEqual(expectedValue, [self.sut currentSchemaVersion],
+                 @"currentSchemaVersion should be 8");
+  XCTAssertEqual(expectedValue, constantVersion, @"currentSupportedVersion should be 8");
 }
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -16,6 +16,7 @@
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#include <stdint.h>
 
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTConfigurator.h"
@@ -531,6 +532,12 @@
   NSString *teamID = [signingID componentsSeparatedByString:@":"][0];
   XCTAssertEqualObjects(signingID, cd.signingID, @"signing IDs should match");
   XCTAssertEqualObjects(teamID, cd.teamID, @"team IDs should match");
+}
+
+// This test ensures that we bump the constant on updates to the rule table
+// schema.
+- (void)testConstantVersionIsUpdated {
+  XCTAssertEqual([self.sut currentSupportedVersion], 8);
 }
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -539,8 +539,7 @@
 - (void)testConstantVersionIsUpdated {
   uint32_t expectedValue = 8;
   uint32_t constantVersion = [self.sut currentSupportedVersion];
-  XCTAssertEqual(expectedValue, [self.sut currentSchemaVersion],
-                 @"currentSchemaVersion should be 8");
+  XCTAssertEqual(expectedValue, [self.sut currentVersion], @"currentSchemaVersion should be 8");
   XCTAssertEqual(expectedValue, constantVersion, @"currentSupportedVersion should be 8");
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/BUILD
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/BUILD
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("//:helper.bzl", "santa_unit_test")
 

--- a/Source/santad/ProcessTree/BUILD
+++ b/Source/santad/ProcessTree/BUILD
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("//:helper.bzl", "santa_unit_test")
 


### PR DESCRIPTION
This PR fixes an issue with the SNTRuleTable's `currentSupportedVersion` method returning the incorrect value due to the constant it wraps not being updated. 

It makes the `currentSupportedVersion` method part of the interface, so as to expose for testing and metrics. 

A unit test is added to ensure that this constant is updated in the future.

This  bug was introduced in #123 was causing all rules to be dropped across builds / restarts.

This PR also adds the imports for the BUILD files to satisfy the linter.
