### PR TITLE
Fix ISO C++ field designators declaration order

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -837,8 +837,8 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   es_event_btm_launch_item_add_t launchItem = {
       .instigator = &instigatorProc,
       .app = &instigatorApp,
-      .executable_path = MakeESStringToken("exec_path"),
       .item = &item,
+      .executable_path = MakeESStringToken("exec_path"),
 #if HAVE_MACOS_15
       .instigator_token = &tokInst,
       .app_token = &tokApp,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -1333,8 +1333,8 @@ void SerializeAndCheckNonESEvents(
   __block es_event_btm_launch_item_add_t launchItem = {
       .instigator = &instigatorProc,
       .app = &instigatorApp,
-      .executable_path = MakeESStringToken("exec_path"),
       .item = &item,
+      .executable_path = MakeESStringToken("exec_path"),
 #if HAVE_MACOS_15
       .instigator_token = &tokInst,
       .app_token = &tokApp,


### PR DESCRIPTION
Fixes

```
error: ISO C++ requires field designators to be specified in declaration order; field 'executable_path' will be initialized after field 'item' [-Werror,-Wreorder-init-list]
```