### PR TITLE
Add Operation ID / fingerprint hash to FileAccess telemetry events

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "rules_swift", version = "2.7.0", repo_name = "build_bazel_rule
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
 bazel_dep(name = "protobuf", version = "30.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
+bazel_dep(name = "xxhash", version = "0.8.2")
 
 # North Pole Protos
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpole_protos")

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -552,6 +552,11 @@ message FileAccess {
     POLICY_DECISION_ALLOWED_AUDIT_ONLY = 3;
   }
   optional PolicyDecision policy_decision = 6;
+
+  // Used to link a single operation emitting multiple FileAccess messages.
+  // This can happen, for example, when a single operation violates both Data
+  // and Process File Access Authorization rules
+  optional string fingerprint = 7;
 }
 
 // Session identifier for a graphical session

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -556,7 +556,7 @@ message FileAccess {
   // Used to link a single operation emitting multiple FileAccess messages.
   // This can happen, for example, when a single operation violates both Data
   // and Process File Access Authorization rules.
-  optional string fingerprint = 7;
+  optional string operation_id = 7;
 }
 
 // Session identifier for a graphical session

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -555,7 +555,7 @@ message FileAccess {
 
   // Used to link a single operation emitting multiple FileAccess messages.
   // This can happen, for example, when a single operation violates both Data
-  // and Process File Access Authorization rules
+  // and Process File Access Authorization rules.
   optional string fingerprint = 7;
 }
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -613,10 +613,14 @@ objc_library(
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
         ":SNTDecisionCache",
+        "//Source/common:AuditUtilities",
         "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
+        "//Source/common:SNTSystemInfo",
+        "//Source/common:String",
+        "@xxhash",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -88,7 +88,15 @@ class MockSerializer : public Empty {
   MOCK_METHOD(std::vector<uint8_t>, SerializeFileAccess,
               (const std::string &policy_version, const std::string &policy_name,
                const santa::Message &msg, const santa::EnrichedProcess &enriched_process,
-               const std::string &target, FileAccessPolicyDecision decision));
+               const std::string &target, FileAccessPolicyDecision decision,
+               std::string_view fingerprint),
+              (override));
+
+  MOCK_METHOD(std::vector<uint8_t>, SerializeFileAccess,
+              (const std::string &policy_version, const std::string &policy_name,
+               const santa::Message &msg, const santa::EnrichedProcess &enriched_process,
+               const std::string &target, FileAccessPolicyDecision decision),
+              (override));
 };
 
 class MockWriter : public Null {
@@ -234,7 +242,8 @@ class MockWriter : public Null {
   es_message_t msg;
 
   mockESApi->SetExpectationsRetainReleaseMessage();
-  EXPECT_CALL(*mockSerializer, SerializeFileAccess);
+  using testing::_;
+  EXPECT_CALL(*mockSerializer, SerializeFileAccess(_, _, _, _, _, _));
   EXPECT_CALL(*mockWriter, Write);
 
   Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter)

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -89,7 +89,7 @@ class MockSerializer : public Empty {
               (const std::string &policy_version, const std::string &policy_name,
                const santa::Message &msg, const santa::EnrichedProcess &enriched_process,
                const std::string &target, FileAccessPolicyDecision decision,
-               std::string_view fingerprint),
+               std::string_view operation_id),
               (override));
 
   MOCK_METHOD(std::vector<uint8_t>, SerializeFileAccess,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -70,12 +70,10 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15
 
-  std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
-                                           const std::string &policy_name,
-                                           const santa::Message &msg,
-                                           const santa::EnrichedProcess &enriched_process,
-                                           const std::string &target,
-                                           FileAccessPolicyDecision decision) override;
+  std::vector<uint8_t> SerializeFileAccess(
+      const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
+      const santa::EnrichedProcess &enriched_process, const std::string &target,
+      FileAccessPolicyDecision decision, std::string_view fingerprint) override;
 
   std::vector<uint8_t> SerializeAllowlist(const santa::Message &, const std::string_view) override;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -73,7 +73,7 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
       const santa::EnrichedProcess &enriched_process, const std::string &target,
-      FileAccessPolicyDecision decision, std::string_view fingerprint) override;
+      FileAccessPolicyDecision decision, std::string_view operation_id) override;
 
   std::vector<uint8_t> SerializeAllowlist(const santa::Message &, const std::string_view) override;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -838,7 +838,7 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedGatekeeperOverr
 std::vector<uint8_t> BasicString::SerializeFileAccess(
     const std::string &policy_version, const std::string &policy_name, const Message &msg,
     const EnrichedProcess &enriched_process, const std::string &target,
-    FileAccessPolicyDecision decision, std::string_view fingerprint) {
+    FileAccessPolicyDecision decision, std::string_view operation_id) {
   std::string str = CreateDefaultString();
 
   str.append("action=FILE_ACCESS|policy_version=");
@@ -851,8 +851,8 @@ std::vector<uint8_t> BasicString::SerializeFileAccess(
   str.append(GetAccessTypeString(msg->event_type));
   str.append("|decision=");
   str.append(GetFileAccessPolicyDecisionString(decision));
-  str.append("|fingerprint=");
-  str.append(fingerprint);
+  str.append("|operation_id=");
+  str.append(operation_id);
 
   AppendProcess(str, msg->process);
   AppendUserGroup(str, msg->process->audit_token, enriched_process.real_user(),

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -835,12 +835,10 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedGatekeeperOverr
 
 #endif  // HAVE_MACOS_15
 
-std::vector<uint8_t> BasicString::SerializeFileAccess(const std::string &policy_version,
-                                                      const std::string &policy_name,
-                                                      const Message &msg,
-                                                      const EnrichedProcess &enriched_process,
-                                                      const std::string &target,
-                                                      FileAccessPolicyDecision decision) {
+std::vector<uint8_t> BasicString::SerializeFileAccess(
+    const std::string &policy_version, const std::string &policy_name, const Message &msg,
+    const EnrichedProcess &enriched_process, const std::string &target,
+    FileAccessPolicyDecision decision, std::string_view fingerprint) {
   std::string str = CreateDefaultString();
 
   str.append("action=FILE_ACCESS|policy_version=");
@@ -853,6 +851,8 @@ std::vector<uint8_t> BasicString::SerializeFileAccess(const std::string &policy_
   str.append(GetAccessTypeString(msg->event_type));
   str.append("|decision=");
   str.append(GetFileAccessPolicyDecisionString(decision));
+  str.append("|fingerprint=");
+  str.append(fingerprint);
 
   AppendProcess(str, msg->process);
   AppendUserGroup(str, msg->process->audit_token, enriched_process.real_user(),

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -894,7 +894,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::string got(ret.begin(), ret.end());
   std::string want =
       "action=FILE_ACCESS|policy_version=v1.0|policy_name=pol_name|path=file_target"
-      "|access_type=OPEN|decision=AUDIT_ONLY|fingerprint=abc123|pid=12|ppid=56"
+      "|access_type=OPEN|decision=AUDIT_ONLY|operation_id=abc123|pid=12|ppid=56"
       "|process=foo|processpath=foo|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
   XCTAssertCppStringEqual(got, want);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -890,13 +890,12 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
       BasicString::Create(nullptr, nil, false)
           ->SerializeFileAccess("v1.0", "pol_name", Message(mockESApi, &esMsg),
                                 Enricher().Enrich(*esMsg.process), "file_target",
-                                FileAccessPolicyDecision::kAllowedAuditOnly);
+                                FileAccessPolicyDecision::kAllowedAuditOnly, "abc123");
   std::string got(ret.begin(), ret.end());
   std::string want =
-      "action=FILE_ACCESS|policy_version=v1.0|policy_name=pol_name|path=file_target|access_type="
-      "OPEN|"
-      "decision=AUDIT_ONLY|pid=12|ppid=56|"
-      "process=foo|processpath=foo|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
+      "action=FILE_ACCESS|policy_version=v1.0|policy_name=pol_name|path=file_target"
+      "|access_type=OPEN|decision=AUDIT_ONLY|fingerprint=abc123|pid=12|ppid=56"
+      "|process=foo|processpath=foo|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
   XCTAssertCppStringEqual(got, want);
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -66,7 +66,7 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
       const santa::EnrichedProcess &enriched_process, const std::string &target,
-      FileAccessPolicyDecision decision, std::string_view fingerprint) override;
+      FileAccessPolicyDecision decision, std::string_view operation_id) override;
 
   std::vector<uint8_t> SerializeAllowlist(const santa::Message &, const std::string_view) override;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -63,12 +63,10 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15
 
-  std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
-                                           const std::string &policy_name,
-                                           const santa::Message &msg,
-                                           const santa::EnrichedProcess &enriched_process,
-                                           const std::string &target,
-                                           FileAccessPolicyDecision decision) override;
+  std::vector<uint8_t> SerializeFileAccess(
+      const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
+      const santa::EnrichedProcess &enriched_process, const std::string &target,
+      FileAccessPolicyDecision decision, std::string_view fingerprint) override;
 
   std::vector<uint8_t> SerializeAllowlist(const santa::Message &, const std::string_view) override;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -140,7 +140,7 @@ std::vector<uint8_t> Empty::SerializeFileAccess(const std::string &policy_versio
                                                 const EnrichedProcess &enriched_process,
                                                 const std::string &target,
                                                 FileAccessPolicyDecision decision,
-                                                std::string_view fingerprint) {
+                                                std::string_view operation_id) {
   return {};
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -139,7 +139,8 @@ std::vector<uint8_t> Empty::SerializeFileAccess(const std::string &policy_versio
                                                 const std::string &policy_name, const Message &msg,
                                                 const EnrichedProcess &enriched_process,
                                                 const std::string &target,
-                                                FileAccessPolicyDecision decision) {
+                                                FileAccessPolicyDecision decision,
+                                                std::string_view fingerprint) {
   return {};
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -73,7 +73,7 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
       const santa::EnrichedProcess &enriched_process, const std::string &target,
-      FileAccessPolicyDecision decision, std::string_view fingerprint) override;
+      FileAccessPolicyDecision decision, std::string_view operation_id) override;
 
   std::vector<uint8_t> SerializeAllowlist(const santa::Message &, const std::string_view) override;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -70,12 +70,10 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15
 
-  std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
-                                           const std::string &policy_name,
-                                           const santa::Message &msg,
-                                           const santa::EnrichedProcess &enriched_process,
-                                           const std::string &target,
-                                           FileAccessPolicyDecision decision) override;
+  std::vector<uint8_t> SerializeFileAccess(
+      const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
+      const santa::EnrichedProcess &enriched_process, const std::string &target,
+      FileAccessPolicyDecision decision, std::string_view fingerprint) override;
 
   std::vector<uint8_t> SerializeAllowlist(const santa::Message &, const std::string_view) override;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -1076,7 +1076,7 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedGatekeeperOverride
 std::vector<uint8_t> Protobuf::SerializeFileAccess(
     const std::string &policy_version, const std::string &policy_name, const Message &msg,
     const EnrichedProcess &enriched_process, const std::string &target,
-    FileAccessPolicyDecision decision, std::string_view fingerprint) {
+    FileAccessPolicyDecision decision, std::string_view operation_id) {
   Arena arena;
   ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena, msg);
 
@@ -1090,7 +1090,7 @@ std::vector<uint8_t> Protobuf::SerializeFileAccess(
 
   file_access->set_access_type(GetAccessType(msg->event_type));
   file_access->set_policy_decision(GetPolicyDecision(decision));
-  file_access->set_fingerprint(fingerprint);
+  file_access->set_operation_id(operation_id);
 
   return FinalizeProto(santa_msg);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -1073,12 +1073,10 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedGatekeeperOverride
 
 #endif  // HAVE_MACOS_15
 
-std::vector<uint8_t> Protobuf::SerializeFileAccess(const std::string &policy_version,
-                                                   const std::string &policy_name,
-                                                   const Message &msg,
-                                                   const EnrichedProcess &enriched_process,
-                                                   const std::string &target,
-                                                   FileAccessPolicyDecision decision) {
+std::vector<uint8_t> Protobuf::SerializeFileAccess(
+    const std::string &policy_version, const std::string &policy_name, const Message &msg,
+    const EnrichedProcess &enriched_process, const std::string &target,
+    FileAccessPolicyDecision decision, std::string_view fingerprint) {
   Arena arena;
   ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena, msg);
 
@@ -1092,6 +1090,7 @@ std::vector<uint8_t> Protobuf::SerializeFileAccess(const std::string &policy_ver
 
   file_access->set_access_type(GetAccessType(msg->event_type));
   file_access->set_policy_decision(GetPolicyDecision(decision));
+  file_access->set_fingerprint(fingerprint);
 
   return FinalizeProto(santa_msg);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -1379,7 +1379,7 @@ void SerializeAndCheckNonESEvents(
       ^std::vector<uint8_t>(std::shared_ptr<Serializer> serializer, const Message &msg) {
         return serializer->SerializeFileAccess("policy_version", "policy_name", msg,
                                                Enricher().Enrich(*msg->process), "target",
-                                               FileAccessPolicyDecision::kDenied);
+                                               FileAccessPolicyDecision::kDenied, "abc123");
       });
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -88,7 +88,7 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,
       const santa::EnrichedProcess &enriched_process, const std::string &target,
-      FileAccessPolicyDecision decision, std::string_view fingerprint) = 0;
+      FileAccessPolicyDecision decision, std::string_view operation_id) = 0;
 
   virtual std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
                                                    const std::string &policy_name,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -90,12 +90,12 @@ class Serializer {
       const santa::EnrichedProcess &enriched_process, const std::string &target,
       FileAccessPolicyDecision decision, std::string_view fingerprint) = 0;
 
-  std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
-                                           const std::string &policy_name,
-                                           const santa::Message &msg,
-                                           const santa::EnrichedProcess &enriched_process,
-                                           const std::string &target,
-                                           FileAccessPolicyDecision decision);
+  virtual std::vector<uint8_t> SerializeFileAccess(const std::string &policy_version,
+                                                   const std::string &policy_name,
+                                                   const santa::Message &msg,
+                                                   const santa::EnrichedProcess &enriched_process,
+                                                   const std::string &target,
+                                                   FileAccessPolicyDecision decision);
 
   virtual std::vector<uint8_t> SerializeAllowlist(const santa::Message &,
                                                   const std::string_view) = 0;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -15,10 +15,17 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
 #include <EndpointSecurity/EndpointSecurity.h>
+#include <assert.h>
 #include <string_view>
 
+#import "Source/common/AuditUtilities.h"
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTSystemInfo.h"
+#import "Source/common/String.h"
 #import "Source/santad/SNTDecisionCache.h"
+
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
 
 namespace santa {
 
@@ -27,6 +34,16 @@ Serializer::Serializer(SNTDecisionCache *decision_cache) : decision_cache_(decis
     enabled_machine_id_ = true;
     machine_id_ = [[[SNTConfigurator configurator] machineID] UTF8String] ?: "";
   }
+
+  // Prime the xxHash state with invariant data
+  common_hash_state_ = XXH3_createState();
+  XXH3_128bits_reset(common_hash_state_);
+  std::string_view uuid = NSStringToUTF8StringView([SNTSystemInfo bootSessionUUID]);
+  XXH3_128bits_update(common_hash_state_, uuid.data(), uuid.length());
+}
+
+Serializer::~Serializer() {
+  XXH3_freeState(common_hash_state_);
 }
 
 bool Serializer::EnabledMachineID() {
@@ -48,6 +65,88 @@ std::vector<uint8_t> Serializer::SerializeMessageTemplate(const santa::EnrichedE
   }
 
   return SerializeMessage(msg, cd);
+}
+
+static inline void CanonicalHashToHex(const XXH128_canonical_t *canonical, char *output) {
+  static const char hex_digits[] = "0123456789abcdef";
+  const unsigned char *digest = canonical->digest;
+
+  // Fully unrolled loop for better performance
+  output[0] = hex_digits[digest[0] >> 4];
+  output[1] = hex_digits[digest[0] & 0xF];
+  output[2] = hex_digits[digest[1] >> 4];
+  output[3] = hex_digits[digest[1] & 0xF];
+  output[4] = hex_digits[digest[2] >> 4];
+  output[5] = hex_digits[digest[2] & 0xF];
+  output[6] = hex_digits[digest[3] >> 4];
+  output[7] = hex_digits[digest[3] & 0xF];
+  output[8] = hex_digits[digest[4] >> 4];
+  output[9] = hex_digits[digest[4] & 0xF];
+  output[10] = hex_digits[digest[5] >> 4];
+  output[11] = hex_digits[digest[5] & 0xF];
+  output[12] = hex_digits[digest[6] >> 4];
+  output[13] = hex_digits[digest[6] & 0xF];
+  output[14] = hex_digits[digest[7] >> 4];
+  output[15] = hex_digits[digest[7] & 0xF];
+  output[16] = hex_digits[digest[8] >> 4];
+  output[17] = hex_digits[digest[8] & 0xF];
+  output[18] = hex_digits[digest[9] >> 4];
+  output[19] = hex_digits[digest[9] & 0xF];
+  output[20] = hex_digits[digest[10] >> 4];
+  output[21] = hex_digits[digest[10] & 0xF];
+  output[22] = hex_digits[digest[11] >> 4];
+  output[23] = hex_digits[digest[11] & 0xF];
+  output[24] = hex_digits[digest[12] >> 4];
+  output[25] = hex_digits[digest[12] & 0xF];
+  output[26] = hex_digits[digest[13] >> 4];
+  output[27] = hex_digits[digest[13] & 0xF];
+  output[28] = hex_digits[digest[14] >> 4];
+  output[29] = hex_digits[digest[14] & 0xF];
+  output[30] = hex_digits[digest[15] >> 4];
+  output[31] = hex_digits[digest[15] & 0xF];
+
+  output[32] = '\0';
+}
+
+std::vector<uint8_t> Serializer::SerializeFileAccess(const std::string &policy_version,
+                                                     const std::string &policy_name,
+                                                     const santa::Message &msg,
+                                                     const santa::EnrichedProcess &enriched_process,
+                                                     const std::string &target,
+                                                     FileAccessPolicyDecision decision) {
+  // Combine fingerprint data into a small, contigious struct to minimize the
+  // number of hash updates necessary.
+  struct {
+    pid_t pid;
+    int pidver;
+    uint64_t mach_time;
+    uint64_t thread_id;
+  } fingerprint_data = {
+      .pid = Pid(msg->process->audit_token),
+      .pidver = Pidversion(msg->process->audit_token),
+      .mach_time = msg->mach_time,
+      .thread_id = msg->thread->thread_id,
+  };
+
+  // Copy the invariant state
+  XXH3_state_t state;
+  XXH3_copyState(&state, common_hash_state_);
+
+  // Consume the variant data and create a digest
+  XXH3_128bits_update(&state, &fingerprint_data, sizeof(fingerprint_data));
+  XXH128_hash_t hash = XXH3_128bits_digest(&state);
+
+  // Convert to canonical representation
+  XXH128_canonical_t canonical_hash;
+  XXH128_canonicalFromHash(&canonical_hash, hash);
+
+  // Hex encode
+  static_assert(sizeof(XXH128_canonical_t) == 16);
+  char fingerprint[sizeof(XXH128_canonical_t) * 2 + 1];
+  CanonicalHashToHex(&canonical_hash, fingerprint);
+
+  return SerializeFileAccess(policy_version, policy_name, msg, enriched_process, target, decision,
+                             std::string_view(fingerprint, sizeof(XXH128_canonical_t) * 2));
 }
 
 };  // namespace santa

--- a/Source/santad/testdata/protobuf/v6/file_access.json
+++ b/Source/santad/testdata/protobuf/v6/file_access.json
@@ -76,5 +76,5 @@
  "policy_name": "policy_name",
  "access_type": "ACCESS_TYPE_OPEN",
  "policy_decision": "POLICY_DECISION_DENIED",
- "fingerprint": "abc123"
+ "operation_id": "abc123"
 }

--- a/Source/santad/testdata/protobuf/v6/file_access.json
+++ b/Source/santad/testdata/protobuf/v6/file_access.json
@@ -75,5 +75,6 @@
  "policy_version": "policy_version",
  "policy_name": "policy_name",
  "access_type": "ACCESS_TYPE_OPEN",
- "policy_decision": "POLICY_DECISION_DENIED"
+ "policy_decision": "POLICY_DECISION_DENIED",
+ "fingerprint": "abc123"
 }

--- a/Source/santad/testdata/protobuf/v7/file_access.json
+++ b/Source/santad/testdata/protobuf/v7/file_access.json
@@ -76,5 +76,5 @@
  "policy_name": "policy_name",
  "access_type": "ACCESS_TYPE_OPEN",
  "policy_decision": "POLICY_DECISION_DENIED",
- "fingerprint": "abc123"
+ "operation_id": "abc123"
 }

--- a/Source/santad/testdata/protobuf/v7/file_access.json
+++ b/Source/santad/testdata/protobuf/v7/file_access.json
@@ -75,5 +75,6 @@
  "policy_version": "policy_version",
  "policy_name": "policy_name",
  "access_type": "ACCESS_TYPE_OPEN",
- "policy_decision": "POLICY_DECISION_DENIED"
+ "policy_decision": "POLICY_DECISION_DENIED",
+ "fingerprint": "abc123"
 }

--- a/Source/santad/testdata/protobuf/v8/file_access.json
+++ b/Source/santad/testdata/protobuf/v8/file_access.json
@@ -76,5 +76,5 @@
  "policy_name": "policy_name",
  "access_type": "ACCESS_TYPE_OPEN",
  "policy_decision": "POLICY_DECISION_DENIED",
- "fingerprint": "abc123"
+ "operation_id": "abc123"
 }

--- a/Source/santad/testdata/protobuf/v8/file_access.json
+++ b/Source/santad/testdata/protobuf/v8/file_access.json
@@ -75,5 +75,6 @@
  "policy_version": "policy_version",
  "policy_name": "policy_name",
  "access_type": "ACCESS_TYPE_OPEN",
- "policy_decision": "POLICY_DECISION_DENIED"
+ "policy_decision": "POLICY_DECISION_DENIED",
+ "fingerprint": "abc123"
 }


### PR DESCRIPTION
It is possible for a single operation to emit multiple FileAccess telemetry log messages if multiple rules are violated. This PR adds an Operation ID (e.g. "fingerprint") value that would allow consumers of telemetry to link all telemetry from a single operation.