### PR TITLE
santactl/status: better output for push notification status

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -205,6 +205,13 @@ typedef NS_ENUM(NSInteger, SNTSigningStatus) {
   SNTSigningStatusProduction,
 };
 
+typedef NS_ENUM(NSInteger, SNTPushNotificationStatus) {
+  SNTPushNotificationStatusUnknown,
+  SNTPushNotificationStatusDisabled,
+  SNTPushNotificationStatusDisconnected,
+  SNTPushNotificationStatusConnected,
+};
+
 #ifdef __cplusplus
 
 enum class FileAccessPolicyDecision {

--- a/Source/common/SNTXPCSyncServiceInterface.h
+++ b/Source/common/SNTXPCSyncServiceInterface.h
@@ -28,7 +28,7 @@
 - (void)postEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events fromBundle:(BOOL)fromBundle;
 - (void)postBundleEventToSyncServer:(SNTStoredEvent *)event
                               reply:(void (^)(SNTBundleEventAction))reply;
-- (void)isPushConnected:(void (^)(BOOL))reply;
+- (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply;
 
 // The syncservice regularly syncs with a configured sync server. Use this method to sync out of
 // band. The syncservice ensures syncs do not run concurrently.

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -91,7 +91,7 @@ struct RuleCounts {
 ///
 ///  Syncd Ops
 ///
-- (void)pushNotifications:(void (^)(BOOL))reply;
+- (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply;
 
 ///
 ///  Bundle Ops

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -356,14 +356,14 @@ double watchdogRAMPeak = 0;
 
 #pragma mark syncd Ops
 
-- (void)pushNotifications:(void (^)(BOOL))reply {
+- (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply {
   // This message should be handled in a timely manner, santactl status waits for the response.
   // Instead of reusing the existing connection, create a new connection to the sync service.
   // Otherwise, the isFCMListening message would potentially be queued behind various long lived
   // sync operations.
   MOLXPCConnection *conn = [SNTXPCSyncServiceInterface configuredConnection];
   [conn resume];
-  [conn.remoteObjectProxy isPushConnected:^(BOOL response) {
+  [conn.remoteObjectProxy pushNotificationStatus:^(SNTPushNotificationStatus response) {
     reply(response);
   }];
 }

--- a/Source/santasyncservice/SNTSyncManager.h
+++ b/Source/santasyncservice/SNTSyncManager.h
@@ -70,7 +70,7 @@
 - (void)postEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events fromBundle:(BOOL)isFromBundle;
 - (void)postBundleEventToSyncServer:(SNTStoredEvent *)event
                               reply:(void (^)(SNTBundleEventAction))reply;
-- (void)isPushConnected:(void (^)(BOOL))reply;
+- (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply;
 - (void)APNSTokenChanged;
 - (void)handleAPNSMessage:(NSDictionary *)message;
 

--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -152,8 +152,14 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
   self.xsrfTokenHeader = syncState.xsrfTokenHeader;
 }
 
-- (void)isPushConnected:(void (^)(BOOL))reply {
-  reply(self.pushNotifications ? self.pushNotifications.isConnected : NO);
+- (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply {
+  if (!self.pushNotifications) {
+    reply(SNTPushNotificationStatusDisabled);
+  }
+  if (!self.pushNotifications.isConnected) {
+    reply(SNTPushNotificationStatusDisconnected);
+  }
+  reply(SNTPushNotificationStatusConnected);
 }
 
 - (void)APNSTokenChanged {

--- a/Source/santasyncservice/SNTSyncService.mm
+++ b/Source/santasyncservice/SNTSyncService.mm
@@ -88,8 +88,8 @@
   [self.syncManager postBundleEventToSyncServer:event reply:reply];
 }
 
-- (void)isPushConnected:(void (^)(BOOL))reply {
-  [self.syncManager isPushConnected:reply];
+- (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply {
+  [self.syncManager pushNotificationStatus:reply];
 }
 
 // TODO(bur): Add support for santactl sync --debug to enable debug logging for that sync.


### PR DESCRIPTION
This change lets us distinguish in santactl/status output whether push notifications between being disconnected or disabled. This also gives us an easy way to return more statuses in the future, should we need to.