### PR TITLE
Config: Adjust perms to 0644 for sync-state.plist.

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1306,7 +1306,7 @@ static SNTConfigurator *sharedConfigurator = nil;
   syncState[kAllowedPathRegexKey] = [syncState[kAllowedPathRegexKey] pattern];
   syncState[kBlockedPathRegexKey] = [syncState[kBlockedPathRegexKey] pattern];
   [syncState writeToFile:self.syncStateFilePath atomically:YES];
-  [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0600}
+  [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0644}
                                    ofItemAtPath:self.syncStateFilePath
                                           error:NULL];
 }


### PR DESCRIPTION
Nothing in this plist is sensitive and preventing the non-root procs from reading it can cause config mismatches