### PR TITLE
Initial infrastructure for Proc FAA client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,10 @@ test:
 reload:
 	bazel run //:reload
 
-.PHONY: fmt build test reload
+clean:
+	bazel clean
+
+realclean:
+	bazel clean --expunge
+
+.PHONY: fmt build test reload clean realclean

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -487,6 +487,19 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTEndpointSecurityProcessFileAccessAuthorizer",
+    srcs = ["EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm"],
+    hdrs = ["EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h"],
+    deps = [
+        ":EndpointSecurityAPI",
+        ":EndpointSecurityMessage",
+        ":Metrics",
+        ":SNTEndpointSecurityClient",
+        ":SNTEndpointSecurityEventHandler",
+    ],
+)
+
+objc_library(
     name = "SNTEndpointSecurityDeviceManager",
     srcs = ["EventProviders/SNTEndpointSecurityDeviceManager.mm"],
     hdrs = ["EventProviders/SNTEndpointSecurityDeviceManager.h"],
@@ -1421,6 +1434,20 @@ santa_unit_test(
 )
 
 santa_unit_test(
+    name = "SNTEndpointSecurityProcessFileAccessAuthorizerTest",
+    srcs = ["EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
+    deps = [
+        ":MockEndpointSecurityAPI",
+        ":SNTEndpointSecurityProcessFileAccessAuthorizer",
+        "//Source/common:TestUtils",
+        "@OCMock",
+    ],
+)
+
+santa_unit_test(
     name = "SNTEndpointSecurityTamperResistanceTest",
     srcs = ["EventProviders/SNTEndpointSecurityTamperResistanceTest.mm"],
     sdk_dylibs = [
@@ -1538,6 +1565,7 @@ test_suite(
         ":SNTEndpointSecurityClientTest",
         ":SNTEndpointSecurityDeviceManagerTest",
         ":SNTEndpointSecurityFileAccessAuthorizerTest",
+        ":SNTEndpointSecurityProcessFileAccessAuthorizerTest",
         ":SNTEndpointSecurityRecorderTest",
         ":SNTEndpointSecurityTamperResistanceTest",
         ":SNTEndpointSecurityTreeAwareClientTest",

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -140,7 +140,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   void BeginPeriodicTask();
 
-  void RegisterClient(id<SNTEndpointSecurityDynamicEventHandler> client);
+  void RegisterDataClient(id<SNTDataFileAccessAuthorizer> client);
+  void RegisterProcessClient(id<SNTProcessFileAccessAuthorizer> client);
 
   void SetConfigPath(NSString *config_path);
   void SetConfig(NSDictionary *config);
@@ -177,7 +178,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   NSDictionary *current_config_ ABSL_GUARDED_BY(lock_);
   NSTimeInterval last_update_time_ ABSL_GUARDED_BY(lock_);
   std::string policy_version_ ABSL_GUARDED_BY(lock_);
-  std::set<id<SNTEndpointSecurityDynamicEventHandler>> registerd_clients_ ABSL_GUARDED_BY(lock_);
+  id<SNTDataFileAccessAuthorizer> registered_data_client_ ABSL_GUARDED_BY(lock_);
+  id<SNTProcessFileAccessAuthorizer> registered_proc_client_ ABSL_GUARDED_BY(lock_);
   bool periodic_task_started_ = false;
   NSString *policy_event_detail_url_ ABSL_GUARDED_BY(lock_);
   NSString *policy_event_detail_text_ ABSL_GUARDED_BY(lock_);

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
@@ -47,6 +47,10 @@ class EndpointSecurityAPI : public std::enable_shared_from_this<EndpointSecurity
   virtual bool UnmuteTargetPath(const Client &client, std::string_view path,
                                 santa::WatchItemPathType path_type);
 
+  virtual bool IsProcessMutingInverted(const Client &client);
+  virtual bool InvertProcessMuting(const Client &client);
+  virtual bool MuteProcess(const Client &client, const audit_token_t *tok);
+
   virtual void RetainMessage(const es_message_t *msg);
   virtual void ReleaseMessage(const es_message_t *msg);
 
@@ -54,8 +58,6 @@ class EndpointSecurityAPI : public std::enable_shared_from_this<EndpointSecurity
                                  bool cache);
   virtual bool RespondFlagsResult(const Client &client, const Message &msg, uint32_t allowed_flags,
                                   bool cache);
-
-  virtual bool MuteProcess(const Client &client, const audit_token_t *tok);
 
   virtual bool ClearCache(const Client &client);
 

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -93,6 +93,34 @@ bool EndpointSecurityAPI::InvertTargetPathMuting(const Client &client) {
   return false;
 }
 
+bool EndpointSecurityAPI::IsProcessMutingInverted(const Client &client) {
+#if HAVE_MACOS_13
+  if (@available(macOS 13.0, *)) {
+    return es_muting_inverted(client.Get(), ES_MUTE_INVERSION_TYPE_PROCESS) == ES_MUTE_INVERTED;
+  }
+#endif
+
+  return false;
+}
+
+bool EndpointSecurityAPI::InvertProcessMuting(const Client &client) {
+#if HAVE_MACOS_13
+  if (@available(macOS 13.0, *)) {
+    if (!IsProcessMutingInverted(client)) {
+      return es_invert_muting(client.Get(), ES_MUTE_INVERSION_TYPE_PROCESS) == ES_RETURN_SUCCESS;
+    } else {
+      return true;
+    }
+  }
+#endif
+
+  return false;
+}
+
+bool EndpointSecurityAPI::MuteProcess(const Client &client, const audit_token_t *tok) {
+  return es_mute_process(client.Get(), tok) == ES_RETURN_SUCCESS;
+}
+
 bool EndpointSecurityAPI::MuteTargetPath(const Client &client, std::string_view path,
                                          WatchItemPathType path_type) {
 #if HAVE_MACOS_13
@@ -129,10 +157,6 @@ bool EndpointSecurityAPI::RespondAuthResult(const Client &client, const Message 
 bool EndpointSecurityAPI::RespondFlagsResult(const Client &client, const Message &msg,
                                              uint32_t allowed_flags, bool cache) {
   return es_respond_flags_result(client.Get(), &(*msg), allowed_flags, cache);
-}
-
-bool EndpointSecurityAPI::MuteProcess(const Client &client, const audit_token_t *tok) {
-  return es_mute_process(client.Get(), tok) == ES_RETURN_SUCCESS;
 }
 
 bool EndpointSecurityAPI::ClearCache(const Client &client) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.h
@@ -36,4 +36,6 @@
               authResultCache:(std::shared_ptr<santa::AuthResultCache>)authResultCache
                     ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter;
 
+- (void)registerAuthExecProbe:(id<SNTEndpointSecurityProbe>)watcher;
+
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
@@ -35,6 +35,7 @@ using santa::Message;
 @interface SNTEndpointSecurityAuthorizer ()
 @property SNTCompilerController *compilerController;
 @property SNTExecutionController *execController;
+@property id<SNTEndpointSecurityProbe> procWatcherProbe;
 @end
 
 @implementation SNTEndpointSecurityAuthorizer {
@@ -66,6 +67,27 @@ using santa::Message;
   return @"Authorizer";
 }
 
+- (bool)respondToMessage:(const santa::Message &)msg
+          withAuthResult:(es_auth_result_t)result
+       forcePreventCache:(BOOL)forcePreventCache {
+  // Don't let the ES framework cache DENY results. Santa only flushes ES cache
+  // when a new DENY rule is received. If DENY results were cached and a rule
+  // update made the executable allowable, ES would continue to apply the DENY
+  // cached result. Note however that the local AuthResultCache will cache
+  // DENY results. The caller may also prevent caching if it has reason to so.
+  bool cacheable = (result == ES_AUTH_RESULT_ALLOW) && !forcePreventCache;
+
+  if (self.procWatcherProbe) {
+    santa::ProbeInterest interest = [self.procWatcherProbe probeInterest:msg];
+
+    // Prevent caching if a probe is interested in the process. But don't re-enable
+    // caching if it was already previously disabled.
+    cacheable = cacheable && (interest == santa::ProbeInterest::kUninterested);
+  }
+
+  return [self respondToMessage:msg withAuthResult:result cacheable:cacheable];
+}
+
 - (void)processMessage:(Message)msg {
   if (msg->event_type == ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME) {
     [self.execController
@@ -95,9 +117,8 @@ using santa::Message;
         default: break;
       }
 
-      [self respondToMessage:msg
-              withAuthResult:authResult
-                   cacheable:(authResult == ES_AUTH_RESULT_ALLOW)];
+      [self respondToMessage:msg withAuthResult:authResult forcePreventCache:NO];
+
       return;
     } else if (returnAction == SNTActionRespondHold) {
       _ttyWriter->Write(
@@ -188,15 +209,11 @@ using santa::Message;
   self->_authResultCache->AddToCache(esMsg->event.exec.target->executable, action);
 
   if (action != SNTActionHoldAllowed && action != SNTActionHoldDenied) {
-    // Don't let the ES framework cache DENY results. Santa only flushes ES cache
-    // when a new DENY rule is received. If DENY results were cached and a rule
-    // update made the executable allowable, ES would continue to apply the DENY
-    // cached result. Note however that the local AuthResultCache will cache
-    // DENY results.
-    return [self
-        respondToMessage:esMsg
-          withAuthResult:authResult
-               cacheable:(authResult == ES_AUTH_RESULT_ALLOW && action != SNTActionRespondHold)];
+    // Do not allow caching when the action is SNTActionRespondHold because Santa
+    // also authorize EXECs that occur while the current authorization is pending.
+    return [self respondToMessage:esMsg
+                   withAuthResult:authResult
+                forcePreventCache:(action == SNTActionRespondHold)];
   } else {
     return true;
   }
@@ -207,6 +224,10 @@ using santa::Message;
                                     ES_EVENT_TYPE_AUTH_EXEC,
                                     ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
                                 }];
+}
+
+- (void)registerAuthExecProbe:(id<SNTEndpointSecurityProbe>)watcher {
+  self.procWatcherProbe = watcher;
 }
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
@@ -210,7 +210,7 @@ using santa::Message;
 
   if (action != SNTActionHoldAllowed && action != SNTActionHoldDenied) {
     // Do not allow caching when the action is SNTActionRespondHold because Santa
-    // also authorize EXECs that occur while the current authorization is pending.
+    // also authorizes EXECs that occur while the current authorization is pending.
     return [self respondToMessage:esMsg
                    withAuthResult:authResult
                 forcePreventCache:(action == SNTActionRespondHold)];

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -217,6 +217,9 @@ using santa::WatchItemPathType;
 - (bool)unsubscribeAll {
   return _esApi->UnsubscribeAll(_esClient);
 }
+- (bool)unmuteAllPaths {
+  return _esApi->UnmuteAllPaths(_esClient);
+}
 
 - (bool)unmuteAllTargetPaths {
   return _esApi->UnmuteAllTargetPaths(_esClient);
@@ -225,6 +228,16 @@ using santa::WatchItemPathType;
 - (bool)enableTargetPathWatching {
   [self unmuteAllTargetPaths];
   return _esApi->InvertTargetPathMuting(_esClient);
+}
+
+- (bool)enableProcessWatching {
+  [self unmuteAllPaths];
+  [self unmuteAllTargetPaths];
+  return _esApi->InvertProcessMuting(_esClient);
+}
+
+- (bool)muteProcess:(const audit_token_t *)tok {
+  return _esApi->MuteProcess(_esClient, tok);
 }
 
 - (bool)muteTargetPaths:(const santa::SetPairPathAndType &)paths {

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -53,6 +53,9 @@
 - (bool)muteTargetPaths:(const santa::SetPairPathAndType &)paths;
 - (bool)unmuteTargetPaths:(const santa::SetPairPathAndType &)paths;
 
+- (bool)enableProcessWatching;
+- (bool)muteProcess:(const audit_token_t *)tok;
+
 /// Responds to the Message with the given auth result
 ///
 /// @param Message The wrapped es_message_t being responded to

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -1,16 +1,17 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     https://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import <Foundation/Foundation.h>
 
@@ -35,16 +36,35 @@
 
 @end
 
-// Extension of the `SNTEndpointSecurityEventHandler` protocol for
-// `SNTEndpointSecurityClient` subclasses that can be dynamically
-// enabled and disabled.
-@protocol SNTEndpointSecurityDynamicEventHandler <SNTEndpointSecurityEventHandler>
-
-// Called when a client should no longer receive events.
-- (void)disable;
+// Protocol for an object that implements the necessary interfaces
+// for handling updates to Data FAA rules.
+@protocol SNTDataFileAccessAuthorizer
 
 - (void)watchItemsCount:(size_t)count
                newPaths:(const santa::SetPairPathAndType &)newPaths
            removedPaths:(const santa::SetPairPathAndType &)removedPaths;
+
+@end
+
+// Protocol for an object that implements the necessary interfaces
+// for handling updates to Data FAA rules.
+@protocol SNTProcessFileAccessAuthorizer
+
+// TODO: Currently just a stub
+
+@end
+
+namespace santa {
+
+enum class ProbeInterest {
+  kInterested,
+  kUninterested,
+};
+
+}  // namespace santa
+
+@protocol SNTEndpointSecurityProbe <NSObject>
+
+- (santa::ProbeInterest)probeInterest:(const santa::Message &)esMsg;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ typedef void (^SNTFileAccessBlockCallback)(SNTFileAccessEvent *event, NSString *
                                            NSString *customURL, NSString *customText);
 
 @interface SNTEndpointSecurityFileAccessAuthorizer
-    : SNTEndpointSecurityClient <SNTEndpointSecurityDynamicEventHandler>
+    : SNTEndpointSecurityClient <SNTEndpointSecurityEventHandler, SNTDataFileAccessAuthorizer>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
                       metrics:(std::shared_ptr<santa::Metrics>)metrics

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -97,6 +98,7 @@ void ClearWatchItemPolicyProcess(WatchItemProcess &proc) {
                                 (std::optional<std::shared_ptr<DataWatchItemPolicy>>)optionalPolicy
                               forTarget:(const PathTarget &)target
                               toMessage:(const Message &)msg;
+- (void)disable;
 
 @property bool isSubscribed;
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h
@@ -1,0 +1,32 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <memory>
+
+#include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
+#import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
+#import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
+#import "Source/santad/Metrics.h"
+
+@interface SNTEndpointSecurityProcessFileAccessAuthorizer
+    : SNTEndpointSecurityClient <SNTEndpointSecurityEventHandler,
+                                 SNTProcessFileAccessAuthorizer,
+                                 SNTEndpointSecurityProbe>
+
+- (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics;
+
+@end

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -1,0 +1,76 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h"
+
+using santa::Message;
+
+@interface SNTEndpointSecurityProcessFileAccessAuthorizer ()
+@property bool isSubscribed;
+@end
+
+@implementation SNTEndpointSecurityProcessFileAccessAuthorizer
+
+- (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics {
+  self = [super initWithESAPI:std::move(esApi)
+                      metrics:std::move(metrics)
+                    processor:santa::Processor::kProcessFileAccessAuthorizer];
+  if (self) {
+    [self establishClientOrDie];
+    [self enableProcessWatching];
+  }
+  return self;
+}
+
+- (NSString *)description {
+  return @"ProcessFileAccessAuthorizer";
+}
+
+- (void)handleMessage:(Message &&)esMsg
+    recordEventMetrics:(void (^)(santa::EventDisposition))recordEventMetrics {
+}
+
+- (santa::ProbeInterest)probeInterest:(const santa::Message &)esMsg {
+  return santa::ProbeInterest::kUninterested;
+}
+
+- (void)enable {
+  std::set<es_event_type_t> events = {
+      ES_EVENT_TYPE_AUTH_CLONE,        ES_EVENT_TYPE_AUTH_COPYFILE, ES_EVENT_TYPE_AUTH_CREATE,
+      ES_EVENT_TYPE_AUTH_EXCHANGEDATA, ES_EVENT_TYPE_AUTH_LINK,     ES_EVENT_TYPE_AUTH_OPEN,
+      ES_EVENT_TYPE_AUTH_RENAME,       ES_EVENT_TYPE_AUTH_TRUNCATE, ES_EVENT_TYPE_AUTH_UNLINK,
+      ES_EVENT_TYPE_NOTIFY_EXIT,
+  };
+
+  if (!self.isSubscribed) {
+    if ([super subscribe:events]) {
+      self.isSubscribed = true;
+    }
+  }
+
+  // Always clear cache to ensure operations that were previously allowed are re-evaluated.
+  [super clearCache];
+}
+
+- (void)disable {
+  if (self.isSubscribed) {
+    if ([super unsubscribeAll]) {
+      self.isSubscribed = false;
+    }
+    [super unmuteAllTargetPaths];
+  }
+}
+
+@end

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
@@ -1,0 +1,60 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h"
+
+#include <EndpointSecurity/EndpointSecurity.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#include <memory>
+#include <set>
+
+#include "Source/common/TestUtils.h"
+#include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
+
+@interface SNTEndpointSecurityProcessFileAccessAuthorizerTest : XCTestCase
+@end
+
+@implementation SNTEndpointSecurityProcessFileAccessAuthorizerTest
+
+- (void)testEnable {
+  std::set<es_event_type_t> expectedEventSubs = {
+      ES_EVENT_TYPE_AUTH_CLONE,        ES_EVENT_TYPE_AUTH_COPYFILE, ES_EVENT_TYPE_AUTH_CREATE,
+      ES_EVENT_TYPE_AUTH_EXCHANGEDATA, ES_EVENT_TYPE_AUTH_LINK,     ES_EVENT_TYPE_AUTH_OPEN,
+      ES_EVENT_TYPE_AUTH_RENAME,       ES_EVENT_TYPE_AUTH_TRUNCATE, ES_EVENT_TYPE_AUTH_UNLINK,
+      ES_EVENT_TYPE_NOTIFY_EXIT,
+  };
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  EXPECT_CALL(*mockESApi, ClearCache)
+      .After(EXPECT_CALL(*mockESApi, Subscribe(testing::_, expectedEventSubs))
+                 .WillOnce(testing::Return(true)))
+      .WillOnce(testing::Return(true));
+
+  id procFAAClient = [[SNTEndpointSecurityProcessFileAccessAuthorizer alloc]
+      initWithESAPI:mockESApi
+            metrics:nullptr
+          processor:santa::Processor::kProcessFileAccessAuthorizer];
+
+  [procFAAClient enable];
+
+  for (const auto &event : expectedEventSubs) {
+    XCTAssertNoThrow(santa::EventTypeToString(event));
+  }
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
+@end

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -45,6 +45,7 @@ enum class Processor {
   kRecorder,
   kTamperResistance,
   kFileAccessAuthorizer,
+  kProcessFileAccessAuthorizer,
 };
 
 enum class FileAccessMetricStatus {

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -29,6 +29,7 @@ static NSString *const kProcessorDeviceManager = @"DeviceManager";
 static NSString *const kProcessorRecorder = @"Recorder";
 static NSString *const kProcessorTamperResistance = @"TamperResistance";
 static NSString *const kProcessorFileAccessAuthorizer = @"FileAccessAuthorizer";
+static NSString *const kProcessorProcessFileAccessAuthorizer = @"ProcessFileAccessAuthorizer";
 
 static NSString *const kEventTypeAuthClone = @"AuthClone";
 static NSString *const kEventTypeAuthCopyfile = @"AuthCopyfile";
@@ -105,6 +106,7 @@ NSString *const ProcessorToString(Processor processor) {
     case Processor::kRecorder: return kProcessorRecorder;
     case Processor::kTamperResistance: return kProcessorTamperResistance;
     case Processor::kFileAccessAuthorizer: return kProcessorFileAccessAuthorizer;
+    case Processor::kProcessFileAccessAuthorizer: return kProcessorProcessFileAccessAuthorizer;
     default:
       [NSException raise:@"Invalid processor"
                   format:@"Unknown processor value: %d", static_cast<int>(processor)];

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -167,6 +167,8 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
       {Processor::kDeviceManager, @"DeviceManager"},
       {Processor::kRecorder, @"Recorder"},
       {Processor::kTamperResistance, @"TamperResistance"},
+      {Processor::kFileAccessAuthorizer, @"FileAccessAuthorizer"},
+      {Processor::kProcessFileAccessAuthorizer, @"ProcessFileAccessAuthorizer"},
   };
 
   for (const auto &kv : processorToString) {

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -147,7 +147,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                  enricher:enricher
             decisionCache:[SNTDecisionCache sharedCache]
                 ttyWriter:tty_writer];
-    watch_items->RegisterClient(access_authorizer_client);
+    watch_items->RegisterDataClient(access_authorizer_client);
 
     access_authorizer_client.fileAccessBlockCallback = ^(
         SNTFileAccessEvent *event, NSString *customMsg, NSString *customURL, NSString *customText) {


### PR DESCRIPTION
This PR lays the foundation for the new Proc FAA client and sets up some of the required interfaces between it and the Authorizer client and the WatchItems class. It also implements newly required ES API interfaces. None of this new code is yet hooked up to the rest of Santa - no new client will be created yet at runtime.

Part of: #124 