### PR TITLE
Add an optional step to add a TeamID rule for NPS Santa

### DIFF
--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -24,7 +24,7 @@ straight to [Getting Started](getting-started.md).
 ## Migration Steps
 
 ### 1. Configure System Extensions
-- (Optional) Add a Team ID Rule for North Pole Security's Team ID (ZMCG7MLDV9) to Google Santa
+- (Optional) Add a Team ID Rule for North Pole Security's Team ID (ZMCG7MLDV9) to Google Santa. This is to guarantee that complex MDM setups don't allow Google Santa to block NPS Santa if they're running simultaneously.
   - Either add it as a [static rule](https://northpole.dev/deployment/configuration.html#static-rules), `santactl rule` or via your sync service
 - First, update your MDM configuration to allow both Google and NPS system
 extensions simultaneously. This dual-authorization is temporary but necessary

--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -24,6 +24,8 @@ straight to [Getting Started](getting-started.md).
 ## Migration Steps
 
 ### 1. Configure System Extensions
+- (Optional) Add a Team ID Rule for North Pole Security's Team ID (ZMCG7MLDV9) to Google Santa
+  - Either add it as a [static rule](https://northpole.dev/deployment/configuration.html#static-rules), `santactl rule` or via your sync service
 - First, update your MDM configuration to allow both Google and NPS system
 extensions simultaneously. This dual-authorization is temporary but necessary
 for a seamless transition.


### PR DESCRIPTION
This PR adds an optional step of adding a `Team ID` rule for NPS to Google Santa in the migration guide.