### PR TITLE
Add support for parsing new proc-based FAA rules

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -48,6 +48,16 @@ objc_library(
     deps = [
         "//Source/common:PrefixTree",
         "//Source/common:Unit",
+        "@com_google_absl//absl/container:flat_hash_set",
+    ],
+)
+
+santa_unit_test(
+    name = "WatchItemPolicyTest",
+    srcs = ["DataLayer/WatchItemPolicyTest.mm"],
+    deps = [
+        ":WatchItemPolicy",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 
@@ -62,6 +72,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:String",
         "//Source/common:Unit",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 
@@ -75,6 +86,7 @@ santa_unit_test(
         "//Source/common:TestUtils",
         "//Source/common:Unit",
         "@OCMock",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 
@@ -1533,6 +1545,7 @@ test_suite(
         ":SNTPolicyProcessorTest",
         ":SNTRuleTableTest",
         ":SantadTest",
+        ":WatchItemPolicyTest",
         ":WatchItemsTest",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool_test",
         "//Source/santad/ProcessTree:process_tree_test",

--- a/Source/santad/DataLayer/WatchItemPolicyTest.mm
+++ b/Source/santad/DataLayer/WatchItemPolicyTest.mm
@@ -80,7 +80,7 @@ using santa::WatchItemRuleType;
 }
 
 - (void)testSetSharedProcessWatchItemPolicy {
-  // Test that hash/eq funcitons for set of shared pointers works as expected
+  // Test that hash/eq functions for set of shared pointers works as expected
   absl::flat_hash_set<std::shared_ptr<ProcessWatchItemPolicy>, SharedPtrProcessWatchItemPolicyHash,
                       SharedPtrProcessWatchItemPolicyEqual>
       procSet;
@@ -97,7 +97,7 @@ using santa::WatchItemRuleType;
       "name", "v1", PathAndTypeVec{{"/bar", WatchItemPathType::kLiteral}}, true, true,
       WatchItemRuleType::kProcessesWithDeniedPaths);
 
-  // UNderlying pointers should be different
+  // Underlying pointers should be different
   XCTAssertNotEqual(sharedProcPolicy1, sharedProcPolicy2);
   XCTAssertNotEqual(sharedProcPolicy1, sharedProcPolicy3);
   XCTAssertNotEqual(sharedProcPolicy2, sharedProcPolicy3);

--- a/Source/santad/DataLayer/WatchItemPolicyTest.mm
+++ b/Source/santad/DataLayer/WatchItemPolicyTest.mm
@@ -1,0 +1,125 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/DataLayer/WatchItemPolicy.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include <memory>
+
+#include "absl/container/flat_hash_set.h"
+
+using santa::PathAndTypePair;
+using santa::PathAndTypeVec;
+using santa::ProcessWatchItemPolicy;
+using santa::SharedPtrProcessWatchItemPolicyEqual;
+using santa::SharedPtrProcessWatchItemPolicyHash;
+using santa::WatchItemPathType;
+using santa::WatchItemProcess;
+using santa::WatchItemRuleType;
+
+@interface WatchItemPolicyTest : XCTestCase
+@end
+
+@implementation WatchItemPolicyTest
+
+- (void)testProcessWatchItemPolicy {
+  // Make sure the hash function for a WatchItemProcess covers all members
+  WatchItemProcess proc{"proc_path_1", "com.example.proc", "PROCTEAMID", {}, "", std::nullopt};
+
+  ProcessWatchItemPolicy pwip("name", "ver",
+                              PathAndTypeVec{PathAndTypePair{"path1", WatchItemPathType::kLiteral}},
+                              true, true, santa::WatchItemRuleType::kProcessesWithAllowedPaths,
+                              false, false, "", nil, nil, {proc});
+
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 1);
+
+  proc.signing_id = "abc";
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 2);
+
+  proc.binary_path = "abc";
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 3);
+
+  proc.team_id = "abc";
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 4);
+
+  proc.platform_binary = true;
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 5);
+
+  proc.certificate_sha256 = "abc";
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 6);
+
+  proc.cdhash = {1};
+  pwip.processes.insert(proc);
+  pwip.processes.insert(proc);
+  XCTAssertEqual(pwip.processes.size(), 7);
+}
+
+- (void)testSetSharedProcessWatchItemPolicy {
+  // Test that hash/eq funcitons for set of shared pointers works as expected
+  absl::flat_hash_set<std::shared_ptr<ProcessWatchItemPolicy>, SharedPtrProcessWatchItemPolicyHash,
+                      SharedPtrProcessWatchItemPolicyEqual>
+      procSet;
+
+  auto sharedProcPolicy1 = std::make_shared<ProcessWatchItemPolicy>(
+      "name", "v1", PathAndTypeVec{{"/foo", WatchItemPathType::kLiteral}}, true, true,
+      WatchItemRuleType::kProcessesWithDeniedPaths);
+
+  auto sharedProcPolicy2 = std::make_shared<ProcessWatchItemPolicy>(
+      "name", "v1", PathAndTypeVec{{"/foo", WatchItemPathType::kLiteral}}, true, true,
+      WatchItemRuleType::kProcessesWithDeniedPaths);
+
+  auto sharedProcPolicy3 = std::make_shared<ProcessWatchItemPolicy>(
+      "name", "v1", PathAndTypeVec{{"/bar", WatchItemPathType::kLiteral}}, true, true,
+      WatchItemRuleType::kProcessesWithDeniedPaths);
+
+  // UNderlying pointers should be different
+  XCTAssertNotEqual(sharedProcPolicy1, sharedProcPolicy2);
+  XCTAssertNotEqual(sharedProcPolicy1, sharedProcPolicy3);
+  XCTAssertNotEqual(sharedProcPolicy2, sharedProcPolicy3);
+
+  // policies 1 and 2 have the same content, but policy 3 has a different path.
+  // Check for expected equality.
+  XCTAssertTrue(*sharedProcPolicy1 == *sharedProcPolicy2);
+  XCTAssertFalse(*sharedProcPolicy1 == *sharedProcPolicy3);
+
+  // Insert the same item multiple times, it should only be added once
+  procSet.insert(sharedProcPolicy1);
+  procSet.insert(sharedProcPolicy1);
+  XCTAssertEqual(procSet.size(), 1);
+
+  // Adding the second policy should also not increase the
+  // size since it is equal to policy 1.
+  procSet.insert(sharedProcPolicy2);
+  XCTAssertEqual(procSet.size(), 1);
+
+  // Adding policy 3 should be allowed since it isn't equal to 1 or 2.
+  procSet.insert(sharedProcPolicy3);
+  XCTAssertEqual(procSet.size(), 2);
+}
+
+@end

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -105,7 +105,6 @@ using ProcessWatchItemPolicySet =
     absl::flat_hash_set<std::shared_ptr<ProcessWatchItemPolicy>,
                         SharedPtrProcessWatchItemPolicyHash, SharedPtrProcessWatchItemPolicyEqual>;
 class ProcessWatchItems {
- private:
  public:
   ProcessWatchItems() = default;
 

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -31,6 +31,7 @@
 #include "Source/common/PrefixTree.h"
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
+#include "absl/container/flat_hash_set.h"
 
 extern NSString *const kWatchItemConfigKeyVersion;
 extern NSString *const kWatchItemConfigKeyWatchItems;
@@ -100,6 +101,30 @@ class DataWatchItems {
   std::set<std::pair<std::string, WatchItemPathType>> paths_;
 };
 
+using ProcessWatchItemPolicySet =
+    absl::flat_hash_set<std::shared_ptr<ProcessWatchItemPolicy>,
+                        SharedPtrProcessWatchItemPolicyHash, SharedPtrProcessWatchItemPolicyEqual>;
+class ProcessWatchItems {
+ private:
+ public:
+  ProcessWatchItems() = default;
+
+  ProcessWatchItems(ProcessWatchItems &&other) = default;
+  ProcessWatchItems &operator=(ProcessWatchItems &&rhs) = default;
+
+  // Copying not supported
+  ProcessWatchItems(const ProcessWatchItems &other) = delete;
+  ProcessWatchItems &operator=(const ProcessWatchItems &other) = delete;
+
+  bool operator==(const ProcessWatchItems &other) const { return policies_ == other.policies_; }
+  bool operator!=(const ProcessWatchItems &other) const { return !(*this == other); }
+
+  bool Build(ProcessWatchItemPolicySet proc_policies);
+
+ private:
+  ProcessWatchItemPolicySet policies_;
+};
+
 class WatchItems : public std::enable_shared_from_this<WatchItems> {
  public:
   using VersionAndPolicies =
@@ -141,7 +166,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   NSDictionary *ReadConfig();
   NSDictionary *ReadConfigLocked() ABSL_SHARED_LOCKS_REQUIRED(lock_);
   void ReloadConfig(NSDictionary *new_config);
-  void UpdateCurrentState(DataWatchItems new_data_watch_items, NSDictionary *new_config);
+  void UpdateCurrentState(DataWatchItems new_data_watch_items,
+                          ProcessWatchItems new_proc_watch_items, NSDictionary *new_config);
 
   NSString *config_path_;
   NSDictionary *embedded_config_;
@@ -152,6 +178,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   absl::Mutex lock_;
 
   DataWatchItems data_watch_items_ ABSL_GUARDED_BY(lock_);
+  ProcessWatchItems proc_watch_items_ ABSL_GUARDED_BY(lock_);
   NSDictionary *current_config_ ABSL_GUARDED_BY(lock_);
   NSTimeInterval last_update_time_ ABSL_GUARDED_BY(lock_);
   std::string policy_version_ ABSL_GUARDED_BY(lock_);

--- a/Testing/fix.sh
+++ b/Testing/fix.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 GIT_ROOT=$(git rev-parse --show-toplevel)
+BUILDIFIER=$(which buildifier 2>/dev/null || echo "${GOPATH:-${HOME}/go}/bin/buildifier")
 
-find ${GIT_ROOT} \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \) -exec xcrun clang-format -i {} \+
-swift format -i -r ${GIT_ROOT}
-buildifier --lint=fix -r ${GIT_ROOT}
+/usr/bin/find ${GIT_ROOT} \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \) -exec xcrun clang-format -i {} \+
+/usr/bin/xcrun swift format -i -r ${GIT_ROOT}
+${BUILDIFIER} --lint=fix -r ${GIT_ROOT}


### PR DESCRIPTION
This adds the ability to parse new Proc-based FAA rules. They are not yet used.

There are some types that will need to change that affect both the proc- and data-based FAA rules, but that work is saved for the next PR to keep the size here sane. 