### PR TITLE
Remove unused OCMExpect from test

### DIFF
--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -606,8 +606,6 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   EXPECT_CALL(faaPolicyProcessor, GetCertificateHash)
       .WillRepeatedly(testing::Return(@(instigatingCertHash)));
 
-  OCMExpect([self.cscMock initWithBinaryPath:OCMOCK_ANY]).andReturn(nil);
-
   WatchItemProcess policyProc("", "", "", {}, "", std::nullopt);
 
   {


### PR DESCRIPTION
Method `initWithBinaryPath` is never called in this test. `OCMExpect` on unused method causes test failure in custom OCMock implementation. 

Verified with
```
OCMReject([self.cscMock initWithBinaryPath:OCMOCK_ANY]);
```