### PR TITLE
standalone: Allow password fallback

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -301,6 +301,19 @@
 #pragma mark - GUI Settings
 
 ///
+///  When in Standalone mode, Santa normally requires TouchID for authorization.
+///  This is slightly safer than password authentication because it requires a physical
+///  interaction that cannot be spoofed by tools that can type into the dialog.
+///
+///  However, for users on desktop machines or using clamshell mode standalone mode is
+///  unusable without the ability to fallback to a password. If this option is enabled,
+///  TouchID is preferred but password fallback is available.
+///
+///  Defaults to NO.
+///
+@property(readonly, nonatomic) BOOL enableStandalonePasswordFallback;
+
+///
 ///  When silent mode is enabled, Santa will never show notifications for
 ///  blocked processes.
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -801,7 +801,7 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (BOOL)enableStandalonePasswordFallback {
   NSNumber *number = self.configState[kEnableStandalonePasswordFallbackKey];
-  return number ? [number boolValue] : NO;
+  return number ? [number boolValue] : YES;
 }
 
 - (BOOL)enableSilentMode {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -92,6 +92,7 @@ static NSString *const kMachineOwnerPlistKeyKey = @"MachineOwnerKey";
 static NSString *const kMachineIDPlistFileKey = @"MachineIDPlist";
 static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
+static NSString *const kEnableStandalonePasswordFallbackKey = @"EnableStandalonePasswordFallback";
 static NSString *const kEnableSilentModeKey = @"EnableSilentMode";
 static NSString *const kEnableSilentTTYModeKey = @"EnableSilentTTYMode";
 static NSString *const kAboutTextKey = @"AboutText";
@@ -226,6 +227,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
       kOnStartUSBOptions : string,
       kEnablePageZeroProtectionKey : number,
       kEnableBadSignatureProtectionKey : number,
+      kEnableStandalonePasswordFallbackKey : number,
       kEnableSilentModeKey : number,
       kEnableSilentTTYModeKey : number,
       kAboutTextKey : string,
@@ -416,6 +418,10 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 + (NSSet *)keyPathsForValuesAffectingEnablePageZeroProtection {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingEnableStandalonePasswordFallback {
   return [self configStateSet];
 }
 
@@ -790,6 +796,11 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (BOOL)enableBadSignatureProtection {
   NSNumber *number = self.configState[kEnableBadSignatureProtectionKey];
+  return number ? [number boolValue] : NO;
+}
+
+- (BOOL)enableStandalonePasswordFallback {
+  NSNumber *number = self.configState[kEnableStandalonePasswordFallbackKey];
   return number ? [number boolValue] : NO;
 }
 

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -383,7 +383,7 @@ struct SNTBinaryMessageWindowView: View {
       )
     } else if !filePath.isEmpty {
       msg = NSLocalizedString(
-        "authorize execution of " + filePath,
+        "authorize execution of " + (filePath as NSString).lastPathComponent,
         comment: "File path"
       )
     }

--- a/Source/gui/SNTMessageView.swift
+++ b/Source/gui/SNTMessageView.swift
@@ -151,7 +151,11 @@ public func OpenEventButton(customText: String? = nil, action: @escaping () -> V
 }
 
 public func AuthorizeViaTouchID(reason: String, replyBlock: @escaping (Bool) -> Void) {
-  LAContext().evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, error in
+  let policy: LAPolicy =
+    SNTConfigurator.configurator().enableStandalonePasswordFallback
+    ? .deviceOwnerAuthentication : .deviceOwnerAuthenticationWithBiometrics
+
+  LAContext().evaluatePolicy(policy, localizedReason: reason) { success, error in
     if error != nil {
       replyBlock(false)
     } else {
@@ -166,7 +170,11 @@ public func CanAuthorizeWithTouchID() -> (Bool, NSError?) {
   let context = LAContext()
   var error: NSError?
 
-  if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+  let policy: LAPolicy =
+    SNTConfigurator.configurator().enableStandalonePasswordFallback
+    ? .deviceOwnerAuthentication : .deviceOwnerAuthenticationWithBiometrics
+
+  if context.canEvaluatePolicy(policy, error: &error) {
     return (true, nil)
   } else {
     return (false, error)

--- a/docs/concepts/mode.md
+++ b/docs/concepts/mode.md
@@ -46,8 +46,7 @@ use-case is important there is a configuration option
 password authentication when TouchID is not available.
 
 {: .note}
-Standalone mode will not override explicit block rules when Santa is configured
-to use a sync service nor will it override static rules.
+Standalone mode will not override explicit block rules nor will it override static rules.
 
 ##### Changing Modes
 

--- a/docs/concepts/mode.md
+++ b/docs/concepts/mode.md
@@ -27,14 +27,27 @@ Running Santa in Lockdown Mode will stop all blocked binaries and additionally
 will prevent all unknown binaries from running. This means that if the binary
 has no rules or scopes that apply, then it will be blocked.
 
-##### Standalone mode
+##### Standalone mode (Beta)
 
-When Santa is in Standalone Mode it will allow the user to approve their own binaries provided they authenticate biometrically with Touch ID. Upon a successful authentication Santa will then add a `SigningID` rule for the binary if it is validly signed and a `BINARY` if it is not signed at all.
+When Santa is in Standalone Mode it will allow the user to approve their own
+binaries provided they authenticate biometrically with TouchID. Upon a
+successful authentication Santa will then add a `SIGNINGID` rule for the binary
+if it is validly signed and a `BINARY` if it is not signed at all.
 
-When paired with Lockdown, it allows a user to quickly self approve in lieu of using a sync service. If one is using a sync service Events will still be sent up to that sync service.
+This allows a user to quickly self approve in lieu of using a sync service. If
+one is using a sync service Events will still be sent up to that sync service.
+
+Standalone mode typically requires TouchID for self-approval because this
+requires a physical interaction and cannot be spoofed by other software acting
+as a mouse/keyboard. Unfortunately this makes Standalone mode unusable for users
+on most desktop machines or using a laptop in clamshell mode. If supporting that
+use-case is important there is a configuration option
+`EnableStandalonePasswordFallback` that can be enabled to allow falling back to
+password authentication when TouchID is not available.
 
 {: .note}
-Standalone mode will not override explicit block rules when Santa is configured to use a sync service nor will it override static rules.
+Standalone mode will not override explicit block rules when Santa is configured
+to use a sync service nor will it override static rules.
 
 ##### Changing Modes
 
@@ -44,7 +57,7 @@ profile and with a sync server configuration.
 ###### Change modes with the configuration profile
 
 Set the `ClientMode` in your configuration profile to the integer value `1` for
-MONITOR or `2` for LOCKDOWN.
+`MONITOR`, `2` for `LOCKDOWN`, or `3` for `STANDALONE`.
 
 ```xml
 <key>ClientMode</key>
@@ -58,4 +71,4 @@ Install your new configuration profile, it will overwrite any old
 ###### Change modes with a sync server
 
 The mode is set in the preflight sync stage. Use the key `client_mode` and a
-value of `MONITOR` or `LOCKDOWN`.
+value of `MONITOR`, `LOCKDOWN`, or `STANDALONE`.

--- a/docs/concepts/mode.md
+++ b/docs/concepts/mode.md
@@ -37,9 +37,13 @@ if it is validly signed and a `BINARY` if it is not signed at all.
 This allows a user to quickly self approve in lieu of using a sync service. If
 one is using a sync service Events will still be sent up to that sync service.
 
-Standalone mode typically requires TouchID  or password to approve binary execution.
+Standalone mode typically requires TouchID  or password to approve binary
+execution.
 
-The configuration option `EnableStandalonePasswordFallback` can be disabled to make Standalone mode require physical access. When disabled only TouchID will be used for self-approval because this requires a physical interaction and cannot be spoofed by other software acting as a mouse/keyboard.
+The configuration option `EnableStandalonePasswordFallback` can be disabled to
+make Standalone mode require physical access. When disabled only TouchID will be
+used for self-approval because this requires a physical interaction and cannot
+be spoofed by other software acting as a mouse/keyboard.
 
 {: .note}
 Standalone mode will not override explicit block rules nor will it override static rules.

--- a/docs/concepts/mode.md
+++ b/docs/concepts/mode.md
@@ -37,13 +37,9 @@ if it is validly signed and a `BINARY` if it is not signed at all.
 This allows a user to quickly self approve in lieu of using a sync service. If
 one is using a sync service Events will still be sent up to that sync service.
 
-Standalone mode typically requires TouchID for self-approval because this
-requires a physical interaction and cannot be spoofed by other software acting
-as a mouse/keyboard. Unfortunately this makes Standalone mode unusable for users
-on most desktop machines or using a laptop in clamshell mode. If supporting that
-use-case is important there is a configuration option
-`EnableStandalonePasswordFallback` that can be enabled to allow falling back to
-password authentication when TouchID is not available.
+Standalone mode typically requires TouchID  or password to approve binary execution.
+
+The configuration option `EnableStandalonePasswordFallback` can be disabled to make Standalone mode require physical access. When disabled only TouchID will be used for self-approval because this requires a physical interaction and cannot be spoofed by other software acting as a mouse/keyboard.
 
 {: .note}
 Standalone mode will not override explicit block rules nor will it override static rules.

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -30,6 +30,7 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | FileChangesPrefixFilters           | Array      | Array of path prefix strings. When an event is logged, if the target path (e.g. the file being written/removed/etc ) matches a prefix it will not be logged. |
 | EnableBadSignatureProtection       | Bool       | If true, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. Defaults to false. |
 | EnablePageZeroProtection           | Bool       | If true, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. Defaults to true. |
+| EnableStandalonePasswordFallback   | Bool       | If true, Santa will fallback to password authorization for Standalone mode. |
 | EnableSilentMode                   | Bool       | If true, Santa will not post any GUI notifications. This can be a very confusing experience for users, use with caution. Defaults to false. |
 | EnableTransitiveRules              | Bool       | If true, Santa will respect compiler rule types and create allow rules for the executables they produce. Defaults to false. |
 | EnableSilentTTYMode                | Bool       | If true, Santa will not post any TTY notifications. This can be a very confusing experience for users, use with caution. Defaults to false. |

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -30,7 +30,7 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | FileChangesPrefixFilters           | Array      | Array of path prefix strings. When an event is logged, if the target path (e.g. the file being written/removed/etc ) matches a prefix it will not be logged. |
 | EnableBadSignatureProtection       | Bool       | If true, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. Defaults to false. |
 | EnablePageZeroProtection           | Bool       | If true, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. Defaults to true. |
-| EnableStandalonePasswordFallback   | Bool       | If true, Santa will fallback to password authorization for Standalone mode. |
+| EnableStandalonePasswordFallback   | Bool       | If true, Santa will fallback to password authorization for Standalone mode. Defaults to YES |
 | EnableSilentMode                   | Bool       | If true, Santa will not post any GUI notifications. This can be a very confusing experience for users, use with caution. Defaults to false. |
 | EnableTransitiveRules              | Bool       | If true, Santa will respect compiler rule types and create allow rules for the executables they produce. Defaults to false. |
 | EnableSilentTTYMode                | Bool       | If true, Santa will not post any TTY notifications. This can be a very confusing experience for users, use with caution. Defaults to false. |


### PR DESCRIPTION
This makes standalone mode usable in clamshell mode or on a desktop machine.

This change also modifies the authorization dialog for unsigned, non-bundled binaries to just show the binary name instead of the full path. In many cases the full path is very long and as the dialog is limited in width it makes the path squash up and become nearly unreadable.