### PR TITLE
Forwards compatibility with string_view proto descriptor names

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
@@ -55,7 +55,8 @@ Spool::Spool(dispatch_queue_t q, dispatch_source_t timer_source, std::string_vie
                                           spool_file_size_threshold_leniency_factor_),
       write_complete_f_(write_complete_f),
       flush_task_complete_f_(flush_task_complete_f) {
-  type_url_ = kTypeGoogleApisComPrefix + ::santa::pb::v1::SantaMessage::descriptor()->full_name();
+  type_url_ = absl::StrCat(kTypeGoogleApisComPrefix,
+                           ::santa::pb::v1::SantaMessage::descriptor()->full_name());
 }
 
 Spool::~Spool() {


### PR DESCRIPTION
Descriptor names can be returned as string_view in the future, so they should be concatenated with absl::StrCat() instead of "+".

See https://protobuf.dev/news/v30/#descriptor-apis ("Descriptor APIs")