### PR TITLE
Tests: Simplify SNTRuleTableTest

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -538,7 +538,7 @@
 // schema.
 - (void)testConstantVersionIsUpdated {
   XCTAssertEqual([self.sut currentSupportedVersion], [self.sut currentVersion],
-      @"initialized database should update to the maximum supported version");
+                 @"initialized database should update to the maximum supported version");
 }
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -537,10 +537,8 @@
 // This test ensures that we bump the constant on updates to the rule table
 // schema.
 - (void)testConstantVersionIsUpdated {
-  uint32_t expectedValue = 8;
-  uint32_t constantVersion = [self.sut currentSupportedVersion];
-  XCTAssertEqual(expectedValue, [self.sut currentVersion], @"currentSchemaVersion should be 8");
-  XCTAssertEqual(expectedValue, constantVersion, @"currentSupportedVersion should be 8");
+  XCTAssertEqual([self.sut currentSupportedVersion], [self.sut currentVersion],
+      @"initialized database should update to the maximum supported version");
 }
 
 @end


### PR DESCRIPTION
Instead of checking a constant version (which will require updating the test each time we update the constant) this compares the version returned from an initialized database against the maximum version supported by the table class