### PR TITLE
Fix: Add signing ID checks for critical binaries

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -146,24 +146,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     if ([csInfo signingInformationMatches:self.launchdCSInfo]) {
       systemBin = YES;
     } else if (![csInfo.teamID isEqualToString:self.santadCSInfo.teamID]) {
-      LOGW(@"Unable to validate critical system binary %@. "
-           @"pid 1: %@, santad: teamID %@ and %@: %@ do not match.",
-           path, self.launchdCSInfo.leafCertificate, self.santadCSInfo.teamID, path, csInfo.teamID);
+      LOGW(
+          @"Unable to validate critical system binary %@. "
+          @"Not signed by same cert as pid 1: %@, and does not match santad TeamID: %@ and %@: %@.",
+          path, self.launchdCSInfo.leafCertificate, self.santadCSInfo.teamID, path, csInfo.teamID);
       continue;
-    } else {
-      NSSet *santaSigningIDs = [[NSSet alloc] initWithArray:@[
-        @"com.northpolesec.santa",
-        @"com.northpolesec.santa.ctl",
-        @"com.northpolesec.santa.bundleservice",
-        @"com.northpolesec.santa.daemon",
-        @"com.northpolesec.santa.metricservice",
-        @"com.northpolesec.santa.syncservice",
-      ]];
-
-      if (![santaSigningIDs containsObject:csInfo.signingID]) {
-        LOGW(@"Unknown Santa binary signing ID %@ ", csInfo.signingID);
-        continue;
-      }
     }
 
     SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import "Source/santad/DataLayer/SNTRuleTable.h"
+#include "Source/common/SNTCommonEnums.h"
 
 #import <EndpointSecurity/EndpointSecurity.h>
 #import <MOLCertificate/MOLCertificate.h>
@@ -169,7 +170,21 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     cd.certCommonName = csInfo.leafCertificate.commonName;
 
     bins[binInfo.SHA256] = cd;
+    // Also add the signing ID to the dictionary.
+    SNTCachedDecision *cd2 = [[SNTCachedDecision alloc] init];
+    cd2.decision = SNTEventStateAllowSigningID;
+    cd2.decisionExtra = systemBin ? @"critical system binary" : @"santa binary";
+    cd2.sha256 = cd.sha256;
+    cd2.teamID = cd.teamID;
+    cd2.signingID = cd.signingID;
+    cd2.cdhash = cd.cdhash;
+    cd2.certChain = cd.certChain;
+    cd2.certSHA256 = cd.certSHA256;
+    cd2.certCommonName = cd.certCommonName;
+    cd2.decision = SNTEventStateAllowSigningID;
+    bins[cd.signingID] = cd2;
   }
+
   self.criticalSystemBinaries = bins;
 }
 

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -146,10 +146,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     if ([csInfo signingInformationMatches:self.launchdCSInfo]) {
       systemBin = YES;
     } else if (![csInfo.teamID isEqualToString:self.santadCSInfo.teamID]) {
-      LOGW(
-          @"Unable to validate critical system binary %@. "
-          @"Not signed by same cert as pid 1: %@ vs %@, and does not match santad TeamID: %@ vs %@.",
-          path, self.launchdCSInfo.leafCertificate, csInfo.leafCertificate, self.santadCSInfo.teamID, csInfo.teamID);
+      LOGW(@"Unable to validate critical system binary %@. "
+           @"Not signed by same cert as pid 1: %@ vs %@, and does not match santad TeamID: %@ vs "
+           @"%@.",
+           path, self.launchdCSInfo.leafCertificate, csInfo.leafCertificate,
+           self.santadCSInfo.teamID, csInfo.teamID);
       continue;
     }
 

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -148,8 +148,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     } else if (![csInfo.teamID isEqualToString:self.santadCSInfo.teamID]) {
       LOGW(
           @"Unable to validate critical system binary %@. "
-          @"Not signed by same cert as pid 1: %@, and does not match santad TeamID: %@ and %@: %@.",
-          path, self.launchdCSInfo.leafCertificate, self.santadCSInfo.teamID, path, csInfo.teamID);
+          @"Not signed by same cert as pid 1: %@ vs %@, and does not match santad TeamID: %@ vs %@.",
+          path, self.launchdCSInfo.leafCertificate, csInfo.leafCertificate, self.santadCSInfo.teamID, csInfo.teamID);
       continue;
     }
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -537,6 +537,33 @@
   XCTAssertEqualObjects(teamID, cd.teamID, @"team IDs should match");
 }
 
+- (void)testCriticalBinariesHaveBothSHAandSigningIDRules {
+  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:@"/usr/libexec/trustd"];
+  MOLCodesignChecker *csInfo = [fi codesignCheckerWithError:nil];
+
+  SNTCachedDecision *cd = self.sut.criticalSystemBinaries[fi.SHA256];
+
+  XCTAssertEqualObjects(fi.SHA256, cd.sha256, @"hashes should match");
+  XCTAssertEqual(SNTEventStateAllowBinary, cd.decision, @"decision should be allow by binary");
+  XCTAssertEqualObjects(csInfo.leafCertificate.SHA256, cd.certSHA256, @"cert hashes should match");
+  XCTAssertEqualObjects(csInfo.cdhash, cd.cdhash, @"cdhashes should match");
+  XCTAssertEqualObjects(csInfo.certificates, cd.certChain, @"cert chains should match");
+  NSString *signingID = FormatSigningID(csInfo);
+  NSString *teamID = [signingID componentsSeparatedByString:@":"][0];
+  XCTAssertEqualObjects(signingID, cd.signingID, @"signing IDs should match");
+  XCTAssertEqualObjects(teamID, cd.teamID, @"team IDs should match");
+
+  SNTCachedDecision *cd2 = self.sut.criticalSystemBinaries[signingID];
+  XCTAssertEqual(SNTEventStateAllowSigningID, cd2.decision,
+                 @"decision should be allow by signing ID");
+  XCTAssertEqualObjects(cd.sha256, cd2.sha256, @"hashes should match");
+  XCTAssertEqualObjects(cd.certSHA256, cd2.certSHA256, @"cert hashes should match");
+  XCTAssertEqualObjects(cd.cdhash, cd2.cdhash, @"cdhashes should match");
+  XCTAssertEqualObjects(cd.certChain, cd2.certChain, @"cert chains should match");
+  XCTAssertEqualObjects(cd.signingID, cd2.signingID, @"signing IDs should match");
+  XCTAssertEqualObjects(cd.teamID, cd2.teamID, @"team IDs should match");
+}
+
 // This test ensures that we bump the constant on updates to the rule table
 // schema.
 - (void)testConstantVersionIsUpdated {

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -595,12 +595,19 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
   OCMStub([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
   OCMStub([self.mockConfigurator enableTransitiveRules]).andReturn(NO);
 
-  SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
-  cd.decision = SNTEventStateAllowBinary;
-  OCMStub([self.mockRuleDatabase criticalSystemBinaries]).andReturn(@{@"a" : cd});
+  NSString *signingID = [NSString stringWithFormat:@"%s:%s", kExampleTeamID, kExampleSigningID];
 
-  [self validateExecEvent:SNTActionRespondAllow];
-  [self checkMetricCounters:kAllowBinary expected:@1];
+  SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
+  cd.decision = SNTEventStateAllowSigningID;
+  OCMStub([self.mockRuleDatabase criticalSystemBinaries]).andReturn(@{signingID : cd});
+
+  [self validateExecEvent:SNTActionRespondAllow
+             messageSetup:^(es_message_t *msg) {
+               msg->event.exec.target->team_id = MakeESStringToken(kExampleTeamID);
+               msg->event.exec.target->signing_id = MakeESStringToken(kExampleSigningID);
+               msg->event.exec.target->codesigning_flags = CS_SIGNED | CS_VALID | CS_KILL | CS_HARD;
+             }];
+  [self checkMetricCounters:kAllowSigningID expected:@1];
   [self checkMetricCounters:kAllowUnknown expected:@0];
 
   XCTAssertEqual(cd.decisionClientMode, SNTClientModeLockdown);

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -198,6 +198,12 @@ static void UpdateCachedDecisionSigningInfo(
   // If the binary is a critical system binary, don't check its signature.
   // The binary was validated at startup when the rule table was initialized.
   SNTCachedDecision *systemCd = self.ruleTable.criticalSystemBinaries[fileHash];
+
+  // If we didn't find the binary by SHA256, try by signingID
+  if (!systemCd) {
+    systemCd = self.ruleTable.criticalSystemBinaries[signingID];
+  }
+
   if (systemCd) {
     systemCd.decisionClientMode = mode;
     return systemCd;

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -197,12 +197,7 @@ static void UpdateCachedDecisionSigningInfo(
 
   // If the binary is a critical system binary, don't check its signature.
   // The binary was validated at startup when the rule table was initialized.
-  SNTCachedDecision *systemCd = self.ruleTable.criticalSystemBinaries[fileHash];
-
-  // If we didn't find the binary by SHA256, try by signingID
-  if (!systemCd) {
-    systemCd = self.ruleTable.criticalSystemBinaries[signingID];
-  }
+  SNTCachedDecision *systemCd = self.ruleTable.criticalSystemBinaries[signingID];
 
   if (systemCd) {
     systemCd.decisionClientMode = mode;


### PR DESCRIPTION
This PR adds signing ID checks for critical system binaries in addition to the hash check. 

In some scenarios e.g. a Santa upgrade in lockdown mode you may have two versions of the critical binary that needs to run on the system. This ensures that the later can run.