### PR TITLE
Add boot session uuid to proto event logs

### DIFF
--- a/Source/common/SNTSystemInfo.m
+++ b/Source/common/SNTSystemInfo.m
@@ -61,7 +61,11 @@
     // much we can really do if this fails, there are no other ways to get this
     // information.
     sysctlbyname("kern.bootsessionuuid", bootSessionUUID, &uuidLength, NULL, 0);
-    uuid = @(bootSessionUUID);
+
+    // Remove hyphens (small space reduction) and convert to lowercase (matching other IDs like
+    // hashes)
+    uuid = [[@(bootSessionUUID) stringByReplacingOccurrencesOfString:@"-"
+                                                          withString:@""] lowercaseString];
   });
   return uuid;
 }

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -926,6 +926,10 @@ message SantaMessage {
   // Timestamp when Santa finished processing the event
   optional google.protobuf.Timestamp processed_time = 3;
 
+  // The boot session UUID uniquely identifies a boot cycle. The value
+  // will remain the same across sleep/wake/hibernate cycles.
+  optional string boot_session_uuid = 4;
+
   // Event type being described by this message
   oneof event {
     Execution execution = 10;

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -630,6 +630,7 @@ objc_library(
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredEvent",
+        "//Source/common:SNTSystemInfo",
         "//Source/common:String",
         "//Source/common:santa_cc_proto_library_wrapper",
         "@com_google_absl//absl/status",

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -34,6 +34,7 @@
 #include "Source/common/SNTCommonEnums.h"
 #include "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
+#include "Source/common/SNTSystemInfo.h"
 #import "Source/common/String.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
@@ -391,6 +392,8 @@ static inline void EncodeCertificateInfo(::pbv1::CertificateInfo *pb_cert_info, 
   }
   EncodeTimestamp(santa_msg->mutable_event_time(), event_time);
   EncodeTimestamp(santa_msg->mutable_processed_time(), processed_time);
+  EncodeString([santa_msg] { return santa_msg->mutable_boot_session_uuid(); },
+               [SNTSystemInfo bootSessionUUID]);
 
   return santa_msg;
 }


### PR DESCRIPTION
Fixes #211 

```
[
  {
   "event_time": "2025-01-29T15:45:09.171590Z",
   "processed_time": "2025-01-29T15:45:09.171590Z",
   "boot_session_uuid": "aa3fade9b04741bd972df8ab4f003e96",
   "disk": { ... }
  },
  {
   "event_time": "2025-01-29T15:45:12.305985602Z",
   "processed_time": "2025-01-29T15:45:12.319282Z",
   "boot_session_uuid": "aa3fade9b04741bd972df8ab4f003e96",
   "execution": { ... }
  },
  ...
]
```