### PR TITLE
Better type representation in FAA, standardize type alias naming

### DIFF
--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -33,13 +33,14 @@ namespace santa {
 // Forward declarations
 enum class WatchItemPathType;
 enum class WatchItemRuleType;
+struct DataWatchItemPolicy;
+struct ProcessWatchItemPolicy;
+struct WatchItemProcess;
+
 template <typename T>
 struct SharedPtrValueHash;
 template <typename T>
 struct SharedPtrValueEqual;
-struct DataWatchItemPolicy;
-struct ProcessWatchItemPolicy;
-struct WatchItemProcess;
 
 // Helper type aliases
 using PairPathAndType = std::pair<std::string, WatchItemPathType>;

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -82,15 +82,14 @@ class DataWatchItems {
 
   bool operator==(const DataWatchItems &other) const { return paths_ == other.paths_; }
   bool operator!=(const DataWatchItems &other) const { return !(*this == other); }
-  std::vector<std::pair<std::string, WatchItemPathType>> operator-(
-      const DataWatchItems &other) const;
+  SetPairPathAndType operator-(const DataWatchItems &other) const;
 
   friend void swap(DataWatchItems &first, DataWatchItems &second) {
     std::swap(first.tree_, second.tree_);
     std::swap(first.paths_, second.paths_);
   }
 
-  bool Build(std::vector<std::shared_ptr<DataWatchItemPolicy>> data_policies);
+  bool Build(SetSharedDataWatchItemPolicy data_policies);
   size_t Count() const { return paths_.size(); }
 
   std::vector<std::optional<std::shared_ptr<DataWatchItemPolicy>>> FindPolcies(
@@ -98,12 +97,9 @@ class DataWatchItems {
 
  private:
   std::unique_ptr<santa::PrefixTree<std::shared_ptr<DataWatchItemPolicy>>> tree_;
-  std::set<std::pair<std::string, WatchItemPathType>> paths_;
+  SetPairPathAndType paths_;
 };
 
-using ProcessWatchItemPolicySet =
-    absl::flat_hash_set<std::shared_ptr<ProcessWatchItemPolicy>,
-                        SharedPtrProcessWatchItemPolicyHash, SharedPtrProcessWatchItemPolicyEqual>;
 class ProcessWatchItems {
  public:
   ProcessWatchItems() = default;
@@ -118,10 +114,10 @@ class ProcessWatchItems {
   bool operator==(const ProcessWatchItems &other) const { return policies_ == other.policies_; }
   bool operator!=(const ProcessWatchItems &other) const { return !(*this == other); }
 
-  bool Build(ProcessWatchItemPolicySet proc_policies);
+  bool Build(SetSharedProcessWatchItemPolicy proc_policies);
 
  private:
-  ProcessWatchItemPolicySet policies_;
+  SetSharedProcessWatchItemPolicy policies_;
 };
 
 class WatchItems : public std::enable_shared_from_this<WatchItems> {

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -227,19 +227,19 @@ using santa::WatchItemPathType;
   return _esApi->InvertTargetPathMuting(_esClient);
 }
 
-- (bool)muteTargetPaths:(const std::vector<std::pair<std::string, WatchItemPathType>> &)paths {
+- (bool)muteTargetPaths:(const santa::SetPairPathAndType &)paths {
   bool result = true;
-  for (const auto &pathAndTypePair : paths) {
+  for (const auto &PairPathAndType : paths) {
     result =
-        _esApi->MuteTargetPath(_esClient, pathAndTypePair.first, pathAndTypePair.second) && result;
+        _esApi->MuteTargetPath(_esClient, PairPathAndType.first, PairPathAndType.second) && result;
   }
   return result;
 }
 
-- (bool)unmuteTargetPaths:(const std::vector<std::pair<std::string, WatchItemPathType>> &)paths {
+- (bool)unmuteTargetPaths:(const santa::SetPairPathAndType &)paths {
   bool result = true;
-  for (const auto &pathAndTypePair : paths) {
-    result = _esApi->UnmuteTargetPath(_esClient, pathAndTypePair.first, pathAndTypePair.second) &&
+  for (const auto &PairPathAndType : paths) {
+    result = _esApi->UnmuteTargetPath(_esClient, PairPathAndType.first, PairPathAndType.second) &&
              result;
   }
   return result;

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -50,10 +50,8 @@
 - (bool)unsubscribeAll;
 - (bool)unmuteAllTargetPaths;
 - (bool)enableTargetPathWatching;
-- (bool)muteTargetPaths:
-    (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)paths;
-- (bool)unmuteTargetPaths:
-    (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)paths;
+- (bool)muteTargetPaths:(const santa::SetPairPathAndType &)paths;
+- (bool)unmuteTargetPaths:(const santa::SetPairPathAndType &)paths;
 
 /// Responds to the Message with the given auth result
 ///

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -42,6 +42,7 @@ using santa::EnrichedMessage;
 using santa::EnrichedProcess;
 using santa::Message;
 using santa::Processor;
+using santa::SetPairPathAndType;
 using santa::WatchItemPathType;
 
 @interface SNTEndpointSecurityClient (Testing)
@@ -338,7 +339,7 @@ using santa::WatchItemPathType;
               MuteTargetPath(testing::_, std::string_view("c"), WatchItemPathType::kPrefix))
       .WillOnce(testing::Return(true));
 
-  std::vector<std::pair<std::string, WatchItemPathType>> paths = {
+  SetPairPathAndType paths = {
       {"a", WatchItemPathType::kLiteral},
       {"b", WatchItemPathType::kLiteral},
       {"c", WatchItemPathType::kPrefix},
@@ -368,7 +369,7 @@ using santa::WatchItemPathType;
               UnmuteTargetPath(testing::_, std::string_view("c"), WatchItemPathType::kPrefix))
       .WillOnce(testing::Return(true));
 
-  std::vector<std::pair<std::string, WatchItemPathType>> paths = {
+  SetPairPathAndType paths = {
       {"a", WatchItemPathType::kLiteral},
       {"b", WatchItemPathType::kLiteral},
       {"c", WatchItemPathType::kPrefix},

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -44,9 +44,7 @@
 - (void)disable;
 
 - (void)watchItemsCount:(size_t)count
-               newPaths:
-                   (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)newPaths
-           removedPaths:
-               (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)removedPaths;
+               newPaths:(const santa::SetPairPathAndType &)newPaths
+           removedPaths:(const santa::SetPairPathAndType &)removedPaths;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -863,9 +863,8 @@ bool ShouldMessageTTY(const std::shared_ptr<DataWatchItemPolicy> &policy, const 
 }
 
 - (void)watchItemsCount:(size_t)count
-               newPaths:(const std::vector<std::pair<std::string, WatchItemPathType>> &)newPaths
-           removedPaths:
-               (const std::vector<std::pair<std::string, WatchItemPathType>> &)removedPaths {
+               newPaths:(const santa::SetPairPathAndType &)newPaths
+           removedPaths:(const santa::SetPairPathAndType &)removedPaths {
   if (count == 0) {
     [self disable];
   } else {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -629,7 +629,7 @@ void ClearWatchItemPolicyProcess(WatchItemProcess &proc) {
   }
 
   auto policy = std::make_shared<DataWatchItemPolicy>("foo_policy", "ver", "/foo");
-  policy->processes.push_back(policyProc);
+  policy->processes.insert(policyProc);
   auto optionalPolicy = std::make_optional<std::shared_ptr<DataWatchItemPolicy>>(policy);
 
   // Signed but invalid instigating processes are automatically

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -36,6 +36,7 @@ using santa::EndpointSecurityAPI;
 using santa::EventDisposition;
 using santa::Logger;
 using santa::Message;
+using santa::SetPairPathAndType;
 using santa::WatchItemPathType;
 
 // The ES client process (com.northpolesec.santa.daemon) will be the only process allowed to
@@ -231,10 +232,9 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
   [super enableTargetPathWatching];
 
   // Get the set of protected paths
-  std::vector<std::pair<std::string, WatchItemPathType>> protectedPaths =
-      [SNTEndpointSecurityTamperResistance getProtectedPaths];
-  protectedPaths.push_back({"/Library/SystemExtensions", WatchItemPathType::kPrefix});
-  protectedPaths.push_back({"/bin/launchctl", WatchItemPathType::kLiteral});
+  SetPairPathAndType protectedPaths = [SNTEndpointSecurityTamperResistance getProtectedPaths];
+  protectedPaths.insert({"/Library/SystemExtensions", WatchItemPathType::kPrefix});
+  protectedPaths.insert({"/bin/launchctl", WatchItemPathType::kLiteral});
 
   // Begin watching the protected set
   [super muteTargetPaths:protectedPaths];
@@ -248,13 +248,11 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message &esMsg) {
                                 }];
 }
 
-+ (std::vector<std::pair<std::string, WatchItemPathType>>)getProtectedPaths {
-  std::vector<std::pair<std::string, WatchItemPathType>> protectedPathsCopy(
-      sizeof(kProtectedFiles) / sizeof(kProtectedFiles[0]));
++ (SetPairPathAndType)getProtectedPaths {
+  SetPairPathAndType protectedPathsCopy;
 
   for (size_t i = 0; i < sizeof(kProtectedFiles) / sizeof(kProtectedFiles[0]); ++i) {
-    protectedPathsCopy.emplace_back(std::string(kProtectedFiles[i].first),
-                                    kProtectedFiles[i].second);
+    protectedPathsCopy.insert({std::string(kProtectedFiles[i].first), kProtectedFiles[i].second});
   }
 
   return protectedPathsCopy;


### PR DESCRIPTION
The goal of this PR is to better represent data with types that match how the FAA configuration is understood. This largely means things like converting vectors to sets to ensure no duplicate data.

Some additional tests were added, but there are no new features with this change.

Finally, type alias names were standardized for better readability.