### PR TITLE
Restructure Watch Items objects to prepare for Proc FAA

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -43,6 +43,10 @@ objc_library(
 objc_library(
     name = "WatchItemPolicy",
     hdrs = ["DataLayer/WatchItemPolicy.h"],
+    deps = [
+        "//Source/common:PrefixTree",
+        "//Source/common:Unit",
+    ],
 )
 
 objc_library(

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -24,6 +24,9 @@
 #include <string_view>
 #include <vector>
 
+#import "Source/common/PrefixTree.h"
+#import "Source/common/Unit.h"
+
 namespace santa {
 
 enum class WatchItemPathType {
@@ -44,47 +47,44 @@ static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType =
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 
-struct WatchItemPolicy {
-  struct Process {
-    Process(std::string bp, std::string sid, std::string ti, std::vector<uint8_t> cdh,
-            std::string ch, std::optional<bool> pb)
-        : binary_path(bp),
-          signing_id(sid),
-          team_id(ti),
-          cdhash(std::move(cdh)),
-          certificate_sha256(ch),
-          platform_binary(pb) {}
+struct WatchItemProcess {
+  WatchItemProcess(std::string bp, std::string sid, std::string ti, std::vector<uint8_t> cdh,
+                   std::string ch, std::optional<bool> pb)
+      : binary_path(bp),
+        signing_id(sid),
+        team_id(ti),
+        cdhash(std::move(cdh)),
+        certificate_sha256(ch),
+        platform_binary(pb) {}
 
-    bool operator==(const Process &other) const {
-      return binary_path == other.binary_path && signing_id == other.signing_id &&
-             team_id == other.team_id && cdhash == other.cdhash &&
-             certificate_sha256 == other.certificate_sha256 &&
-             platform_binary.has_value() == other.platform_binary.has_value() &&
-             platform_binary.value_or(false) == other.platform_binary.value_or(false);
-    }
+  bool operator==(const WatchItemProcess &other) const {
+    return binary_path == other.binary_path && signing_id == other.signing_id &&
+           team_id == other.team_id && cdhash == other.cdhash &&
+           certificate_sha256 == other.certificate_sha256 &&
+           platform_binary.has_value() == other.platform_binary.has_value() &&
+           platform_binary.value_or(false) == other.platform_binary.value_or(false);
+  }
 
-    bool operator!=(const Process &other) const { return !(*this == other); }
+  bool operator!=(const WatchItemProcess &other) const { return !(*this == other); }
 
-    std::string binary_path;
-    std::string signing_id;
-    std::string team_id;
-    std::vector<uint8_t> cdhash;
-    std::string certificate_sha256;
-    std::optional<bool> platform_binary;
-  };
+  std::string binary_path;
+  std::string signing_id;
+  std::string team_id;
+  std::vector<uint8_t> cdhash;
+  std::string certificate_sha256;
+  std::optional<bool> platform_binary;
+};
 
-  WatchItemPolicy(std::string_view n, std::string_view v, std::string_view p,
-                  WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
-                  bool ara = kWatchItemPolicyDefaultAllowReadAccess,
-                  bool ao = kWatchItemPolicyDefaultAuditOnly,
-                  WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
-                  bool esm = kWatchItemPolicyDefaultEnableSilentMode,
-                  bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode, std::string_view cm = "",
-                  NSString *edu = nil, NSString *edt = nil, std::vector<Process> procs = {})
+struct WatchItemPolicyBase {
+  WatchItemPolicyBase(std::string_view n, std::string_view v,
+                      bool ara = kWatchItemPolicyDefaultAllowReadAccess,
+                      bool ao = kWatchItemPolicyDefaultAuditOnly,
+                      WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
+                      bool esm = kWatchItemPolicyDefaultEnableSilentMode,
+                      bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
+                      std::string_view cm = "", NSString *edu = nil, NSString *edt = nil)
       : name(n),
         version(v),
-        path(p),
-        path_type(pt),
         allow_read_access(ara),
         audit_only(ao),
         rule_type(rt),
@@ -94,24 +94,22 @@ struct WatchItemPolicy {
         // Note: Empty string considered valid for event_detail_url to allow rules
         // overriding global setting in order to hide the button.
         event_detail_url(edu == nil ? std::nullopt : std::make_optional<NSString *>(edu)),
-        event_detail_text(edt.length == 0 ? std::nullopt : std::make_optional<NSString *>(edt)),
-        processes(std::move(procs)) {}
+        event_detail_text(edt.length == 0 ? std::nullopt : std::make_optional<NSString *>(edt)) {}
 
-  bool operator==(const WatchItemPolicy &other) const {
+  virtual ~WatchItemPolicyBase() = default;
+
+  virtual bool operator==(const WatchItemPolicyBase &other) const {
     // Note: custom_message, event_detail_url, and event_detail_text are not currently considered
     // for equality purposes
-    return name == other.name && version == other.version && path == other.path &&
-           path_type == other.path_type && allow_read_access == other.allow_read_access &&
-           audit_only == other.audit_only && rule_type == other.rule_type &&
-           silent == other.silent && silent_tty == other.silent_tty && processes == other.processes;
+    return name == other.name && version == other.version &&
+           allow_read_access == other.allow_read_access && audit_only == other.audit_only &&
+           rule_type == other.rule_type && silent == other.silent && silent_tty == other.silent_tty;
   }
 
-  bool operator!=(const WatchItemPolicy &other) const { return !(*this == other); }
+  virtual bool operator!=(const WatchItemPolicyBase &other) const { return !(*this == other); }
 
   std::string name;
   std::string version;  // WIP - No current way to control via config
-  std::string path;
-  WatchItemPathType path_type;
   bool allow_read_access;
   bool audit_only;
   WatchItemRuleType rule_type;
@@ -120,7 +118,56 @@ struct WatchItemPolicy {
   std::optional<std::string> custom_message;
   std::optional<NSString *> event_detail_url;
   std::optional<NSString *> event_detail_text;
-  std::vector<Process> processes;
+};
+
+struct DataWatchItemPolicy : public WatchItemPolicyBase {
+  DataWatchItemPolicy(std::string_view n, std::string_view v, std::string_view p,
+                      WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
+                      bool ara = kWatchItemPolicyDefaultAllowReadAccess,
+                      bool ao = kWatchItemPolicyDefaultAuditOnly,
+                      WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
+                      bool esm = kWatchItemPolicyDefaultEnableSilentMode,
+                      bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
+                      std::string_view cm = "", NSString *edu = nil, NSString *edt = nil,
+                      std::vector<WatchItemProcess> procs = {})
+      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt),
+        path(p),
+        path_type(pt),
+        processes(std::move(procs)) {}
+
+  bool operator==(const WatchItemPolicyBase &other) const override {
+    const DataWatchItemPolicy *otherPolicy = dynamic_cast<const DataWatchItemPolicy *>(&other);
+    if (!otherPolicy) {
+      return false;
+    }
+
+    // Now compare base and derived class attributes
+    return WatchItemPolicyBase::operator==(*otherPolicy) && path_type == otherPolicy->path_type &&
+           path == otherPolicy->path && processes == otherPolicy->processes;
+  }
+
+  bool operator!=(const WatchItemPolicyBase &other) const override { return !(*this == other); }
+
+  std::string path;
+  WatchItemPathType path_type;
+  std::vector<WatchItemProcess> processes;
+};
+
+struct ProcessWatchItemPolicy : public WatchItemPolicyBase {
+  ProcessWatchItemPolicy(std::string_view n, std::string_view v, std::string_view p,
+                         WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
+                         bool ara = kWatchItemPolicyDefaultAllowReadAccess,
+                         bool ao = kWatchItemPolicyDefaultAuditOnly,
+                         WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
+                         bool esm = kWatchItemPolicyDefaultEnableSilentMode,
+                         bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
+                         std::string_view cm = "", NSString *edu = nil, NSString *edt = nil,
+                         std::vector<WatchItemProcess> procs = {})
+      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt),
+        processes(std::move(procs)) {}
+
+  PrefixTree<Unit> paths;
+  std::vector<WatchItemProcess> processes;
 };
 
 }  // namespace santa


### PR DESCRIPTION
This PR starts the process of breaking up `WatchItemPolicy` into `DataWatchItemPolicy` and `ProcessWatchItemPolicy` to as a first step in implementing Proc FAA.

`WatchItems` is also being broken up to abstract out the `DataWatchItems` into their own object so that it can be operated on singularly. A future PR will add `ProcessWatchItems` to work similarly.