### PR TITLE
Revert "Config: Adjust perms to 0644 for sync-state.plist."

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1306,7 +1306,7 @@ static SNTConfigurator *sharedConfigurator = nil;
   syncState[kAllowedPathRegexKey] = [syncState[kAllowedPathRegexKey] pattern];
   syncState[kBlockedPathRegexKey] = [syncState[kBlockedPathRegexKey] pattern];
   [syncState writeToFile:self.syncStateFilePath atomically:YES];
-  [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0644}
+  [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0600}
                                    ofItemAtPath:self.syncStateFilePath
                                           error:NULL];
 }


### PR DESCRIPTION
Reverts northpolesec/santa#218

While there is nothing sensitive about the content of this file, we've decided not to modify permissions at this time.