### PR TITLE
Enforce direct BUILD dependencies by adding layering check (1/2)

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -5,7 +5,7 @@ load("//:helper.bzl", "santa_unit_test")
 package(
     default_visibility = ["//:santa_package_group"],
     features = [
-        "-layering_check",
+        "layering_check",
     ],
 )
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -4,6 +4,9 @@ load("//:helper.bzl", "santa_unit_test")
 
 package(
     default_visibility = ["//:santa_package_group"],
+    features = [
+        "-layering_check",
+    ],
 )
 
 licenses(["notice"])
@@ -1414,6 +1417,7 @@ santa_unit_test(
         ":MockEndpointSecurityAPI",
         ":SNTEndpointSecurityTamperResistance",
         ":WatchItemPolicy",
+        "//Source/common:SNTCommonEnums",
         "//Source/common:SNTLogging",
         "//Source/common:TestUtils",
         "@OCMock",


### PR DESCRIPTION
 It ensures that code includes the headers it needs directly instead of transitively.