### PR TITLE
docs: Correct signing_id format in JSON example

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -72,7 +72,7 @@ JSON blob. Here is an example of Firefox being blocked and sent for upload:
         }
       ],
       "team_id": "43AQ936H96",
-      "signing_id": "org.mozilla.firefox",
+      "signing_id": "43AQ936H96:org.mozilla.firefox",
       "cdhash": "ac14c49901a9cd05ff7bceea122f534d3c6c6ab7",
       "file_bundle_name": "Firefox",
       "executing_user": "bur",


### PR DESCRIPTION
Fixes #320