### PR TITLE
Print troubleshooting steps when santactl cannot connect to daemon

### DIFF
--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -81,7 +81,31 @@ static NSMutableDictionary *registeredCommands;
 
   if (required) {
     daemonConn.invalidationHandler = ^{
-      printf("An error occurred communicating with the daemon, is it running?\n");
+      // Disabling clang format to make desired formatting more apparent
+      // clang-format off
+      printf("An error occurred communicating with the Santa daemon, is it running?\n"
+             "\n"
+             "Common troubleshooting steps:\n"
+             "\n"
+             "    1. Check that the Santa system extension is properly loaded. Run the following\n"
+             "       command in a terminal and verify a line item exists for \"com.northpolesec.santa.daemon\"\n"
+             "       and it is in the \"activated enabled\" state:\n"
+             "\n"
+             "       systemextensionsctl list com.apple.system_extension.endpoint_security\n"
+             "\n"
+             "       If the expected data isn't found, reinstall Santa.\n"
+             "\n"
+             "    2. Ensure the Santa daemon has been granted Full Disk Access permissions:\n"
+             "        * Open System Settings and navigate to \"Privacy & Security > Full Disk Access\"\n"
+             "        * Ensure \"com.northpolesec.santa.daemon\" is enabled\n"
+             "\n"
+             "    3. Check system logs. The daemon will attempt to start about every 10 seconds and\n"
+             "       will log if any errors are encountered. In a terminal, run the following command\n"
+             "       to view the Santa daemon logs:\n"
+             "\n"
+             "       log stream --level debug --predicate 'sender == \"com.northpolesec.santa.daemon\"'\n");
+      // clang-format on
+
       exit(1);
     };
     [daemonConn resume];

--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -81,10 +81,10 @@ static NSMutableDictionary *registeredCommands;
 
   if (required) {
     daemonConn.invalidationHandler = ^{
-      printf(
-          "An error occurred communicating with the Santa daemon. Check to make sure the process\n"
-          "is running and has been granted Full Disk Access permissions. For more detailed\n"
-          "troubleshooting steps, please see: https://northpole.dev/deployment/troubleshooting\n");
+      printf("An error occurred communicating with the Santa daemon. Check to make sure\n"
+             "the process is running and has been granted Full Disk Access permissions.\n"
+             "\n"
+             "For detailed steps, see: https://northpole.dev/deployment/troubleshooting\n");
       exit(1);
     };
     [daemonConn resume];

--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -81,31 +81,10 @@ static NSMutableDictionary *registeredCommands;
 
   if (required) {
     daemonConn.invalidationHandler = ^{
-      // Disabling clang format to make desired formatting more apparent
-      // clang-format off
-      printf("An error occurred communicating with the Santa daemon, is it running?\n"
-             "\n"
-             "Common troubleshooting steps:\n"
-             "\n"
-             "    1. Check that the Santa system extension is properly loaded. Run the following\n"
-             "       command in a terminal and verify a line item exists for \"com.northpolesec.santa.daemon\"\n"
-             "       and it is in the \"activated enabled\" state:\n"
-             "\n"
-             "       systemextensionsctl list com.apple.system_extension.endpoint_security\n"
-             "\n"
-             "       If the expected data isn't found, reinstall Santa.\n"
-             "\n"
-             "    2. Ensure the Santa daemon has been granted Full Disk Access permissions:\n"
-             "        * Open System Settings and navigate to \"Privacy & Security > Full Disk Access\"\n"
-             "        * Ensure \"com.northpolesec.santa.daemon\" is enabled\n"
-             "\n"
-             "    3. Check system logs. The daemon will attempt to start about every 10 seconds and\n"
-             "       will log if any errors are encountered. In a terminal, run the following command\n"
-             "       to view the Santa daemon logs:\n"
-             "\n"
-             "       log stream --level debug --predicate 'sender == \"com.northpolesec.santa.daemon\"'\n");
-      // clang-format on
-
+      printf(
+          "An error occurred communicating with the Santa daemon. Check to make sure the process\n"
+          "is running and has been granted Full Disk Access permissions. For more detailed\n"
+          "troubleshooting steps, please see: https://northpole.dev/deployment/troubleshooting\n");
       exit(1);
     };
     [daemonConn resume];

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -6,48 +6,110 @@ nav_order: 6
 
 # Troubleshooting
 
-As kernel extensions have been considered deprecated for several OS releases,
-this page will cover troublshooting the system extension and related topics.
+This page outlines common troubleshooting steps for confirming proper Santa
+daemon operation and steps to diagnose and correct common issues.
 
-## Confirming Status
+## Confirming Proper Santa Daemon Operation
 
-While there's an entire page on [santactl](../binaries/santactl.md), it's one of the best ways to start
-determining the cause of an issue:
+The best way to start diagnosing the Santa daemon is by running:
 
 ```sh
 /usr/local/bin/santactl status
 ```
 
-Conveniently, the order the information is displayed may indicate the likelihood
-of commonly experienced issues:
+If the daemon is up and running, you should see [normal status output](../binaries/santactl.md#status).
 
-- In the first section, if "Driver Connected" does not read Yes, start by
-confirming the MDM is considered 'supervising' the computer via DEP or UAMDM,
-(see [configuration.md](configuration.md)) this command would help:
+However, if you see a message like "`An error occurred communicating with the
+Santa daemon...`", then use the following tips to diagnose the issue.
+
+## Enabling Full Disk Access
+
+The Santa daemon is required by the system to have "Full Disk Access" enabled
+in order to function. On recent macOS versions, you can ensure this is enabled
+using System Settings:
+
+1. Open System Settings from the Apple menu
+1. In the left pane, click on "Privacy & Security"
+1. In the right pane, click on "Full Disk Access"
+1. Ensure that `com.northpolesec.santa.daemon` is selected
+
+If "Full Disk Access" wasn't enabled, re-check `santactl status` to see if the
+issue is now resolved. Note that it may take up to 15 seconds for the daemon
+to become active if no other issues are present.
+
+## Enabling the System Extension
+
+To confirm the Santa system extension is properly loaded, check the
+output of the following command:
+
+```sh
+/usr/bin/systemextensionsctl list com.apple.system_extension.endpoint_security
+```
+
+Confirm that a line item exists for `com.northpolesec.santa.daemon` with the
+expected version and the state is `activated enabled`.
+
+If the extension is in the `activated waiting for the user` state, it must
+first be approved to run using System Settings:
+
+1. Open System Settings from the Apple menu.
+1. In the left pane, click on "General"
+1. In the right pane, click on "Login Items & Extensions"
+1. Scroll to "Endpoint Security Extensions" and click the info button
+1. Ensure that "Santa" is toggled on.
+
+If Santa wasn't enabled, re-check `systemextensionsctl list`. If it's still
+not in the `activated enabled` state, try forcing the extension to load:
+
+```sh
+/Applications/Santa.app/Contents/MacOS/Santa --load-system-extension
+```
+
+After loading, re-check the output of `systemextensionsctl list`. If issues
+persist, reinstall Santa.
+
+## Checking Santa Daemon Logs
+
+The Santa daemon emits warning and error messages for encountered issues. If
+it fails to start, check the logs for the cause. Daemon logs can be viewed
+with the following command:
+
+```sh
+/usr/bin/log stream --level debug --predicate 'sender == "com.northpolesec.santa.daemon"'
+```
+
+## Enterprise Deployments
+
+Enterprise deployments are typically managed via MDM, so administrators should
+follow the guide on the [Getting Started](./getting-started.md) page for
+information on creating the necessary configuration profiles.
+
+To diagnose a user device, administrators should first confirm that the MDM is
+supervising the computer (via DEP or UAMDM) using the following command:
 
 ```sh
 /usr/bin/profiles status -type enrollment
 ```
 
-The profile payloads that rely on the supervision relationship cannot be applied
-manually for testing, so it's important to ensure the MDM connection is as
-expected when mass-deploying.
+Profile payloads that require a supervision relationship cannot be applied
+manually for testing. Therefore, it's crucial to ensure the MDM connection is
+working as expected during mass deployments.
 
-- Additionally, confirm the system extension and TCC/PPPC profiles are present
-as mentioned under the ["MDM-Specific Client Configuration"](configuration.md) section of that page
+Additionally, confirm the system extension and TCC/PPPC profiles are present,
+as described in the ["MDM-Specific Client Configuration"](configuration.md)
+section of the Configuration page. After confirming that Santa is running, you
+can verify that settings are being applied as expected by running
+`santactl status`.
 
-- The local preferences would dictate the sync server used as well, and the
-next sections help you confirm how many rules have in fact been recognized by
-Santa as well as its details and live connection state
+## Verifying Expected Functionality
 
-## Confirming Actions
+Reviewing the [logs](../concepts/logs.md) is helpful for understanding Santa's
+operation. The documentation on [scopes](../concepts/scopes.md) and
+[rules](../concepts/rules.md) explains precedence and decision-making. To see
+how Santa evaluates binary execution, use the santactl fileinfo command with a
+binary path (see the [santactl docs](../binaries/santactl.md) for more
+information):
 
-Looking into [logs](../concepts/logs.md) would be instructive for the majority
-of how Santa is operating, and the pages on [scopes](../concepts/scopes.md) and [rules](../concepts/rules.md) would assist in
-determining precedence and why decisions are made. Most helpful is the output of
-`/usr/local/bin/santactl`'s `fileinfo` verb when called with the path/binary in
-question as described on the [santactl](../binaries/santactl.md) page.
-
-Depending on the presence or implementation details of a sync server, there may
-be queues and a process for allowing binaries or updated developer certificates.
-Events may also be observable from the server
+```sh
+/usr/local/bin/santactl fileinfo /path/to/binary
+```


### PR DESCRIPTION
```
$ santactl status
An error occurred communicating with the Santa daemon. Check to make sure
the process is running and has been granted Full Disk Access permissions.

For detailed steps, see: https://northpole.dev/deployment/troubleshooting
```
![full_page_screenshot_deployment_troubleshooting html](https://github.com/user-attachments/assets/ac59eeb7-850a-4e90-9818-808f7102dc1b)
