### PR TITLE
Add config bundling

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -327,6 +327,25 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTConfigBundle",
+    srcs = ["SNTConfigBundle.mm"],
+    hdrs = ["SNTConfigBundle.h"],
+    deps = [
+        ":CoderMacros",
+        ":SNTCommonEnums",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTConfigBundleTest",
+    srcs = ["SNTConfigBundleTest.mm"],
+    deps = [
+        ":SNTCommonEnums",
+        ":SNTConfigBundle",
+    ],
+)
+
+objc_library(
     name = "SNTKVOManager",
     srcs = ["SNTKVOManager.mm"],
     hdrs = ["SNTKVOManager.h"],
@@ -503,6 +522,7 @@ objc_library(
         ":MOLCodesignChecker",
         ":MOLXPCConnection",
         ":SNTCommonEnums",
+        ":SNTConfigBundle",
         ":SNTConfigurator",
         ":SNTRule",
         ":SNTRuleIdentifiers",
@@ -640,6 +660,7 @@ test_suite(
         ":RingBufferTest",
         ":SNTBlockMessageTest",
         ":SNTCachedDecisionTest",
+        ":SNTConfigBundleTest",
         ":SNTConfiguratorTest",
         ":SNTFileInfoTest",
         ":SNTKVOManagerTest",

--- a/Source/common/EncodeEntitlements.h
+++ b/Source/common/EncodeEntitlements.h
@@ -15,7 +15,7 @@
 #ifndef SANTA__COMMON__ENCODEENTITLEMENTS_H
 #define SANTA__COMMON__ENCODEENTITLEMENTS_H
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 namespace santa {
 

--- a/Source/common/MOLAuthenticatingURLSession.m
+++ b/Source/common/MOLAuthenticatingURLSession.m
@@ -14,7 +14,7 @@
 
 #import "MOLAuthenticatingURLSession.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <Security/Security.h>
 
 #import "Source/common/MOLCertificate.h"

--- a/Source/common/RingBuffer.h
+++ b/Source/common/RingBuffer.h
@@ -15,7 +15,7 @@
 #ifndef SANTA__COMMON__RINGBUFFER_H
 #define SANTA__COMMON__RINGBUFFER_H
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 #include <cstdlib>
 #include <deque>

--- a/Source/common/RingBufferTest.mm
+++ b/Source/common/RingBufferTest.mm
@@ -14,7 +14,7 @@
 
 #include "Source/common/RingBuffer.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #include <optional>

--- a/Source/common/SNTConfigBundle.h
+++ b/Source/common/SNTConfigBundle.h
@@ -1,0 +1,34 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include "Source/common/SNTCommonEnums.h"
+
+@interface SNTConfigBundle : NSObject <NSSecureCoding>
+
+/// If the value for the backing property was set, the given block will be called.
+- (void)clientMode:(void (^)(SNTClientMode))block;
+- (void)syncType:(void (^)(SNTSyncType))block;
+- (void)allowlistRegex:(void (^)(NSString *))block;
+- (void)blocklistRegex:(void (^)(NSString *))block;
+- (void)blockUSBMount:(void (^)(BOOL))block;
+- (void)remountUSBMode:(void (^)(NSArray *))block;
+- (void)enableBundles:(void (^)(BOOL))block;
+- (void)enableTransitiveRules:(void (^)(BOOL))block;
+- (void)enableAllEventUpload:(void (^)(BOOL))block;
+- (void)disableUnknownEventUpload:(void (^)(BOOL))block;
+- (void)overrideFileAccessAction:(void (^)(NSString *))block;
+
+@end

--- a/Source/common/SNTConfigBundle.h
+++ b/Source/common/SNTConfigBundle.h
@@ -30,5 +30,7 @@
 - (void)enableAllEventUpload:(void (^)(BOOL))block;
 - (void)disableUnknownEventUpload:(void (^)(BOOL))block;
 - (void)overrideFileAccessAction:(void (^)(NSString *))block;
+- (void)fullSyncLastSuccess:(void (^)(NSDate *))block;
+- (void)ruleSyncLastSuccess:(void (^)(NSDate *))block;
 
 @end

--- a/Source/common/SNTConfigBundle.mm
+++ b/Source/common/SNTConfigBundle.mm
@@ -1,0 +1,137 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTConfigBundle.h"
+
+#import "Source/common/CoderMacros.h"
+
+@interface SNTConfigBundle ()
+@property NSNumber *clientMode;
+@property NSNumber *syncType;
+@property NSString *allowlistRegex;
+@property NSString *blocklistRegex;
+@property NSNumber *blockUSBMount;
+@property NSArray *remountUSBMode;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
+@property NSString *overrideFileAccessAction;
+@end
+
+@implementation SNTConfigBundle
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  ENCODE(coder, clientMode);
+  ENCODE(coder, syncType);
+  ENCODE(coder, allowlistRegex);
+  ENCODE(coder, blocklistRegex);
+  ENCODE(coder, blockUSBMount);
+  ENCODE(coder, remountUSBMode);
+  ENCODE(coder, enableBundles);
+  ENCODE(coder, enableTransitiveRules);
+  ENCODE(coder, enableAllEventUpload);
+  ENCODE(coder, disableUnknownEventUpload);
+  ENCODE(coder, overrideFileAccessAction);
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  self = [super init];
+  if (self) {
+    DECODE(decoder, clientMode, NSNumber);
+    DECODE(decoder, syncType, NSNumber);
+    DECODE(decoder, allowlistRegex, NSString);
+    DECODE(decoder, blocklistRegex, NSString);
+    DECODE(decoder, blockUSBMount, NSNumber);
+    DECODE_ARRAY(decoder, remountUSBMode, NSString);
+    DECODE(decoder, enableBundles, NSNumber);
+    DECODE(decoder, enableTransitiveRules, NSNumber);
+    DECODE(decoder, enableAllEventUpload, NSNumber);
+    DECODE(decoder, disableUnknownEventUpload, NSNumber);
+    DECODE(decoder, overrideFileAccessAction, NSString);
+  }
+  return self;
+}
+
+- (void)clientMode:(void (^)(SNTClientMode))block {
+  if (self.clientMode) {
+    block((SNTClientMode)[self.clientMode integerValue]);
+  }
+}
+
+- (void)syncType:(void (^)(SNTSyncType))block {
+  if (self.syncType) {
+    block((SNTSyncType)[self.syncType integerValue]);
+  }
+}
+
+- (void)allowlistRegex:(void (^)(NSString *))block {
+  if (self.allowlistRegex) {
+    block(self.allowlistRegex);
+  }
+}
+
+- (void)blocklistRegex:(void (^)(NSString *))block {
+  if (self.blocklistRegex) {
+    block(self.blocklistRegex);
+  }
+}
+
+- (void)blockUSBMount:(void (^)(BOOL))block {
+  if (self.blockUSBMount) {
+    block([self.blockUSBMount boolValue]);
+  }
+}
+
+- (void)remountUSBMode:(void (^)(NSArray *))block {
+  if (self.remountUSBMode) {
+    block(self.remountUSBMode);
+  }
+}
+
+- (void)enableBundles:(void (^)(BOOL))block {
+  if (self.enableBundles) {
+    block([self.enableBundles boolValue]);
+  }
+}
+
+- (void)enableTransitiveRules:(void (^)(BOOL))block {
+  if (self.enableTransitiveRules) {
+    block([self.enableTransitiveRules boolValue]);
+  }
+}
+
+- (void)enableAllEventUpload:(void (^)(BOOL))block {
+  if (self.enableAllEventUpload) {
+    block([self.enableAllEventUpload boolValue]);
+  }
+}
+
+- (void)disableUnknownEventUpload:(void (^)(BOOL))block {
+  if (self.disableUnknownEventUpload) {
+    block([self.disableUnknownEventUpload boolValue]);
+  }
+}
+
+- (void)overrideFileAccessAction:(void (^)(NSString *))block {
+  if (self.overrideFileAccessAction) {
+    block(self.overrideFileAccessAction);
+  }
+}
+
+@end

--- a/Source/common/SNTConfigBundle.mm
+++ b/Source/common/SNTConfigBundle.mm
@@ -28,6 +28,8 @@
 @property NSNumber *enableAllEventUpload;
 @property NSNumber *disableUnknownEventUpload;
 @property NSString *overrideFileAccessAction;
+@property NSDate *fullSyncLastSuccess;
+@property NSDate *ruleSyncLastSuccess;
 @end
 
 @implementation SNTConfigBundle
@@ -48,6 +50,8 @@
   ENCODE(coder, enableAllEventUpload);
   ENCODE(coder, disableUnknownEventUpload);
   ENCODE(coder, overrideFileAccessAction);
+  ENCODE(coder, fullSyncLastSuccess);
+  ENCODE(coder, ruleSyncLastSuccess);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
@@ -64,6 +68,8 @@
     DECODE(decoder, enableAllEventUpload, NSNumber);
     DECODE(decoder, disableUnknownEventUpload, NSNumber);
     DECODE(decoder, overrideFileAccessAction, NSString);
+    DECODE(decoder, fullSyncLastSuccess, NSDate);
+    DECODE(decoder, ruleSyncLastSuccess, NSDate);
   }
   return self;
 }
@@ -131,6 +137,17 @@
 - (void)overrideFileAccessAction:(void (^)(NSString *))block {
   if (self.overrideFileAccessAction) {
     block(self.overrideFileAccessAction);
+  }
+}
+
+- (void)fullSyncLastSuccess:(void (^)(NSDate *))block {
+  if (self.fullSyncLastSuccess) {
+    block(self.fullSyncLastSuccess);
+  }
+}
+- (void)ruleSyncLastSuccess:(void (^)(NSDate *))block {
+  if (self.ruleSyncLastSuccess) {
+    block(self.ruleSyncLastSuccess);
   }
 }
 

--- a/Source/common/SNTConfigBundleTest.mm
+++ b/Source/common/SNTConfigBundleTest.mm
@@ -31,6 +31,8 @@
 @property NSNumber *enableAllEventUpload;
 @property NSNumber *disableUnknownEventUpload;
 @property NSString *overrideFileAccessAction;
+@property NSDate *fullSyncLastSuccess;
+@property NSDate *ruleSyncLastSuccess;
 @end
 
 @interface SNTConfigBundleTest : XCTestCase
@@ -40,7 +42,8 @@
 
 - (void)testGettersWithValues {
   __block XCTestExpectation *exp = [self expectationWithDescription:@"Result Blocks"];
-  exp.expectedFulfillmentCount = 11;
+  exp.expectedFulfillmentCount = 13;
+  NSDate *nowDate = [NSDate now];
 
   SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
   bundle.clientMode = @(SNTClientModeLockdown);
@@ -54,6 +57,8 @@
   bundle.enableAllEventUpload = @(NO);
   bundle.disableUnknownEventUpload = @(YES);
   bundle.overrideFileAccessAction = @"disable";
+  bundle.fullSyncLastSuccess = nowDate;
+  bundle.ruleSyncLastSuccess = nowDate;
 
   [bundle clientMode:^(SNTClientMode val) {
     XCTAssertEqual(val, SNTClientModeLockdown);
@@ -110,7 +115,18 @@
     [exp fulfill];
   }];
 
-  [self waitForExpectationsWithTimeout:3.0 handler:NULL];
+  [bundle fullSyncLastSuccess:^(NSDate *val) {
+    XCTAssertEqualObjects(val, nowDate);
+    [exp fulfill];
+  }];
+
+  [bundle ruleSyncLastSuccess:^(NSDate *val) {
+    XCTAssertEqualObjects(val, nowDate);
+    [exp fulfill];
+  }];
+
+  // Low timeout because code above is synchronous
+  [self waitForExpectationsWithTimeout:0.1 handler:NULL];
 }
 
 - (void)testGettersWithoutValues {
@@ -171,6 +187,16 @@
 
   [bundle overrideFileAccessAction:^(NSString *val) {
     XCTAssertEqualObjects(val, @"disable");
+    [exp fulfill];
+  }];
+
+  [bundle fullSyncLastSuccess:^(NSDate *val) {
+    XCTAssertEqualObjects(val, [NSDate now]);
+    [exp fulfill];
+  }];
+
+  [bundle ruleSyncLastSuccess:^(NSDate *val) {
+    XCTAssertEqualObjects(val, [NSDate now]);
     [exp fulfill];
   }];
 

--- a/Source/common/SNTConfigBundleTest.mm
+++ b/Source/common/SNTConfigBundleTest.mm
@@ -14,7 +14,7 @@
 
 #import "Source/common/SNTConfigBundle.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTCommonEnums.h"

--- a/Source/common/SNTConfigBundleTest.mm
+++ b/Source/common/SNTConfigBundleTest.mm
@@ -1,0 +1,181 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTConfigBundle.h"
+
+#include <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTCommonEnums.h"
+
+@interface SNTConfigBundle (Testing)
+@property NSNumber *clientMode;
+@property NSNumber *syncType;
+@property NSString *allowlistRegex;
+@property NSString *blocklistRegex;
+@property NSNumber *blockUSBMount;
+@property NSArray *remountUSBMode;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
+@property NSString *overrideFileAccessAction;
+@end
+
+@interface SNTConfigBundleTest : XCTestCase
+@end
+
+@implementation SNTConfigBundleTest
+
+- (void)testGettersWithValues {
+  __block XCTestExpectation *exp = [self expectationWithDescription:@"Result Blocks"];
+  exp.expectedFulfillmentCount = 11;
+
+  SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
+  bundle.clientMode = @(SNTClientModeLockdown);
+  bundle.syncType = @(SNTSyncTypeNormal);
+  bundle.allowlistRegex = @"allow";
+  bundle.blocklistRegex = @"block";
+  bundle.blockUSBMount = @(YES);
+  bundle.remountUSBMode = @[ @"foo" ];
+  bundle.enableBundles = @(YES);
+  bundle.enableTransitiveRules = @(YES);
+  bundle.enableAllEventUpload = @(NO);
+  bundle.disableUnknownEventUpload = @(YES);
+  bundle.overrideFileAccessAction = @"disable";
+
+  [bundle clientMode:^(SNTClientMode val) {
+    XCTAssertEqual(val, SNTClientModeLockdown);
+    [exp fulfill];
+  }];
+
+  [bundle syncType:^(SNTSyncType val) {
+    XCTAssertEqual(val, SNTSyncTypeNormal);
+    [exp fulfill];
+  }];
+
+  [bundle allowlistRegex:^(NSString *val) {
+    XCTAssertEqualObjects(val, @"allow");
+    [exp fulfill];
+  }];
+
+  [bundle blocklistRegex:^(NSString *val) {
+    XCTAssertEqualObjects(val, @"block");
+    [exp fulfill];
+  }];
+
+  [bundle blockUSBMount:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle remountUSBMode:^(NSArray *val) {
+    XCTAssertEqualObjects(val, @[ @"foo" ]);
+    [exp fulfill];
+  }];
+
+  [bundle enableBundles:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle enableTransitiveRules:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle enableAllEventUpload:^(BOOL val) {
+    XCTAssertEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle disableUnknownEventUpload:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle overrideFileAccessAction:^(NSString *val) {
+    XCTAssertEqualObjects(val, @"disable");
+    [exp fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:3.0 handler:NULL];
+}
+
+- (void)testGettersWithoutValues {
+  __block XCTestExpectation *exp = [self expectationWithDescription:@"Result Blocks"];
+  exp.inverted = YES;
+
+  SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
+
+  [bundle clientMode:^(SNTClientMode val) {
+    XCTAssertEqual(val, SNTClientModeLockdown);
+    [exp fulfill];
+  }];
+
+  [bundle syncType:^(SNTSyncType val) {
+    XCTAssertEqual(val, SNTSyncTypeNormal);
+    [exp fulfill];
+  }];
+
+  [bundle allowlistRegex:^(NSString *val) {
+    XCTAssertEqualObjects(val, @"allow");
+    [exp fulfill];
+  }];
+
+  [bundle blocklistRegex:^(NSString *val) {
+    XCTAssertEqualObjects(val, @"block");
+    [exp fulfill];
+  }];
+
+  [bundle blockUSBMount:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle remountUSBMode:^(NSArray *val) {
+    XCTAssertEqualObjects(val, @[ @"foo" ]);
+    [exp fulfill];
+  }];
+
+  [bundle enableBundles:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle enableTransitiveRules:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle enableAllEventUpload:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle disableUnknownEventUpload:^(BOOL val) {
+    XCTAssertNotEqual(val, NO);
+    [exp fulfill];
+  }];
+
+  [bundle overrideFileAccessAction:^(NSString *val) {
+    XCTAssertEqualObjects(val, @"disable");
+    [exp fulfill];
+  }];
+
+  // Low timeout because code above is synchronous
+  [self waitForExpectationsWithTimeout:0.1 handler:NULL];
+}
+
+@end

--- a/Source/common/SNTError.m
+++ b/Source/common/SNTError.m
@@ -14,7 +14,7 @@
 
 #import "Source/common/SNTError.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 const NSErrorDomain SantaErrorDomain = @"com.northpolesec.santa.error";
 

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -47,9 +47,7 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
 ///
 ///  Config ops
 ///
-- (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply;
-- (void)setSyncTypeRequired:(SNTSyncType)syncType reply:(void (^)(void))reply;
-- (void)postflightResult:(SNTConfigBundle *)result reply:(void (^)(void))reply;
+- (void)updateSyncSettings:(SNTConfigBundle *)result reply:(void (^)(void))reply;
 
 ///
 ///  Syncd Ops

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -13,6 +13,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+#import "Source/common/SNTConfigBundle.h"
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCUnprivilegedControlInterface.h"
 
@@ -46,19 +47,9 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
 ///
 ///  Config ops
 ///
-- (void)setClientMode:(SNTClientMode)mode reply:(void (^)(void))reply;
-- (void)setFullSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply;
 - (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply;
 - (void)setSyncTypeRequired:(SNTSyncType)syncType reply:(void (^)(void))reply;
-- (void)setAllowedPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
-- (void)setBlockedPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
-- (void)setBlockUSBMount:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply;
-- (void)setEnableBundles:(BOOL)bundlesEnabled reply:(void (^)(void))reply;
-- (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setDisableUnknownEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
-- (void)setOverrideFileAccessAction:(NSString *)action reply:(void (^)(void))reply;
+- (void)postflightResult:(SNTConfigBundle *)result reply:(void (^)(void))reply;
 
 ///
 ///  Syncd Ops

--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -17,7 +17,7 @@
 #define SANTA__COMMON__STRING_H
 
 #include <EndpointSecurity/ESTypes.h>
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 #include <optional>
 #include <string>

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -1,16 +1,17 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import <Foundation/Foundation.h>
 
@@ -39,6 +40,9 @@
 ///
 - (void)inDatabase:(void (^)(FMDatabase *db))block;
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
+
+///  Vacuum the database
+- (void)vacuum;
 
 ///
 ///  Current supported version of the table schema. This should be overriden in

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -1,16 +1,17 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     http://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #import "Source/santad/DataLayer/SNTDatabaseTable.h"
 #include <stdint.h>
@@ -99,9 +100,7 @@
   }];
 
   // Vacuum the database to cleanup after version upgrades.
-  [self inDatabase:^(FMDatabase *db) {
-    [db executeUpdate:@"VACUUM"];
-  }];
+  [self vacuum];
 }
 
 - (void)inDatabase:(void (^)(FMDatabase *db))block {
@@ -110,6 +109,12 @@
 
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block {
   [self.dbQ inTransaction:block];
+}
+
+- (void)vacuum {
+  [self.dbQ inDatabase:^(FMDatabase *db) {
+    [db executeUpdate:@"VACUUM"];
+  }];
 }
 
 @end

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -14,9 +14,9 @@
 /// limitations under the License.
 
 #import "Source/santad/DataLayer/SNTDatabaseTable.h"
-#include <stdint.h>
 
 #include <sqlite3.h>
+#include <stdint.h>
 
 #import "Source/common/SNTLogging.h"
 

--- a/Source/santad/DataLayer/SNTEventTable.m
+++ b/Source/santad/DataLayer/SNTEventTable.m
@@ -205,7 +205,6 @@ static const uint32_t kEventTableCurrentVersion = 4;
     for (NSNumber *index in indexes) {
       [db executeUpdate:@"DELETE FROM events WHERE idx=?", index];
     }
-    [db executeUpdate:@"VACUUM"];
   }];
 }
 

--- a/Source/santad/EventProviders/AuthResultCacheTest.mm
+++ b/Source/santad/EventProviders/AuthResultCacheTest.mm
@@ -14,7 +14,7 @@
 /// limitations under the License.
 
 #include <EndpointSecurity/EndpointSecurity.h>
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 #include <gmock/gmock.h>

--- a/Source/santad/EventProviders/DiskArbitrationTestUtil.h
+++ b/Source/santad/EventProviders/DiskArbitrationTestUtil.h
@@ -15,7 +15,7 @@
 #include <CoreFoundation/CFDictionary.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <DiskArbitration/DiskArbitration.h>
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <sys/mount.h>
 #include <sys/param.h>
 #include <sys/ucred.h>

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -14,7 +14,7 @@
 
 #include "Source/santad/EventProviders/FAAPolicyProcessor.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 #include <gmock/gmock.h>

--- a/Source/santad/EventProviders/RateLimiterTest.mm
+++ b/Source/santad/EventProviders/RateLimiterTest.mm
@@ -14,7 +14,7 @@
 
 #include "Source/santad/EventProviders/RateLimiter.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #include "Source/common/SystemResources.h"

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -13,7 +13,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 #include <gmock/gmock.h>

--- a/Source/santad/Logs/EndpointSecurity/Writers/File.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.h
@@ -17,7 +17,7 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <dispatch/dispatch.h>
 
 #include <memory>

--- a/Source/santad/ProcessTree/SNTEndpointSecurityAdapter.mm
+++ b/Source/santad/ProcessTree/SNTEndpointSecurityAdapter.mm
@@ -14,7 +14,7 @@
 #include "Source/santad/ProcessTree/SNTEndpointSecurityAdapter.h"
 
 #include <EndpointSecurity/EndpointSecurity.h>
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <bsm/libbsm.h>
 
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"

--- a/Source/santad/ProcessTree/process_tree_macos.mm
+++ b/Source/santad/ProcessTree/process_tree_macos.mm
@@ -13,7 +13,7 @@
 /// limitations under the License.
 #include "Source/santad/ProcessTree/process_tree.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <bsm/libbsm.h>
 #include <libproc.h>
 #include <mach/message.h>

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -225,18 +225,8 @@ double watchdogRAMPeak = 0;
   reply([[SNTConfigurator configurator] clientMode]);
 }
 
-- (void)setClientMode:(SNTClientMode)mode reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setSyncServerClientMode:mode];
-  reply();
-}
-
 - (void)fullSyncLastSuccess:(void (^)(NSDate *))reply {
   reply([[SNTConfigurator configurator] fullSyncLastSuccess]);
-}
-
-- (void)setFullSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setFullSyncLastSuccess:date];
-  reply();
 }
 
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))reply {
@@ -257,78 +247,90 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
-- (void)setAllowedPathRegex:(NSString *)pattern reply:(void (^)(void))reply {
-  NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern
-                                                                      options:0
-                                                                        error:NULL];
-  [[SNTConfigurator configurator] setSyncServerAllowedPathRegex:re];
-  reply();
-}
-
-- (void)setBlockedPathRegex:(NSString *)pattern reply:(void (^)(void))reply {
-  NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern
-                                                                      options:0
-                                                                        error:NULL];
-  [[SNTConfigurator configurator] setSyncServerBlockedPathRegex:re];
-  reply();
-}
-
 - (void)blockUSBMount:(void (^)(BOOL))reply {
   reply([[SNTConfigurator configurator] blockUSBMount]);
-}
-
-- (void)setBlockUSBMount:(BOOL)enabled reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setBlockUSBMount:enabled];
-  reply();
 }
 
 - (void)remountUSBMode:(void (^)(NSArray<NSString *> *))reply {
   reply([[SNTConfigurator configurator] remountUSBMode]);
 }
 
-- (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setRemountUSBMode:remountUSBMode];
-  reply();
-}
-
-- (void)setOverrideFileAccessAction:(NSString *)action reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setSyncServerOverrideFileAccessAction:action];
-  reply();
-}
-
 - (void)enableBundles:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableBundles);
-}
-
-- (void)setEnableBundles:(BOOL)enableBundles reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setEnableBundles:enableBundles];
-  reply();
 }
 
 - (void)enableTransitiveRules:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableTransitiveRules);
 }
 
-- (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setEnableTransitiveRules:enabled];
-  reply();
-}
-
 - (void)enableAllEventUpload:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableAllEventUpload);
-}
-
-- (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setEnableAllEventUpload:enabled];
-  reply();
 }
 
 - (void)disableUnknownEventUpload:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].disableUnknownEventUpload);
 }
 
-- (void)setDisableUnknownEventUpload:(BOOL)enabled reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setDisableUnknownEventUpload:enabled];
+- (void)postflightResult:(SNTConfigBundle *)result reply:(void (^)(void))reply {
+  SNTConfigurator *configurator = [SNTConfigurator configurator];
+
+  [result clientMode:^(SNTClientMode m) {
+    [configurator setSyncServerClientMode:m];
+  }];
+
+  [result syncType:^(SNTSyncType val) {
+    [configurator setSyncTypeRequired:val];
+  }];
+
+  [result allowlistRegex:^(NSString *val) {
+    [configurator
+        setSyncServerAllowedPathRegex:[NSRegularExpression regularExpressionWithPattern:val
+                                                                                options:0
+                                                                                  error:NULL]];
+  }];
+
+  [result blocklistRegex:^(NSString *val) {
+    [configurator
+        setSyncServerBlockedPathRegex:[NSRegularExpression regularExpressionWithPattern:val
+                                                                                options:0
+                                                                                  error:NULL]];
+  }];
+
+  [result blockUSBMount:^(BOOL val) {
+    [configurator setBlockUSBMount:val];
+  }];
+
+  [result remountUSBMode:^(NSArray *val) {
+    [configurator setRemountUSBMode:val];
+  }];
+
+  [result enableBundles:^(BOOL val) {
+    [configurator setEnableBundles:val];
+  }];
+
+  [result enableTransitiveRules:^(BOOL val) {
+    [configurator setEnableTransitiveRules:val];
+  }];
+
+  [result enableAllEventUpload:^(BOOL val) {
+    [configurator setEnableAllEventUpload:val];
+  }];
+
+  [result disableUnknownEventUpload:^(BOOL val) {
+    [configurator setDisableUnknownEventUpload:val];
+  }];
+
+  [result overrideFileAccessAction:^(NSString *val) {
+    [configurator setSyncServerOverrideFileAccessAction:val];
+  }];
+
+  [configurator setFullSyncLastSuccess:[NSDate now]];
+
+  // Vacuum the event databases when postflight is complete since it has just been drained.
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+    [[SNTDatabaseController eventTable] vacuum];
+  });
+
   reply();
 }
 

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -233,18 +233,8 @@ double watchdogRAMPeak = 0;
   reply([[SNTConfigurator configurator] ruleSyncLastSuccess]);
 }
 
-- (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setRuleSyncLastSuccess:date];
-  reply();
-}
-
 - (void)syncTypeRequired:(void (^)(SNTSyncType))reply {
   reply([[SNTConfigurator configurator] syncTypeRequired]);
-}
-
-- (void)setSyncTypeRequired:(SNTSyncType)syncType reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setSyncTypeRequired:syncType];
-  reply();
 }
 
 - (void)blockUSBMount:(void (^)(BOOL))reply {
@@ -271,7 +261,7 @@ double watchdogRAMPeak = 0;
   reply([SNTConfigurator configurator].disableUnknownEventUpload);
 }
 
-- (void)postflightResult:(SNTConfigBundle *)result reply:(void (^)(void))reply {
+- (void)updateSyncSettings:(SNTConfigBundle *)result reply:(void (^)(void))reply {
   SNTConfigurator *configurator = [SNTConfigurator configurator];
 
   [result clientMode:^(SNTClientMode m) {
@@ -324,12 +314,13 @@ double watchdogRAMPeak = 0;
     [configurator setSyncServerOverrideFileAccessAction:val];
   }];
 
-  [configurator setFullSyncLastSuccess:[NSDate now]];
+  [result fullSyncLastSuccess:^(NSDate *val) {
+    [configurator setFullSyncLastSuccess:val];
+  }];
 
-  // Vacuum the event database when postflight is complete since it has just been drained.
-  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
-    [[SNTDatabaseController eventTable] vacuum];
-  });
+  [result ruleSyncLastSuccess:^(NSDate *val) {
+    [configurator setFullSyncLastSuccess:val];
+  }];
 
   reply();
 }

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -15,7 +15,7 @@
 
 #import "Source/santad/SNTDaemonControlController.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 #include <memory>
 
@@ -326,7 +326,7 @@ double watchdogRAMPeak = 0;
 
   [configurator setFullSyncLastSuccess:[NSDate now]];
 
-  // Vacuum the event databases when postflight is complete since it has just been drained.
+  // Vacuum the event database when postflight is complete since it has just been drained.
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
     [[SNTDatabaseController eventTable] vacuum];
   });

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -15,7 +15,7 @@
 
 #import "Source/santad/SNTNotificationQueue.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/RingBuffer.h"

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -15,7 +15,7 @@
 
 #import "Source/santad/SNTPolicyProcessor.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <Kernel/kern/cs_blobs.h>
 #import <Security/SecCode.h>
 #import <Security/Security.h>

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -14,7 +14,7 @@
 
 #import "Source/santad/SNTPolicyProcessor.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTCachedDecision.h"

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -14,7 +14,7 @@
 
 #import "Source/santad/SNTSyncdQueue.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 

--- a/Source/santad/main.mm
+++ b/Source/santad/main.mm
@@ -13,7 +13,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #include <dispatch/dispatch.h>
 #include <mach/task.h>
 #include <memory>

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -28,6 +28,36 @@ objc_library(
     ],
 )
 
+objc_library(
+    name = "SNTSyncState",
+    srcs = ["SNTSyncState.m"],
+    hdrs = ["SNTSyncState.h"],
+    deps = [
+        "//Source/common:SNTCommonEnums",
+    ],
+)
+
+objc_library(
+    name = "SNTPostflightConfigBundle",
+    srcs = ["SNTPostflightConfigBundle.mm"],
+    hdrs = ["SNTPostflightConfigBundle.h"],
+    deps = [
+        ":SNTSyncState",
+        "//Source/common:SNTConfigBundle",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTPostflightConfigBundleTest",
+    srcs = ["SNTPostflightConfigBundleTest.mm"],
+    deps = [
+        ":SNTPostflightConfigBundle",
+        ":SNTSyncState",
+        "//Source/common:SNTCommonEnums",
+        "//Source/common:SNTConfigBundle",
+    ],
+)
+
 # This setting is used to enable storing all sync requests as JSON files on disk.
 # This can be useful for debugging purposes.
 config_setting(
@@ -60,8 +90,6 @@ objc_library(
         "SNTSyncRuleDownload.mm",
         "SNTSyncStage.h",
         "SNTSyncStage.mm",
-        "SNTSyncState.h",
-        "SNTSyncState.m",
     ],
     hdrs = ["SNTSyncManager.h"],
     defines = select({
@@ -72,6 +100,8 @@ objc_library(
     sdk_frameworks = ["Network"],
     deps = [
         ":FCM_lib",
+        ":SNTPostflightConfigBundle",
+        ":SNTSyncState",
         ":broadcaster_lib",
         ":polaris_lib",
         "//Source/common:EncodeEntitlements",
@@ -123,8 +153,6 @@ santa_unit_test(
         "SNTSyncRuleDownload.mm",
         "SNTSyncStage.h",
         "SNTSyncStage.mm",
-        "SNTSyncState.h",
-        "SNTSyncState.m",
         "SNTSyncTest.mm",
     ],
     resources = glob([
@@ -134,6 +162,8 @@ santa_unit_test(
     sdk_dylibs = ["libz"],
     deps = [
         ":FCM_lib",
+        ":SNTPostflightConfigBundle",
+        ":SNTSyncState",
         ":broadcaster_lib",
         "//Source/common:EncodeEntitlements",
         "//Source/common:MOLAuthenticatingURLSession",
@@ -220,6 +250,7 @@ test_suite(
     name = "unit_tests",
     tests = [
         ":NSDataZlibTest",
+        ":SNTPostflightConfigBundleTest",
         ":SNTSyncTest",
     ],
     visibility = ["//:santa_package_group"],

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -38,9 +38,9 @@ objc_library(
 )
 
 objc_library(
-    name = "SNTPostflightConfigBundle",
-    srcs = ["SNTPostflightConfigBundle.mm"],
-    hdrs = ["SNTPostflightConfigBundle.h"],
+    name = "SNTSyncConfigBundle",
+    srcs = ["SNTSyncConfigBundle.mm"],
+    hdrs = ["SNTSyncConfigBundle.h"],
     deps = [
         ":SNTSyncState",
         "//Source/common:SNTConfigBundle",
@@ -48,10 +48,10 @@ objc_library(
 )
 
 santa_unit_test(
-    name = "SNTPostflightConfigBundleTest",
-    srcs = ["SNTPostflightConfigBundleTest.mm"],
+    name = "SNTSyncConfigBundleTest",
+    srcs = ["SNTSyncConfigBundleTest.mm"],
     deps = [
-        ":SNTPostflightConfigBundle",
+        ":SNTSyncConfigBundle",
         ":SNTSyncState",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigBundle",
@@ -100,7 +100,7 @@ objc_library(
     sdk_frameworks = ["Network"],
     deps = [
         ":FCM_lib",
-        ":SNTPostflightConfigBundle",
+        ":SNTSyncConfigBundle",
         ":SNTSyncState",
         ":broadcaster_lib",
         ":polaris_lib",
@@ -162,7 +162,7 @@ santa_unit_test(
     sdk_dylibs = ["libz"],
     deps = [
         ":FCM_lib",
-        ":SNTPostflightConfigBundle",
+        ":SNTSyncConfigBundle",
         ":SNTSyncState",
         ":broadcaster_lib",
         "//Source/common:EncodeEntitlements",
@@ -250,7 +250,7 @@ test_suite(
     name = "unit_tests",
     tests = [
         ":NSDataZlibTest",
-        ":SNTPostflightConfigBundleTest",
+        ":SNTSyncConfigBundleTest",
         ":SNTSyncTest",
     ],
     visibility = ["//:santa_package_group"],

--- a/Source/santasyncservice/SNTPostflightConfigBundle.h
+++ b/Source/santasyncservice/SNTPostflightConfigBundle.h
@@ -1,0 +1,19 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTConfigBundle.h"
+#import "Source/santasyncservice/SNTSyncState.h"
+
+SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState);

--- a/Source/santasyncservice/SNTPostflightConfigBundle.mm
+++ b/Source/santasyncservice/SNTPostflightConfigBundle.mm
@@ -1,0 +1,48 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTPostflightConfigBundle.h"
+
+// Expose necessary setters for SNTConfigBundle properties related to Postflight
+@interface SNTConfigBundle (ConfigBundleCreator)
+@property NSNumber *clientMode;
+@property NSNumber *syncType;
+@property NSString *allowlistRegex;
+@property NSString *blocklistRegex;
+@property NSNumber *blockUSBMount;
+@property NSArray *remountUSBMode;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
+@property NSString *overrideFileAccessAction;
+@end
+
+SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
+  SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
+
+  bundle.clientMode = syncState.clientMode ? @(syncState.clientMode) : nil;
+  bundle.syncType = syncState.syncType != SNTSyncTypeNormal ? @(SNTSyncTypeNormal) : nil;
+  bundle.allowlistRegex = syncState.allowlistRegex;
+  bundle.blocklistRegex = syncState.blocklistRegex;
+  bundle.blockUSBMount = syncState.blockUSBMount;
+  bundle.remountUSBMode = syncState.remountUSBMode;
+  bundle.enableBundles = syncState.enableBundles;
+  bundle.enableTransitiveRules = syncState.enableTransitiveRules;
+  bundle.enableAllEventUpload = syncState.enableAllEventUpload;
+  bundle.disableUnknownEventUpload = syncState.disableUnknownEventUpload;
+  bundle.overrideFileAccessAction = syncState.overrideFileAccessAction;
+
+  return bundle;
+}

--- a/Source/santasyncservice/SNTPostflightConfigBundleTest.mm
+++ b/Source/santasyncservice/SNTPostflightConfigBundleTest.mm
@@ -14,7 +14,7 @@
 
 #import "Source/santasyncservice/SNTPostflightConfigBundle.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTCommonEnums.h"

--- a/Source/santasyncservice/SNTPostflightConfigBundleTest.mm
+++ b/Source/santasyncservice/SNTPostflightConfigBundleTest.mm
@@ -1,0 +1,68 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTPostflightConfigBundle.h"
+
+#include <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTConfigBundle.h"
+#import "Source/santasyncservice/SNTSyncState.h"
+
+@interface SNTConfigBundle (ConfigBundleCreator)
+@property NSNumber *clientMode;
+@property NSNumber *syncType;
+@property NSString *allowlistRegex;
+@property NSString *blocklistRegex;
+@property NSNumber *blockUSBMount;
+@property NSArray *remountUSBMode;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
+@property NSString *overrideFileAccessAction;
+@end
+
+@interface SNTPostflightConfigBundleTest : XCTestCase
+@end
+
+@implementation SNTPostflightConfigBundleTest
+
+- (void)testInit {
+  SNTConfigBundle *bundle;
+  SNTSyncState *syncState = [[SNTSyncState alloc] init];
+
+  syncState.clientMode = SNTClientModeUnknown;
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertNil(bundle.clientMode);
+
+  syncState.clientMode = SNTClientModeMonitor;
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertEqualObjects(bundle.clientMode, @(SNTClientModeMonitor));
+
+  syncState.syncType = SNTSyncTypeNormal;
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertNil(bundle.syncType);
+
+  syncState.syncType = SNTSyncTypeClean;
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeNormal));
+
+  syncState.syncType = SNTSyncTypeCleanAll;
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeNormal));
+}
+
+@end

--- a/Source/santasyncservice/SNTSyncConfigBundle.h
+++ b/Source/santasyncservice/SNTSyncConfigBundle.h
@@ -12,10 +12,16 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+#include <sys/cdefs.h>
+
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
+__BEGIN_DECLS
+
 SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState);
 SNTConfigBundle *RuleSyncConfigBundle();
 SNTConfigBundle *SyncTypeConfigBundle(SNTSyncType syncType);
+
+__END_DECLS

--- a/Source/santasyncservice/SNTSyncConfigBundle.h
+++ b/Source/santasyncservice/SNTSyncConfigBundle.h
@@ -17,3 +17,5 @@
 #import "Source/santasyncservice/SNTSyncState.h"
 
 SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState);
+SNTConfigBundle *RuleSyncConfigBundle();
+SNTConfigBundle *SyncTypeConfigBundle(SNTSyncType syncType);

--- a/Source/santasyncservice/SNTSyncConfigBundle.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundle.mm
@@ -12,7 +12,9 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#import "Source/santasyncservice/SNTPostflightConfigBundle.h"
+#import <Foundation/Foundation.h>
+
+#import "Source/santasyncservice/SNTSyncConfigBundle.h"
 
 // Expose necessary setters for SNTConfigBundle properties related to Postflight
 @interface SNTConfigBundle (ConfigBundleCreator)
@@ -27,6 +29,8 @@
 @property NSNumber *enableAllEventUpload;
 @property NSNumber *disableUnknownEventUpload;
 @property NSString *overrideFileAccessAction;
+@property NSDate *fullSyncLastSuccess;
+@property NSDate *ruleSyncLastSuccess;
 @end
 
 SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
@@ -43,6 +47,24 @@ SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
   bundle.enableAllEventUpload = syncState.enableAllEventUpload;
   bundle.disableUnknownEventUpload = syncState.disableUnknownEventUpload;
   bundle.overrideFileAccessAction = syncState.overrideFileAccessAction;
+
+  bundle.fullSyncLastSuccess = [NSDate now];
+
+  return bundle;
+}
+
+SNTConfigBundle *RuleSyncConfigBundle() {
+  SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
+
+  bundle.ruleSyncLastSuccess = [NSDate now];
+
+  return bundle;
+}
+
+SNTConfigBundle *SyncTypeConfigBundle(SNTSyncType syncType) {
+  SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
+
+  bundle.syncType = @(syncType);
 
   return bundle;
 }

--- a/Source/santasyncservice/SNTSyncConfigBundleTest.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundleTest.mm
@@ -33,6 +33,8 @@
 @property NSNumber *enableAllEventUpload;
 @property NSNumber *disableUnknownEventUpload;
 @property NSString *overrideFileAccessAction;
+@property NSDate *fullSyncLastSuccess;
+@property NSDate *ruleSyncLastSuccess;
 @end
 
 @interface SNTSyncConfigBundleTest : XCTestCase
@@ -40,7 +42,7 @@
 
 @implementation SNTSyncConfigBundleTest
 
-- (void)testInit {
+- (void)testPostflightConfigBundle {
   SNTConfigBundle *bundle;
   SNTSyncState *syncState = [[SNTSyncState alloc] init];
 
@@ -63,6 +65,52 @@
   syncState.syncType = SNTSyncTypeCleanAll;
   bundle = PostflightConfigBundle(syncState);
   XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeNormal));
+}
+
+- (void)testRuleSyncConfigBundle {
+  NSDate *curTime = [NSDate now];
+  SNTConfigBundle *bundle = RuleSyncConfigBundle();
+  XCTAssertGreaterThanOrEqual([bundle.ruleSyncLastSuccess timeIntervalSince1970],
+                              [curTime timeIntervalSince1970]);
+
+  XCTAssertNil(bundle.clientMode);
+  XCTAssertNil(bundle.syncType);
+  XCTAssertNil(bundle.allowlistRegex);
+  XCTAssertNil(bundle.blocklistRegex);
+  XCTAssertNil(bundle.blockUSBMount);
+  XCTAssertNil(bundle.remountUSBMode);
+  XCTAssertNil(bundle.enableBundles);
+  XCTAssertNil(bundle.enableTransitiveRules);
+  XCTAssertNil(bundle.enableAllEventUpload);
+  XCTAssertNil(bundle.disableUnknownEventUpload);
+  XCTAssertNil(bundle.overrideFileAccessAction);
+  XCTAssertNil(bundle.fullSyncLastSuccess);
+}
+
+- (void)testSyncTypeConfigBundle {
+  SNTConfigBundle *bundle;
+
+  bundle = SyncTypeConfigBundle(SNTSyncTypeNormal);
+  XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeNormal));
+
+  bundle = SyncTypeConfigBundle(SNTSyncTypeCleanAll);
+  XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeCleanAll));
+
+  bundle = SyncTypeConfigBundle(SNTSyncTypeClean);
+  XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeClean));
+
+  XCTAssertNil(bundle.clientMode);
+  XCTAssertNil(bundle.allowlistRegex);
+  XCTAssertNil(bundle.blocklistRegex);
+  XCTAssertNil(bundle.blockUSBMount);
+  XCTAssertNil(bundle.remountUSBMode);
+  XCTAssertNil(bundle.enableBundles);
+  XCTAssertNil(bundle.enableTransitiveRules);
+  XCTAssertNil(bundle.enableAllEventUpload);
+  XCTAssertNil(bundle.disableUnknownEventUpload);
+  XCTAssertNil(bundle.overrideFileAccessAction);
+  XCTAssertNil(bundle.fullSyncLastSuccess);
+  XCTAssertNil(bundle.ruleSyncLastSuccess);
 }
 
 @end

--- a/Source/santasyncservice/SNTSyncConfigBundleTest.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundleTest.mm
@@ -12,7 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#import "Source/santasyncservice/SNTPostflightConfigBundle.h"
+#import "Source/santasyncservice/SNTSyncConfigBundle.h"
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
@@ -35,10 +35,10 @@
 @property NSString *overrideFileAccessAction;
 @end
 
-@interface SNTPostflightConfigBundleTest : XCTestCase
+@interface SNTSyncConfigBundleTest : XCTestCase
 @end
 
-@implementation SNTPostflightConfigBundleTest
+@implementation SNTSyncConfigBundleTest
 
 - (void)testInit {
   SNTConfigBundle *bundle;

--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -29,6 +29,7 @@
 #import "Source/santasyncservice/SNTPushClientAPNS.h"
 #import "Source/santasyncservice/SNTPushClientFCM.h"
 #import "Source/santasyncservice/SNTPushNotifications.h"
+#import "Source/santasyncservice/SNTSyncConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncEventUpload.h"
 #import "Source/santasyncservice/SNTSyncLogging.h"
 #import "Source/santasyncservice/SNTSyncPostflight.h"
@@ -193,10 +194,10 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     SLOGI(@"Starting sync...");
     if (syncType != SNTSyncTypeNormal) {
       dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-      [[self.daemonConn remoteObjectProxy] setSyncTypeRequired:syncType
-                                                         reply:^() {
-                                                           dispatch_semaphore_signal(sema);
-                                                         }];
+      [[self.daemonConn remoteObjectProxy] updateSyncSettings:SyncTypeConfigBundle(syncType)
+                                                        reply:^() {
+                                                          dispatch_semaphore_signal(sema);
+                                                        }];
       if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC))) {
         SLOGE(@"Timeout waiting for daemon");
         if (reply) reply(SNTSyncStatusTypeDaemonTimeout);

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -19,6 +19,7 @@
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/common/String.h"
+#include "Source/santasyncservice/SNTPostflightConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
 #include <google/protobuf/arena.h>
@@ -50,79 +51,10 @@ using santa::NSStringToUTF8String;
   ::pbv1::PostflightResponse response;
   [self performRequest:[self requestWithMessage:req] intoMessage:&response timeout:30];
 
-  id<SNTDaemonControlXPC> rop = [self.daemonConn synchronousRemoteObjectProxy];
-
-  // Set client mode if it changed
-  if (self.syncState.clientMode) {
-    [rop setClientMode:self.syncState.clientMode
+  [[self.daemonConn synchronousRemoteObjectProxy]
+      postflightResult:PostflightConfigBundle(self.syncState)
                  reply:^{
                  }];
-  }
-
-  // Remove clean sync flag if we did a clean or clean all sync
-  if (self.syncState.syncType != SNTSyncTypeNormal) {
-    [rop setSyncTypeRequired:SNTSyncTypeNormal
-                       reply:^{
-                       }];
-  }
-
-  // Update allowlist/blocklist regexes
-  if (self.syncState.allowlistRegex) {
-    [rop setAllowedPathRegex:self.syncState.allowlistRegex
-                       reply:^{
-                       }];
-  }
-  if (self.syncState.blocklistRegex) {
-    [rop setBlockedPathRegex:self.syncState.blocklistRegex
-                       reply:^{
-                       }];
-  }
-
-  if (self.syncState.blockUSBMount != nil) {
-    [rop setBlockUSBMount:[self.syncState.blockUSBMount boolValue]
-                    reply:^{
-                    }];
-  }
-  if (self.syncState.remountUSBMode) {
-    [rop setRemountUSBMode:self.syncState.remountUSBMode
-                     reply:^{
-                     }];
-  }
-
-  if (self.syncState.enableBundles) {
-    [rop setEnableBundles:[self.syncState.enableBundles boolValue]
-                    reply:^{
-                    }];
-  }
-
-  if (self.syncState.enableTransitiveRules) {
-    [rop setEnableTransitiveRules:[self.syncState.enableTransitiveRules boolValue]
-                            reply:^{
-                            }];
-  }
-
-  if (self.syncState.enableAllEventUpload) {
-    [rop setEnableAllEventUpload:[self.syncState.enableAllEventUpload boolValue]
-                           reply:^{
-                           }];
-  }
-
-  if (self.syncState.disableUnknownEventUpload) {
-    [rop setDisableUnknownEventUpload:[self.syncState.disableUnknownEventUpload boolValue]
-                                reply:^{
-                                }];
-  }
-
-  if (self.syncState.overrideFileAccessAction) {
-    [rop setOverrideFileAccessAction:self.syncState.overrideFileAccessAction
-                               reply:^{
-                               }];
-  }
-
-  // Update last sync success
-  [rop setFullSyncLastSuccess:[NSDate date]
-                        reply:^{
-                        }];
 
   return YES;
 }

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -19,7 +19,7 @@
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/common/String.h"
-#import "Source/santasyncservice/SNTPostflightConfigBundle.h"
+#import "Source/santasyncservice/SNTSyncConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
 #include <google/protobuf/arena.h>
@@ -52,9 +52,9 @@ using santa::NSStringToUTF8String;
   [self performRequest:[self requestWithMessage:req] intoMessage:&response timeout:30];
 
   [[self.daemonConn synchronousRemoteObjectProxy]
-      postflightResult:PostflightConfigBundle(self.syncState)
-                 reply:^{
-                 }];
+      updateSyncSettings:PostflightConfigBundle(self.syncState)
+                   reply:^{
+                   }];
 
   return YES;
 }

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -19,7 +19,7 @@
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/common/String.h"
-#include "Source/santasyncservice/SNTPostflightConfigBundle.h"
+#import "Source/santasyncservice/SNTPostflightConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
 #include <google/protobuf/arena.h>

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -22,6 +22,7 @@
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/common/String.h"
 #import "Source/santasyncservice/SNTPushNotificationsTracker.h"
+#import "Source/santasyncservice/SNTSyncConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncLogging.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
@@ -79,10 +80,10 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 
   // Tell santad to record a successful rules sync and wait for it to finish.
   sema = dispatch_semaphore_create(0);
-  [[self.daemonConn remoteObjectProxy] setRuleSyncLastSuccess:[NSDate date]
-                                                        reply:^{
-                                                          dispatch_semaphore_signal(sema);
-                                                        }];
+  [[self.daemonConn remoteObjectProxy] updateSyncSettings:RuleSyncConfigBundle()
+                                                    reply:^{
+                                                      dispatch_semaphore_signal(sema);
+                                                    }];
   dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
 
   SLOGI(@"Processed %lu rules", newRules.count);

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -15,7 +15,7 @@
 
 #import "Source/santasyncservice/SNTSyncStage.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTCommonEnums.h"

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -864,7 +864,7 @@
   [self stubRequestBody:nil response:nil error:nil validateBlock:nil];
 
   XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop postflightResult:OCMOCK_ANY reply:OCMOCK_ANY]);
+  OCMVerify([self.daemonConnRop updateSyncSettings:OCMOCK_ANY reply:OCMOCK_ANY]);
 }
 
 @end

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -13,7 +13,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -14,9 +14,8 @@
 ///    limitations under the License.
 
 #include <Foundation/Foundation.h>
-#import <XCTest/XCTest.h>
-
 #import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
 
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTCommonEnums.h"
@@ -865,41 +864,7 @@
   [self stubRequestBody:nil response:nil error:nil validateBlock:nil];
 
   XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setFullSyncLastSuccess:OCMOCK_ANY reply:OCMOCK_ANY]);
-
-  self.syncState.clientMode = SNTClientModeMonitor;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setClientMode:SNTClientModeMonitor reply:OCMOCK_ANY]);
-
-  // For Clean syncs, the sync type required should be reset to normal
-  self.syncState.syncType = SNTSyncTypeClean;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setSyncTypeRequired:SNTSyncTypeNormal reply:OCMOCK_ANY]);
-
-  // For Clean All syncs, the sync type required should be reset to normal
-  self.syncState.syncType = SNTSyncTypeCleanAll;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setSyncTypeRequired:SNTSyncTypeNormal reply:OCMOCK_ANY]);
-
-  self.syncState.allowlistRegex = @"^horse$";
-  self.syncState.blocklistRegex = @"^donkey$";
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setAllowedPathRegex:@"^horse$" reply:OCMOCK_ANY]);
-  OCMVerify([self.daemonConnRop setBlockedPathRegex:@"^donkey$" reply:OCMOCK_ANY]);
-
-  self.syncState.blockUSBMount = @1;
-  self.syncState.remountUSBMode = @[ @"readonly" ];
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setBlockUSBMount:YES reply:OCMOCK_ANY]);
-  OCMVerify([self.daemonConnRop setRemountUSBMode:@[ @"readonly" ] reply:OCMOCK_ANY]);
-
-  self.syncState.blockUSBMount = @0;
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setBlockUSBMount:NO reply:OCMOCK_ANY]);
-
-  self.syncState.overrideFileAccessAction = @"Disable";
-  XCTAssertTrue([sut sync]);
-  OCMVerify([self.daemonConnRop setOverrideFileAccessAction:@"Disable" reply:OCMOCK_ANY]);
+  OCMVerify([self.daemonConnRop postflightResult:OCMOCK_ANY reply:OCMOCK_ANY]);
 }
 
 @end


### PR DESCRIPTION
This PR introduces the "config bundles" which are a way to generically refer to some config state that can be passed between components. This is then used to pass settings between the sync service and main Santa daemon.

Vacuuming the events database has been removed. The reason is that we now vacuum on startup. Given it would be extremely rare for the database to grow large, this only has the impact of adding database contention unnecessarily. Additionally, constantly shrinking the database, even on the "happy path", results in a performance penalty of having to keep grow and shrink things.


