### PR TITLE
Make SNTRule initWithDictionary case insensitive

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1445,7 +1445,7 @@ static SNTConfigurator *sharedConfigurator = nil;
       [NSMutableDictionary dictionaryWithCapacity:staticRules.count];
   for (id rule in staticRules) {
     if (![rule isKindOfClass:[NSDictionary class]]) return;
-    SNTRule *r = [[SNTRule alloc] initWithDictionary:rule];
+    SNTRule *r = [[SNTRule alloc] initWithDictionarySlow:rule];
     if (!r) continue;
     rules[r.identifier] = r;
   }

--- a/Source/common/SNTRule.h
+++ b/Source/common/SNTRule.h
@@ -78,7 +78,7 @@
 ///
 ///  Initialize with a dictionary received from a sync server.
 ///
-- (instancetype)initWithDictionary:(NSDictionary *)dict;
+- (instancetype)initWithDictionarySlow:(NSDictionary *)dict;
 
 ///
 ///  Sets timestamp of rule to the current time.

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -164,10 +164,11 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   return newDict;
 }
 
-// Converts rule information downloaded from the server into a SNTRule.  Because any information
-// not recorded by SNTRule is thrown away here, this method is also responsible for dealing with
-// the extra bundle rule information (bundle_hash & rule_count).
-- (instancetype)initWithDictionary:(NSDictionary *)rawDict {
+// Converts rule information from santactl or static rules into a SNTRule.
+// Because any information not recorded by SNTRule is thrown away here, this
+// method is also responsible for dealing with the extra bundle rule information
+// (bundle_hash & rule_count).
+- (instancetype)initWithDictionarySlow:(NSDictionary *)rawDict {
   if (![rawDict isKindOfClass:[NSDictionary class]]) return nil;
 
   NSDictionary *dict = [self normalizeRuleDictionary:rawDict];

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -147,14 +147,14 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   return self;
 }
 
-//
-- (NSDictionary *)normalizeKeys:(NSDictionary *)dict {
+// lowercase policy keys and upper case the policy decision.
+- (NSDictionary *)normalizeRuleDictionary:(NSDictionary *)dict {
   NSMutableDictionary *newDict = [NSMutableDictionary dictionaryWithCapacity:dict.count];
   for (id rawKey in dict) {
-    if (![rawKey isKindOfClass:[NSString class]) continue;
-    NSString *key = (NSString *)rawKey; 
+    if (![rawKey isKindOfClass:[NSString class]]) continue;
+    NSString *key = (NSString *)rawKey;
     NSString *newKey = [key lowercaseString];
-    if (([newKey isEqualToString:kRulePolicy] || [newKey isEqualToString:kRuleType]) && 
+    if (([newKey isEqualToString:kRulePolicy] || [newKey isEqualToString:kRuleType]) &&
         [dict[key] isKindOfClass:[NSString class]]) {
       newDict[newKey] = [dict[key] uppercaseString];
     } else {
@@ -170,7 +170,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
 - (instancetype)initWithDictionary:(NSDictionary *)rawDict {
   if (![rawDict isKindOfClass:[NSDictionary class]]) return nil;
 
-  NSDictionary *dict = [self normalizeKeys:rawDict];
+  NSDictionary *dict = [self normalizeRuleDictionary:rawDict];
 
   NSString *identifier = dict[kRuleIdentifier];
   if (![identifier isKindOfClass:[NSString class]] || !identifier.length) {

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -154,7 +154,12 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     if (![rawKey isKindOfClass:[NSString class]) continue;
     NSString *key = (NSString *)rawKey; 
     NSString *newKey = [key lowercaseString];
-    newDict[newKey] = dict[key];
+    if (([newKey isEqualToString:kRulePolicy] || [newKey isEqualToString:kRuleType]) && 
+        [dict[key] isKindOfClass:[NSString class]]) {
+      newDict[newKey] = [dict[key] uppercasestring];
+    } else {
+      newDict[newKey] = dict[key];
+    }
   }
   return newDict;
 }

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -156,7 +156,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     NSString *newKey = [key lowercaseString];
     if (([newKey isEqualToString:kRulePolicy] || [newKey isEqualToString:kRuleType]) && 
         [dict[key] isKindOfClass:[NSString class]]) {
-      newDict[newKey] = [dict[key] uppercasestring];
+      newDict[newKey] = [dict[key] uppercaseString];
     } else {
       newDict[newKey] = dict[key];
     }

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -150,7 +150,9 @@ static const NSUInteger kExpectedTeamIDLength = 10;
 //
 - (NSDictionary *)normalizeKeys:(NSDictionary *)dict {
   NSMutableDictionary *newDict = [NSMutableDictionary dictionaryWithCapacity:dict.count];
-  for (NSString *key in dict) {
+  for (id rawKey in dict) {
+    if (![rawKey isKindOfClass:[NSString class]) continue;
+    NSString *key = (NSString *)rawKey; 
     NSString *newKey = [key lowercaseString];
     newDict[newKey] = dict[key];
   }

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -147,11 +147,23 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   return self;
 }
 
+//
+- (NSDictionary *)normalizeKeys:(NSDictionary *)dict {
+  NSMutableDictionary *newDict = [NSMutableDictionary dictionaryWithCapacity:dict.count];
+  for (NSString *key in dict) {
+    NSString *newKey = [key lowercaseString];
+    newDict[newKey] = dict[key];
+  }
+  return newDict;
+}
+
 // Converts rule information downloaded from the server into a SNTRule.  Because any information
 // not recorded by SNTRule is thrown away here, this method is also responsible for dealing with
 // the extra bundle rule information (bundle_hash & rule_count).
-- (instancetype)initWithDictionary:(NSDictionary *)dict {
-  if (![dict isKindOfClass:[NSDictionary class]]) return nil;
+- (instancetype)initWithDictionary:(NSDictionary *)rawDict {
+  if (![rawDict isKindOfClass:[NSDictionary class]]) return nil;
+
+  NSDictionary *dict = [self normalizeKeys:rawDict];
 
   NSString *identifier = dict[kRuleIdentifier];
   if (![identifier isKindOfClass:[NSString class]] || !identifier.length) {

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -278,6 +278,31 @@
   XCTAssertEqualObjects(kRulePolicyRemove, [sut dictionaryRepresentation][kRulePolicy]);
 }
 
+- (void)testKeyCaseForInitWithDictionary {
+  NSLog(@"PLM PLM PLM PLM PLM\n");
+  for (NSString *key in
+       @[ kRulePolicy, kRuleIdentifier, kRuleType, kRuleCustomMsg, kRuleCustomURL, kRuleComment ]) {
+    NSDictionary *expected = @{
+      @"identifier" : @"84de9c61777ca36b13228e2446d53e966096e78db7a72c632b5c185b2ffe68a6",
+      @"policy" : @"ALLOWLIST",
+      @"rule_type" : @"BINARY",
+      @"custom_msg" : @"A custom block message",
+      @"custom_url" : @"https://example.com",
+      @"comment" : @"",
+    };
+
+    NSMutableDictionary *dict = [expected mutableCopy];
+    NSString *value = dict[key];
+    XCTAssertNotNil(value);
+    dict[[key uppercaseString]] = dict[key];
+    [dict removeObjectForKey:key];
+
+    SNTRule *rule = [[SNTRule alloc] initWithDictionary:dict];
+    NSDictionary *final = [rule dictionaryRepresentation];
+    XCTAssertEqualObjects(expected, final);
+  }
+}
+
 /*
 - (void)testRuleTypeToString {
   SNTRule *sut = [[SNTRule alloc] init];

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -279,7 +279,6 @@
 }
 
 - (void)testKeyCaseForInitWithDictionary {
-  NSLog(@"PLM PLM PLM PLM PLM\n");
   for (NSString *key in
        @[ kRulePolicy, kRuleIdentifier, kRuleType, kRuleCustomMsg, kRuleCustomURL, kRuleComment ]) {
     NSDictionary *expected = @{

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -27,7 +27,7 @@
 - (void)testInitWithDictionaryValid {
   SNTRule *sut;
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"BINARY",
@@ -38,7 +38,7 @@
   XCTAssertEqual(sut.type, SNTRuleTypeBinary);
   XCTAssertEqual(sut.state, SNTRuleStateAllow);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"sha256" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"BLOCKLIST",
     @"rule_type" : @"CERTIFICATE",
@@ -51,7 +51,7 @@
 
   // Ensure a Binary and Certificate rules properly convert identifiers to lowercase.
   for (NSString *ruleType in @[ @"BINARY", @"CERTIFICATE" ]) {
-    sut = [[SNTRule alloc] initWithDictionary:@{
+    sut = [[SNTRule alloc] initWithDictionarySlow:@{
       @"identifier" : @"B7C1E3FD640C5F211C89B02C2C6122F78CE322AA5C56EB0BB54BC422A8F8B670",
       @"policy" : @"BLOCKLIST",
       @"rule_type" : ruleType,
@@ -61,7 +61,7 @@
                           @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   }
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"ABCDEFGHIJ",
     @"policy" : @"SILENT_BLOCKLIST",
     @"rule_type" : @"TEAMID",
@@ -71,7 +71,7 @@
   XCTAssertEqual(sut.type, SNTRuleTypeTeamID);
   XCTAssertEqual(sut.state, SNTRuleStateSilentBlock);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"ALLOWLIST_COMPILER",
     @"rule_type" : @"BINARY",
@@ -82,7 +82,7 @@
   XCTAssertEqual(sut.type, SNTRuleTypeBinary);
   XCTAssertEqual(sut.state, SNTRuleStateAllowCompiler);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"ABCDEFGHIJ",
     @"policy" : @"REMOVE",
     @"rule_type" : @"TEAMID",
@@ -92,7 +92,7 @@
   XCTAssertEqual(sut.type, SNTRuleTypeTeamID);
   XCTAssertEqual(sut.state, SNTRuleStateRemove);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"ABCDEFGHIJ",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"TEAMID",
@@ -107,7 +107,7 @@
   XCTAssertEqualObjects(sut.customURL, @"https://example.com");
 
   // TeamIDs must be 10 chars in length
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"A",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"TEAMID",
@@ -115,7 +115,7 @@
   XCTAssertNil(sut);
 
   // TeamIDs must be only alphanumeric chars
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"ßßßßßßßßßß",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"TEAMID",
@@ -123,7 +123,7 @@
   XCTAssertNil(sut);
 
   // TeamIDs are converted to uppercase
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"abcdefghij",
     @"policy" : @"REMOVE",
     @"rule_type" : @"TEAMID",
@@ -132,7 +132,7 @@
   XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ");
 
   // SigningID tests
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"ABCDEFGHIJ:com.example",
     @"policy" : @"REMOVE",
     @"rule_type" : @"SIGNINGID",
@@ -150,7 +150,7 @@
          @":",                // missing team and signing IDs
          @"",                 // empty string
        ]) {
-    sut = [[SNTRule alloc] initWithDictionary:@{
+    sut = [[SNTRule alloc] initWithDictionarySlow:@{
       @"identifier" : ident,
       @"policy" : @"REMOVE",
       @"rule_type" : @"SIGNINGID",
@@ -159,7 +159,7 @@
   }
 
   // Signing ID with lower team ID has case fixed up
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"abcdefghij:com.example",
     @"policy" : @"REMOVE",
     @"rule_type" : @"SIGNINGID",
@@ -168,7 +168,7 @@
   XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ:com.example");
 
   // Signing ID with lower platform team ID is left alone
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"platform:com.example",
     @"policy" : @"REMOVE",
     @"rule_type" : @"SIGNINGID",
@@ -183,7 +183,7 @@
          @"ABCDEFGHIJ::",
          @"ABCDEFGHIJ:com:example:with:more:components:",
        ]) {
-    sut = [[SNTRule alloc] initWithDictionary:@{
+    sut = [[SNTRule alloc] initWithDictionarySlow:@{
       @"identifier" : ident,
       @"policy" : @"ALLOWLIST",
       @"rule_type" : @"SIGNINGID",
@@ -196,29 +196,29 @@
 - (void)testInitWithDictionaryInvalid {
   SNTRule *sut;
 
-  sut = [[SNTRule alloc] initWithDictionary:@{}];
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{}];
   XCTAssertNil(sut);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
   }];
   XCTAssertNil(sut);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"an-identifier",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"BINARY",
   }];
   XCTAssertNil(sut);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"OTHERPOLICY",
     @"rule_type" : @"BINARY",
   }];
   XCTAssertNil(sut);
 
-  sut = [[SNTRule alloc] initWithDictionary:@{
+  sut = [[SNTRule alloc] initWithDictionarySlow:@{
     @"identifier" : @"an-identifier",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"OTHER_RULE_TYPE",
@@ -236,7 +236,7 @@
     @"comment" : @"",
   };
 
-  SNTRule *sut = [[SNTRule alloc] initWithDictionary:expectedTeamID];
+  SNTRule *sut = [[SNTRule alloc] initWithDictionarySlow:expectedTeamID];
   NSDictionary *dict = [sut dictionaryRepresentation];
   XCTAssertEqualObjects(expectedTeamID, dict);
 
@@ -249,7 +249,7 @@
     @"comment" : @"",
   };
 
-  sut = [[SNTRule alloc] initWithDictionary:expectedBinary];
+  sut = [[SNTRule alloc] initWithDictionarySlow:expectedBinary];
   dict = [sut dictionaryRepresentation];
 
   XCTAssertEqualObjects(expectedBinary, dict);
@@ -264,7 +264,7 @@
     @"custom_url" : @"https://example.com",
   };
 
-  SNTRule *sut = [[SNTRule alloc] initWithDictionary:expected];
+  SNTRule *sut = [[SNTRule alloc] initWithDictionarySlow:expected];
   sut.state = SNTRuleStateBlock;
   XCTAssertEqualObjects(kRulePolicyBlocklist, [sut dictionaryRepresentation][kRulePolicy]);
   sut.state = SNTRuleStateSilentBlock;
@@ -296,7 +296,7 @@
     dict[[key uppercaseString]] = dict[key];
     [dict removeObjectForKey:key];
 
-    SNTRule *rule = [[SNTRule alloc] initWithDictionary:dict];
+    SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:dict];
     NSDictionary *final = [rule dictionaryRepresentation];
     XCTAssertEqualObjects(expected, final);
   }

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -487,7 +487,7 @@ REGISTER_COMMAND_NAME(@"rule")
   NSMutableArray<SNTRule *> *parsedRules = [[NSMutableArray alloc] init];
 
   for (NSDictionary *jsonRule in rules[@"rules"]) {
-    SNTRule *rule = [[SNTRule alloc] initWithDictionary:jsonRule];
+    SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:jsonRule];
     if (!rule) {
       [self printErrorUsageAndExit:[NSString stringWithFormat:@"Invalid rule: %@", jsonRule]];
     }

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -66,7 +66,7 @@
 }
 
 - (void)testDecisionForBlockByCDHashRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CDHASH",
     @"identifier" : @"a023fbe5361a5bbd793dc3889556e93f41ec9bb8",
     @"policy" : @"BLOCKLIST"
@@ -88,7 +88,7 @@
 }
 
 - (void)testDecisionForSilentBlockByCDHashRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CDHASH",
     @"identifier" : @"a023fbe5361a5bbd793dc3889556e93f41ec9bb8",
     @"policy" : @"SILENT_BLOCKLIST"
@@ -111,7 +111,7 @@
 }
 
 - (void)testDecisionForAllowbyCDHashRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CDHASH",
     @"identifier" : @"a023fbe5361a5bbd793dc3889556e93f41ec9bb8",
     @"policy" : @"ALLOWLIST"
@@ -134,7 +134,7 @@
 }
 
 - (void)testDecisionForBlockBySHA256RuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"BLOCKLIST"
@@ -158,7 +158,7 @@
 }
 
 - (void)testDecisionForSilenBlockBySHA256RuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"SILENT_BLOCKLIST"
@@ -182,7 +182,7 @@
 }
 
 - (void)testDecisionForAllowBySHA256RuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST"
@@ -205,7 +205,7 @@
 }
 
 - (void)testDecisionForSigningIDBlockRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"SIGNINGID",
     @"identifier" : @"ABCDEFGHIJ:ABCDEFGHIJ",
     @"policy" : @"BLOCKLIST"
@@ -229,7 +229,7 @@
 
 // Signing ID rules
 - (void)testDecisionForSigningIDSilentBlockRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"SIGNINGID",
     @"identifier" : @"TEAMID1234:ABCDEFGHIJ",
     @"policy" : @"SILENT_BLOCKLIST"
@@ -252,7 +252,7 @@
 }
 
 - (void)testDecisionForSigningIDAllowRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"SIGNINGID",
     @"identifier" : @"TEAMID1234:ABCDEFGHIJ",
     @"policy" : @"ALLOWLIST"
@@ -276,7 +276,7 @@
 
 //  Certificate rules
 - (void)testDecisionForCertificateBlockRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CERTIFICATE",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"BLOCKLIST"
@@ -299,7 +299,7 @@
 }
 
 - (void)testDecisionForCertificateSilentBlockRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CERTIFICATE",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"SILENT_BLOCKLIST"
@@ -322,7 +322,7 @@
 }
 
 - (void)testDecisionForCertificateAllowRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CERTIFICATE",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST"
@@ -346,7 +346,7 @@
 
 // Team ID rules
 - (void)testDecisionForTeamIDBlockRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"TEAMID",
     @"identifier" : @"TEAMID1234",
     @"policy" : @"BLOCKLIST"
@@ -369,7 +369,7 @@
 }
 
 - (void)testDecisionForTeamIDSilentBlockRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"TEAMID",
     @"identifier" : @"TEAMID1234",
     @"policy" : @"SILENT_BLOCKLIST"
@@ -392,7 +392,7 @@
 }
 
 - (void)testDecisionForTeamIDAllowRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"TEAMID",
     @"identifier" : @"TEAMID1234",
     @"policy" : @"ALLOWLIST"
@@ -417,7 +417,7 @@
 // Compiler rules
 // CDHash
 - (void)testDecisionForCDHashCompilerRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"CDHASH",
     @"identifier" : @"a023fbe5361a5bbd793dc3889556e93f41ec9bb8",
     @"policy" : @"ALLOWLIST_COMPILER"
@@ -441,7 +441,7 @@
 
 // SHA256
 - (void)testDecisionForSHA256CompilerRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST_COMPILER"
@@ -465,7 +465,7 @@
 
 // SigningID
 - (void)testDecisionForSigningIDCompilerRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"SIGNINGID",
     @"identifier" : @"TEAMID1234:ABCDEFGHIJ",
     @"policy" : @"ALLOWLIST_COMPILER"
@@ -489,7 +489,7 @@
 
 // Transitive allowlist rules
 - (void)testDecisionForTransitiveAllowlistRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST"
@@ -516,7 +516,7 @@
 }
 
 - (void)testEnsureANonMatchingRuleResultsInUnknown {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST"
@@ -542,7 +542,7 @@
 }
 
 - (void)testEnsureCustomURLAndMessageAreSet {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  SNTRule *rule = [[SNTRule alloc] initWithDictionarySlow:@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST",


### PR DESCRIPTION
This PR makes SNTRule's initWithDictionary method case insensitive by normalizing the keys of the dictionary to be lowercase.

This avoids issues like typing `rule_Type` when adding static rules or when importing rules from a JSON file.