### PR TITLE
Add unique index to the filesha256 column in the events table

### DIFF
--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -97,6 +97,11 @@
 
     [db setUserVersion:newVersion];
   }];
+
+  // Vacuum the database to cleanup after version upgrades.
+  [self inDatabase:^(FMDatabase *db) {
+    [db executeUpdate:@"VACUUM"];
+  }];
 }
 
 - (void)inDatabase:(void (^)(FMDatabase *db))block {


### PR DESCRIPTION
This change adds a unique index to the `filesha256` column in the events table.  This will effectively add deduplication for the same file between either a full sync, or 10 minute local cache (part of SNTSyncdQueue to reduce immediate event uploads for the same file), whichever time is smallest.

**IMPORTANT NOTE**: This will result in the following changes in observed behavior:

1. an overall reduction of events uploaded to the sync server, potentially a large reduction for executables that are executed/blocked frequently
2. When upgrading Santa from a release before this change to after (likely 2025.4), events with duplicate file hashes will be dropped
3. While the `EnableAllEventUpload` has never been about ensuring sync servers see all executions (only evaluated ones), this change will also likely result in a reduction of allowed executions as well in some scenarios.