### PR TITLE
Add back metrics and rate limiting shared across FAA clients

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -460,6 +460,8 @@ objc_library(
         ":EndpointSecurityEnricher",
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
+        ":Metrics",
+        ":RateLimiter",
         ":SNTDecisionCache",
         ":SNTEndpointSecurityEventHandler",
         ":TTYWriter",
@@ -1017,6 +1019,7 @@ objc_library(
     deps = [
         ":EndpointSecurityEnricher",
         ":EndpointSecurityLogger",
+        ":Metrics",
         ":SNTDecisionCache",
         ":TTYWriter",
         ":WatchItemPolicy",

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -34,8 +34,10 @@
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Enricher.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "Source/santad/EventProviders/RateLimiter.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#include "Source/santad/Metrics.h"
 #import "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
@@ -96,6 +98,7 @@ class FAAPolicyProcessor {
 
   FAAPolicyProcessor(SNTDecisionCache *decision_cache, std::shared_ptr<Enricher> enricher,
                      std::shared_ptr<Logger> logger, std::shared_ptr<TTYWriter> tty_writer,
+                     std::shared_ptr<Metrics> metrics,
                      GenerateEventDetailLinkBlock generate_event_detail_link_block);
 
   virtual ~FAAPolicyProcessor() = default;
@@ -112,6 +115,7 @@ class FAAPolicyProcessor {
   std::shared_ptr<Enricher> enricher_;
   std::shared_ptr<Logger> logger_;
   std::shared_ptr<TTYWriter> tty_writer_;
+  std::shared_ptr<Metrics> metrics_;
   GenerateEventDetailLinkBlock generate_event_detail_link_block_;
   santa::SantaSetCache<ReadsCacheKey, std::pair<dev_t, ino_t>> reads_cache_;
   santa::SantaSetCache<std::pair<pid_t, int>, std::pair<std::string, std::string>>
@@ -119,6 +123,7 @@ class FAAPolicyProcessor {
   SantaCache<SantaVnode, NSString *> cert_hash_cache_;
   SNTConfigurator *configurator_;
   dispatch_queue_t queue_;
+  RateLimiter rate_limiter_;
 
   virtual NSString *__strong GetCertificateHash(const es_file_t *es_file);
 

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -223,7 +223,7 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   auto policy = std::make_shared<santa::WatchItemPolicyBase>("foo_policy", "ver", "/foo");
   FAAPolicyProcessor::PathTarget target = {.path = "/some/random/path", .is_readable = true};
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil);
 
   EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
       .WillRepeatedly([&faaPolicyProcessor](const Message &msg,
@@ -323,7 +323,7 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil);
   EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
       .WillRepeatedly(testing::Return(false));
 
@@ -508,7 +508,7 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   NSString *want;
   id certMock = OCMClassMock([MOLCertificate class]);
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil);
 
   EXPECT_CALL(faaPolicyProcessor, GetCertificateHash)
       .WillRepeatedly([&faaPolicyProcessor](const es_file_t *es_file) {
@@ -595,7 +595,7 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
   cd.certSHA256 = @(instigatingCertHash);
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil);
 
   EXPECT_CALL(faaPolicyProcessor, PolicyMatchesProcess)
       .WillRepeatedly([&faaPolicyProcessor](const WatchItemProcess &policy_proc,

--- a/Source/santad/EventProviders/MockFAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/MockFAAPolicyProcessor.h
@@ -26,6 +26,7 @@
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Enricher.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#include "Source/santad/Metrics.h"
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
@@ -35,10 +36,10 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
  public:
   MockFAAPolicyProcessor(
       SNTDecisionCache *dc, std::shared_ptr<Enricher> enricher, std::shared_ptr<Logger> logger,
-      std::shared_ptr<TTYWriter> tty_writer,
+      std::shared_ptr<TTYWriter> tty_writer, std::shared_ptr<Metrics> metrics,
       FAAPolicyProcessor::GenerateEventDetailLinkBlock generate_event_detail_link_block)
       : FAAPolicyProcessor(dc, std::move(enricher), std::move(logger), std::move(tty_writer),
-                           std::move(generate_event_detail_link_block)) {}
+                           std::move(metrics), std::move(generate_event_detail_link_block)) {}
   virtual ~MockFAAPolicyProcessor() {}
 
   MOCK_METHOD(bool, PolicyMatchesProcess,

--- a/Source/santad/EventProviders/RateLimiter.h
+++ b/Source/santad/EventProviders/RateLimiter.h
@@ -38,12 +38,11 @@ namespace santa {
 class RateLimiter {
  public:
   // Factory
-  static std::shared_ptr<RateLimiter> Create(
-      std::shared_ptr<santa::Metrics> metrics, santa::Processor processor,
-      uint16_t max_qps, NSTimeInterval reset_duration = kDefaultResetDuration);
+  static RateLimiter Create(
+      std::shared_ptr<santa::Metrics> metrics, uint16_t max_qps,
+      NSTimeInterval reset_duration = kDefaultResetDuration);
 
-  RateLimiter(std::shared_ptr<santa::Metrics> metrics,
-              santa::Processor processor, uint16_t max_qps,
+  RateLimiter(std::shared_ptr<santa::Metrics> metrics, uint16_t max_qps,
               NSTimeInterval reset_duration);
 
   enum class Decision {
@@ -63,7 +62,6 @@ class RateLimiter {
   static constexpr NSTimeInterval kDefaultResetDuration = 15.0;
 
   std::shared_ptr<santa::Metrics> metrics_;
-  santa::Processor processor_;
   size_t log_count_total_ = 0;
   size_t max_log_count_total_;
   uint64_t reset_mach_time_;

--- a/Source/santad/EventProviders/RateLimiter.mm
+++ b/Source/santad/EventProviders/RateLimiter.mm
@@ -22,16 +22,14 @@ using santa::Processor;
 
 namespace santa {
 
-std::shared_ptr<RateLimiter> RateLimiter::Create(std::shared_ptr<Metrics> metrics,
-                                                 Processor processor, uint16_t max_qps,
-                                                 NSTimeInterval reset_duration) {
-  return std::make_shared<RateLimiter>(std::move(metrics), processor, max_qps, reset_duration);
+RateLimiter RateLimiter::Create(std::shared_ptr<Metrics> metrics, uint16_t max_qps,
+                                NSTimeInterval reset_duration) {
+  return RateLimiter(std::move(metrics), max_qps, reset_duration);
 }
 
-RateLimiter::RateLimiter(std::shared_ptr<Metrics> metrics, Processor processor, uint16_t max_qps,
+RateLimiter::RateLimiter(std::shared_ptr<Metrics> metrics, uint16_t max_qps,
                          NSTimeInterval reset_duration)
     : metrics_(std::move(metrics)),
-      processor_(processor),
       max_log_count_total_(reset_duration * max_qps),
       reset_mach_time_(0),
       reset_duration_ns_(reset_duration * NSEC_PER_SEC) {
@@ -56,7 +54,7 @@ size_t RateLimiter::EventsRateLimitedSerialized() {
 void RateLimiter::TryResetSerialized(uint64_t cur_mach_time) {
   if (cur_mach_time > reset_mach_time_) {
     if (metrics_) {
-      metrics_->SetRateLimitingMetrics(processor_, EventsRateLimitedSerialized());
+      metrics_->AddRateLimitingMetrics(EventsRateLimitedSerialized());
     }
 
     log_count_total_ = 0;

--- a/Source/santad/EventProviders/RateLimiterTest.mm
+++ b/Source/santad/EventProviders/RateLimiterTest.mm
@@ -22,8 +22,6 @@
 
 using santa::RateLimiter;
 
-static const santa::Processor kDefaultProcessor = santa::Processor::kFileAccessAuthorizer;
-
 namespace santa {
 
 class RateLimiterPeer : public RateLimiter {
@@ -51,7 +49,7 @@ using santa::RateLimiterPeer;
   // Create an object supporting 1 QPS, and a reset duration of 2s
   uint16_t maxQps = 1;
   NSTimeInterval resetDuration = 2;
-  RateLimiterPeer rlp(nullptr, kDefaultProcessor, maxQps, resetDuration);
+  RateLimiterPeer rlp(nullptr, maxQps, resetDuration);
 
   // Check the current reset_mach_time_ is 0 so that it gets
   // set when the first decision is made
@@ -89,7 +87,7 @@ using santa::RateLimiterPeer;
   uint16_t maxQps = 2;
   NSTimeInterval resetDuration = 4;
   uint64_t allowedLogsPerDuration = maxQps * resetDuration;
-  RateLimiterPeer rlp(nullptr, kDefaultProcessor, maxQps, resetDuration);
+  RateLimiterPeer rlp(nullptr, maxQps, resetDuration);
 
   // Check the current log count is initially 0
   XCTAssertEqual(rlp.log_count_total_, 0);
@@ -126,7 +124,7 @@ using santa::RateLimiterPeer;
   NSTimeInterval resetDuration = 4;
   uint64_t allowedLogsPerDuration = maxQps * resetDuration;
   uint64_t logsOverQPS = 5;
-  RateLimiterPeer rlp(nullptr, kDefaultProcessor, maxQps, resetDuration);
+  RateLimiterPeer rlp(nullptr, maxQps, resetDuration);
 
   // Initially no rate limiting should apply
   XCTAssertFalse(rlp.ShouldRateLimitSerialized());

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
@@ -96,7 +96,8 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
   SetExpectationsForProcessFileAccessAuthorizerInit(mockESApi);
 
   // First call will not match, second call will match
-  auto mockFAA = std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nil);
+  auto mockFAA =
+      std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nullptr, nil);
   EXPECT_CALL(*mockFAA, PolicyMatchesProcess)
       .WillOnce(testing::Return(false))
       .WillOnce(testing::Return(true));

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 #include <dispatch/dispatch.h>
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -91,7 +92,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   void SetEventMetrics(Processor processor, EventDisposition event_disposition, int64_t nanos,
                        const santa::Message &msg);
 
-  void SetRateLimitingMetrics(Processor processor, int64_t events_rate_limited_count);
+  void AddRateLimitingMetrics(int64_t events_rate_limited_count);
 
   void SetFileAccessEventMetrics(std::string policy_version, std::string rule_name,
                                  FileAccessMetricStatus status, es_event_type_t event_type,
@@ -131,7 +132,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   // Small caches for storing event metrics between metrics export operations
   std::map<EventCountTuple, int64_t> event_counts_cache_;
   std::map<EventTimesTuple, int64_t> event_times_cache_;
-  std::map<Processor, int64_t> rate_limit_counts_cache_;
+  std::atomic<int64_t> rate_limit_counts_cache_;
   std::map<FileAccessEventCountTuple, int64_t> faa_event_counts_cache_;
   std::map<EventStatsTuple, SequenceStats> drop_cache_;
 };

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -142,7 +142,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
   if (@available(macOS 13.0, *)) {
     auto faaPolicyProcessor = std::make_shared<santa::FAAPolicyProcessor>(
-        [SNTDecisionCache sharedCache], enricher, logger, tty_writer,
+        [SNTDecisionCache sharedCache], enricher, logger, tty_writer, metrics,
         ^santa::FAAPolicyProcessor::URLTextPair(
             const std::shared_ptr<santa::WatchItemPolicyBase> &policy) {
           return watch_items->EventDetailLinkInfo(policy);


### PR DESCRIPTION
FAA logs are now rate limited. This only applies to the telemetry emitted, not to event processing - meaning block rules are still enforced, but some logging might be dropped.

Metrics that were temporarily removed in #297 are also added back in, and also now apply to both Data and Proc FAA clients (keys: `/santa/file_access_authorizer/log/count` and `/santa/rate_limit_count`).