### PR TITLE
santad: use santa cache for event upload backoff

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -218,7 +218,7 @@ santa_unit_test(
 
 objc_library(
     name = "SNTSyncdQueue",
-    srcs = ["SNTSyncdQueue.m"],
+    srcs = ["SNTSyncdQueue.mm"],
     hdrs = ["SNTSyncdQueue.h"],
     deps = [
         "//Source/common:MOLXPCConnection",
@@ -226,6 +226,18 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTXPCSyncServiceInterface",
+        "//Source/common:SantaCache",
+        "//Source/common:String",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTSyncdQueueTest",
+    srcs = ["SNTSyncdQueueTest.mm"],
+    deps = [
+        ":SNTSyncdQueue",
+        "//Source/common:SNTStoredEvent",
+        "@OCMock",
     ],
 )
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1652,6 +1652,7 @@ test_suite(
         ":SNTNotificationQueueTest",
         ":SNTPolicyProcessorTest",
         ":SNTRuleTableTest",
+        ":SNTSyncdQueueTest",
         ":SantadTest",
         ":WatchItemPolicyTest",
         ":WatchItemsTest",

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -15,23 +15,27 @@
 
 #import "Source/santad/SNTSyncdQueue.h"
 
+#include <memory>
+
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTXPCSyncServiceInterface.h"
+#include "Source/common/SantaCache.h"
+#include "Source/common/String.h"
 
 @interface SNTSyncdQueue ()
-@property NSCache<NSString *, NSDate *> *uploadBackoff;
 @property dispatch_queue_t syncdQueue;
 @end
 
-@implementation SNTSyncdQueue
+@implementation SNTSyncdQueue {
+  std::unique_ptr<SantaCache<std::string, NSDate *>> _uploadBackoff;
+}
 
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _uploadBackoff = [[NSCache alloc] init];
-    _uploadBackoff.countLimit = 128;
+    _uploadBackoff = std::make_unique<SantaCache<std::string, NSDate *>>(128);
     _syncdQueue = dispatch_queue_create("com.northpolesec.syncd_queue", DISPATCH_QUEUE_SERIAL);
   }
   return self;
@@ -41,14 +45,16 @@
   if (!events.count) return;
   SNTStoredEvent *first = events.firstObject;
   NSString *hash = isFromBundle ? first.fileBundleHash : first.fileSHA256;
-  if (![self backoffForPrimaryHash:hash]) return;
+  if ([self backoffForPrimaryHash:hash]) {
+    return;
+  }
   [self dispatchBlockOnSyncdQueue:^{
     [self.syncConnection.remoteObjectProxy postEventsToSyncServer:events fromBundle:isFromBundle];
   }];
 }
 
 - (void)addBundleEvent:(SNTStoredEvent *)event reply:(void (^)(SNTBundleEventAction))reply {
-  if (![self backoffForPrimaryHash:event.fileBundleHash]) return;
+  if ([self backoffForPrimaryHash:event.fileBundleHash]) return;
   [self dispatchBlockOnSyncdQueue:^{
     [self.syncConnection.remoteObjectProxy
         postBundleEventToSyncServer:event
@@ -57,7 +63,8 @@
                                 // event will be included in the related events synced using
                                 // addEvents:isFromBundle:.
                                 if (action == SNTBundleEventActionSendEvents) {
-                                  [self.uploadBackoff removeObjectForKey:event.fileBundleHash];
+                                  _uploadBackoff->remove(
+                                      santa::NSStringToUTF8String(event.fileBundleHash));
                                 }
                                 reply(action);
                               }];
@@ -74,11 +81,11 @@
 // The event upload is skipped if an event has been initiated for it in the last 10 minutes.
 // The passed-in hash is fileBundleHash for a bundle event, or fileSHA256 for a normal event.
 - (BOOL)backoffForPrimaryHash:(NSString *)hash {
-  NSDate *backoff = [self.uploadBackoff objectForKey:hash];
+  NSDate *backoff = _uploadBackoff->get(santa::NSStringToUTF8String(hash));
   NSDate *now = [NSDate date];
-  if (([now timeIntervalSince1970] - [backoff timeIntervalSince1970]) < 600) return NO;
-  [self.uploadBackoff setObject:now forKey:hash];
-  return YES;
+  if (([now timeIntervalSince1970] - [backoff timeIntervalSince1970]) < 600) return YES;
+  _uploadBackoff->set(santa::NSStringToUTF8String(hash), now);
+  return NO;
 }
 
 @end

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -29,14 +29,14 @@
 @end
 
 @implementation SNTSyncdQueue {
-  // TODO: Eventually replace with an LRU.
+  // TODO(https://github.com/northpolesec/santa/issues/344): Eventually replace with an LRU.
   std::unique_ptr<SantaCache<std::string, NSDate *>> _uploadBackoff;
 }
 
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _uploadBackoff = std::make_unique<SantaCache<std::string, NSDate *>>(128);
+    _uploadBackoff = std::make_unique<SantaCache<std::string, NSDate *>>(256);
     _syncdQueue = dispatch_queue_create("com.northpolesec.syncd_queue", DISPATCH_QUEUE_SERIAL);
   }
   return self;

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -29,6 +29,7 @@
 @end
 
 @implementation SNTSyncdQueue {
+  // TODO: Eventually replace with an LRU.
   std::unique_ptr<SantaCache<std::string, NSDate *>> _uploadBackoff;
 }
 

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -46,9 +46,7 @@
   if (!events.count) return;
   SNTStoredEvent *first = events.firstObject;
   NSString *hash = isFromBundle ? first.fileBundleHash : first.fileSHA256;
-  if ([self backoffForPrimaryHash:hash]) {
-    return;
-  }
+  if ([self backoffForPrimaryHash:hash]) return;
   [self dispatchBlockOnSyncdQueue:^{
     [self.syncConnection.remoteObjectProxy postEventsToSyncServer:events fromBundle:isFromBundle];
   }];

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -79,6 +79,7 @@
 
 // The event upload is skipped if an event has been initiated for it in the last 10 minutes.
 // The passed-in hash is fileBundleHash for a bundle event, or fileSHA256 for a normal event.
+// Returns YES if backoff is needed, NO otherwise.
 - (BOOL)backoffForPrimaryHash:(NSString *)hash {
   NSDate *backoff = _uploadBackoff->get(santa::NSStringToUTF8String(hash));
   NSDate *now = [NSDate date];

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -15,9 +15,8 @@
 #import "Source/santad/SNTSyncdQueue.h"
 
 #include <Foundation/Foundation.h>
-#import <XCTest/XCTest.h>
-
 #import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
 
 #import "Source/common/SNTStoredEvent.h"
 

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -1,0 +1,92 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import "Source/santad/SNTSyncdQueue.h"
+
+#include <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import "Source/common/SNTStoredEvent.h"
+
+@interface SNTSyncdQueue (Testing)
+- (BOOL)backoffForPrimaryHash:(NSString *)hash;
+- (void)dispatchBlockOnSyncdQueue:(void (^)(void))block;
+@end
+
+@interface SNTSyncdQueueTest : XCTestCase
+@end
+
+@implementation SNTSyncdQueueTest
+
+- (void)testBackoffForPrimaryHash {
+  SNTSyncdQueue *sut = [[SNTSyncdQueue alloc] init];
+
+  // Fill up the cache.
+  for (int i = 0; i < 128; ++i) {
+    BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
+    XCTAssertFalse(backoff);
+  }
+
+  // These hashes should now backoff.
+  for (int i = 0; i < 128; ++i) {
+    BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
+    XCTAssertTrue(backoff);
+  }
+
+  // Overfill the cache, the cache should now only contain "justonemorebyte".
+  XCTAssertFalse([sut backoffForPrimaryHash:@"justonemorebyte"]);
+  XCTAssertTrue([sut backoffForPrimaryHash:@"justonemorebyte"]);
+
+  // These hashes should not backoff, remember the cache was just cleared. However, only check 127
+  // of the hashes, "justonemorebyte" takes us a slot. Checking the full 128 hashes here would
+  // overfill the cache again.
+  for (int i = 0; i < 127; ++i) {
+    BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
+    XCTAssertFalse(backoff);
+  }
+
+  // Again, these hashes should now backoff.
+  for (int i = 0; i < 127; ++i) {
+    BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
+    XCTAssertTrue(backoff);
+  }
+
+  // A new hash arrives, and is then checked over and over.
+  XCTAssertFalse([sut backoffForPrimaryHash:@"yes"]);
+  for (int i = 0; i < 1000; ++i) {
+    XCTAssertTrue([sut backoffForPrimaryHash:@"yes"]);
+  }
+}
+
+- (void)testAddEvents {
+  SNTSyncdQueue *sut = [[SNTSyncdQueue alloc] init];
+  sut = OCMPartialMock(sut);
+  OCMStub([sut dispatchBlockOnSyncdQueue:[OCMArg any]]);
+
+  // Add an event, it should be dispatched to the sync service for upload.
+  SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
+  se.fileSHA256 = @"123";
+  [sut addEvents:@[ se ] isFromBundle:false];
+  OCMVerify(times(1), [sut dispatchBlockOnSyncdQueue:[OCMArg any]]);
+
+  // Add the same event many times, they all should be dropped.
+  for (int i = 0; i < 1000; ++i) {
+    [sut addEvents:@[ se ] isFromBundle:false];
+  }
+  OCMVerify(times(1), [sut dispatchBlockOnSyncdQueue:[OCMArg any]]);
+}
+
+@end

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -34,13 +34,13 @@
   SNTSyncdQueue *sut = [[SNTSyncdQueue alloc] init];
 
   // Fill up the cache.
-  for (int i = 0; i < 128; ++i) {
+  for (int i = 0; i < 256; ++i) {
     BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
     XCTAssertFalse(backoff);
   }
 
   // These hashes should now backoff.
-  for (int i = 0; i < 128; ++i) {
+  for (int i = 0; i < 256; ++i) {
     BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
     XCTAssertTrue(backoff);
   }
@@ -49,16 +49,16 @@
   XCTAssertFalse([sut backoffForPrimaryHash:@"justonemorebyte"]);
   XCTAssertTrue([sut backoffForPrimaryHash:@"justonemorebyte"]);
 
-  // These hashes should not backoff, remember the cache was just cleared. However, only check 127
-  // of the hashes, "justonemorebyte" takes us a slot. Checking the full 128 hashes here would
+  // These hashes should not backoff, remember the cache was just cleared. However, only check 255
+  // of the hashes, "justonemorebyte" takes us a slot. Checking the full 256 hashes here would
   // overfill the cache again.
-  for (int i = 0; i < 127; ++i) {
+  for (int i = 0; i < 255; ++i) {
     BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
     XCTAssertFalse(backoff);
   }
 
   // Again, these hashes should now backoff.
-  for (int i = 0; i < 127; ++i) {
+  for (int i = 0; i < 255; ++i) {
     BOOL backoff = [sut backoffForPrimaryHash:[NSString stringWithFormat:@"%d", i]];
     XCTAssertTrue(backoff);
   }


### PR DESCRIPTION
This CL replaces the NSCache used for event upload backoff with SantaCache.

On full cache boundaries, NSCache, has exhibited some odd behavior. Namely, it is possible to get into a situation where a hash is successfully added to the cache, but is immediately cleared. Once in this state, that hash is not able to be successfully retrieved. Even after repeatedly being successfully added to the cache.

If an execution is being blocked in a tight loop like `while true; do yes; done`, this could result in an event being uploaded every [1500ms](https://github.com/northpolesec/santa/blob/82b09a99f3440a9eb6456a859a32905c6e2a5f90/Source/santad/EventProviders/AuthResultCache.h#L58).

Switching to SantaCache gives us better guarantees around full cache boundaries. We know the cache will be cleared when overfilled, and we know we can start filling it back up again. Once a usable LRU is introduced to Santa's codebase, we could go that route, but it is not pressing.



Also this CL adds some tests for SNTSyncdQueue.