### PR TITLE
Create a new build and entitlements for live debugging

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -50,10 +50,9 @@ config_setting(
 # Used for live debugging with SIP enabled.
 config_setting(
     name = "debugger_build",
-    values = {"define": "SANTA_BUILD_TYPE=debug"},
+    values = {"define": "SANTA_BUILD_TYPE=debugger"},
     visibility = [":santa_package_group"],
 )
-
 
 # Used to detect optimized builds
 config_setting(

--- a/BUILD
+++ b/BUILD
@@ -46,6 +46,15 @@ config_setting(
     visibility = [":santa_package_group"],
 )
 
+# Production signed but has get-task-allow
+# Used for live debugging with SIP enabled.
+config_setting(
+    name = "debugger_build",
+    values = {"define": "SANTA_BUILD_TYPE=debug"},
+    visibility = [":santa_package_group"],
+)
+
+
 # Used to detect optimized builds
 config_setting(
     name = "opt_build",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -982,8 +982,8 @@ macos_bundle(
     ],
     entitlements = select({
         "//:adhoc_build": "com.northpolesec.santa.daemon.systemextension-adhoc.entitlements",
-        # Non-adhoc builds get their entitlements from the provisioning profile.
         "//:debugger_build": "com.northpolesec.santa.daemon.systemextension-debugger.entitlements",
+        # By default builds get their entitlements from the provisioning profile.
         "//conditions:default": None,
     }),
     infoplists = [

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -983,6 +983,7 @@ macos_bundle(
     entitlements = select({
         "//:adhoc_build": "com.northpolesec.santa.daemon.systemextension-adhoc.entitlements",
         # Non-adhoc builds get their entitlements from the provisioning profile.
+        "//:debugger_build": "com.northpolesec.santa.daemon.systemextension-debugger.entitlements",
         "//conditions:default": None,
     }),
     infoplists = [

--- a/Source/santad/com.northpolesec.santa.daemon.systemextension-debugger.entitlements
+++ b/Source/santad/com.northpolesec.santa.daemon.systemextension-debugger.entitlements
@@ -4,13 +4,13 @@
 <dict>
         <key>com.apple.security.get-task-allow</key>
         <true/>
-	<key>com.apple.developer.endpoint-security.client</key>
-	<true/>
+        <key>com.apple.developer.endpoint-security.client</key>
+        <true/>
         <key>com.apple.application-identifier</key>
         <string>ZMCG7MLDV9.com.northpolesec.santa.daemon</string>
         <key>keychain-access-groups</key>
         <array>
-           <string>ZMCG7MLDV9.com.northpolesec.santa.daemon</string> 
+          <string>ZMCG7MLDV9.com.northpolesec.santa.daemon</string> 
         </array>
         <key>com.apple.developer.team-identifier</key>
         <string>ZMCG7MLDV9</string>

--- a/Source/santad/com.northpolesec.santa.daemon.systemextension-debugger.entitlements
+++ b/Source/santad/com.northpolesec.santa.daemon.systemextension-debugger.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>com.apple.security.get-task-allow</key>
+        <true/>
+	<key>com.apple.developer.endpoint-security.client</key>
+	<true/>
+        <key>com.apple.application-identifier</key>
+        <string>ZMCG7MLDV9.com.northpolesec.santa.daemon</string>
+        <key>keychain-access-groups</key>
+        <array>
+           <string>ZMCG7MLDV9.com.northpolesec.santa.daemon</string> 
+        </array>
+        <key>com.apple.developer.team-identifier</key>
+        <string>ZMCG7MLDV9</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds a new build target that lets you add the `com.apple.security.get-task-allow` entitlement to your Santa builds so you can debug them with lldb or other tools with SIP enabled by adding the `--define=SANTA_BUILD_TYPE=debugger` flag

e.g.

`$  bazel build --define=SANTA_BUILD_TYPE=debugger -c opt //:release`