### PR TITLE
Handle FAA policy changes affecting watched processes

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -121,8 +121,9 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
 
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_NOTIFY_EXEC: {
-      // On EXEC, the previous process was replaced with the new one. The old
-      // process must be cleaned up since there will be no EXIT event for it.
+      // On EXEC, the previously executing process image is replaced with a new
+      // image and the pidversion is incremented. The old pid+pidversion pair
+      // must be cleaned up since there will be no EXIT event for it.
       // There will be a corresponding EXIT for the newly executed process
       // regardless of whether or not it was allowed or denied.
       _procRuleCache->remove(PidPidversion(esMsg->process->audit_token));


### PR DESCRIPTION
With this change, when the FAA config changes Santa will now re-evaluate processes that are currently being watched because of the old policies to ensure they should still be watched under the new policies.

This is done by simply clearing the rule cache and having policy lookup be re-triggered the next time some event from a watched process comes in. This also has the nice side effect that cache eviction is now handled the same way.

This also fixes tracking/cleanup issues that existed on FORK/EXEC events.