### PR TITLE
Inject necessary WatchItems method instead of full object

### DIFF
--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -68,6 +68,8 @@ class WatchItemsPeer;
 // process policy.
 using CheckPolicyBlock = bool (^)(std::shared_ptr<ProcessWatchItemPolicy>);
 using IterateProcessPoliciesBlock = void (^)(CheckPolicyBlock);
+using FindPoliciesForTargetsBlock = std::vector<FAAPolicyProcessor::TargetPolicyPair> (^)(
+    const std::vector<FAAPolicyProcessor::PathTarget> &targets);
 
 struct WatchItemsState {
   uint64_t rule_count;

--- a/Source/santad/EventProviders/SNTEndpointSecurityDataFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDataFileAccessAuthorizer.h
@@ -32,13 +32,13 @@
     : SNTEndpointSecurityClient <SNTEndpointSecurityEventHandler, SNTDataFileAccessAuthorizer>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::Metrics>)metrics
-                       logger:(std::shared_ptr<santa::Logger>)logger
-                   watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
-                     enricher:(std::shared_ptr<santa::Enricher>)enricher
-           faaPolicyProcessor:
-               (std::shared_ptr<santa::DataFAAPolicyProcessorProxy>)faaPolicyProcessorProxy
-                    ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter;
+                        metrics:(std::shared_ptr<santa::Metrics>)metrics
+                         logger:(std::shared_ptr<santa::Logger>)logger
+                       enricher:(std::shared_ptr<santa::Enricher>)enricher
+             faaPolicyProcessor:
+                 (std::shared_ptr<santa::DataFAAPolicyProcessorProxy>)faaPolicyProcessorProxy
+                      ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter
+    findPoliciesForTargetsBlock:(santa::FindPoliciesForTargetsBlock)findPoliciesForTargetsBlock;
 
 @property SNTFileAccessDeniedBlock fileAccessDeniedBlock;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityDataFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDataFileAccessAuthorizerTest.mm
@@ -101,10 +101,10 @@ void SetExpectationsForDataFileAccessAuthorizerInit(
       [[SNTEndpointSecurityDataFileAccessAuthorizer alloc] initWithESAPI:mockESApi
                                                                  metrics:nullptr
                                                                   logger:nullptr
-                                                              watchItems:nullptr
                                                                 enricher:nullptr
                                                       faaPolicyProcessor:nil
-                                                               ttyWriter:nullptr];
+                                                               ttyWriter:nullptr
+                                             findPoliciesForTargetsBlock:nil];
 
   EXPECT_CALL(*mockESApi, UnsubscribeAll);
   EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths).WillOnce(testing::Return(true));

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -150,14 +150,17 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
     SNTEndpointSecurityDataFileAccessAuthorizer *data_faa_client =
         [[SNTEndpointSecurityDataFileAccessAuthorizer alloc]
-                 initWithESAPI:esapi
-                       metrics:metrics
-                        logger:logger
-                    watchItems:watch_items
-                      enricher:enricher
-            faaPolicyProcessor:std::make_shared<santa::DataFAAPolicyProcessorProxy>(
-                                   faaPolicyProcessor)
-                     ttyWriter:tty_writer];
+                          initWithESAPI:esapi
+                                metrics:metrics
+                                 logger:logger
+                               enricher:enricher
+                     faaPolicyProcessor:std::make_shared<santa::DataFAAPolicyProcessorProxy>(
+                                            faaPolicyProcessor)
+                              ttyWriter:tty_writer
+            findPoliciesForTargetsBlock:^std::vector<santa::FAAPolicyProcessor::TargetPolicyPair>(
+                const std::vector<santa::FAAPolicyProcessor::PathTarget> &targets) {
+              return watch_items->FindPoliciesForTargets(targets);
+            }];
     watch_items->RegisterDataClient(data_faa_client);
 
     data_faa_client.fileAccessDeniedBlock = ^(SNTFileAccessEvent *event, NSString *customMsg,


### PR DESCRIPTION
This change offers better encapsulation since the Data FAA client doesn't need access to the full WatchItems instance.