### PR TITLE
Add back the ability to block scripts by hash

### DIFF
--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -45,6 +45,7 @@
 @property BOOL entitlementsFiltered;
 @property uint32_t codesigningFlags;
 @property SNTSigningStatus signingStatus;
+@property BOOL scriptExecutionDenied;
 
 @property NSString *quarantineURL;
 

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -76,6 +76,10 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 }
 
 - (instancetype)initWithEndpointSecurityFile:(const es_file_t *)esFile error:(NSError **)error {
+  if (!esFile) {
+    return nil;
+  }
+
   return [self initWithResolvedPath:@(esFile->path.data) stat:&esFile->stat error:error];
 }
 

--- a/Source/common/SantaCache.h
+++ b/Source/common/SantaCache.h
@@ -135,6 +135,13 @@ class SantaCache {
   inline void remove(const KeyT &key) { set(key, zero_); }
 
   /**
+    An alias for `set(key, zero_, previous_value)`
+  */
+  inline bool remove(const KeyT &key, const ValueT &previous_value) {
+    return set(key, zero_, previous_value);
+  }
+
+  /**
     Remove all entries and free bucket memory.
   */
   void clear() {

--- a/Source/santad/EventProviders/AuthResultCache.h
+++ b/Source/santad/EventProviders/AuthResultCache.h
@@ -68,6 +68,7 @@ class AuthResultCache {
 
   virtual bool AddToCache(const es_file_t *es_file, SNTAction decision);
   virtual void RemoveFromCache(const es_file_t *es_file);
+  virtual void ResetPending(const es_file_t *es_file);
   virtual SNTAction CheckCache(const es_file_t *es_file);
   virtual SNTAction CheckCache(SantaVnode vnode_id);
 

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -146,6 +146,11 @@ void AuthResultCache::RemoveFromCache(const es_file_t *es_file) {
   CacheForVnodeID(vnode_id)->remove(vnode_id);
 }
 
+void AuthResultCache::ResetPending(const es_file_t *es_file) {
+  SantaVnode vnode_id = SantaVnode::VnodeForFile(es_file);
+  CacheForVnodeID(vnode_id)->remove(vnode_id, CacheableAction(SNTActionRequestBinary, 0));
+}
+
 SNTAction AuthResultCache::CheckCache(const es_file_t *es_file) {
   return CheckCache(SantaVnode::VnodeForFile(es_file));
 }

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -76,7 +76,8 @@ const static NSString *kBlockLongPath = @"BlockLongPath";
 ///  @param message The message received from the EndpointSecurity event provider.
 ///  @param postAction The block invoked with the desired response result.
 ///
-- (void)validateExecEvent:(const santa::Message &)esMsg postAction:(bool (^)(SNTAction))postAction;
+- (void)validateExecEvent:(const santa::Message &)esMsg
+               postAction:(bool (^)(SNTAction, BOOL))postAction;
 
 ///
 ///  Handles the logic of deciding whether to allow a pid_suspend/pid_resume through to a binary or

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -258,6 +258,10 @@ static NSString *const kPrinterProxyPostMonterey =
     return;
   }
 
+  SNTFileInfo *scriptInfo =
+      [[SNTFileInfo alloc] initWithEndpointSecurityFile:esMsg->event.exec.script
+                                                  error:&fileInfoError];
+
   // PrinterProxy workaround, see description above the method for more details.
   if ([self printerProxyWorkaround:binInfo]) {
     postAction(SNTActionRespondDeny);
@@ -269,6 +273,7 @@ static NSString *const kPrinterProxyPostMonterey =
   // if (binInfo.fileSize > SomeUpperLimit) ...
 
   SNTCachedDecision *cd = [self.policyProcessor decisionForFileInfo:binInfo
+      scriptInfo:scriptInfo
       targetProcess:targetProc
       configState:configState
       preCodesignCheckCallback:^(void) {

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -48,6 +48,7 @@
 ///  any async processing without extending their lifetimes.
 ///
 - (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
+                                        scriptInfo:(nonnull SNTFileInfo *)scriptInfo
                                      targetProcess:(nonnull const es_process_t *)targetProc
                                        configState:(nonnull SNTConfigState *)configState
                           preCodesignCheckCallback:(void (^_Nullable)(void))preCodesignCheckCallback

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -393,6 +393,7 @@ static void UpdateCachedDecisionSigningInfo(
                              preCodesignCheckCallback:nil];
 
     if ((cd.decision & SNTEventStateBlock) != 0) {
+      cd.scriptExecutionDenied = YES;
       return cd;
     }
   }

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -9,12 +9,11 @@ nav_order: 7
     against dynamic libraries loaded with dlopen, libraries on disk that have
     been replaced, or libraries loaded using `DYLD_INSERT_LIBRARIES`.
 
-*   Scripts: Santa is written to ignore any execution that isn't a binary. After
-    weighing the administrative cost versus the benefit, we found it wasn't
-    worthwhile to manage the execution of scripts. Additionally, several
-    applications make use of temporary scripts, and blocking these could cause
-    problems. We're happy to revisit this (or at least make it an option) if it
-    would be useful to others.
+*   Scripts: By default, Santa will allow script exections. However, it is
+    possible to provide an explicit block rule using the SHA256 hash of the
+    script. An important caveat is that Santa only evaluates scripts when
+    they are directly executed (e.g. `./foo.sh`, not `/bin/sh ./foo.sh`).
+    The `BlockedPathRegex` configuration key may also be used.
 
 *   USB Mass Storage Blocking: Santa's USB Mass Storage blocking feature only
     stops incidental data exfiltration. It is not meant as a hard control. It


### PR DESCRIPTION
Several years ago when Santa was kext-based (prior to adopting EndpointSecurity), it had the ability to block scripts by hash under specific scenarios. This change adds back this functionality. The same limitations as before still apply:

1. Block only - Santa will allow all scripts by default unless a specific block rule exists
2. Block rules for scripts only support the SHA256 identifier since they are unsigned. (note: `BlockedPathRegex` configuration key may also be used)
3. As with before, Santa can only evaluate script execution when the script is directly executed (e.g., `./foo.sh`, not `/bin/sh ./foo.sh`).
