### PR TITLE
Remove pending standalone notifications on UI connection invalidation

### DIFF
--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -446,7 +446,7 @@ static NSString *const kPrinterProxyPostMonterey =
           return msg;
         });
 
-        void (^replyBlock)(BOOL) = nil;
+        NotificationReplyBlock replyBlock = nil;
 
         if (holdAndAsk) {
           replyBlock = ^(BOOL authenticated) {

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -22,6 +22,8 @@
 @class SNTStoredEvent;
 @class MOLXPCConnection;
 
+using NotificationReplyBlock = void (^)(BOOL);
+
 @interface SNTNotificationQueue : NSObject
 
 @property(nonatomic) MOLXPCConnection *notifierConnection;

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -128,7 +128,7 @@
 
     NotificationReplyBlock replyBlock = d[@"reply"];
     if (replyBlock == nil) {
-      // The reply block sent tflushQueueSerializedo the GUI cannot be nil.
+      // The reply block sent to the GUI cannot be nil. Provide one now if one was not given.
       // The copy is necessary so the block is on the heap.
       replyBlock = [^(BOOL _) {
       } copy];

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -25,3 +25,11 @@ nav_order: 7
 *   Metrics reported by Santa are not currently in a format that is friendly to
     open source solutions
     ([Issue #563](https://github.com/google/santa/issues/563))
+
+*   Standalone Mode
+    *   Users will not be notified of processes that were blocked while a user
+        was not logged in to the system.
+    *   Fast user switching and/or logging out while an authorization dialog is
+        presented to the user can sometimes result in the process being kept in a
+        suspended state, preventing subsequent launches. The user must manually
+        kill the affected process (e.g. `kill -9 <pid>`).


### PR DESCRIPTION
This change makes it so that not only are the pending blocks responded to with a FALSE argument, but the notifications themselves are also cleared from the queue.

Previously, the notifications were left  in the queue to replicate behavior similar to LOCKDOWN mode where the user would be notified of blocks that occurred while not logged in and allow them to remedy the situation.

However for standalone mode, the reply blocks were getting cleared, but leaving the notification intact. This resulted in the user being notified about the block event and given the option to approve the binary. However since the reply block was cleared, santad would take no action and no rule would be created. This would be confusing to users.

Some better potential long term fixes would be to add additional AuthResultCache states to allow the replyBlock to be called after the user eventually logged in. Another solution would be to present the dialog to the user to inform them of the block but don't allow for authorization. The user would still be able to perform manual authorization (e.g. via santactl).