### PR TITLE
Support invert Proc FAA rules and ES layer caching when possible

### DIFF
--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -60,6 +60,11 @@ class FAAPolicyProcessor {
     std::optional<std::pair<dev_t, ino_t>> devno_ino;
   };
 
+  struct ESResult {
+    es_auth_result_t auth_result;
+    bool cacheable;
+  };
+
   using TargetPolicyPair =
       std::pair<PathTarget, std::optional<std::shared_ptr<WatchItemPolicyBase>>>;
 
@@ -68,7 +73,7 @@ class FAAPolicyProcessor {
   using ReadsCacheUpdateBlock = void (^)(const es_process_t *, std::pair<dev_t, ino_t>);
   /// When this block is called, the policy enforcement client must determine
   /// whether or not the given policy applies to the given ES message.
-  using CheckIfPolicyMatchesBlock = bool (^)(const WatchItemPolicyBase &, PathTarget target,
+  using CheckIfPolicyMatchesBlock = bool (^)(const WatchItemPolicyBase &, const PathTarget &target,
                                              const Message &msg);
   using URLTextPair = std::pair<NSString *, NSString *>;
   /// A block that generates custom URL and Text pairs from a given policy.
@@ -106,12 +111,12 @@ class FAAPolicyProcessor {
   /// 3. Let caller know if appropriate to update their "reads cache" (ReadsCacheUpdateBlock())
   /// 4. Combine results of each target into an ES decision
   /// 5. Return the final ES decision
-  es_auth_result_t ProcessMessage(const Message &msg,
-                                  std::vector<TargetPolicyPair> target_policy_pairs,
-                                  ReadsCacheUpdateBlock reads_cache_update_block,
-                                  CheckIfPolicyMatchesBlock check_if_policy_matches_block,
-                                  SNTFileAccessDeniedBlock file_access_denied_block,
-                                  SNTOverrideFileAccessAction overrideAction);
+  FAAPolicyProcessor::ESResult ProcessMessage(
+      const Message &msg, std::vector<TargetPolicyPair> target_policy_pairs,
+      ReadsCacheUpdateBlock reads_cache_update_block,
+      CheckIfPolicyMatchesBlock check_if_policy_matches_block,
+      SNTFileAccessDeniedBlock file_access_denied_block,
+      SNTOverrideFileAccessAction overrideAction);
 
   static std::vector<FAAPolicyProcessor::PathTarget> PathTargets(const Message &msg);
 

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -335,8 +335,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   {
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, std::nullopt,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -355,8 +355,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     esMsg.process->codesigning_flags = CS_SIGNED;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -372,8 +372,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     esMsg.process->codesigning_flags = CS_SIGNED;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return true;
                        }),
@@ -389,8 +389,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = false;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -403,8 +403,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = true;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -422,8 +422,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = false;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -441,8 +441,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = false;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -456,8 +456,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = true;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return false;
                        }),
@@ -471,8 +471,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = true;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return true;
                        }),
@@ -486,8 +486,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
     policy->audit_only = false;
     XCTAssertEqual(faaPolicyProcessor.ApplyPolicyWrapper(
                        Message(mockESApi, &esMsg), target, optionalPolicy,
-                       ^bool(const santa::WatchItemPolicyBase &, FAAPolicyProcessor::PathTarget,
-                             const Message &) {
+                       ^bool(const santa::WatchItemPolicyBase &,
+                             const FAAPolicyProcessor::PathTarget &, const Message &) {
                          dispatch_semaphore_signal(sema);
                          return true;
                        }),


### PR DESCRIPTION
This PR moves checking target paths into the `CheckIfPolicyMatchesBlock` block to support inverted Proc FAA rules. ES cacheability is also now supported when possible.