### PR TITLE
santactl/fileinfo: Handle missing entitlements, with better output

### DIFF
--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -560,8 +560,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 - (SNTAttributeBlock)entitlements {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    if (csc.entitlements.count) return csc.entitlements;
-    return @"No entitlements";
+    return csc.entitlements ?: @{};
   };
 }
 
@@ -1076,7 +1075,9 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 }
 
 - (NSString *)stringForEntitlements:(NSDictionary *)entitlements key:(NSString *)key {
-  if (!entitlements.count) return @"none";
+  if (!entitlements.count) {
+    return [NSString stringWithFormat:@"%-*s: None\n", (int)self.maxKeyWidth, key.UTF8String];
+  }
 
   NSMutableString *result = [NSMutableString string];
   [result appendFormat:@"%@:\n", key];
@@ -1089,7 +1090,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       // so don't print it.
       if (!val) return;
 
-      // If hte value of the entitlement is true, don't bother printing the
+      // If the value of the entitlement is true, don't bother printing the
       // 'value', just print the entitlement name.
       [result appendFormat:@"   %2d. %@\n", ++i, key];
       return;


### PR DESCRIPTION
```
Type                   : Executable (x86_64, arm64e)
Code-signed            : Yes
Rule                   : Blocked (Signing ID)
Entitlements           : None
Signing Chain:
    1. SHA-256             : d84db96af8c2e60ac4c851a21ec460f6f84e0235beb17d24a78712b9b021ed57
```