### PR TITLE
 Add support for Gatekeeper Override event

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -194,6 +194,7 @@ objc_library(
     srcs = ["TelemetryEventMap.mm"],
     hdrs = ["TelemetryEventMap.h"],
     deps = [
+        ":Platform",
         ":String",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
@@ -202,7 +203,10 @@ objc_library(
 santa_unit_test(
     name = "TelemetryEventMapTest",
     srcs = ["TelemetryEventMapTest.mm"],
-    deps = [":TelemetryEventMap"],
+    deps = [
+        ":Platform",
+        ":TelemetryEventMap",
+    ],
 )
 
 objc_library(

--- a/Source/common/TelemetryEventMap.h
+++ b/Source/common/TelemetryEventMap.h
@@ -43,6 +43,7 @@ enum class TelemetryEvent : uint64_t {
   kAuthentication          = 1 << 17,
   kClone                   = 1 << 18,
   kCopyfile                = 1 << 19,
+  kGatekeeperOverride      = 1 << 20,
   kEverything              = ~0ULL,
 };
 // clang-format on

--- a/Source/common/TelemetryEventMap.mm
+++ b/Source/common/TelemetryEventMap.mm
@@ -16,6 +16,7 @@
 
 #include <string_view>
 
+#include "Source/common/Platform.h"
 #include "Source/common/String.h"
 #include "absl/container/flat_hash_map.h"
 
@@ -43,6 +44,7 @@ static inline TelemetryEvent EventNameToMask(std::string_view event) {
       {"authentication", TelemetryEvent::kAuthentication},
       {"clone", TelemetryEvent::kClone},
       {"copyfile", TelemetryEvent::kCopyfile},
+      {"gatekeeper_override", TelemetryEvent::kGatekeeperOverride},
 
       // special cases
       {"none", TelemetryEvent::kNone},
@@ -100,6 +102,9 @@ TelemetryEvent ESEventToTelemetryEvent(es_event_type_t event) {
     case ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH: return TelemetryEvent::kScreenSharing;
     case ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN: return TelemetryEvent::kOpenSSH;
     case ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT: return TelemetryEvent::kOpenSSH;
+#if HAVE_MACOS_15
+    case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE: return TelemetryEvent::kGatekeeperOverride;
+#endif  // HAVE_MACOS_15
     default: return TelemetryEvent::kNone;
   }
 }

--- a/Source/common/TelemetryEventMapTest.mm
+++ b/Source/common/TelemetryEventMapTest.mm
@@ -19,6 +19,8 @@
 
 #include <map>
 
+#include "Source/common/Platform.h"
+
 using santa::ESEventToTelemetryEvent;
 using santa::TelemetryConfigToBitmask;
 using santa::TelemetryEvent;
@@ -52,6 +54,7 @@ using santa::TelemetryEvent;
       {"authentication", TelemetryEvent::kAuthentication},
       {"clone", TelemetryEvent::kClone},
       {"copyfile", TelemetryEvent::kCopyfile},
+      {"gatekeeper_override", TelemetryEvent::kGatekeeperOverride},
 
       // special cases
       {"none", TelemetryEvent::kNone},
@@ -103,6 +106,9 @@ using santa::TelemetryEvent;
       {ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH, TelemetryEvent::kScreenSharing},
       {ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN, TelemetryEvent::kOpenSSH},
       {ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT, TelemetryEvent::kOpenSSH},
+#if HAVE_MACOS_15
+      {ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE, TelemetryEvent::kGatekeeperOverride},
+#endif  // HAVE_MACOS_15
   };
 
   // Ensure ESEventToTelemetryEvent returns TelemetryEvent::kNone for

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -914,6 +914,18 @@ message Copyfile {
   int32 flags = 6;
 }
 
+// Information captured when a user overrides Gatekeeper decisions
+message GatekeeperOverride {
+  // The process creating the override
+  optional ProcessInfoLight instigator = 1;
+
+  // The target file that had Gatekeeper policy overridden
+  optional FileInfo target = 2;
+
+  // Codesigning information related to the target file
+  optional CodeSignature code_signature = 3;
+}
+
 // A message encapsulating a single event
 message SantaMessage {
   // Machine ID of the host emitting this log
@@ -952,6 +964,7 @@ message SantaMessage {
     Authentication authentication = 27;
     Clone clone = 28;
     Copyfile copyfile = 29;
+    GatekeeperOverride gatekeeper_override = 30;
   };
 }
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -565,6 +565,7 @@ objc_library(
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
         ":SNTDecisionCache",
+        "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
@@ -593,6 +594,7 @@ objc_library(
     hdrs = ["Logs/EndpointSecurity/Serializers/Empty.h"],
     deps = [
         ":EndpointSecuritySerializer",
+        "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
     ],
 )

--- a/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
@@ -610,6 +610,19 @@ class EnrichedCopyfile : public EnrichedEventType {
   EnrichedFile source_;
 };
 
+class EnrichedGatekeeperOverride : public EnrichedEventType {
+ public:
+  EnrichedGatekeeperOverride(Message &&es_msg, EnrichedProcess &&instigator,
+                             std::optional<EnrichedFile> target)
+      : EnrichedEventType(std::move(es_msg), std::move(instigator)),
+        target_(std::move(target)){};
+
+  const std::optional<EnrichedFile> &Target() const { return target_; }
+
+ private:
+  std::optional<EnrichedFile> target_;
+};
+
 using EnrichedType = std::variant<
     EnrichedClose, EnrichedExchange, EnrichedExec, EnrichedExit, EnrichedFork,
     EnrichedLink, EnrichedRename, EnrichedUnlink, EnrichedCSInvalidated,
@@ -619,7 +632,12 @@ using EnrichedType = std::variant<
     EnrichedOpenSSHLogin, EnrichedOpenSSHLogout, EnrichedLoginLogin,
     EnrichedLoginLogout, EnrichedAuthenticationOD,
     EnrichedAuthenticationTouchID, EnrichedAuthenticationToken,
-    EnrichedAuthenticationAutoUnlock, EnrichedClone, EnrichedCopyfile>;
+    EnrichedAuthenticationAutoUnlock, EnrichedClone, EnrichedCopyfile
+#if HAVE_MACOS_15
+    ,
+    EnrichedGatekeeperOverride
+#endif  // HAVE_MACOS_15
+    >;
 
 class EnrichedMessage {
  public:

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -155,7 +155,16 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
     case ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT:
       return std::make_unique<EnrichedMessage>(
           EnrichedLoginLogout(std::move(es_msg), Enrich(*es_msg->process)));
-#endif
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+    case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE:
+      return std::make_unique<EnrichedMessage>(EnrichedGatekeeperOverride(
+          std::move(es_msg), Enrich(*es_msg->process),
+          es_msg->event.gatekeeper_user_override->file_type ==
+                  ES_GATEKEEPER_USER_OVERRIDE_FILE_TYPE_FILE
+              ? std::make_optional(Enrich(*es_msg->event.gatekeeper_user_override->file.file))
+              : std::nullopt));
+#endif  // HAVE_MACOS_15
     default:
       // This is a programming error
       LOGE(@"Attempting to enrich an unhandled event type: %d", es_msg->event_type);

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -226,7 +226,13 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
       ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN,
       ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT});
   }
-#endif
+#endif  // HAVE_MACOS_13
+
+#if HAVE_MACOS_15
+  if (@available(macOS 15.0, *)) {
+    events.insert(ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE);
+  }
+#endif  // HAVE_MACOS_15
   // clang-format on
 
   [super subscribe:events];

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -106,7 +106,13 @@ class MockAuthResultCache : public AuthResultCache {
         ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT,
     });
   }
-#endif
+#endif  // HAVE_MACOS_13
+
+#if HAVE_MACOS_15
+  if (@available(macOS 15.0, *)) {
+    expectedEventSubs.insert(ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE);
+  }
+#endif  // HAVE_MACOS_15
 
   return expectedEventSubs;
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -65,7 +65,10 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationAutoUnlock &) override;
-#endif
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
+#endif  // HAVE_MACOS_15
 
   std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                            const std::string &policy_name,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -791,6 +791,18 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedAuthenticationA
 
 #endif  // HAVE_MACOS_13
 
+#if HAVE_MACOS_15
+
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedGatekeeperOverride &msg) {
+  std::string str = CreateDefaultString();
+
+  str.append("action=GATEKEEPER_OVERRIDE");
+
+  return FinalizeString(str);
+}
+
+#endif  // HAVE_MACOS_15
+
 std::vector<uint8_t> BasicString::SerializeFileAccess(const std::string &policy_version,
                                                       const std::string &policy_name,
                                                       const Message &msg,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#include "Source/common/Platform.h"
 #include "Source/common/SNTCachedDecision.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
@@ -42,6 +43,7 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCSInvalidated &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedClone &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCopyfile &) override;
+#if HAVE_MACOS_13
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLock &) override;
@@ -56,6 +58,10 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationAutoUnlock &) override;
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
+#endif  // HAVE_MACOS_15
 
   std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                            const std::string &policy_name,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -67,6 +67,8 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedCopyfile &msg) {
   return {};
 }
 
+#if HAVE_MACOS_13
+
 std::vector<uint8_t> Empty::SerializeMessage(const EnrichedLoginWindowSessionLogin &msg) {
   return {};
 }
@@ -122,6 +124,16 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedAuthenticationToken &
 std::vector<uint8_t> Empty::SerializeMessage(const EnrichedAuthenticationAutoUnlock &) {
   return {};
 }
+
+#endif  // HAVE_MACOS_13
+
+#if HAVE_MACOS_15
+
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedGatekeeperOverride &) {
+  return {};
+}
+
+#endif  // HAVE_MACOS_15
 
 std::vector<uint8_t> Empty::SerializeFileAccess(const std::string &policy_version,
                                                 const std::string &policy_name, const Message &msg,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -65,7 +65,10 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationTouchID &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationAutoUnlock &) override;
-#endif
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
+#endif  // HAVE_MACOS_15
 
   std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                            const std::string &policy_name,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -1013,6 +1013,14 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedAuthenticationAuto
 
 #endif  // HAVE_MACOS_13
 
+#if HAVE_MACOS_15
+
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedGatekeeperOverride &msg) {
+  return {};
+}
+
+#endif  // HAVE_MACOS_15
+
 std::vector<uint8_t> Protobuf::SerializeFileAccess(const std::string &policy_version,
                                                    const std::string &policy_name,
                                                    const Message &msg,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <vector>
 
+#include "Source/common/Platform.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTCommonEnums.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
@@ -56,6 +57,7 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedCSInvalidated &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedClone &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedCopyfile &) = 0;
+#if HAVE_MACOS_13
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogin &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(
       const santa::EnrichedLoginWindowSessionLogout &) = 0;
@@ -73,6 +75,10 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedAuthenticationToken &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(
       const santa::EnrichedAuthenticationAutoUnlock &) = 0;
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+  virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) = 0;
+#endif  // HAVE_MACOS_15
 
   virtual std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                                    const std::string &policy_name,

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -70,7 +70,10 @@ static NSString *const kEventTypeNotifyScreensharingAttach = @"NotifyScreenshari
 static NSString *const kEventTypeNotifyScreensharingDetach = @"NotifyScreensharingDetach";
 static NSString *const kEventTypeNotifyOpenSSHLogin = @"NotifyOpenSSHLogin";
 static NSString *const kEventTypeNotifyOpenSSHLogout = @"NotifyOpenSSHLogout";
-#endif
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+static NSString *const kEventTypeNotifyGatekeeperOverride = @"NotifyGatekeeperOverride";
+#endif  // HAVE_MACOS_15
 
 static NSString *const kEventDispositionDropped = @"Dropped";
 static NSString *const kEventDispositionProcessed = @"Processed";
@@ -150,7 +153,10 @@ NSString *const EventTypeToString(es_event_type_t eventType) {
     case ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH: return kEventTypeNotifyScreensharingDetach;
     case ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN: return kEventTypeNotifyOpenSSHLogin;
     case ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT: return kEventTypeNotifyOpenSSHLogout;
-#endif
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+    case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE: return kEventTypeNotifyGatekeeperOverride;
+#endif  // HAVE_MACOS_15
     case ES_EVENT_TYPE_LAST: return kPseudoEventTypeGlobal;
     default:
       [NSException raise:@"Invalid event type" format:@"Invalid event type: %d", eventType];

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -216,7 +216,10 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
       {ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH, @"NotifyScreensharingDetach"},
       {ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN, @"NotifyOpenSSHLogin"},
       {ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT, @"NotifyOpenSSHLogout"},
-#endif
+#endif  // HAVE_MACOS_13
+#if HAVE_MACOS_15
+      {ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE, @"NotifyGatekeeperOverride"},
+#endif  // HAVE_MACOS_15
       {ES_EVENT_TYPE_LAST, @"Global"},
   };
 


### PR DESCRIPTION
Adds support for the Gatekeeper Override ES event type. Serialization support will come in a followup PR to keep sizes smaller.

Part of: #129 