### PR TITLE
Set some additional compiler flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,9 @@ build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
 build --copt=-Werror
 build --copt=-Wall
 build --copt=-Wno-error=deprecated-declarations
+build --copt=-Wreorder-init-list
+build --copt=-Wc99-designator
+build --copt=-Wno-c++20-designator
 # Disable -Wunknown-warning-option because deprecated-non-prototype
 # isn't recognized on older SDKs
 build --copt=-Wno-unknown-warning-option

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -1009,7 +1009,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 
   es_event_gatekeeper_user_override_t gatekeeper = {
       .file_type = ES_GATEKEEPER_USER_OVERRIDE_FILE_TYPE_FILE,
-      .file= {.file = &gkFile},
+      .file = {.file = &gkFile},
       .sha256 = &fileHash,
       .signing_info = &signingInfo,
   };

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -1009,7 +1009,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 
   es_event_gatekeeper_user_override_t gatekeeper = {
       .file_type = ES_GATEKEEPER_USER_OVERRIDE_FILE_TYPE_FILE,
-      .file.file = &gkFile,
+      .file= {.file = &gkFile},
       .sha256 = &fileHash,
       .signing_info = &signingInfo,
   };

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -1447,7 +1447,7 @@ void SerializeAndCheckNonESEvents(
 
   __block es_event_gatekeeper_user_override_t gatekeeper = {
       .file_type = ES_GATEKEEPER_USER_OVERRIDE_FILE_TYPE_FILE,
-      .file.file = &targetFile,
+      .file = {.file = &targetFile},
       .sha256 = &fileHash,
       .signing_info = &signingInfo,
   };


### PR DESCRIPTION
This adds some additional warnings to our build, but disables a subset to allow us to stay on C++17 for now (tho this will likely soon change).