### PR TITLE
Rework how valid rule IDs are tracked

### DIFF
--- a/Source/common/CertificateHelpers.h
+++ b/Source/common/CertificateHelpers.h
@@ -1,4 +1,5 @@
 /// Copyright 2023 Google LLC
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -39,5 +40,14 @@ NSString *Publisher(NSArray<MOLCertificate *> *certs, NSString *teamID);
   for a long time be careful to properly CFRetain/CFRelease the returned items.
 */
 NSArray<id> *CertificateChain(NSArray<MOLCertificate *> *certs);
+
+/**
+  Test if the given certificate contains development OID values.
+
+  @param cert The cert to test
+
+  @return True if any development OIDs exist, otherwise false.
+*/
+BOOL IsDevelopmentCert(MOLCertificate *cert);
 
 __END_DECLS

--- a/Source/common/CertificateHelpers.m
+++ b/Source/common/CertificateHelpers.m
@@ -43,3 +43,18 @@ NSArray<id> *CertificateChain(NSArray<MOLCertificate *> *certs) {
 
   return certArray;
 }
+
+BOOL IsDevelopmentCert(MOLCertificate *cert) {
+  // Development OID values defined by Apple and used by the Security Framework
+  // https://images.apple.com/certificateauthority/pdf/Apple_WWDR_CPS_v1.31.pdf
+  static NSArray *const keys = @[ @"1.2.840.113635.100.6.1.2", @"1.2.840.113635.100.6.1.12" ];
+
+  if (!cert || !cert.certRef) {
+    return NO;
+  }
+
+  NSDictionary *vals =
+      CFBridgingRelease(SecCertificateCopyValues(cert.certRef, (__bridge CFArrayRef)keys, NULL));
+
+  return vals.count > 0;
+}

--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -43,6 +43,8 @@
 @property NSString *cdhash;
 @property NSDictionary *entitlements;
 @property BOOL entitlementsFiltered;
+@property uint32_t codesigningFlags;
+@property SNTSigningStatus signingStatus;
 
 @property NSString *quarantineURL;
 

--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -1,16 +1,17 @@
 /// Copyright 2015-2022 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import <Foundation/Foundation.h>
 
@@ -183,6 +184,14 @@ typedef NS_ENUM(NSInteger, SNTRuleCleanup) {
   SNTRuleCleanupNone,
   SNTRuleCleanupAll,
   SNTRuleCleanupNonTransitive,
+};
+
+typedef NS_ENUM(NSInteger, SNTSigningStatus) {
+  SNTSigningStatusUnsigned,
+  SNTSigningStatusInvalid,
+  SNTSigningStatusAdhoc,
+  SNTSigningStatusDevelopment,
+  SNTSigningStatusProduction,
 };
 
 #ifdef __cplusplus

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -114,6 +114,16 @@
 @property NSString *cdhash;
 
 ///
+/// Codesigning flags for the process (from `<Kernel/kern/cs_blobs.h>`)
+///
+@property uint32_t codesigningFlags;
+
+///
+/// The signing status of the executable file
+///
+@property SNTSigningStatus signingStatus;
+
+///
 ///  The user who executed the binary.
 ///
 @property NSString *executingUser;

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -59,6 +59,8 @@
   ENCODE(self.teamID, @"teamID");
   ENCODE(self.signingID, @"signingID");
   ENCODE(self.cdhash, @"cdhash");
+  ENCODE(@(self.codesigningFlags), @"codesigningFlags");
+  ENCODE(@(self.signingStatus), @"signingStatus");
   ENCODE(self.entitlements, @"entitlements");
   ENCODE(@(self.entitlementsFiltered), @"entitlementsFiltered");
 
@@ -108,6 +110,8 @@
     _teamID = DECODE(NSString, @"teamID");
     _signingID = DECODE(NSString, @"signingID");
     _cdhash = DECODE(NSString, @"cdhash");
+    _codesigningFlags = [DECODE(NSNumber, @"codesigningFlags") unsignedIntValue];
+    _signingStatus = (SNTSigningStatus)[DECODE(NSNumber, @"signingStatus") integerValue];
     _entitlements = DECODEDICT(@"entitlements");
     _entitlementsFiltered = [DECODE(NSNumber, @"entitlementsFiltered") boolValue];
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -26,6 +26,7 @@ objc_library(
     ],
     deps = [
         ":SNTDatabaseTable",
+        "//Source/common:CertificateHelpers",
         "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
@@ -201,6 +202,7 @@ objc_library(
     hdrs = ["SNTPolicyProcessor.h"],
     deps = [
         ":SNTRuleTable",
+        "//Source/common:CertificateHelpers",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
@@ -955,6 +957,7 @@ santa_unit_test(
         "EndpointSecurity",
     ],
     deps = [
+        "//Source/common:CertificateHelpers",
         "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -1,16 +1,17 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2024 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #include "Source/common/SNTCommonEnums.h"
@@ -19,6 +20,7 @@
 #import <MOLCertificate/MOLCertificate.h>
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 
+#import "Source/common/CertificateHelpers.h"
 #import "Source/common/Platform.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTConfigurator.h"
@@ -161,6 +163,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     cd.sha256 = binInfo.SHA256;
     cd.signingID = FormatSigningID(csInfo);
     cd.cdhash = csInfo.cdhash;
+    cd.signingStatus = IsDevelopmentCert(csInfo.leafCertificate) ? SNTSigningStatusDevelopment
+                                                                 : SNTSigningStatusProduction;
 
     // Normalized by the FormatSigningID function so this will always have a
     // prefix.


### PR DESCRIPTION
The main purpose of this PR is to address a crash that could occur in STANDALONE mode when attempting to approve ad hoc signed binaries.

This PR also changes behavior for how to identify which fields are valid for rule lookup. Instead of clearing values form the SNTCachedDecision, the signing status of the executing binary is tracked separately and used to compute valid identifiers. This will allow reporting of all fields in sync events instead of clearing this critical info (separate PR).