### PR TITLE
Project: Don't build Polaris in debug builds to shorten build time

### DIFF
--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -24,13 +24,21 @@ objc_library(
         "SNTPolaris.h",
         "SNTPolaris.mm",
     ],
+    defines = select({
+        "//:release_build": ["SANTA_ENABLE_POLARIS"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//Source/common:SNTLogging",
         "//Source/common:SNTSystemInfo",
         "//Source/common:String",
-        "@grpc//:grpc++",
-        "@northpole_protos//stats:v1_cc_grpc",
-    ],
+    ] + select({
+        "//:release_build": [
+            "@grpc//:grpc++",
+            "@northpole_protos//stats:v1_cc_grpc",
+        ],
+        "//conditions:default": None,
+    }),
 )
 
 objc_library(

--- a/Source/santasyncservice/SNTPolaris.mm
+++ b/Source/santasyncservice/SNTPolaris.mm
@@ -25,6 +25,7 @@
 #include "Source/common/SNTSystemInfo.h"
 #include "Source/common/String.h"
 
+#ifdef SANTA_ENABLE_POLARIS
 #include <google/protobuf/arena.h>
 
 #include <grpc/grpc.h>
@@ -36,6 +37,7 @@
 #include "stats/v1.grpc.pb.h"
 
 namespace pbv1 = ::santa::stats::v1;
+#endif
 
 namespace santa {
 
@@ -48,6 +50,7 @@ std::string machineIdHash(std::string_view machineID) {
 }
 
 void SubmitStats(NSString *orgID) {
+#ifdef SANTA_ENABLE_POLARIS
   google::protobuf::Arena arena;
   auto channel_creds = grpc::SslCredentials(grpc::SslCredentialsOptions());
   auto chan = grpc::CreateChannel(kPolarisHostname, channel_creds);
@@ -85,6 +88,9 @@ void SubmitStats(NSString *orgID) {
     return;
   }
   LOGI(@"Submitted stats to %s", kPolarisHostname);
+#else
+  LOGI(@"Stats submission is disabled in non-release builds");
+#endif  // SANTA_ENABLE_POLARIS
 }
 
 }  // namespace santa

--- a/Source/santasyncservice/SNTSyncService.mm
+++ b/Source/santasyncservice/SNTSyncService.mm
@@ -138,11 +138,7 @@
       LOGI(@"Stats collection is disabled, skipping submission");
       return;
     }
-#ifdef DEBUG
-    LOGI(@"Stats collection is disabled in DEBUG builds");
-#else
     santa::SubmitStats([[SNTConfigurator configurator] statsOrganizationID]);
-#endif
   });
   dispatch_resume(self.statsSubmissionTimer);
 }


### PR DESCRIPTION
Stats collection is disabled in non-release builds so there's no point building all of gRPC for them.