### PR TITLE
Add handling for TCC Modify telemetry event

### DIFF
--- a/Source/common/Platform.h
+++ b/Source/common/Platform.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -21,14 +22,14 @@
     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_13_0
 #define HAVE_MACOS_13 1
 #else
-#define HAVE_MACOS_13 0
+#undef HAVE_MACOS_13
 #endif
 
 #if defined(MAC_OS_VERSION_14_0) && \
     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_14_0
 #define HAVE_MACOS_14 1
 #else
-#define HAVE_MACOS_14 0
+#undef HAVE_MACOS_14
 #endif
 
 // Note: MAC_OS_X_VERSION_MAX_ALLOWED (non-underscore version) stopped
@@ -37,7 +38,14 @@
     __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_15_0
 #define HAVE_MACOS_15 1
 #else
-#define HAVE_MACOS_15 0
+#undef HAVE_MACOS_15
+#endif
+
+#if defined(MAC_OS_VERSION_15_4) && \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_15_4
+#define HAVE_MACOS_15_4 1
+#else
+#undef HAVE_MACOS_15_4
 #endif
 
 #endif

--- a/Source/common/TelemetryEventMap.h
+++ b/Source/common/TelemetryEventMap.h
@@ -47,6 +47,7 @@ enum class TelemetryEvent : uint64_t {
   kCopyfile                = 1 << 19,
   kGatekeeperOverride      = 1 << 20,
   kLaunchItem              = 1 << 21,
+  kTCCModification         = 1 << 22,
   kEverything              = ~0ULL,
 };
 // clang-format on

--- a/Source/common/TelemetryEventMap.mm
+++ b/Source/common/TelemetryEventMap.mm
@@ -48,6 +48,7 @@ static inline TelemetryEvent EventNameToMask(std::string_view event) {
       {"copyfile", TelemetryEvent::kCopyfile},
       {"gatekeeperoverride", TelemetryEvent::kGatekeeperOverride},
       {"launchitem", TelemetryEvent::kLaunchItem},
+      {"tccmodification", TelemetryEvent::kTCCModification},
 
       // special cases
       {"none", TelemetryEvent::kNone},
@@ -110,6 +111,9 @@ TelemetryEvent ESEventToTelemetryEvent(es_event_type_t event) {
 #if HAVE_MACOS_15
     case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE: return TelemetryEvent::kGatekeeperOverride;
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+    case ES_EVENT_TYPE_NOTIFY_TCC_MODIFY: return TelemetryEvent::kTCCModification;
+#endif  // HAVE_MACOS_15_4
     default: return TelemetryEvent::kNone;
   }
 }

--- a/Source/common/TelemetryEventMapTest.mm
+++ b/Source/common/TelemetryEventMapTest.mm
@@ -57,6 +57,7 @@ using santa::TelemetryEvent;
       {"copyfile", TelemetryEvent::kCopyfile},
       {"gatekeeperoverride", TelemetryEvent::kGatekeeperOverride},
       {"LaunchItem", TelemetryEvent::kLaunchItem},
+      {"TCCModification", TelemetryEvent::kTCCModification},
 
       // special cases
       {"none", TelemetryEvent::kNone},
@@ -113,6 +114,9 @@ using santa::TelemetryEvent;
 #if HAVE_MACOS_15
       {ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE, TelemetryEvent::kGatekeeperOverride},
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+      {ES_EVENT_TYPE_NOTIFY_TCC_MODIFY, TelemetryEvent::kTCCModification},
+#endif  // HAVE_MACOS_15_4
   };
 
   // Ensure ESEventToTelemetryEvent returns TelemetryEvent::kNone for

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -297,7 +297,7 @@ message Execution {
     REASON_UNKNOWN = 0;
     REASON_BINARY = 1;
     REASON_CERT = 2;
-    REASON_COMPILER = 3 [deprecated=true];
+    REASON_COMPILER = 3 [deprecated = true];
     REASON_PENDING_TRANSITIVE = 5;
     REASON_SCOPE = 6;
     REASON_TEAM_ID = 7;
@@ -879,7 +879,6 @@ message AuthenticationAutoUnlock {
     TYPE_UNKNOWN = 0;
     // Unlock the machine using Apple Watch
     TYPE_MACHINE_UNLOCK = 1;
-
     // Approve an authorization prompt using Apple Watch
     TYPE_AUTH_PROMPT = 2;
   }
@@ -961,7 +960,7 @@ message LaunchItem {
     ACTION_UNKNOWN = 0;
     ACTION_ADD = 1;
     ACTION_REMOVE = 2;
-  };
+  }
   Action action = 2;
 
   // The process that triggered the BTM operation. One will always be set.
@@ -976,8 +975,8 @@ message LaunchItem {
 
   // The app the registered the launch item. This field is optional and it is
   // possible that neither case is set.
-  // Note: If the registering app has exited, only process id information will
-  // exist.
+  // Note: If the registering app has exited, only registrant_id information will
+  // exist. It is also possible no app information exists.
   oneof app {
     ProcessInfoLight registrant_process = 5;
     ProcessID registrant_id = 6;
@@ -1011,6 +1010,88 @@ message LaunchItem {
 
   // If available, associated executable path from a launch item's plist
   optional string executable_path = 13;
+}
+
+// Information captured when a TCC permission is granted or revoked.
+message TCCModification {
+  // The process that emitted the event
+  optional ProcessInfoLight instigator = 1;
+  // The TCC service for which permissions are being modified.
+  optional string service = 2;
+  // The identity of the application that is the subject of the permission.
+  optional string identity = 3;
+
+  // The identity type of an application which has access to a TCC service.
+  enum IdentityType {
+    IDENTITY_TYPE_UNKNOWN = 0;
+    IDENTITY_TYPE_BUNDLE_ID = 1;
+    IDENTITY_TYPE_EXECUTABLE_PATH = 2;
+    IDENTITY_TYPE_POLICY_ID = 3;
+    IDENTITY_TYPE_FILE_PROVIDER_DOMAIN_ID = 4;
+  }
+  optional IdentityType identity_type = 4;
+
+  // The type of TCC modification event.
+  enum EventType {
+    // Unknown prior state.
+    EVENT_TYPE_UNKNOWN = 0;
+    // A new TCC authorization record was created.
+    EVENT_TYPE_CREATE = 1;
+    // An existing TCC authorization record was modified.
+    EVENT_TYPE_MODIFY = 2;
+    // An existing TCC authorization record was deleted.
+    EVENT_TYPE_DELETE = 3;
+  }
+  optional EventType event_type = 5;
+
+  // The type of authorization permission an application has to a TCC Service.
+  enum AuthorizationRight {
+    AUTHORIZATION_RIGHT_UNKNOWN = 0;
+    AUTHORIZATION_RIGHT_DENIED = 1;
+    AUTHORIZATION_RIGHT_ALLOWED = 2;
+    AUTHORIZATION_RIGHT_LIMITED = 3;
+    AUTHORIZATION_RIGHT_ADD_MODIFY_ADDED = 4;
+    AUTHORIZATION_RIGHT_SESSION_PID = 5;
+    AUTHORIZATION_RIGHT_LEARN_MORE = 6;
+  }
+  optional AuthorizationRight authorization_right = 6;
+
+  // The reason a TCC permission was updated.
+  enum AuthorizationReason {
+    AUTHORIZATION_REASON_UNKNOWN = 0;
+   AUTHORIZATION_REASON_NONE = 1;
+    AUTHORIZATION_REASON_ERROR = 2;
+    AUTHORIZATION_REASON_USER_CONSENT = 3;
+    AUTHORIZATION_REASON_USER_SET = 4;
+    AUTHORIZATION_REASON_SYSTEM_SET = 5;
+    AUTHORIZATION_REASON_SERVICE_POLICY = 6;
+    AUTHORIZATION_REASON_MDM_POLICY = 7;
+    AUTHORIZATION_REASON_SERVICE_OVERRIDE_POLICY = 8;
+    AUTHORIZATION_REASON_MISSING_USAGE_STRING = 9;
+    AUTHORIZATION_REASON_PROMPT_TIMEOUT = 10;
+    AUTHORIZATION_REASON_PREFLIGHT_UNKNOWN = 11;
+    AUTHORIZATION_REASON_ENTITLED = 12;
+    AUTHORIZATION_REASON_APP_TYPE_POLICY = 13;
+    AUTHORIZATION_REASON_PROMPT_CANCEL = 14;
+  }
+  optional AuthorizationReason authorization_reason = 7;
+
+  // The process that triggered the TCC event.
+  // Note: Due to macOS system limitations, the process that triggered the
+  // event may have already exited before the event could be generated. This
+  // results in only a small subset of the information from the triggering
+  // process to be reported.
+  oneof tcc_instigator {
+    ProcessInfoLight trigger_process = 8;
+    ProcessID trigger_id = 9;
+  }
+
+  // The responsible process for the process that triggered the TCC event.
+  // This field is completely optional and it's possible neither field is set.
+  oneof responsible_instigator {
+    ProcessInfoLight responsible_process = 10;
+    ProcessID responsible_id = 11;
+  }
 }
 
 // A message encapsulating a single event
@@ -1053,6 +1134,7 @@ message SantaMessage {
     Copyfile copyfile = 29;
     GatekeeperOverride gatekeeper_override = 30;
     LaunchItem launch_item = 31;
+    TCCModification tcc_modification = 32;
   }
 }
 

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -1059,7 +1059,7 @@ message TCCModification {
   // The reason a TCC permission was updated.
   enum AuthorizationReason {
     AUTHORIZATION_REASON_UNKNOWN = 0;
-   AUTHORIZATION_REASON_NONE = 1;
+    AUTHORIZATION_REASON_NONE = 1;
     AUTHORIZATION_REASON_ERROR = 2;
     AUTHORIZATION_REASON_USER_CONSENT = 3;
     AUTHORIZATION_REASON_USER_SET = 4;

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -177,6 +177,12 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
               ? std::make_optional(Enrich(*es_msg->event.gatekeeper_user_override->file.file))
               : std::nullopt));
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+    case ES_EVENT_TYPE_NOTIFY_TCC_MODIFY:
+      return std::make_unique<EnrichedMessage>(EnrichedTCCModification(
+          std::move(es_msg), Enrich(*es_msg->process), Enrich(es_msg->event.tcc_modify->instigator),
+          Enrich(es_msg->event.tcc_modify->responsible)));
+#endif  // HAVE_MACOS_15_4
     default:
       // This is a programming error
       LOGE(@"Attempting to enrich an unhandled event type: %d", es_msg->event_type);

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -235,6 +235,12 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
     events.insert(ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE);
   }
 #endif  // HAVE_MACOS_15
+
+#if HAVE_MACOS_15_4
+  if (@available(macOS 15.4, *)) {
+    events.insert(ES_EVENT_TYPE_NOTIFY_TCC_MODIFY);
+  }
+#endif  // HAVE_MACOS_15_4
   // clang-format on
 
   [super subscribe:events];

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -116,6 +116,12 @@ class MockAuthResultCache : public AuthResultCache {
   }
 #endif  // HAVE_MACOS_15
 
+#if HAVE_MACOS_15_4
+  if (@available(macOS 15.4, *)) {
+    expectedEventSubs.insert(ES_EVENT_TYPE_NOTIFY_TCC_MODIFY);
+  }
+#endif  // HAVE_MACOS_15_4
+
   return expectedEventSubs;
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -17,6 +17,7 @@
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_BASICSTRING_H
 
 #import <Foundation/Foundation.h>
+#include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 
 #include <memory>
 #include <sstream>
@@ -70,6 +71,9 @@ class BasicString : public Serializer {
 #if HAVE_MACOS_15
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedTCCModification &) override;
+#endif  // HAVE_MACOS_15_4
 
   std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -939,6 +939,18 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedGatekeeperOverr
 
 #endif  // HAVE_MACOS_15
 
+#if HAVE_MACOS_15_4
+
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedTCCModification &msg) {
+  std::string str = CreateDefaultString();
+
+  str.append("action=TCC_MODIFICATION");
+
+  return FinalizeString(str);
+}
+
+#endif  // HAVE_MACOS_15_4
+
 std::vector<uint8_t> BasicString::SerializeFileAccess(
     const std::string &policy_version, const std::string &policy_name, const Message &msg,
     const EnrichedProcess &enriched_process, const std::string &target,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -63,6 +63,9 @@ class Empty : public Serializer {
 #if HAVE_MACOS_15
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedTCCModification &) override;
+#endif  // HAVE_MACOS_15_4
 
   std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -139,6 +139,14 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedGatekeeperOverride &)
 
 #endif  // HAVE_MACOS_15
 
+#if HAVE_MACOS_15_4
+
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedTCCModification &) {
+  return {};
+}
+
+#endif  // HAVE_MACOS_15_4
+
 std::vector<uint8_t> Empty::SerializeFileAccess(const std::string &policy_version,
                                                 const std::string &policy_name, const Message &msg,
                                                 const EnrichedProcess &enriched_process,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -70,6 +70,9 @@ class Protobuf : public Serializer {
 #if HAVE_MACOS_15
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+  std::vector<uint8_t> SerializeMessage(const santa::EnrichedTCCModification &) override;
+#endif  // HAVE_MACOS_15_4
 
   std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -1185,6 +1185,14 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedGatekeeperOverride
 
 #endif  // HAVE_MACOS_15
 
+#if HAVE_MACOS_15_4
+
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedTCCModification &msg) {
+  return {};
+}
+
+#endif  // HAVE_MACOS_15_4
+
 std::vector<uint8_t> Protobuf::SerializeFileAccess(
     const std::string &policy_version, const std::string &policy_name, const Message &msg,
     const EnrichedProcess &enriched_process, const std::string &target,

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -85,6 +85,9 @@ class Serializer {
 #if HAVE_MACOS_15
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) = 0;
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+  virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedTCCModification &) = 0;
+#endif  // HAVE_MACOS_15_4
 
   virtual std::vector<uint8_t> SerializeFileAccess(
       const std::string &policy_version, const std::string &policy_name, const santa::Message &msg,

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -77,6 +77,9 @@ static NSString *const kEventTypeNotifyLaunchItemRemove = @"NotifyLaunchItemRemo
 #if HAVE_MACOS_15
 static NSString *const kEventTypeNotifyGatekeeperOverride = @"NotifyGatekeeperOverride";
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+static NSString *const kEventTypeNotifyTCCModification = @"NotifyTCCModification";
+#endif  // HAVE_MACOS_15_4
 
 static NSString *const kEventDispositionDropped = @"Dropped";
 static NSString *const kEventDispositionProcessed = @"Processed";
@@ -163,6 +166,9 @@ NSString *const EventTypeToString(es_event_type_t eventType) {
 #if HAVE_MACOS_15
     case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE: return kEventTypeNotifyGatekeeperOverride;
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+    case ES_EVENT_TYPE_NOTIFY_TCC_MODIFY: return kEventTypeNotifyTCCModification;
+#endif  // HAVE_MACOS_15_4
     case ES_EVENT_TYPE_LAST: return kPseudoEventTypeGlobal;
     default:
       [NSException raise:@"Invalid event type" format:@"Invalid event type: %d", eventType];

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -204,6 +204,9 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
 #if HAVE_MACOS_15
       {ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE, @"NotifyGatekeeperOverride"},
 #endif  // HAVE_MACOS_15
+#if HAVE_MACOS_15_4
+      {ES_EVENT_TYPE_NOTIFY_TCC_MODIFY, @"NotifyTCCModification"},
+#endif  // HAVE_MACOS_15_4
       {ES_EVENT_TYPE_LAST, @"Global"},
   };
 


### PR DESCRIPTION
Adds initial support for the TCC Modify ES event type. Serialization support will come in a followup PR to keep sizes smaller.

Part of #326 
