### PR TITLE
Add serializations for clone and copyfile

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -475,7 +475,13 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedCSInvalidated &
 std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedClone &msg) {
   std::string str = CreateDefaultString();
 
-  str.append("action=CLONE");
+  str.append("action=CLONE|source=");
+  str.append(FilePath(msg->event.clone.source).Sanitized());
+  str.append("|target=");
+  str.append(FilePath(msg->event.clone.target_dir).Sanitized());
+  str.append("/");
+  str.append(SanitizableString(msg->event.clone.target_name).Sanitized());
+  AppendInstigator(str, msg);
 
   return FinalizeString(str);
 }
@@ -483,7 +489,13 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedClone &msg) {
 std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedCopyfile &msg) {
   std::string str = CreateDefaultString();
 
-  str.append("action=COPYFILE");
+  str.append("action=COPYFILE|source=");
+  str.append(FilePath(msg->event.copyfile.source).Sanitized());
+  str.append("|target=");
+  str.append(FilePath(msg->event.copyfile.target_dir).Sanitized());
+  str.append("/");
+  str.append(SanitizableString(msg->event.copyfile.target_name).Sanitized());
+  AppendInstigator(str, msg);
 
   return FinalizeString(str);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -263,6 +263,42 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   XCTAssertCppStringEqual(got, want);
 }
 
+- (void)testSerializeMessageClone {
+  es_file_t procFile = MakeESFile("foo");
+  es_file_t srcFile = MakeESFile("clone_src");
+  es_file_t targetDirFile = MakeESFile("target_dir");
+  es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(12, 34), MakeAuditToken(56, 78));
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_CLONE, &proc);
+  esMsg.event.clone.source = &srcFile;
+  esMsg.event.clone.target_dir = &targetDirFile;
+  esMsg.event.clone.target_name = MakeESStringToken("target_name");
+
+  std::string got = BasicStringSerializeMessage(&esMsg);
+  std::string want = "action=CLONE|source=clone_src|target=target_dir/target_name"
+                     "|pid=12|ppid=56|process=foo|processpath=foo"
+                     "|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
+
+  XCTAssertCppStringEqual(got, want);
+}
+
+- (void)testSerializeMessageCopyfile {
+  es_file_t procFile = MakeESFile("foo");
+  es_file_t srcFile = MakeESFile("copyfile_src");
+  es_file_t targetDirFile = MakeESFile("target_dir");
+  es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(12, 34), MakeAuditToken(56, 78));
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_COPYFILE, &proc);
+  esMsg.event.copyfile.source = &srcFile;
+  esMsg.event.copyfile.target_dir = &targetDirFile;
+  esMsg.event.copyfile.target_name = MakeESStringToken("target_name");
+
+  std::string got = BasicStringSerializeMessage(&esMsg);
+  std::string want = "action=COPYFILE|source=copyfile_src|target=target_dir/target_name"
+                     "|pid=12|ppid=56|process=foo|processpath=foo"
+                     "|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
+
+  XCTAssertCppStringEqual(got, want);
+}
+
 #if HAVE_MACOS_13
 
 - (void)testSerializeMessageLoginWindowSessionLogin {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -639,11 +639,33 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedCSInvalidated &msg
 }
 
 std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedClone &msg) {
-  return {};
+  Arena arena;
+  ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena, msg);
+
+  ::pbv1::Clone *pb_clone = santa_msg->mutable_clone();
+  EncodeProcessInfoLight(pb_clone->mutable_instigator(), msg);
+  EncodeFileInfo(pb_clone->mutable_source(), msg->event.clone.source, msg.source());
+  EncodePath(pb_clone->mutable_target(), msg->event.clone.target_dir, msg->event.clone.target_name);
+
+  return FinalizeProto(santa_msg);
 }
 
 std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedCopyfile &msg) {
-  return {};
+  Arena arena;
+  ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena, msg);
+
+  ::pbv1::Copyfile *pb_copyfile = santa_msg->mutable_copyfile();
+  EncodeProcessInfoLight(pb_copyfile->mutable_instigator(), msg);
+  EncodeFileInfo(pb_copyfile->mutable_source(), msg->event.copyfile.source, msg.source());
+  EncodePath(pb_copyfile->mutable_target(), msg->event.copyfile.target_dir,
+             msg->event.copyfile.target_name);
+
+  // If `target_file` is set, it is an existing file that will be overwritten
+  pb_copyfile->set_target_existed(msg->event.copyfile.target_file != NULL);
+  pb_copyfile->set_mode(msg->event.copyfile.mode);
+  pb_copyfile->set_flags(msg->event.copyfile.flags);
+
+  return FinalizeProto(santa_msg);
 }
 
 #if HAVE_MACOS_13

--- a/Source/santad/testdata/protobuf/v1/clone.json
+++ b/Source/santad/testdata/protobuf/v1/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v2/clone.json
+++ b/Source/santad/testdata/protobuf/v2/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v4/clone.json
+++ b/Source/santad/testdata/protobuf/v4/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v4/copyfile.json
+++ b/Source/santad/testdata/protobuf/v4/copyfile.json
@@ -1,0 +1,67 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": true,
+ "mode": 291,
+ "flags": 1110
+}

--- a/Source/santad/testdata/protobuf/v5/clone.json
+++ b/Source/santad/testdata/protobuf/v5/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v5/copyfile.json
+++ b/Source/santad/testdata/protobuf/v5/copyfile.json
@@ -1,0 +1,67 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": true,
+ "mode": 291,
+ "flags": 1110
+}

--- a/Source/santad/testdata/protobuf/v6/clone.json
+++ b/Source/santad/testdata/protobuf/v6/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v6/copyfile.json
+++ b/Source/santad/testdata/protobuf/v6/copyfile.json
@@ -1,0 +1,67 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": true,
+ "mode": 291,
+ "flags": 1110
+}

--- a/Source/santad/testdata/protobuf/v7/clone.json
+++ b/Source/santad/testdata/protobuf/v7/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v7/copyfile.json
+++ b/Source/santad/testdata/protobuf/v7/copyfile.json
@@ -1,0 +1,67 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": false,
+ "mode": 291,
+ "flags": 1110
+}

--- a/Source/santad/testdata/protobuf/v8/clone.json
+++ b/Source/santad/testdata/protobuf/v8/clone.json
@@ -1,0 +1,64 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file"
+}

--- a/Source/santad/testdata/protobuf/v8/copyfile.json
+++ b/Source/santad/testdata/protobuf/v8/copyfile.json
@@ -1,0 +1,67 @@
+{
+ "instigator": {
+  "id": {
+   "pid": 12,
+   "pidversion": 34
+  },
+  "parent_id": {
+   "pid": 56,
+   "pidversion": 78
+  },
+  "original_parent_pid": 56,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "foo",
+   "truncated": false
+  }
+ },
+ "source": {
+  "path": "source",
+  "truncated": false,
+  "stat": {
+   "dev": 301,
+   "mode": 302,
+   "nlink": 303,
+   "ino": "304",
+   "user": {
+    "uid": -2,
+    "name": "nobody"
+   },
+   "group": {
+    "gid": -1,
+    "name": "nogroup"
+   },
+   "rdev": 305,
+   "access_time": "1970-01-01T00:06:40.000000500Z",
+   "modification_time": "1970-01-01T00:06:41.000000321Z",
+   "change_time": "1970-01-01T00:06:42.000000502Z",
+   "birth_time": "1970-01-01T00:06:43.000000503Z",
+   "size": "306",
+   "blocks": "307",
+   "blksize": 308,
+   "flags": 309,
+   "gen": 310
+  }
+ },
+ "target": "target_dir/target_file",
+ "target_existed": true,
+ "mode": 291,
+ "flags": 1110
+}


### PR DESCRIPTION
The bulk of the PR is new test golden files.

The main thing to call out is that the string serialization doesn't include "mode", "flags", and "previously existed" like is done for proto. This is largely because encoding these types is more cumbersome. We often don't add these for the string serializations, but could add them (maybe as hex and true/false strings?) if anyone feels strongly.