### PR TITLE
Basic wildcard support for FAA SigningID values

### DIFF
--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -82,7 +82,9 @@ struct WatchItemProcess {
         team_id(ti),
         cdhash(std::move(cdh)),
         certificate_sha256(ch),
-        platform_binary(pb) {}
+        platform_binary(pb) {
+    signing_id_wildcard_pos = signing_id.find('*');
+  }
 
   bool operator==(const WatchItemProcess &other) const {
     return binary_path == other.binary_path && signing_id == other.signing_id &&
@@ -94,17 +96,25 @@ struct WatchItemProcess {
 
   bool operator!=(const WatchItemProcess &other) const { return !(*this == other); }
 
+  /// This interface should only be used for testing
+  void UnsafeUpdateSigningId(std::string new_signing_id) {
+    const std::string &ref_sid = signing_id;
+    const_cast<std::string &>(ref_sid) = new_signing_id;
+    signing_id_wildcard_pos = signing_id.find('*');
+  }
+
   template <typename H>
   friend H AbslHashValue(H h, const WatchItemProcess &p) {
     return H::combine(std::move(h), p.binary_path, p.signing_id, p.team_id, p.cdhash,
                       p.certificate_sha256, p.platform_binary);
   }
   std::string binary_path;
-  std::string signing_id;
+  const std::string signing_id;
   std::string team_id;
   std::vector<uint8_t> cdhash;
   std::string certificate_sha256;
   std::optional<bool> platform_binary;
+  size_t signing_id_wildcard_pos;
 };
 
 struct WatchItemPolicyBase {

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -96,12 +96,14 @@ struct WatchItemProcess {
 
   bool operator!=(const WatchItemProcess &other) const { return !(*this == other); }
 
+#ifdef DEBUG
   /// This interface should only be used for testing
   void UnsafeUpdateSigningId(std::string new_signing_id) {
     const std::string &ref_sid = signing_id;
     const_cast<std::string &>(ref_sid) = new_signing_id;
     signing_id_wildcard_pos = signing_id.find('*');
   }
+#endif
 
   template <typename H>
   friend H AbslHashValue(H h, const WatchItemProcess &p) {

--- a/Source/santad/DataLayer/WatchItemPolicyTest.mm
+++ b/Source/santad/DataLayer/WatchItemPolicyTest.mm
@@ -49,7 +49,7 @@ using santa::WatchItemRuleType;
   pwip.processes.insert(proc);
   XCTAssertEqual(pwip.processes.size(), 1);
 
-  proc.signing_id = "abc";
+  proc.UnsafeUpdateSigningId("abc");
   pwip.processes.insert(proc);
   pwip.processes.insert(proc);
   XCTAssertEqual(pwip.processes.size(), 2);

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -394,6 +394,17 @@ std::variant<Unit, SetWatchItemProcess> VerifyConfigWatchItemProcesses(NSDiction
               return false;
             }
 
+            // Ensure that if the SigningID is a prefix, either PlatformBinary or TeamID is set
+            if ([process[kWatchItemConfigKeyProcessesSigningID] hasSuffix:@"*"] &&
+                ([process[kWatchItemConfigKeyProcessesPlatformBinary] boolValue] == false &&
+                 process[kWatchItemConfigKeyProcessesTeamID] == nil)) {
+              PopulateError(
+                  err, [NSString stringWithFormat:@"A SigningID prefix (%@) requires either the "
+                                                  @"PlatformBinary or TeamID keys be set",
+                                                  process[kWatchItemConfigKeyProcessesSigningID]]);
+              return false;
+            }
+
             proc_list.insert(WatchItemProcess(
                 NSStringToUTF8String(process[kWatchItemConfigKeyProcessesBinaryPath] ?: @""),
                 NSStringToUTF8String(process[kWatchItemConfigKeyProcessesSigningID] ?: @""),

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -395,14 +395,18 @@ std::variant<Unit, SetWatchItemProcess> VerifyConfigWatchItemProcesses(NSDiction
             }
 
             // Ensure that if the SigningID is a prefix, either PlatformBinary or TeamID is set
-            if ([process[kWatchItemConfigKeyProcessesSigningID] hasSuffix:@"*"] &&
-                ([process[kWatchItemConfigKeyProcessesPlatformBinary] boolValue] == false &&
-                 process[kWatchItemConfigKeyProcessesTeamID] == nil)) {
-              PopulateError(
-                  err, [NSString stringWithFormat:@"A SigningID prefix (%@) requires either the "
-                                                  @"PlatformBinary or TeamID keys be set",
-                                                  process[kWatchItemConfigKeyProcessesSigningID]]);
-              return false;
+            if (process[kWatchItemConfigKeyProcessesSigningID]) {
+              std::string sid([process[kWatchItemConfigKeyProcessesSigningID] UTF8String]);
+              if (sid.find('*') != std::string::npos &&
+                  (([process[kWatchItemConfigKeyProcessesPlatformBinary] boolValue] == false &&
+                    process[kWatchItemConfigKeyProcessesTeamID] == nil))) {
+                PopulateError(
+                    err,
+                    [NSString stringWithFormat:@"A SigningID prefix (%@) requires either the "
+                                               @"PlatformBinary or TeamID keys be set",
+                                               process[kWatchItemConfigKeyProcessesSigningID]]);
+                return false;
+              }
             }
 
             proc_list.insert(WatchItemProcess(

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -602,6 +602,42 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
                  WatchItemProcess("", "com.northpolesec.test", "", {}, "", std::nullopt));
 
+  // Test SigningID prefix but PlatformBinary or TeamID are not set
+  proc_list = VerifyConfigWatchItemProcesses(@{
+    kWatchItemConfigKeyProcesses : @[ @{
+      kWatchItemConfigKeyProcessesPlatformBinary : @(NO),
+      kWatchItemConfigKeyProcessesSigningID : @"com.northpolesec.*"
+    } ]
+  },
+                                             &err);
+  XCTAssertTrue(std::holds_alternative<Unit>(proc_list));
+
+  // Test SigningID prefix with PlatformBinary set
+  proc_list = VerifyConfigWatchItemProcesses(@{
+    kWatchItemConfigKeyProcesses : @[ @{
+      kWatchItemConfigKeyProcessesPlatformBinary : @(YES),
+      kWatchItemConfigKeyProcessesSigningID : @"com.northpolesec.*"
+    } ]
+  },
+                                             &err);
+  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
+  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+                 WatchItemProcess("", "com.northpolesec.*", "", {}, "", std::make_optional(true)));
+
+  // Test SigningID prefix with TeamID set
+  proc_list = VerifyConfigWatchItemProcesses(@{
+    kWatchItemConfigKeyProcesses : @[ @{
+      kWatchItemConfigKeyProcessesTeamID : @"myvalidtid",
+      kWatchItemConfigKeyProcessesSigningID : @"com.northpolesec.*"
+    } ]
+  },
+                                             &err);
+  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
+  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+                 WatchItemProcess("", "com.northpolesec.*", "myvalidtid", {}, "", std::nullopt));
+
   // Test TeamID length limits
   proc_list = VerifyConfigWatchItemProcesses(@{
     kWatchItemConfigKeyProcesses :

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -223,13 +223,15 @@ bool FAAPolicyProcessor::PolicyMatchesProcess(const WatchItemProcess &policy_pro
     // SigningID checks
     if (!policy_proc.signing_id.empty()) {
       if (!es_proc->signing_id.data) {
-        // Policy has SID is set, but process has no SID
+        // Policy has SID set, but process has no SID
         return false;
       }
 
       if (policy_proc.signing_id.back() == '*') {
         if (!policy_proc.platform_binary.value_or(false) && policy_proc.team_id.empty()) {
           // Policy SID is a prefix but neither Platform Binary nor Team ID were set
+          // Note: Config parsing should have ensured this isn't possible, but the runtime check here
+          // is meant as a fallback.
           return false;
         }
         if (strncmp(policy_proc.signing_id.c_str(), es_proc->signing_id.data,

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -40,7 +40,7 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 | `TeamID`                      | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
 | `CertificateSha256`           | `Processes`  | String     | No       | v2023.1+      | SHA256 of the leaf certificate of the instigating process. |
 | `CDHash`                      | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
-| `SigningID`                   | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. If the value ends with an asterisk (`*`), it is treated as a prefix. However when a prefix SigningID value is used, either `PlatformBinary` must be true or `TeamID` must be set.<br/>Note that unlike in binary authorization, the Signing ID for file access authorization is specified separately from the Team ID; see the example below. |
+| `SigningID`                   | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. The first asterisk (`*`) character in the value will be treated as a wildcard character and can appear at any index in the string. For example, `com.northpolesec.*` and `com.northpolesec.*.daemon` are both allowed. When the SigningID contains a wildcard character, either `PlatformBinary` must be true or `TeamID` must also be set.<br/>Note that unlike in binary authorization, the Signing ID for file access authorization is specified separately from the Team ID; see the example below. |
 | `PlatformBinary`              | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
 
 ## Data-centric vs. Process-centric FAA Rules

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -40,7 +40,7 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 | `TeamID`                      | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
 | `CertificateSha256`           | `Processes`  | String     | No       | v2023.1+      | SHA256 of the leaf certificate of the instigating process. |
 | `CDHash`                      | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
-| `SigningID`                   | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. Note that unlike in binary authorization, the Signing ID for file access authorization is specified separately from the Team ID; see the example below. |
+| `SigningID`                   | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. If the value ends with an asterisk (`*`), it is treated as a prefix. However when a prefix SigningID value is used, either `PlatformBinary` must be true or `TeamID` must be set.<br/>Note that unlike in binary authorization, the Signing ID for file access authorization is specified separately from the Team ID; see the example below. |
 | `PlatformBinary`              | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
 
 ## Data-centric vs. Process-centric FAA Rules


### PR DESCRIPTION
This adds support for a single wildcard character to be used for SigningID values in FAA rules. E.g.

```xml
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>Version</key>
  <string>v0.1-experimental</string>
  <key>WatchItems</key>
  <dict>
    <key>UserFoo</key>
    <dict>
      <key>Paths</key>
      <array>
        <!-- Restrict access to the foo.txt temporary file -->
        <string>/private/tmp/foo.txt</string>
      </array>
      <key>Options</key>
      <dict>
        <key>AllowReadAccess</key>
        <false/>
        <key>AuditOnly</key>
        <true/>
        <key>RuleType</key>
        <string>PathsWithAllowedProcesses</string>
      </dict>
      <key>Processes</key>
      <array>
        <dict>
          <!-- Only allow access from Chrome-related Google binaries -->
          <key>TeamID</key>
          <string>EQHXZ8M8AV</string>
          <key>SigningID</key>
          <string>com.google.Chrome*</string>
        </dict>
      </array>
    </dict>
  </dict>
</dict>
</plist>
```

Related: https://github.com/google/santa/issues/1163
