### PR TITLE
Proc FAA - hookup probe and proc policy iteration interfaces

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -496,6 +496,8 @@ objc_library(
         ":Metrics",
         ":SNTEndpointSecurityClient",
         ":SNTEndpointSecurityEventHandler",
+        ":WatchItemPolicy",
+        ":WatchItems",
     ],
 )
 
@@ -837,6 +839,7 @@ objc_library(
         ":SNTEndpointSecurityAuthorizer",
         ":SNTEndpointSecurityDeviceManager",
         ":SNTEndpointSecurityFileAccessAuthorizer",
+        ":SNTEndpointSecurityProcessFileAccessAuthorizer",
         ":SNTEndpointSecurityRecorder",
         ":SNTEndpointSecurityTamperResistance",
         ":SNTExecutionController",

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -54,12 +54,15 @@ extern NSString *const kWatchItemConfigKeyProcessesTeamID;
 extern NSString *const kWatchItemConfigKeyProcessesCDHash;
 extern NSString *const kWatchItemConfigKeyProcessesPlatformBinary;
 
-// Forward declarations
 namespace santa {
-class WatchItemsPeer;
-}
 
-namespace santa {
+// Forward declarations
+class ProcessWatchItems;
+class WatchItemsPeer;
+
+// Type aliases
+using CheckPolicyBlock = bool (^)(std::shared_ptr<ProcessWatchItemPolicy>);
+using IterateProcessPoliciesBlock = void (^)(CheckPolicyBlock);
 
 struct WatchItemsState {
   uint64_t rule_count;
@@ -116,6 +119,9 @@ class ProcessWatchItems {
 
   bool Build(SetSharedProcessWatchItemPolicy proc_policies);
 
+  size_t Count() const { return policies_.size(); }
+  void IterateProcessPolicies(CheckPolicyBlock checkPolicyBlock);
+
  private:
   SetSharedProcessWatchItemPolicy policies_;
 };
@@ -147,6 +153,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   void SetConfig(NSDictionary *config);
 
   VersionAndPolicies FindPolciesForPaths(const std::vector<std::string_view> &paths);
+  void IterateProcessPolicies(CheckPolicyBlock checkPolicyBlock);
 
   std::optional<WatchItemsState> State();
 

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -61,6 +61,10 @@ class ProcessWatchItems;
 class WatchItemsPeer;
 
 // Type aliases
+// Implementations that call IterateProcessPoliciesBlock must provide a block
+// of type CheckPolicyBlock. The CheckPolicyBlock should return `true` if the
+// iteration should stop, or `false` if iteration should continue to the next
+// process policy.
 using CheckPolicyBlock = bool (^)(std::shared_ptr<ProcessWatchItemPolicy>);
 using IterateProcessPoliciesBlock = void (^)(CheckPolicyBlock);
 

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -19,8 +19,6 @@
 
 #include "Source/common/Platform.h"
 
-using santa::WatchItemPathType;
-
 namespace santa {
 
 Client EndpointSecurityAPI::NewClient(void (^message_handler)(es_client_t *, Message)) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -45,7 +45,6 @@ using santa::EventDisposition;
 using santa::Message;
 using santa::Metrics;
 using santa::Processor;
-using santa::WatchItemPathType;
 
 @interface SNTEndpointSecurityClient ()
 @property(nonatomic) double defaultBudget;

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -38,7 +38,7 @@
 
 // Protocol for an object that implements the necessary interfaces
 // for handling updates to Data FAA rules.
-@protocol SNTDataFileAccessAuthorizer
+@protocol SNTDataFileAccessAuthorizer <NSObject>
 
 - (void)watchItemsCount:(size_t)count
                newPaths:(const santa::SetPairPathAndType &)newPaths
@@ -48,9 +48,9 @@
 
 // Protocol for an object that implements the necessary interfaces
 // for handling updates to Data FAA rules.
-@protocol SNTProcessFileAccessAuthorizer
+@protocol SNTProcessFileAccessAuthorizer <NSObject>
 
-// TODO: Currently just a stub
+- (void)processWatchItemsCount:(size_t)count;
 
 @end
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -65,7 +65,6 @@ using santa::OptionalStringToNSString;
 using santa::RateLimiter;
 using santa::StringToNSString;
 using santa::TTYWriter;
-using santa::WatchItemPathType;
 using santa::WatchItemProcess;
 using santa::WatchItems;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "Source/santad/DataLayer/WatchItems.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
@@ -27,6 +28,7 @@
                                  SNTEndpointSecurityProbe>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::Metrics>)metrics;
+                        metrics:(std::shared_ptr<santa::Metrics>)metrics
+    iterateProcessPoliciesBlock:(santa::IterateProcessPoliciesBlock)findProcessPoliciesBlock;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -22,7 +22,7 @@ using santa::ProcessWatchItemPolicy;
 
 @interface SNTEndpointSecurityProcessFileAccessAuthorizer ()
 @property bool isSubscribed;
-@property (copy) IterateProcessPoliciesBlock iterateProcessPoliciesBlock;
+@property(copy) IterateProcessPoliciesBlock iterateProcessPoliciesBlock;
 @end
 
 @implementation SNTEndpointSecurityProcessFileAccessAuthorizer

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -22,7 +22,7 @@ using santa::ProcessWatchItemPolicy;
 
 @interface SNTEndpointSecurityProcessFileAccessAuthorizer ()
 @property bool isSubscribed;
-@property IterateProcessPoliciesBlock iterateProcessPoliciesBlock;
+@property (copy) IterateProcessPoliciesBlock iterateProcessPoliciesBlock;
 @end
 
 @implementation SNTEndpointSecurityProcessFileAccessAuthorizer


### PR DESCRIPTION
This PR sets the stage for the probe interface to do meaningful work by hooking it up to the exec authorizer client as well as adding the interfaces in WatchItems to support iterating policies.  The "block taking a block" design is to mitigate the need for the WatchItems class to be aware of EndpointSecurity, and keeps policy matching in the FAA clients.

Next PR will begin abstracting functions from the existing Data FAA client for reuse in the Proc FAA client.