### PR TITLE
Clarify uniqueness properties of PID + pidversion

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -22,7 +22,10 @@ message GroupInfo {
   optional string name = 2;
 }
 
-// A process is uniquely identified on macOS by its pid and pidversion
+// A macOS process is identified by its pid and pidversion.
+//
+// This identifier is unique during the runtime of the operating system,
+// but not unique across restarts.
 message ProcessID {
   optional int32 pid = 1;
   optional int32 pidversion = 2;


### PR DESCRIPTION
This is, among other places, documented in the ESMessage.h header, where it says that (pid, pidversion) "is not meant to be unique across reboots or across multiple systems".