### PR TITLE
Fix serializing wrong field for LaunchItem Add registrant info

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -1059,8 +1059,9 @@ std::vector<uint8_t> Protobuf::SerializeMessageLaunchItemAdd(const EnrichedLaunc
   EncodeEventInstigatorOrFallback(
       msg, [pb_launch_item] { return pb_launch_item->mutable_trigger_process(); },
       [pb_launch_item] { return pb_launch_item->mutable_trigger_id(); });
-  EncodeEventInstigatorOrFallback(
-      msg, [pb_launch_item] { return pb_launch_item->mutable_registrant_process(); },
+  EncodeEventProcessOrFallback(
+      msg, msg.AppRegistrant(), msg.AppRegistrantToken(), msg.EnrichedAppRegistrant(),
+      [pb_launch_item] { return pb_launch_item->mutable_registrant_process(); },
       [pb_launch_item] { return pb_launch_item->mutable_registrant_id(); });
 
   pb_launch_item->set_item_type(GetBTMLaunchItemType(btm->item->item_type));

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -1327,7 +1327,7 @@ void SerializeAndCheckNonESEvents(
 
   es_file_t instigatorAppFile = MakeESFile("fooApp");
   es_process_t instigatorApp =
-      MakeESProcess(&instigatorAppFile, MakeAuditToken(21, 43), MakeAuditToken(65, 87));
+      MakeESProcess(&instigatorAppFile, MakeAuditToken(22, 33), MakeAuditToken(44, 55));
 #if HAVE_MACOS_15
   audit_token_t tokInst = MakeAuditToken(654, 321);
   audit_token_t tokApp = MakeAuditToken(111, 222);
@@ -1379,6 +1379,15 @@ void SerializeAndCheckNonESEvents(
                     esMsg->event.btm_launch_item_add = &launchItem;
                   }
                        variant:@"relative_null_app"];
+
+  launchItem.app = NULL;
+  launchItem.instigator = &instigatorProc;
+  [self serializeAndCheckEvent:ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD
+                  messageSetup:^(std::shared_ptr<MockEndpointSecurityAPI> mockESApi,
+                                 es_message_t *esMsg) {
+                    esMsg->event.btm_launch_item_add = &launchItem;
+                  }
+                       variant:@"null_app"];
 }
 
 - (void)testSerializeMessageLaunchItemRemove {

--- a/Source/santad/testdata/protobuf/v6/launch_item_add.json
+++ b/Source/santad/testdata/protobuf/v6/launch_item_add.json
@@ -68,14 +68,14 @@
  },
  "registrant_process": {
   "id": {
-   "pid": 21,
-   "pidversion": 43
+   "pid": 22,
+   "pidversion": 33
   },
   "parent_id": {
-   "pid": 65,
-   "pidversion": 87
+   "pid": 44,
+   "pidversion": 55
   },
-  "original_parent_pid": 65,
+  "original_parent_pid": 44,
   "group_id": 111,
   "session_id": 222,
   "effective_user": {
@@ -95,7 +95,7 @@
    "name": "nogroup"
   },
   "executable": {
-   "path": "fooInst",
+   "path": "fooApp",
    "truncated": false
   }
  },

--- a/Source/santad/testdata/protobuf/v6/launch_item_add_null_app.json
+++ b/Source/santad/testdata/protobuf/v6/launch_item_add_null_app.json
@@ -33,20 +33,16 @@
   }
  },
  "action": "ACTION_ADD",
- "trigger_id": {
-  "pid": 654,
-  "pidversion": 321
- },
- "registrant_process": {
+ "trigger_process": {
   "id": {
-   "pid": 22,
-   "pidversion": 33
+   "pid": 21,
+   "pidversion": 43
   },
   "parent_id": {
-   "pid": 44,
-   "pidversion": 55
+   "pid": 65,
+   "pidversion": 87
   },
-  "original_parent_pid": 44,
+  "original_parent_pid": 65,
   "group_id": 111,
   "session_id": 222,
   "effective_user": {
@@ -66,18 +62,17 @@
    "name": "nogroup"
   },
   "executable": {
-   "path": "fooApp",
+   "path": "fooInst",
    "truncated": false
   }
  },
- "item_type": "ITEM_TYPE_DAEMON",
+ "item_type": "ITEM_TYPE_AGENT",
  "legacy": true,
  "managed": false,
  "item_user": {
   "uid": -2,
   "name": "nobody"
  },
- "item_path": "/path/url/relative/path",
- "app_path": "/path/url",
- "executable_path": "/path/url/exec_path"
+ "item_path": "relative/path",
+ "executable_path": "exec_path"
 }

--- a/Source/santad/testdata/protobuf/v6/launch_item_add_relative.json
+++ b/Source/santad/testdata/protobuf/v6/launch_item_add_relative.json
@@ -33,6 +33,39 @@
   }
  },
  "action": "ACTION_ADD",
+ "registrant_process": {
+  "id": {
+   "pid": 22,
+   "pidversion": 33
+  },
+  "parent_id": {
+   "pid": 44,
+   "pidversion": 55
+  },
+  "original_parent_pid": 44,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "fooApp",
+   "truncated": false
+  }
+ },
  "item_type": "ITEM_TYPE_DAEMON",
  "legacy": true,
  "managed": false,

--- a/Source/santad/testdata/protobuf/v6/launch_item_add_relative_null_app.json
+++ b/Source/santad/testdata/protobuf/v6/launch_item_add_relative_null_app.json
@@ -33,6 +33,39 @@
   }
  },
  "action": "ACTION_ADD",
+ "registrant_process": {
+  "id": {
+   "pid": 22,
+   "pidversion": 33
+  },
+  "parent_id": {
+   "pid": 44,
+   "pidversion": 55
+  },
+  "original_parent_pid": 44,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "fooApp",
+   "truncated": false
+  }
+ },
  "item_type": "ITEM_TYPE_AGENT",
  "legacy": true,
  "managed": false,

--- a/Source/santad/testdata/protobuf/v7/launch_item_add.json
+++ b/Source/santad/testdata/protobuf/v7/launch_item_add.json
@@ -68,14 +68,14 @@
  },
  "registrant_process": {
   "id": {
-   "pid": 21,
-   "pidversion": 43
+   "pid": 22,
+   "pidversion": 33
   },
   "parent_id": {
-   "pid": 65,
-   "pidversion": 87
+   "pid": 44,
+   "pidversion": 55
   },
-  "original_parent_pid": 65,
+  "original_parent_pid": 44,
   "group_id": 111,
   "session_id": 222,
   "effective_user": {
@@ -95,7 +95,7 @@
    "name": "nogroup"
   },
   "executable": {
-   "path": "fooInst",
+   "path": "fooApp",
    "truncated": false
   }
  },

--- a/Source/santad/testdata/protobuf/v7/launch_item_add_null_app.json
+++ b/Source/santad/testdata/protobuf/v7/launch_item_add_null_app.json
@@ -33,20 +33,16 @@
   }
  },
  "action": "ACTION_ADD",
- "trigger_id": {
-  "pid": 654,
-  "pidversion": 321
- },
- "registrant_process": {
+ "trigger_process": {
   "id": {
-   "pid": 22,
-   "pidversion": 33
+   "pid": 21,
+   "pidversion": 43
   },
   "parent_id": {
-   "pid": 44,
-   "pidversion": 55
+   "pid": 65,
+   "pidversion": 87
   },
-  "original_parent_pid": 44,
+  "original_parent_pid": 65,
   "group_id": 111,
   "session_id": 222,
   "effective_user": {
@@ -66,18 +62,17 @@
    "name": "nogroup"
   },
   "executable": {
-   "path": "fooApp",
+   "path": "fooInst",
    "truncated": false
   }
  },
- "item_type": "ITEM_TYPE_DAEMON",
+ "item_type": "ITEM_TYPE_AGENT",
  "legacy": true,
  "managed": false,
  "item_user": {
   "uid": -2,
   "name": "nobody"
  },
- "item_path": "/path/url/relative/path",
- "app_path": "/path/url",
- "executable_path": "/path/url/exec_path"
+ "item_path": "relative/path",
+ "executable_path": "exec_path"
 }

--- a/Source/santad/testdata/protobuf/v7/launch_item_add_relative.json
+++ b/Source/santad/testdata/protobuf/v7/launch_item_add_relative.json
@@ -33,6 +33,39 @@
   }
  },
  "action": "ACTION_ADD",
+ "registrant_process": {
+  "id": {
+   "pid": 22,
+   "pidversion": 33
+  },
+  "parent_id": {
+   "pid": 44,
+   "pidversion": 55
+  },
+  "original_parent_pid": 44,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "fooApp",
+   "truncated": false
+  }
+ },
  "item_type": "ITEM_TYPE_DAEMON",
  "legacy": true,
  "managed": false,

--- a/Source/santad/testdata/protobuf/v7/launch_item_add_relative_null_app.json
+++ b/Source/santad/testdata/protobuf/v7/launch_item_add_relative_null_app.json
@@ -33,6 +33,39 @@
   }
  },
  "action": "ACTION_ADD",
+ "registrant_process": {
+  "id": {
+   "pid": 22,
+   "pidversion": 33
+  },
+  "parent_id": {
+   "pid": 44,
+   "pidversion": 55
+  },
+  "original_parent_pid": 44,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "fooApp",
+   "truncated": false
+  }
+ },
  "item_type": "ITEM_TYPE_AGENT",
  "legacy": true,
  "managed": false,

--- a/Source/santad/testdata/protobuf/v8/launch_item_add.json
+++ b/Source/santad/testdata/protobuf/v8/launch_item_add.json
@@ -68,14 +68,14 @@
  },
  "registrant_process": {
   "id": {
-   "pid": 21,
-   "pidversion": 43
+   "pid": 22,
+   "pidversion": 33
   },
   "parent_id": {
-   "pid": 65,
-   "pidversion": 87
+   "pid": 44,
+   "pidversion": 55
   },
-  "original_parent_pid": 65,
+  "original_parent_pid": 44,
   "group_id": 111,
   "session_id": 222,
   "effective_user": {
@@ -95,7 +95,7 @@
    "name": "nogroup"
   },
   "executable": {
-   "path": "fooInst",
+   "path": "fooApp",
    "truncated": false
   }
  },

--- a/Source/santad/testdata/protobuf/v8/launch_item_add_null_app.json
+++ b/Source/santad/testdata/protobuf/v8/launch_item_add_null_app.json
@@ -33,20 +33,16 @@
   }
  },
  "action": "ACTION_ADD",
- "trigger_id": {
-  "pid": 654,
-  "pidversion": 321
- },
- "registrant_process": {
+ "trigger_process": {
   "id": {
-   "pid": 22,
-   "pidversion": 33
+   "pid": 21,
+   "pidversion": 43
   },
   "parent_id": {
-   "pid": 44,
-   "pidversion": 55
+   "pid": 65,
+   "pidversion": 87
   },
-  "original_parent_pid": 44,
+  "original_parent_pid": 65,
   "group_id": 111,
   "session_id": 222,
   "effective_user": {
@@ -66,18 +62,21 @@
    "name": "nogroup"
   },
   "executable": {
-   "path": "fooApp",
+   "path": "fooInst",
    "truncated": false
   }
  },
- "item_type": "ITEM_TYPE_DAEMON",
+ "registrant_id": {
+  "pid": 111,
+  "pidversion": 222
+ },
+ "item_type": "ITEM_TYPE_AGENT",
  "legacy": true,
  "managed": false,
  "item_user": {
   "uid": -2,
   "name": "nobody"
  },
- "item_path": "/path/url/relative/path",
- "app_path": "/path/url",
- "executable_path": "/path/url/exec_path"
+ "item_path": "relative/path",
+ "executable_path": "exec_path"
 }

--- a/Source/santad/testdata/protobuf/v8/launch_item_add_relative_null_app.json
+++ b/Source/santad/testdata/protobuf/v8/launch_item_add_relative_null_app.json
@@ -37,9 +37,38 @@
   "pid": 654,
   "pidversion": 321
  },
- "registrant_id": {
-  "pid": 654,
-  "pidversion": 321
+ "registrant_process": {
+  "id": {
+   "pid": 22,
+   "pidversion": 33
+  },
+  "parent_id": {
+   "pid": 44,
+   "pidversion": 55
+  },
+  "original_parent_pid": 44,
+  "group_id": 111,
+  "session_id": 222,
+  "effective_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "effective_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "real_user": {
+   "uid": -2,
+   "name": "nobody"
+  },
+  "real_group": {
+   "gid": -1,
+   "name": "nogroup"
+  },
+  "executable": {
+   "path": "fooApp",
+   "truncated": false
+  }
  },
  "item_type": "ITEM_TYPE_AGENT",
  "legacy": true,


### PR DESCRIPTION
Fixes an issue where the wrong info was encoded for the app registrant field in LaunchItem Add events in #322. LaunchItem Remove events were done correctly.