### PR TITLE
Remove stat change detection metrics that are no longer necessary

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -214,18 +214,6 @@ enum class FileAccessPolicyDecision {
   kAllowedAuditOnly,
 };
 
-enum class StatChangeStep {
-  kNoChange = 0,
-  kMessageCreate,
-  kCodesignValidation,
-};
-
-enum class StatResult {
-  kOK = 0,
-  kStatError,
-  kDevnoInodeMismatch,
-};
-
 #endif
 
 static const char *kSantaDPath =

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -771,7 +771,6 @@ objc_library(
     deps = [
         ":EndpointSecurityClient",
         ":WatchItemPolicy",
-        "//Source/common:SNTCommonEnums",
         "//Source/santad/ProcessTree:process_tree",
     ],
 )

--- a/Source/santad/EventProviders/EndpointSecurity/Message.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.h
@@ -20,13 +20,11 @@
 #include <memory>
 #include <string>
 
-#import "Source/common/SNTCommonEnums.h"
 #include "Source/santad/ProcessTree/process_tree.h"
 
 namespace santa {
 
 class EndpointSecurityAPI;
-class MessagePeer;
 
 class Message {
  public:
@@ -55,22 +53,12 @@ class Message {
 
   std::string ParentProcessName() const;
 
-  void UpdateStatState(enum StatChangeStep step) const;
-
-  inline StatChangeStep StatChangeStep() const { return stat_change_step_; }
-  inline StatResult StatResult() const { return stat_result_; }
-
-  friend class santa::MessagePeer;
-
  private:
   std::shared_ptr<EndpointSecurityAPI> esapi_;
   const es_message_t* es_msg_;
   std::optional<santa::santad::process_tree::ProcessToken> process_token_;
 
   std::string GetProcessName(pid_t pid) const;
-
-  mutable enum StatChangeStep stat_change_step_ = StatChangeStep::kNoChange;
-  mutable enum StatResult stat_result_ = StatResult::kOK;
 };
 
 }  // namespace santa

--- a/Source/santad/EventProviders/EndpointSecurity/Message.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.mm
@@ -25,7 +25,6 @@ namespace santa {
 Message::Message(std::shared_ptr<EndpointSecurityAPI> esapi, const es_message_t *es_msg)
     : esapi_(std::move(esapi)), es_msg_(es_msg), process_token_(std::nullopt) {
   esapi_->RetainMessage(es_msg);
-  UpdateStatState(StatChangeStep::kMessageCreate);
 }
 
 Message::~Message() {
@@ -40,8 +39,6 @@ Message::Message(Message &&other) {
   other.es_msg_ = nullptr;
   process_token_ = std::move(other.process_token_);
   other.process_token_ = std::nullopt;
-  stat_change_step_ = other.stat_change_step_;
-  stat_result_ = other.stat_result_;
 }
 
 Message::Message(const Message &other) {
@@ -49,27 +46,6 @@ Message::Message(const Message &other) {
   es_msg_ = other.es_msg_;
   esapi_->RetainMessage(es_msg_);
   process_token_ = other.process_token_;
-  stat_change_step_ = other.stat_change_step_;
-  stat_result_ = other.stat_result_;
-}
-
-void Message::UpdateStatState(enum StatChangeStep step) const {
-  // Only update state for AUTH EXEC events and if no previous change was detected
-  if (es_msg_->event_type == ES_EVENT_TYPE_AUTH_EXEC &&
-      stat_change_step_ == StatChangeStep::kNoChange &&
-      // Note: The following checks are required due to tests that only
-      // partially construct an es_message_t.
-      es_msg_->event.exec.target && es_msg_->event.exec.target->executable) {
-    struct stat &es_sb = es_msg_->event.exec.target->executable->stat;
-    struct stat sb;
-    int ret = stat(es_msg_->event.exec.target->executable->path.data, &sb);
-    // If stat failed, or if devno/inode changed, update state.
-    if (ret != 0 || es_sb.st_ino != sb.st_ino || es_sb.st_dev != sb.st_dev) {
-      stat_change_step_ = step;
-      // Determine the specific condition that failed for tracking purposes
-      stat_result_ = (ret != 0) ? StatResult::kStatError : StatResult::kDevnoInodeMismatch;
-    }
-  }
 }
 
 void Message::SetProcessToken(santa::santad::process_tree::ProcessToken tok) {

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -57,7 +57,6 @@ enum class FileAccessMetricStatus {
 using EventCountTuple = std::tuple<Processor, es_event_type_t, EventDisposition>;
 using EventTimesTuple = std::tuple<Processor, es_event_type_t>;
 using EventStatsTuple = std::tuple<Processor, es_event_type_t>;
-using EventStatChangeTuple = std::tuple<StatChangeStep, StatResult>;
 using FileAccessMetricsPolicyVersion = std::string;
 using FileAccessMetricsPolicyName = std::string;
 using FileAccessEventCountTuple =
@@ -73,8 +72,8 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   Metrics(dispatch_queue_t q, dispatch_source_t timer_source, uint64_t interval,
           SNTMetricInt64Gauge *event_processing_times, SNTMetricCounter *event_counts,
           SNTMetricCounter *rate_limit_counts, SNTMetricCounter *drop_counts,
-          SNTMetricCounter *faa_event_counts, SNTMetricCounter *stat_change_counts,
-          SNTMetricSet *metric_set, void (^run_on_first_start)(Metrics *));
+          SNTMetricCounter *faa_event_counts, SNTMetricSet *metric_set,
+          void (^run_on_first_start)(Metrics *));
 
   ~Metrics();
 
@@ -118,7 +117,6 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   SNTMetricCounter *rate_limit_counts_;
   SNTMetricCounter *faa_event_counts_;
   SNTMetricCounter *drop_counts_;
-  SNTMetricCounter *stat_change_counts_;
   SNTMetricSet *metric_set_;
   // Tracks whether or not the timer_source should be running.
   // This helps manage dispatch source state to ensure the source is not
@@ -136,7 +134,6 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   std::map<Processor, int64_t> rate_limit_counts_cache_;
   std::map<FileAccessEventCountTuple, int64_t> faa_event_counts_cache_;
   std::map<EventStatsTuple, SequenceStats> drop_cache_;
-  std::map<EventStatChangeTuple, int64_t> stat_change_cache_;
 };
 
 }  // namespace santa

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -268,12 +268,11 @@ static NSString *const kPrinterProxyPostMonterey =
   // TODO(markowsky): Maybe add a metric here for how many large executables we're seeing.
   // if (binInfo.fileSize > SomeUpperLimit) ...
 
-  SNTCachedDecision *cd = [self.policyProcessor decisionForFileInfo:binInfo
-      targetProcess:targetProc
-      configState:configState
-      preCodesignCheckCallback:^(void) {
-        esMsg.UpdateStatState(StatChangeStep::kCodesignValidation);
-      }
+  SNTCachedDecision *cd = [self.policyProcessor
+             decisionForFileInfo:binInfo
+                   targetProcess:targetProc
+                     configState:configState
+        preCodesignCheckCallback:nil
       entitlementsFilterCallback:^NSDictionary *(const char *teamID, NSDictionary *entitlements) {
         if (!entitlements) {
           return nil;

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -272,7 +272,6 @@ static NSString *const kPrinterProxyPostMonterey =
              decisionForFileInfo:binInfo
                    targetProcess:targetProc
                      configState:configState
-        preCodesignCheckCallback:nil
       entitlementsFilterCallback:^NSDictionary *(const char *teamID, NSDictionary *entitlements) {
         if (!entitlements) {
           return nil;

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -50,7 +50,6 @@
 - (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
                                      targetProcess:(nonnull const es_process_t *)targetProc
                                        configState:(nonnull SNTConfigState *)configState
-                          preCodesignCheckCallback:(void (^_Nullable)(void))preCodesignCheckCallback
                         entitlementsFilterCallback:
                             (NSDictionary *_Nullable (^_Nonnull)(
                                 const char *_Nullable teamID,

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -238,9 +238,9 @@ static void UpdateCachedDecisionSigningInfo(
                      signingID:(nullable NSString *)signingID
            platformBinaryState:(PlatformBinaryState)platformBinaryState
          signingStatusCallback:(SNTSigningStatus (^_Nonnull)())signingStatusCallback
-    entitlementsFilterCallback:(NSDictionary *_Nullable (^_Nullable)(
-                                   NSDictionary *_Nullable entitlements))entitlementsFilterCallback
-      preCodesignCheckCallback:(void (^_Nullable)(void))preCodesignCheckCallback {
+    entitlementsFilterCallback:
+        (NSDictionary *_Nullable (^_Nullable)(NSDictionary *_Nullable entitlements))
+            entitlementsFilterCallback {
   // Check the hash before allocating a SNTCachedDecision.
   NSString *fileHash = fileSHA256 ?: fileInfo.SHA256;
   SNTClientMode mode = configState.clientMode;
@@ -268,10 +268,6 @@ static void UpdateCachedDecisionSigningInfo(
   if (certificateSHA256.length) {
     cd.certSHA256 = certificateSHA256;
   } else {
-    if (preCodesignCheckCallback) {
-      preCodesignCheckCallback();
-    }
-
     // Grab the code signature, if there's an error don't try to capture
     // any of the signature details.
     // TODO(mlw): MOLCodesignChecker should be updated to still grab signing information
@@ -332,7 +328,6 @@ static void UpdateCachedDecisionSigningInfo(
 - (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
                                      targetProcess:(nonnull const es_process_t *)targetProc
                                        configState:(nonnull SNTConfigState *)configState
-                          preCodesignCheckCallback:(void (^_Nullable)(void))preCodesignCheckCallback
                         entitlementsFilterCallback:
                             (NSDictionary *_Nullable (^_Nonnull)(
                                 const char *_Nullable teamID,
@@ -399,8 +394,7 @@ static void UpdateCachedDecisionSigningInfo(
       }
       entitlementsFilterCallback:^NSDictionary *(NSDictionary *entitlements) {
         return entitlementsFilterCallback(entitlementsFilterTeamID, entitlements);
-      }
-      preCodesignCheckCallback:preCodesignCheckCallback];
+      }];
 }
 
 // Used by `$ santactl fileinfo`.
@@ -445,8 +439,7 @@ static void UpdateCachedDecisionSigningInfo(
                  }
                }
              }
-        entitlementsFilterCallback:nil
-          preCodesignCheckCallback:nil];
+        entitlementsFilterCallback:nil];
 }
 
 ///


### PR DESCRIPTION
This removes the metrics collection that was largely added here:
* https://github.com/google/santa/pull/1348
* https://github.com/google/santa/pull/1354
