### PR TITLE
Send all postflight results together

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -333,6 +333,17 @@ objc_library(
     ],
 )
 
+objc_library(
+    name = "SNTPostflightResult",
+    srcs = ["SNTPostflightResult.mm"],
+    hdrs = ["SNTPostflightResult.h"],
+    deps = [
+        ":CoderMacros",
+        ":SNTCommonEnums",
+        "//Source/santasyncservice:SNTSyncState",
+    ],
+)
+
 santa_unit_test(
     name = "SNTKVOManagerTest",
     srcs = ["SNTKVOManagerTest.mm"],
@@ -499,6 +510,7 @@ objc_library(
         ":MOLXPCConnection",
         ":SNTCommonEnums",
         ":SNTConfigurator",
+        ":SNTPostflightResult",
         ":SNTRule",
         ":SNTRuleIdentifiers",
         ":SNTStoredEvent",

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -345,6 +345,16 @@ objc_library(
 )
 
 santa_unit_test(
+    name = "SNTPostflightResultTest",
+    srcs = ["SNTPostflightResultTest.mm"],
+    deps = [
+        ":SNTCommonEnums",
+        ":SNTPostflightResult",
+        "//Source/santasyncservice:SNTSyncState",
+    ],
+)
+
+santa_unit_test(
     name = "SNTKVOManagerTest",
     srcs = ["SNTKVOManagerTest.mm"],
     deps = [

--- a/Source/common/SNTPostflightResult.h
+++ b/Source/common/SNTPostflightResult.h
@@ -1,0 +1,38 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include "Source/common/SNTCommonEnums.h"
+
+@class SNTSyncState;
+
+@interface SNTPostflightResult : NSObject <NSSecureCoding>
+
+- (instancetype)initWithSyncState:(SNTSyncState *)syncState;
+
+/// If the value for the backing property was set, the given block will be called.
+- (void)clientMode:(void (^)(SNTClientMode))block;
+- (void)syncType:(void (^)(SNTSyncType))block;
+- (void)allowlistRegex:(void (^)(NSString *))block;
+- (void)blocklistRegex:(void (^)(NSString *))block;
+- (void)blockUSBMount:(void (^)(BOOL))block;
+- (void)remountUSBMode:(void (^)(NSArray *))block;
+- (void)enableBundles:(void (^)(BOOL))block;
+- (void)enableTransitiveRules:(void (^)(BOOL))block;
+- (void)enableAllEventUpload:(void (^)(BOOL))block;
+- (void)disableUnknownEventUpload:(void (^)(BOOL))block;
+- (void)overrideFileAccessAction:(void (^)(NSString *))block;
+
+@end

--- a/Source/common/SNTPostflightResult.mm
+++ b/Source/common/SNTPostflightResult.mm
@@ -1,0 +1,157 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTPostflightResult.h"
+
+#import "Source/santasyncservice/SNTSyncState.h"
+#import "Source/common/CoderMacros.h"
+
+@interface SNTPostflightResult ()
+@property NSNumber *clientMode;
+@property NSNumber *syncType;
+@property NSString *allowlistRegex;
+@property NSString *blocklistRegex;
+@property NSNumber *blockUSBMount;
+@property NSArray *remountUSBMode;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
+@property NSString *overrideFileAccessAction;
+@end
+
+@implementation SNTPostflightResult
+
+- (instancetype)initWithSyncState:(SNTSyncState *)syncState {
+  self = [super init];
+  if (self) {
+    _clientMode = syncState.clientMode ? @(syncState.clientMode) : nil;
+    _syncType = syncState.syncType != SNTSyncTypeNormal ? @(SNTSyncTypeNormal) : nil;
+
+    _allowlistRegex = syncState.allowlistRegex;
+    _blocklistRegex = syncState.blocklistRegex;
+    _blockUSBMount = syncState.blockUSBMount;
+    _remountUSBMode = syncState.remountUSBMode;
+    _enableBundles = syncState.enableBundles;
+    _enableTransitiveRules = syncState.enableTransitiveRules;
+    _enableAllEventUpload = syncState.enableAllEventUpload;
+    _disableUnknownEventUpload = syncState.disableUnknownEventUpload;
+    _overrideFileAccessAction = syncState.overrideFileAccessAction;
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  ENCODE(coder, clientMode);
+  ENCODE(coder, syncType);
+  ENCODE(coder, allowlistRegex);
+  ENCODE(coder, blocklistRegex);
+  ENCODE(coder, blockUSBMount);
+  ENCODE(coder, remountUSBMode);
+  ENCODE(coder, enableBundles);
+  ENCODE(coder, enableTransitiveRules);
+  ENCODE(coder, enableAllEventUpload);
+  ENCODE(coder, disableUnknownEventUpload);
+  ENCODE(coder, overrideFileAccessAction);
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  self = [super init];
+  if (self) {
+    DECODE(decoder, clientMode, NSNumber);
+    DECODE(decoder, syncType, NSNumber);
+    DECODE(decoder, allowlistRegex, NSString);
+    DECODE(decoder, blocklistRegex, NSString);
+    DECODE(decoder, blockUSBMount, NSNumber);
+    DECODE_ARRAY(decoder, remountUSBMode, NSString);
+    DECODE(decoder, enableBundles, NSNumber);
+    DECODE(decoder, enableTransitiveRules, NSNumber);
+    DECODE(decoder, enableAllEventUpload, NSNumber);
+    DECODE(decoder, disableUnknownEventUpload, NSNumber);
+    DECODE(decoder, overrideFileAccessAction, NSString);
+  }
+  return self;
+}
+
+- (void)clientMode:(void (^)(SNTClientMode))block {
+  if (self.clientMode) {
+    block((SNTClientMode)[self.clientMode integerValue]);
+  }
+}
+
+- (void)syncType:(void (^)(SNTSyncType))block {
+  if (self.syncType) {
+    block((SNTSyncType)[self.syncType integerValue]);
+  }
+}
+
+- (void)allowlistRegex:(void (^)(NSString *))block {
+  if (self.allowlistRegex) {
+    block(self.allowlistRegex);
+  }
+}
+
+- (void)blocklistRegex:(void (^)(NSString *))block {
+  if (self.blocklistRegex) {
+    block(self.blocklistRegex);
+  }
+}
+
+- (void)blockUSBMount:(void (^)(BOOL))block {
+  if (self.blockUSBMount) {
+    block([self.blockUSBMount boolValue]);
+  }
+}
+
+- (void)remountUSBMode:(void (^)(NSArray *))block {
+  if (self.remountUSBMode) {
+    block(self.remountUSBMode);
+  }
+}
+
+- (void)enableBundles:(void (^)(BOOL))block {
+  if (self.enableBundles) {
+    block(self.enableBundles);
+  }
+}
+
+- (void)enableTransitiveRules:(void (^)(BOOL))block {
+  if (self.enableTransitiveRules) {
+    block(self.enableTransitiveRules);
+  }
+}
+
+- (void)enableAllEventUpload:(void (^)(BOOL))block {
+  if (self.enableAllEventUpload) {
+    block(self.enableAllEventUpload);
+  }
+}
+
+- (void)disableUnknownEventUpload:(void (^)(BOOL))block {
+  if (self.disableUnknownEventUpload) {
+    block(self.disableUnknownEventUpload);
+  }
+}
+
+- (void)overrideFileAccessAction:(void (^)(NSString *))block {
+  if (self.overrideFileAccessAction) {
+    block(self.overrideFileAccessAction);
+  }
+}
+
+@end

--- a/Source/common/SNTPostflightResult.mm
+++ b/Source/common/SNTPostflightResult.mm
@@ -14,8 +14,8 @@
 
 #import "Source/common/SNTPostflightResult.h"
 
-#import "Source/santasyncservice/SNTSyncState.h"
 #import "Source/common/CoderMacros.h"
+#import "Source/santasyncservice/SNTSyncState.h"
 
 @interface SNTPostflightResult ()
 @property NSNumber *clientMode;

--- a/Source/common/SNTPostflightResult.mm
+++ b/Source/common/SNTPostflightResult.mm
@@ -126,25 +126,25 @@
 
 - (void)enableBundles:(void (^)(BOOL))block {
   if (self.enableBundles) {
-    block(self.enableBundles);
+    block([self.enableBundles boolValue]);
   }
 }
 
 - (void)enableTransitiveRules:(void (^)(BOOL))block {
   if (self.enableTransitiveRules) {
-    block(self.enableTransitiveRules);
+    block([self.enableTransitiveRules boolValue]);
   }
 }
 
 - (void)enableAllEventUpload:(void (^)(BOOL))block {
   if (self.enableAllEventUpload) {
-    block(self.enableAllEventUpload);
+    block([self.enableAllEventUpload boolValue]);
   }
 }
 
 - (void)disableUnknownEventUpload:(void (^)(BOOL))block {
   if (self.disableUnknownEventUpload) {
-    block(self.disableUnknownEventUpload);
+    block([self.disableUnknownEventUpload boolValue]);
   }
 }
 

--- a/Source/common/SNTPostflightResultTest.mm
+++ b/Source/common/SNTPostflightResultTest.mm
@@ -1,0 +1,213 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTPostflightResult.h"
+
+#include <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTCommonEnums.h"
+#import "Source/santasyncservice/SNTSyncState.h"
+
+@interface SNTPostflightResult (Testing)
+@property NSNumber *clientMode;
+@property NSNumber *syncType;
+@property NSString *allowlistRegex;
+@property NSString *blocklistRegex;
+@property NSNumber *blockUSBMount;
+@property NSArray *remountUSBMode;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
+@property NSString *overrideFileAccessAction;
+@end
+
+@interface SNTPostflightResultTest : XCTestCase
+@end
+
+@implementation SNTPostflightResultTest
+
+- (void)testInit {
+  SNTPostflightResult *postflightResult;
+  SNTSyncState *state = [[SNTSyncState alloc] init];
+
+  state.clientMode = SNTClientModeUnknown;
+  postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+  XCTAssertNil(postflightResult.clientMode);
+
+  state.clientMode = SNTClientModeMonitor;
+  postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+  XCTAssertEqualObjects(postflightResult.clientMode, @(SNTClientModeMonitor));
+
+  state.syncType = SNTSyncTypeNormal;
+  postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+  XCTAssertNil(postflightResult.syncType);
+
+  state.syncType = SNTSyncTypeClean;
+  postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+  XCTAssertEqualObjects(postflightResult.syncType, @(SNTSyncTypeNormal));
+
+  state.syncType = SNTSyncTypeCleanAll;
+  postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+  XCTAssertEqualObjects(postflightResult.syncType, @(SNTSyncTypeNormal));
+}
+
+- (void)testGettersWithValues {
+  SNTSyncState *state = [[SNTSyncState alloc] init];
+  state.clientMode = SNTClientModeLockdown;
+  state.syncType = SNTSyncTypeClean;
+  state.allowlistRegex = @"allow";
+  state.blocklistRegex = @"block";
+  state.blockUSBMount = @(YES);
+  state.remountUSBMode = @[ @"foo" ];
+  state.enableBundles = @(YES);
+  state.enableTransitiveRules = @(YES);
+  state.enableAllEventUpload = @(YES);
+  state.disableUnknownEventUpload = @(YES);
+  state.overrideFileAccessAction = @"disable";
+
+  __block XCTestExpectation *exp = [self expectationWithDescription:@"Result Blocks"];
+
+  exp.expectedFulfillmentCount = 11;
+
+  SNTPostflightResult *postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+
+  [postflightResult clientMode:^(SNTClientMode val){
+    XCTAssertEqual(val, SNTClientModeLockdown);
+    [exp fulfill];
+  }];
+
+  [postflightResult syncType:^(SNTSyncType val){
+    XCTAssertEqual(val, SNTSyncTypeNormal);
+    [exp fulfill];
+  }];
+
+  [postflightResult allowlistRegex:^(NSString *val){
+    XCTAssertEqualObjects(val, @"allow");
+    [exp fulfill];
+  }];
+
+  [postflightResult blocklistRegex:^(NSString *val){
+    XCTAssertEqualObjects(val, @"block");
+    [exp fulfill];
+  }];
+
+  [postflightResult blockUSBMount:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult remountUSBMode:^(NSArray *val){
+    XCTAssertEqualObjects(val, @[ @"foo" ]);
+    [exp fulfill];
+  }];
+
+  [postflightResult enableBundles:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult enableTransitiveRules:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult enableAllEventUpload:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult disableUnknownEventUpload:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult overrideFileAccessAction:^(NSString *val){
+    XCTAssertEqualObjects(val, @"disable");
+    [exp fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:3.0 handler:NULL];
+}
+
+- (void)testGettersWithoutValues {
+  SNTSyncState *state = [[SNTSyncState alloc] init];
+  state.syncType = SNTSyncTypeNormal;
+
+  __block XCTestExpectation *exp = [self expectationWithDescription:@"Result Blocks"];
+  exp.inverted = YES;
+
+  SNTPostflightResult *postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
+
+  [postflightResult clientMode:^(SNTClientMode val){
+    XCTAssertEqual(val, SNTClientModeLockdown);
+    [exp fulfill];
+  }];
+
+  [postflightResult syncType:^(SNTSyncType val){
+    XCTAssertEqual(val, SNTSyncTypeNormal);
+    [exp fulfill];
+  }];
+
+  [postflightResult allowlistRegex:^(NSString *val){
+    XCTAssertEqualObjects(val, @"allow");
+    [exp fulfill];
+  }];
+
+  [postflightResult blocklistRegex:^(NSString *val){
+    XCTAssertEqualObjects(val, @"block");
+    [exp fulfill];
+  }];
+
+  [postflightResult blockUSBMount:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult remountUSBMode:^(NSArray *val){
+    XCTAssertEqualObjects(val, @[ @"foo" ]);
+    [exp fulfill];
+  }];
+
+  [postflightResult enableBundles:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult enableTransitiveRules:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult enableAllEventUpload:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult disableUnknownEventUpload:^(BOOL val){
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [postflightResult overrideFileAccessAction:^(NSString *val){
+    XCTAssertEqualObjects(val, @"disable");
+    [exp fulfill];
+  }];
+
+  // Low timeout because code above is synchronous
+  [self waitForExpectationsWithTimeout:0.1 handler:NULL];
+}
+
+@end

--- a/Source/common/SNTPostflightResultTest.mm
+++ b/Source/common/SNTPostflightResultTest.mm
@@ -84,57 +84,57 @@
 
   SNTPostflightResult *postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
 
-  [postflightResult clientMode:^(SNTClientMode val){
+  [postflightResult clientMode:^(SNTClientMode val) {
     XCTAssertEqual(val, SNTClientModeLockdown);
     [exp fulfill];
   }];
 
-  [postflightResult syncType:^(SNTSyncType val){
+  [postflightResult syncType:^(SNTSyncType val) {
     XCTAssertEqual(val, SNTSyncTypeNormal);
     [exp fulfill];
   }];
 
-  [postflightResult allowlistRegex:^(NSString *val){
+  [postflightResult allowlistRegex:^(NSString *val) {
     XCTAssertEqualObjects(val, @"allow");
     [exp fulfill];
   }];
 
-  [postflightResult blocklistRegex:^(NSString *val){
+  [postflightResult blocklistRegex:^(NSString *val) {
     XCTAssertEqualObjects(val, @"block");
     [exp fulfill];
   }];
 
-  [postflightResult blockUSBMount:^(BOOL val){
+  [postflightResult blockUSBMount:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult remountUSBMode:^(NSArray *val){
+  [postflightResult remountUSBMode:^(NSArray *val) {
     XCTAssertEqualObjects(val, @[ @"foo" ]);
     [exp fulfill];
   }];
 
-  [postflightResult enableBundles:^(BOOL val){
+  [postflightResult enableBundles:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult enableTransitiveRules:^(BOOL val){
+  [postflightResult enableTransitiveRules:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult enableAllEventUpload:^(BOOL val){
+  [postflightResult enableAllEventUpload:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult disableUnknownEventUpload:^(BOOL val){
+  [postflightResult disableUnknownEventUpload:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult overrideFileAccessAction:^(NSString *val){
+  [postflightResult overrideFileAccessAction:^(NSString *val) {
     XCTAssertEqualObjects(val, @"disable");
     [exp fulfill];
   }];
@@ -151,57 +151,57 @@
 
   SNTPostflightResult *postflightResult = [[SNTPostflightResult alloc] initWithSyncState:state];
 
-  [postflightResult clientMode:^(SNTClientMode val){
+  [postflightResult clientMode:^(SNTClientMode val) {
     XCTAssertEqual(val, SNTClientModeLockdown);
     [exp fulfill];
   }];
 
-  [postflightResult syncType:^(SNTSyncType val){
+  [postflightResult syncType:^(SNTSyncType val) {
     XCTAssertEqual(val, SNTSyncTypeNormal);
     [exp fulfill];
   }];
 
-  [postflightResult allowlistRegex:^(NSString *val){
+  [postflightResult allowlistRegex:^(NSString *val) {
     XCTAssertEqualObjects(val, @"allow");
     [exp fulfill];
   }];
 
-  [postflightResult blocklistRegex:^(NSString *val){
+  [postflightResult blocklistRegex:^(NSString *val) {
     XCTAssertEqualObjects(val, @"block");
     [exp fulfill];
   }];
 
-  [postflightResult blockUSBMount:^(BOOL val){
+  [postflightResult blockUSBMount:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult remountUSBMode:^(NSArray *val){
+  [postflightResult remountUSBMode:^(NSArray *val) {
     XCTAssertEqualObjects(val, @[ @"foo" ]);
     [exp fulfill];
   }];
 
-  [postflightResult enableBundles:^(BOOL val){
+  [postflightResult enableBundles:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult enableTransitiveRules:^(BOOL val){
+  [postflightResult enableTransitiveRules:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult enableAllEventUpload:^(BOOL val){
+  [postflightResult enableAllEventUpload:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult disableUnknownEventUpload:^(BOOL val){
+  [postflightResult disableUnknownEventUpload:^(BOOL val) {
     XCTAssertNotEqual(val, NO);
     [exp fulfill];
   }];
 
-  [postflightResult overrideFileAccessAction:^(NSString *val){
+  [postflightResult overrideFileAccessAction:^(NSString *val) {
     XCTAssertEqualObjects(val, @"disable");
     [exp fulfill];
   }];

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -13,6 +13,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+#include "Source/common/SNTPostflightResult.h"
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCUnprivilegedControlInterface.h"
 
@@ -53,12 +54,14 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
 - (void)setAllowedPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
 - (void)setBlockedPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
 - (void)setBlockUSBMount:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply;
-- (void)setEnableBundles:(BOOL)bundlesEnabled reply:(void (^)(void))reply;
-- (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setDisableUnknownEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setOverrideFileAccessAction:(NSString *)action reply:(void (^)(void))reply;
+// - (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply;
+// - (void)setEnableBundles:(BOOL)bundlesEnabled reply:(void (^)(void))reply;
+// - (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply;
+// - (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
+// - (void)setDisableUnknownEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
+// - (void)setOverrideFileAccessAction:(NSString *)action reply:(void (^)(void))reply;
+
+- (void)postflightResult:(SNTPostflightResult *)result reply:(void (^)(void))reply;
 
 ///
 ///  Syncd Ops

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -47,19 +47,8 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
 ///
 ///  Config ops
 ///
-- (void)setClientMode:(SNTClientMode)mode reply:(void (^)(void))reply;
-- (void)setFullSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply;
 - (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply;
 - (void)setSyncTypeRequired:(SNTSyncType)syncType reply:(void (^)(void))reply;
-- (void)setAllowedPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
-- (void)setBlockedPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
-- (void)setBlockUSBMount:(BOOL)enabled reply:(void (^)(void))reply;
-// - (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply;
-// - (void)setEnableBundles:(BOOL)bundlesEnabled reply:(void (^)(void))reply;
-// - (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply;
-// - (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
-// - (void)setDisableUnknownEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
-// - (void)setOverrideFileAccessAction:(NSString *)action reply:(void (^)(void))reply;
 
 - (void)postflightResult:(SNTPostflightResult *)result reply:(void (^)(void))reply;
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -825,6 +825,7 @@ objc_library(
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
+        "//Source/common:SNTPostflightResult",
         "//Source/common:SNTRule",
         "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SNTStoredEvent",

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -40,6 +40,9 @@
 - (void)inDatabase:(void (^)(FMDatabase *db))block;
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
+///  Vacuum the database
+- (void)vacuum;
+
 ///
 ///  Current supported version of the table schema. This should be overriden in
 ///  subclasses.

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -1,16 +1,17 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import "Source/santad/DataLayer/SNTDatabaseTable.h"
 #include <stdint.h>

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -112,4 +112,10 @@
   [self.dbQ inTransaction:block];
 }
 
+- (void)vacuum {
+  [self.dbQ inDatabase:^(FMDatabase *db) {
+    [db executeUpdate:@"VACUUM"];
+  }];
+}
+
 @end

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -99,9 +99,7 @@
   }];
 
   // Vacuum the database to cleanup after version upgrades.
-  [self inDatabase:^(FMDatabase *db) {
-    [db executeUpdate:@"VACUUM"];
-  }];
+  [self vacuum];
 }
 
 - (void)inDatabase:(void (^)(FMDatabase *db))block {

--- a/Source/santad/DataLayer/SNTEventTable.m
+++ b/Source/santad/DataLayer/SNTEventTable.m
@@ -205,7 +205,6 @@ static const uint32_t kEventTableCurrentVersion = 4;
     for (NSNumber *index in indexes) {
       [db executeUpdate:@"DELETE FROM events WHERE idx=?", index];
     }
-    [db executeUpdate:@"VACUUM"];
   }];
 }
 

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -225,18 +225,8 @@ double watchdogRAMPeak = 0;
   reply([[SNTConfigurator configurator] clientMode]);
 }
 
-- (void)setClientMode:(SNTClientMode)mode reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setSyncServerClientMode:mode];
-  reply();
-}
-
 - (void)fullSyncLastSuccess:(void (^)(NSDate *))reply {
   reply([[SNTConfigurator configurator] fullSyncLastSuccess]);
-}
-
-- (void)setFullSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setFullSyncLastSuccess:date];
-  reply();
 }
 
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))reply {
@@ -257,14 +247,6 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
-- (void)setAllowedPathRegex:(NSString *)pattern reply:(void (^)(void))reply {
-  NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern
-                                                                      options:0
-                                                                        error:NULL];
-  [[SNTConfigurator configurator] setSyncServerAllowedPathRegex:re];
-  reply();
-}
-
 - (void)setBlockedPathRegex:(NSString *)pattern reply:(void (^)(void))reply {
   NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern
                                                                       options:0
@@ -277,76 +259,38 @@ double watchdogRAMPeak = 0;
   reply([[SNTConfigurator configurator] blockUSBMount]);
 }
 
-- (void)setBlockUSBMount:(BOOL)enabled reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setBlockUSBMount:enabled];
-  reply();
-}
-
 - (void)remountUSBMode:(void (^)(NSArray<NSString *> *))reply {
   reply([[SNTConfigurator configurator] remountUSBMode]);
 }
-
-// - (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply {
-//   [[SNTConfigurator configurator] setRemountUSBMode:remountUSBMode];
-//   reply();
-// }
-
-// - (void)setOverrideFileAccessAction:(NSString *)action reply:(void (^)(void))reply {
-//   [[SNTConfigurator configurator] setSyncServerOverrideFileAccessAction:action];
-//   reply();
-// }
 
 - (void)enableBundles:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableBundles);
 }
 
-// - (void)setEnableBundles:(BOOL)enableBundles reply:(void (^)(void))reply {
-//   [[SNTConfigurator configurator] setEnableBundles:enableBundles];
-//   reply();
-// }
-
 - (void)enableTransitiveRules:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableTransitiveRules);
 }
-
-// - (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply {
-//   [[SNTConfigurator configurator] setEnableTransitiveRules:enabled];
-//   reply();
-// }
 
 - (void)enableAllEventUpload:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableAllEventUpload);
 }
 
-// - (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply {
-//   [[SNTConfigurator configurator] setEnableAllEventUpload:enabled];
-//   reply();
-// }
-
 - (void)disableUnknownEventUpload:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].disableUnknownEventUpload);
 }
-
-// - (void)setDisableUnknownEventUpload:(BOOL)enabled reply:(void (^)(void))reply {
-//   [[SNTConfigurator configurator] setDisableUnknownEventUpload:enabled];
-//   reply();
-// }
 
 - (void)postflightResult:(SNTPostflightResult *)result reply:(void (^)(void))reply {
   SNTConfigurator *configurator = [SNTConfigurator configurator];
 
   [result clientMode:^(SNTClientMode m) {
-    LOGE(@"Set config from sync server: clientMode");
     [configurator setSyncServerClientMode:m];
   }];
 
   [result syncType:^(SNTSyncType val) {
-    LOGE(@"Set config from sync server: syncType");
     [configurator setSyncTypeRequired:val];
   }];
 
   [result allowlistRegex:^(NSString *val) {
-  LOGE(@"Set config from sync server: allowRegex");
     [configurator
         setSyncServerAllowedPathRegex:[NSRegularExpression regularExpressionWithPattern:val
                                                                                 options:0
@@ -354,7 +298,6 @@ double watchdogRAMPeak = 0;
   }];
 
   [result blocklistRegex:^(NSString *val) {
-  LOGE(@"Set config from sync server: blockRegex");
     [configurator
         setSyncServerBlockedPathRegex:[NSRegularExpression regularExpressionWithPattern:val
                                                                                 options:0
@@ -362,37 +305,30 @@ double watchdogRAMPeak = 0;
   }];
 
   [result blockUSBMount:^(BOOL val) {
-    LOGE(@"Set config from sync server: block usb mount");
     [configurator setBlockUSBMount:val];
   }];
 
   [result remountUSBMode:^(NSArray *val) {
-    LOGE(@"Set config from sync server: remount usb mode");
     [configurator setRemountUSBMode:val];
   }];
 
   [result enableBundles:^(BOOL val) {
-    LOGE(@"Set config from sync server: enable bundles");
     [configurator setEnableBundles:val];
   }];
 
   [result enableTransitiveRules:^(BOOL val) {
-    LOGE(@"Set config from sync server: enable transitive rules");
     [configurator setEnableTransitiveRules:val];
   }];
 
   [result enableAllEventUpload:^(BOOL val) {
-    LOGE(@"Set config from sync server: enable all event upload");
     [configurator setEnableAllEventUpload:val];
   }];
 
   [result disableUnknownEventUpload:^(BOOL val) {
-    LOGE(@"Set config from sync server: disable unknown event upload");
     [configurator setDisableUnknownEventUpload:val];
   }];
 
   [result overrideFileAccessAction:^(NSString *val) {
-  LOGE(@"Set config from sync server: override file access");
     [configurator setSyncServerOverrideFileAccessAction:val];
   }];
 
@@ -401,7 +337,6 @@ double watchdogRAMPeak = 0;
   // Vacuum the event databases when postflight is
   // complete since it has just been drained.
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
-    LOGE(@"Do vacuum");
     [[SNTDatabaseController eventTable] vacuum];
   });
 

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -9,6 +9,15 @@ package(
 )
 
 objc_library(
+    name = "SNTSyncState",
+    srcs = ["SNTSyncState.m"],
+    hdrs = ["SNTSyncState.h"],
+    deps = [
+        "//Source/common:SNTCommonEnums",
+    ],
+)
+
+objc_library(
     name = "FCM_lib",
     srcs = ["SNTSyncFCM.m"],
     hdrs = ["SNTSyncFCM.h"],
@@ -64,8 +73,6 @@ objc_library(
         "SNTSyncRuleDownload.mm",
         "SNTSyncStage.h",
         "SNTSyncStage.mm",
-        "SNTSyncState.h",
-        "SNTSyncState.m",
     ],
     hdrs = ["SNTSyncManager.h"],
     defines = select({
@@ -76,6 +83,7 @@ objc_library(
     sdk_frameworks = ["Network"],
     deps = [
         ":FCM_lib",
+        ":SNTSyncState",
         ":broadcaster_lib",
         ":polaris_lib",
         "//Source/common:EncodeEntitlements",
@@ -86,6 +94,7 @@ objc_library(
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTPostflightResult",
         "//Source/common:SNTRule",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTStrengthify",
@@ -126,8 +135,6 @@ santa_unit_test(
         "SNTSyncRuleDownload.mm",
         "SNTSyncStage.h",
         "SNTSyncStage.mm",
-        "SNTSyncState.h",
-        "SNTSyncState.m",
         "SNTSyncTest.mm",
     ],
     resources = glob([
@@ -137,6 +144,7 @@ santa_unit_test(
     sdk_dylibs = ["libz"],
     deps = [
         ":FCM_lib",
+        ":SNTSyncState",
         ":broadcaster_lib",
         "//Source/common:EncodeEntitlements",
         "//Source/common:MOLAuthenticatingURLSession",
@@ -147,6 +155,7 @@ santa_unit_test(
         "//Source/common:SNTDropRootPrivs",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTPostflightResult",
         "//Source/common:SNTRule",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTStrengthify",

--- a/Source/santasyncservice/SNTSyncPostflight.h
+++ b/Source/santasyncservice/SNTSyncPostflight.h
@@ -1,20 +1,21 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import <Foundation/Foundation.h>
 
-#import "SNTSyncStage.h"
+#import "Source/santasyncservice/SNTSyncStage.h"
 
 @interface SNTSyncPostflight : SNTSyncStage
 @end

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -16,6 +16,7 @@
 #import "Source/santasyncservice/SNTSyncPostflight.h"
 
 #import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTPostflightResult.h"
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/common/String.h"
@@ -50,79 +51,10 @@ using santa::NSStringToUTF8String;
   ::pbv1::PostflightResponse response;
   [self performRequest:[self requestWithMessage:req] intoMessage:&response timeout:30];
 
-  id<SNTDaemonControlXPC> rop = [self.daemonConn synchronousRemoteObjectProxy];
-
-  // Set client mode if it changed
-  if (self.syncState.clientMode) {
-    [rop setClientMode:self.syncState.clientMode
+  [[self.daemonConn synchronousRemoteObjectProxy]
+      postflightResult:[[SNTPostflightResult alloc] initWithSyncState:self.syncState]
                  reply:^{
                  }];
-  }
-
-  // Remove clean sync flag if we did a clean or clean all sync
-  if (self.syncState.syncType != SNTSyncTypeNormal) {
-    [rop setSyncTypeRequired:SNTSyncTypeNormal
-                       reply:^{
-                       }];
-  }
-
-  // Update allowlist/blocklist regexes
-  if (self.syncState.allowlistRegex) {
-    [rop setAllowedPathRegex:self.syncState.allowlistRegex
-                       reply:^{
-                       }];
-  }
-  if (self.syncState.blocklistRegex) {
-    [rop setBlockedPathRegex:self.syncState.blocklistRegex
-                       reply:^{
-                       }];
-  }
-
-  if (self.syncState.blockUSBMount != nil) {
-    [rop setBlockUSBMount:[self.syncState.blockUSBMount boolValue]
-                    reply:^{
-                    }];
-  }
-  if (self.syncState.remountUSBMode) {
-    [rop setRemountUSBMode:self.syncState.remountUSBMode
-                     reply:^{
-                     }];
-  }
-
-  if (self.syncState.enableBundles) {
-    [rop setEnableBundles:[self.syncState.enableBundles boolValue]
-                    reply:^{
-                    }];
-  }
-
-  if (self.syncState.enableTransitiveRules) {
-    [rop setEnableTransitiveRules:[self.syncState.enableTransitiveRules boolValue]
-                            reply:^{
-                            }];
-  }
-
-  if (self.syncState.enableAllEventUpload) {
-    [rop setEnableAllEventUpload:[self.syncState.enableAllEventUpload boolValue]
-                           reply:^{
-                           }];
-  }
-
-  if (self.syncState.disableUnknownEventUpload) {
-    [rop setDisableUnknownEventUpload:[self.syncState.disableUnknownEventUpload boolValue]
-                                reply:^{
-                                }];
-  }
-
-  if (self.syncState.overrideFileAccessAction) {
-    [rop setOverrideFileAccessAction:self.syncState.overrideFileAccessAction
-                               reply:^{
-                               }];
-  }
-
-  // Update last sync success
-  [rop setFullSyncLastSuccess:[NSDate date]
-                        reply:^{
-                        }];
 
   return YES;
 }

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -5,13 +5,13 @@
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import "Source/santasyncservice/SNTSyncPostflight.h"
 

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -14,13 +14,13 @@
 ///    limitations under the License.
 
 #include <Foundation/Foundation.h>
-#import <XCTest/XCTest.h>
-
 #import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
 
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTPostflightResult.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTSyncConstants.h"
@@ -865,41 +865,7 @@
   [self stubRequestBody:nil response:nil error:nil validateBlock:nil];
 
   XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setFullSyncLastSuccess:OCMOCK_ANY reply:OCMOCK_ANY]);
-
-  self.syncState.clientMode = SNTClientModeMonitor;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setClientMode:SNTClientModeMonitor reply:OCMOCK_ANY]);
-
-  // For Clean syncs, the sync type required should be reset to normal
-  self.syncState.syncType = SNTSyncTypeClean;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setSyncTypeRequired:SNTSyncTypeNormal reply:OCMOCK_ANY]);
-
-  // For Clean All syncs, the sync type required should be reset to normal
-  self.syncState.syncType = SNTSyncTypeCleanAll;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setSyncTypeRequired:SNTSyncTypeNormal reply:OCMOCK_ANY]);
-
-  self.syncState.allowlistRegex = @"^horse$";
-  self.syncState.blocklistRegex = @"^donkey$";
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setAllowedPathRegex:@"^horse$" reply:OCMOCK_ANY]);
-  OCMVerify([self.daemonConnRop setBlockedPathRegex:@"^donkey$" reply:OCMOCK_ANY]);
-
-  self.syncState.blockUSBMount = @1;
-  self.syncState.remountUSBMode = @[ @"readonly" ];
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setBlockUSBMount:YES reply:OCMOCK_ANY]);
-  OCMVerify([self.daemonConnRop setRemountUSBMode:@[ @"readonly" ] reply:OCMOCK_ANY]);
-
-  self.syncState.blockUSBMount = @0;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setBlockUSBMount:NO reply:OCMOCK_ANY]);
-
-  self.syncState.overrideFileAccessAction = @"Disable";
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setOverrideFileAccessAction:@"Disable" reply:OCMOCK_ANY]);
+  OCMVerify([self.daemonConnRop postflightResult:OCMOCK_ANY reply:OCMOCK_ANY]);
 }
 
 @end


### PR DESCRIPTION
This PR changes the sync service to send the daemon all postflight results within a single XPC message. The primary goal is to create a single choke point for the daemon to know when a sync in complete. This is then used to defer vacuuming the events database until the end of a sync, drastically increasing event processing throughput and decreasing CPU load in the daemon - especially on larger event databases.