### PR TITLE
Project: Fix most deprecation warnings

### DIFF
--- a/Source/santad/ProcessTree/BUILD
+++ b/Source/santad/ProcessTree/BUILD
@@ -1,5 +1,6 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "objc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//:helper.bzl", "santa_unit_test")
 
 package(

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -145,7 +145,10 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   SNTRule *r = [[SNTRule alloc] init];
 
   r.identifier = StringToNSString(rule.identifier());
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (!r.identifier.length) r.identifier = StringToNSString(rule.deprecated_sha256());
+#pragma clang diagnostic pop
   if (!r.identifier.length) return nil;
 
   SNTRuleState state;


### PR DESCRIPTION
The only warnings this leaves behind are for the uses of SecAsn1, which is deprecated but Apple offers no alternative for.