### PR TITLE
Add indirection layer between Configurator and CFPreferences API

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -318,6 +318,7 @@ objc_library(
     ],
     deps = [
         ":SNTCommonEnums",
+        ":SNTMdmConfigSource",
         ":SNTRule",
         ":SNTStrengthify",
         ":SNTSystemInfo",
@@ -609,10 +610,12 @@ santa_unit_test(
 
 santa_unit_test(
     name = "SNTConfiguratorTest",
+    size = "small",
     srcs = ["SNTConfiguratorTest.m"],
     deps = [
         ":SNTCommonEnums",
         ":SNTConfigurator",
+        ":SNTMdmConfigSource",
         "@OCMock",
     ],
 )
@@ -744,6 +747,13 @@ objc_library(
     hdrs = ["MOLAuthenticatingURLSession.h"],
     sdk_frameworks = ["Security"],
     deps = [":MOLCertificate"],
+)
+
+objc_library(
+    name = "SNTMdmConfigSource",
+    srcs = ["SNTMdmConfigSource.m"],
+    hdrs = ["SNTMdmConfigSource.h"],
+    sdk_frameworks = ["Foundation"],
 )
 
 santa_unit_test(

--- a/Source/common/SNTConfiguratorTest.m
+++ b/Source/common/SNTConfiguratorTest.m
@@ -104,7 +104,7 @@
                               }];
 }
 
-- (void)testMock {
+- (void)testForcedMetricExportTimeoutReturnsForcedValue {
   NSString *syncStatePlistPath =
       [NSString stringWithFormat:@"%@/test-sync-state.plist", self.testDir];
   SNTMdmConfigSource *mdmConfigSource = OCMPartialMock([[SNTMdmConfigSource alloc] init]);

--- a/Source/common/SNTMdmConfigSource.h
+++ b/Source/common/SNTMdmConfigSource.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface SNTMdmConfigSource : NSObject
+
+- (int)appValueIsForced:(NSString *)key;
+
+- (id)copyAppValue:(NSString *)key;
+
+@end

--- a/Source/common/SNTMdmConfigSource.m
+++ b/Source/common/SNTMdmConfigSource.m
@@ -1,0 +1,21 @@
+#import "Source/common/SNTMdmConfigSource.h"
+
+@interface SNTMdmConfigSource ()
+@end
+
+/// The domain used by mobileconfig.
+static const CFStringRef kMobileConfigDomain = CFSTR("com.northpolesec.santa");
+
+@implementation SNTMdmConfigSource
+
+- (int)appValueIsForced:(NSString *)key {
+  CFStringRef keyRef = (__bridge CFStringRef)key;
+  return CFPreferencesAppValueIsForced(keyRef, kMobileConfigDomain);
+}
+
+- (id)copyAppValue:(NSString *)key {
+  CFStringRef keyRef = (__bridge CFStringRef)key;
+  return CFBridgingRelease(CFPreferencesCopyAppValue(keyRef, kMobileConfigDomain));
+}
+
+@end


### PR DESCRIPTION
While working on a new config option, I couldn't find a way to unit-test if it would be propagated correctly from MDM because `SNTConfigurator` is tightly coupled to system APIs. An additional layer between `SNTConfigurator` and the `CFPreferences` API makes it possible to inject MDM configuration in unit tests.

Added `MetricExportTimeout` config unit test as an example.