### PR TITLE
project: Fix build visibility

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -2,6 +2,8 @@ load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "objc_library")
 load("//:helper.bzl", "santa_unit_test")
 
+# Common is the folder containing all the code that's shared between multiple
+# components, so every library in this package is visible to the whole group.
 package(
     default_visibility = ["//:santa_package_group"],
 )

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -5,10 +5,6 @@ load("//:helper.bzl", "santa_unit_test")
 
 licenses(["notice"])
 
-package(
-    default_visibility = ["//:santa_package_group"],
-)
-
 swift_library(
     name = "SNTMessageView",
     srcs = ["SNTMessageView.swift"],

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -3,10 +3,6 @@ load("@rules_cc//cc:defs.bzl", "objc_library")
 
 licenses(["notice"])
 
-package(
-    default_visibility = ["//:santa_package_group"],
-)
-
 objc_library(
     name = "santabs_lib",
     srcs = [

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -4,10 +4,6 @@ load("//:helper.bzl", "santa_unit_test")
 
 licenses(["notice"])
 
-package(
-    default_visibility = ["//:santa_package_group"],
-)
-
 objc_library(
     name = "santactl_cmd",
     srcs = [
@@ -93,7 +89,6 @@ objc_library(
         "//Source/common:SNTXPCSyncServiceInterface",
         "//Source/common:SNTXPCUnprivilegedControlInterface",
         "//Source/common:SigningIDHelpers",
-        "//Source/santasyncservice:sync_lib",
         "@FMDB",
     ],
 )
@@ -116,6 +111,7 @@ macos_command_line_application(
         "//conditions:default": "//profiles:santa_dev",
     }),
     version = "//:version",
+    visibility = ["//:santa_package_group"],
     deps = [":santactl_lib"],
 )
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//:helper.bzl", "santa_unit_test")
 
 package(
-    default_visibility = ["//:santa_package_group"],
+    default_visibility = [":__subpackages__"],
 )
 
 licenses(["notice"])
@@ -635,6 +635,9 @@ objc_library(
     hdrs = ["Logs/EndpointSecurity/Serializers/Utilities.h"],
     sdk_dylibs = [
         "bsm",
+    ],
+    visibility = [
+        "//Source/common:__pkg__",
     ],
     deps = [
         ":EndpointSecurityMessage",

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -2,10 +2,6 @@ load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_applicatio
 load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//:helper.bzl", "santa_unit_test")
 
-package(
-    default_visibility = ["//:santa_package_group"],
-)
-
 licenses(["notice"])
 
 objc_library(

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -4,10 +4,6 @@ load("//:helper.bzl", "santa_unit_test")
 
 licenses(["notice"])
 
-package(
-    default_visibility = ["//:santa_package_group"],
-)
-
 objc_library(
     name = "FCM_lib",
     srcs = ["SNTSyncFCM.m"],


### PR DESCRIPTION
Stop exporting all build rules to the entire project. Allow access in the few places where it's absolutely needed.