### PR TITLE
santactl status: fix hang when sync server is unresponsive

### DIFF
--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -352,7 +352,13 @@ double watchdogRAMPeak = 0;
 #pragma mark syncd Ops
 
 - (void)pushNotifications:(void (^)(BOOL))reply {
-  [self.syncdQueue.syncConnection.remoteObjectProxy isFCMListening:^(BOOL response) {
+  // This message should be handled in a timely manner, santactl status waits for the response.
+  // Instead of reusing the existing connection, create a new connection to the sync service.
+  // Otherwise, the isFCMListening message would potentially be queued behind various long lived
+  // sync operations.
+  MOLXPCConnection *conn = [SNTXPCSyncServiceInterface configuredConnection];
+  [conn resume];
+  [conn.remoteObjectProxy isFCMListening:^(BOOL response) {
     reply(response);
   }];
 }


### PR DESCRIPTION
Because install.sh (and postinstall) now use output from `santactl status`, this CL also fixes the intermittent hanging we have noticed during `bazel :reload`.

https://github.com/northpolesec/santa/blob/ce65385ca5234e071bdefac96cbf9ef46ff69605/Conf/install.sh#L40