### PR TITLE
Add reads cache support to the FAA Policy Processor

### DIFF
--- a/Source/common/SantaSetCache.h
+++ b/Source/common/SantaSetCache.h
@@ -64,8 +64,9 @@ class SantaSetCache {
   /// the key causes the cache capacity to overflow, the cache
   /// is cleared. If adding the value to the set causes it to
   /// overflow, it is first cleared.
-  /// Return true if the set at the given key contained the
-  /// given value. Otherwise false.
+  /// Return true if the new value was inserted into the inner
+  /// set. Otherwise returns false if the inner set already
+  /// contained the value.
   bool Set(const KeyT &key, ValueT val) {
     __block bool did_set = false;
     __block ValueT tmp_val = std::move(val);

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -462,6 +462,7 @@ objc_library(
         ":SNTEndpointSecurityEventHandler",
         ":TTYWriter",
         ":WatchItemPolicy",
+        "//Source/common:AuditUtilities",
         "//Source/common:MOLCertificate",
         "//Source/common:MOLCodesignChecker",
         "//Source/common:SNTBlockMessage",
@@ -470,6 +471,7 @@ objc_library(
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTFileAccessEvent",
         "//Source/common:SantaCache",
+        "//Source/common:SantaSetCache",
         "//Source/common:SantaVnode",
         "//Source/common:String",
     ],
@@ -497,6 +499,7 @@ objc_library(
         ":TTYWriter",
         ":WatchItemPolicy",
         ":WatchItems",
+        "//Source/common:AuditUtilities",
         "//Source/common:MOLCertificate",
         "//Source/common:MOLCodesignChecker",
         "//Source/common:Platform",
@@ -506,12 +509,8 @@ objc_library(
         "//Source/common:SNTFileAccessEvent",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTStrengthify",
-        "//Source/common:SantaCache",
         "//Source/common:SantaSetCache",
-        "//Source/common:SantaVnode",
         "//Source/common:String",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 
@@ -530,6 +529,8 @@ objc_library(
         ":WatchItems",
         "//Source/common:AuditUtilities",
         "//Source/common:SNTLogging",
+        "//Source/common:SantaCache",
+        "//Source/common:SantaSetCache",
     ],
 )
 

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -85,8 +85,6 @@ class FAAPolicyProcessor {
       URLTextPair (^)(const std::shared_ptr<WatchItemPolicyBase> &watch_item);
 
   using ReadsCacheKey = std::tuple<pid_t, int, FAAClientType>;
-  template <typename ValueT>
-  using ProcessSetCache = santa::SantaSetCache<ReadsCacheKey, ValueT>;
 
   // Friend classes that can call private methods requiring FAAClientType parameters
   friend class DataFAAPolicyProcessorProxy;
@@ -114,7 +112,9 @@ class FAAPolicyProcessor {
   std::shared_ptr<Logger> logger_;
   std::shared_ptr<TTYWriter> tty_writer_;
   GenerateEventDetailLinkBlock generate_event_detail_link_block_;
-  ProcessSetCache<std::pair<dev_t, ino_t>> reads_cache_;
+  santa::SantaSetCache<ReadsCacheKey, std::pair<dev_t, ino_t>> reads_cache_;
+  santa::SantaSetCache<std::pair<pid_t, int>, std::pair<std::string, std::string>>
+      tty_message_cache_;
   SantaCache<SantaVnode, NSString *> cert_hash_cache_;
   SNTConfigurator *configurator_;
   dispatch_queue_t queue_;
@@ -164,6 +164,10 @@ class FAAPolicyProcessor {
 
   virtual bool PolicyAllowsReadsForTarget(const Message &msg, const PathTarget &target,
                                           std::shared_ptr<WatchItemPolicyBase> policy);
+
+  /// Return true if the TTY was previously messaged for the given
+  /// process/policy pair. Otherwise false.
+  bool HaveMessagedTTYForPolicy(const WatchItemPolicyBase &policy, const Message &msg);
 
   void LogTelemetry(const WatchItemPolicyBase &policy, const PathTarget &target, const Message &msg,
                     FileAccessPolicyDecision decision);

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -51,9 +51,6 @@ extern NSString *const kBadCertHash;
 
 namespace santa {
 
-// Forward declaration
-class MockFAAPolicyProcessor;
-
 enum class FAAClientType {
   kData,
   kProcess,
@@ -174,6 +171,8 @@ class FAAPolicyProcessor {
               const WatchItemPolicyBase &policy);
 };
 
+/// The proxy classes are used to wrap calls into the FAAPolicyProcessor and not expose
+/// the FAAClientType to FAAPolicyProcessor users.
 class FAAPolicyProcessorProxy {
  public:
   FAAPolicyProcessorProxy(std::shared_ptr<FAAPolicyProcessor> policy_processor)
@@ -196,9 +195,8 @@ class ProcessFAAPolicyProcessorProxy : public FAAPolicyProcessorProxy {
       SNTFileAccessDeniedBlock file_access_denied_block,
       SNTOverrideFileAccessAction overrideAction) {
     return policy_processor_->ProcessMessage(
-        msg, std::move(target_policy_pairs),
-        check_if_policy_matches_block, file_access_denied_block, overrideAction,
-        FAAClientType::kProcess);
+        msg, std::move(target_policy_pairs), check_if_policy_matches_block,
+        file_access_denied_block, overrideAction, FAAClientType::kProcess);
   }
 
   std::optional<FAAPolicyProcessor::ESResult> ImmediateResponse(const Message &msg) {
@@ -221,9 +219,8 @@ class DataFAAPolicyProcessorProxy : public FAAPolicyProcessorProxy {
       SNTFileAccessDeniedBlock file_access_denied_block,
       SNTOverrideFileAccessAction overrideAction) {
     return policy_processor_->ProcessMessage(
-        msg, std::move(target_policy_pairs),
-        check_if_policy_matches_block, file_access_denied_block, overrideAction,
-        FAAClientType::kData);
+        msg, std::move(target_policy_pairs), check_if_policy_matches_block,
+        file_access_denied_block, overrideAction, FAAClientType::kData);
   }
 
   std::optional<FAAPolicyProcessor::ESResult> ImmediateResponse(const Message &msg) {

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -452,7 +452,6 @@ static inline FAAPolicyProcessor::ReadsCacheKey MakeReadsCacheKey(const Message 
 
 FAAPolicyProcessor::ESResult FAAPolicyProcessor::ProcessMessage(
     const Message &msg, std::vector<TargetPolicyPair> target_policy_pairs,
-    ReadsCacheUpdateBlock reads_cache_update_block,
     CheckIfPolicyMatchesBlock check_if_policy_matches_block,
     SNTFileAccessDeniedBlock file_access_denied_block, SNTOverrideFileAccessAction overrideAction,
     FAAClientType client_type) {
@@ -463,7 +462,7 @@ FAAPolicyProcessor::ESResult FAAPolicyProcessor::ProcessMessage(
     FileAccessPolicyDecision decision = ProcessTargetAndPolicy(
         msg, target_policy_pair.first, target_policy_pair.second, check_if_policy_matches_block,
         file_access_denied_block, overrideAction);
-    // Trigger the caller's ReadsCacheUpdateBlock if:
+    // Populate the reads_cache_ if:
     //   1. The policy applied
     //   2. The process wasn't invalid
     //   3. A devno/ino pair existed for the target

--- a/Source/santad/EventProviders/MockFAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/MockFAAPolicyProcessor.h
@@ -33,9 +33,10 @@ namespace santa {
 
 class MockFAAPolicyProcessor : public FAAPolicyProcessor {
  public:
-  MockFAAPolicyProcessor(SNTDecisionCache *dc, std::shared_ptr<Enricher> enricher,
-                         std::shared_ptr<Logger> logger, std::shared_ptr<TTYWriter> tty_writer,
-                         GenerateEventDetailLinkBlock generate_event_detail_link_block)
+  MockFAAPolicyProcessor(
+      SNTDecisionCache *dc, std::shared_ptr<Enricher> enricher, std::shared_ptr<Logger> logger,
+      std::shared_ptr<TTYWriter> tty_writer,
+      FAAPolicyProcessor::GenerateEventDetailLinkBlock generate_event_detail_link_block)
       : FAAPolicyProcessor(dc, std::move(enricher), std::move(logger), std::move(tty_writer),
                            std::move(generate_event_detail_link_block)) {}
   virtual ~MockFAAPolicyProcessor() {}
@@ -45,13 +46,13 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
   MOCK_METHOD(SNTCachedDecision *, GetCachedDecision, (const struct stat &stat_buf), (override));
   MOCK_METHOD(NSString *, GetCertificateHash, (const es_file_t *es_file), (override));
   MOCK_METHOD(bool, PolicyAllowsReadsForTarget,
-              (const Message &msg, const PathTarget &target,
+              (const Message &msg, const FAAPolicyProcessor::PathTarget &target,
                std::shared_ptr<WatchItemPolicyBase> policy),
               (override));
   MOCK_METHOD(FileAccessPolicyDecision, ApplyPolicy,
-              (const Message &msg, const PathTarget &target,
+              (const Message &msg, const FAAPolicyProcessor::PathTarget &target,
                const std::optional<std::shared_ptr<santa::WatchItemPolicyBase>> optional_policy,
-               CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock),
+               FAAPolicyProcessor::CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock),
               (override));
 
   //
@@ -61,15 +62,16 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
     return FAAPolicyProcessor::GetCertificateHash(es_file);
   }
 
-  bool PolicyAllowsReadsForTargetWrapper(const Message &msg, const PathTarget &target,
+  bool PolicyAllowsReadsForTargetWrapper(const Message &msg,
+                                         const FAAPolicyProcessor::PathTarget &target,
                                          std::shared_ptr<WatchItemPolicyBase> policy) {
     return FAAPolicyProcessor::PolicyAllowsReadsForTarget(msg, target, policy);
   }
 
   FileAccessPolicyDecision ApplyPolicyWrapper(
-      const Message &msg, const PathTarget &target,
+      const Message &msg, const FAAPolicyProcessor::PathTarget &target,
       const std::optional<std::shared_ptr<WatchItemPolicyBase>> optional_policy,
-      CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock) {
+      FAAPolicyProcessor::CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock) {
     return FAAPolicyProcessor::ApplyPolicy(msg, target, optional_policy, checkIfPolicyMatchesBlock);
   }
 };

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -36,7 +36,8 @@
                        logger:(std::shared_ptr<santa::Logger>)logger
                    watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
                      enricher:(std::shared_ptr<santa::Enricher>)enricher
-           faaPolicyProcessor:(std::shared_ptr<santa::FAAPolicyProcessor>)faaPolicyProcessor
+           faaPolicyProcessor:
+               (std::shared_ptr<santa::DataFAAPolicyProcessorProxy>)faaPolicyProcessorProxy
                     ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter;
 
 @property SNTFileAccessDeniedBlock fileAccessDeniedBlock;

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -43,15 +43,12 @@
 #import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTStrengthify.h"
 #include "Source/common/SantaSetCache.h"
-#include "Source/common/SantaVnode.h"
 #include "Source/common/String.h"
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #include "Source/santad/DataLayer/WatchItems.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/EventProviders/RateLimiter.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 
 using santa::DataWatchItemPolicy;
 using santa::EndpointSecurityAPI;

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h
@@ -30,7 +30,8 @@
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
                         metrics:(std::shared_ptr<santa::Metrics>)metrics
-             faaPolicyProcessor:(std::shared_ptr<santa::FAAPolicyProcessor>)faaPolicyProcessor
+             faaPolicyProcessor:
+                 (std::shared_ptr<santa::ProcessFAAPolicyProcessorProxy>)faaPolicyProcessorProxy
     iterateProcessPoliciesBlock:(santa::IterateProcessPoliciesBlock)findProcessPoliciesBlock;
 
 @property SNTFileAccessDeniedBlock fileAccessDeniedBlock;

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -88,9 +88,6 @@ using ProcessSetCache = santa::SantaSetCache<std::pair<pid_t, int>, ValueT>;
 
   FAAPolicyProcessor::ESResult result = self.faaPolicyProcessorProxy->ProcessMessage(
       msg, targetPolicyPairs,
-      ^(const es_process_t *, std::pair<dev_t, ino_t>){
-          // TODO: reads cache updates
-      },
       ^bool(const santa::WatchItemPolicyBase &base_policy,
             const FAAPolicyProcessor::PathTarget &target, const Message &msg) {
         const ProcessWatchItemPolicy *policy =

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -139,6 +139,7 @@ using ProcessSetCache = santa::SantaSetCache<std::pair<pid_t, int>, ValueT>;
 
     case ES_EVENT_TYPE_NOTIFY_EXIT: {
       _procRuleCache->remove(PidPidversion(esMsg->process->audit_token));
+      self.faaPolicyProcessorProxy->NotifyExit(esMsg);
       return;
     };
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -35,8 +35,6 @@ using santa::ProcessWatchItemPolicy;
 
 using PidPidverPair = std::pair<pid_t, int>;
 using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchItemPolicy>>;
-template <typename ValueT>
-using ProcessSetCache = santa::SantaSetCache<std::pair<pid_t, int>, ValueT>;
 
 @interface SNTEndpointSecurityProcessFileAccessAuthorizer ()
 @property bool isSubscribed;

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
@@ -12,6 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+#include "Source/santad/EventProviders/FAAPolicyProcessor.h"
 #include "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.h"
 
@@ -99,6 +100,7 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
   EXPECT_CALL(*mockFAA, PolicyMatchesProcess)
       .WillOnce(testing::Return(false))
       .WillOnce(testing::Return(true));
+  auto mockFAAProxy = std::make_shared<santa::ProcessFAAPolicyProcessorProxy>(mockFAA);
 
   // Test object to provide to the CheckPolicyBlock
   WatchItemProcess proc{"proc_path_1", "com.example.proc", "PROCTEAMID", {}, "", std::nullopt};
@@ -116,7 +118,7 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
   SNTEndpointSecurityProcessFileAccessAuthorizer *procFAAClient =
       [[SNTEndpointSecurityProcessFileAccessAuthorizer alloc] initWithESAPI:mockESApi
                                                                     metrics:nullptr
-                                                         faaPolicyProcessor:mockFAA
+                                                         faaPolicyProcessor:mockFAAProxy
                                                 iterateProcessPoliciesBlock:iterPoliciesBlock];
   id mockProcFAAClient = OCMPartialMock(procFAAClient);
 

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -174,7 +174,8 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
         [[SNTEndpointSecurityProcessFileAccessAuthorizer alloc]
                           initWithESAPI:esapi
                                 metrics:metrics
-                     faaPolicyProcessor:faaPolicyProcessor
+                     faaPolicyProcessor:std::make_shared<santa::ProcessFAAPolicyProcessorProxy>(
+                                            faaPolicyProcessor)
             iterateProcessPoliciesBlock:^(santa::CheckPolicyBlock checkPolicyBlock) {
               watch_items->IterateProcessPolicies(checkPolicyBlock);
             }];

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -149,13 +149,15 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
         });
 
     SNTEndpointSecurityFileAccessAuthorizer *data_faa_client =
-        [[SNTEndpointSecurityFileAccessAuthorizer alloc] initWithESAPI:esapi
-                                                               metrics:metrics
-                                                                logger:logger
-                                                            watchItems:watch_items
-                                                              enricher:enricher
-                                                    faaPolicyProcessor:faaPolicyProcessor
-                                                             ttyWriter:tty_writer];
+        [[SNTEndpointSecurityFileAccessAuthorizer alloc]
+                 initWithESAPI:esapi
+                       metrics:metrics
+                        logger:logger
+                    watchItems:watch_items
+                      enricher:enricher
+            faaPolicyProcessor:std::make_shared<santa::DataFAAPolicyProcessorProxy>(
+                                   faaPolicyProcessor)
+                     ttyWriter:tty_writer];
     watch_items->RegisterDataClient(data_faa_client);
 
     data_faa_client.fileAccessDeniedBlock = ^(SNTFileAccessEvent *event, NSString *customMsg,


### PR DESCRIPTION
This PR adds reads cache to the FAA policy processor. Because moving the cache to this layer will require differentiating between Data and Proc FAA clients, a new `FAAPolicyProcessorProxy` class is introduced that is appropriately subclassed and hides the details of setting the proper FAAClientType enum so that callers cannot accidentally use the wrong value.