### PR TITLE
Stats state

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -757,4 +757,22 @@
 ///
 - (nullable NSArray *)validateConfiguration;
 
+#pragma mark Stats Submission State
+
+///
+/// Timestamp of the last time a stats submission was attempted
+///
+@property(nullable, readonly, nonatomic) NSDate *lastStatsSubmissionTimestamp;
+
+///
+/// Santa version information from the last time a stats submission was attempted
+///
+@property(nullable, readonly, nonatomic) NSString *lastStatsSubmissionVersion;
+
+///
+/// Update the stats state file
+///
+- (void)saveStatsSubmissionAttemptTime:(nullable NSDate *)timestamp
+                               version:(nullable NSString *)version;
+
 @end

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -54,7 +54,10 @@ static NSArray<NSString *> *EnsureArrayOfStrings(id obj) {
 @property(atomic) NSDictionary *cachedStaticRules;
 
 @property(readonly, nonatomic) NSString *syncStateFilePath;
-@property(nonatomic, copy) BOOL (^syncStateAccessAuthorizerBlock)();
+@property(readonly, nonatomic) NSString *statsStateFilePath;
+
+typedef BOOL (^StateFileAccessAuthorizer)(void);
+@property(nonatomic, copy) StateFileAccessAuthorizer syncStateAccessAuthorizerBlock;
 
 @end
 
@@ -62,6 +65,13 @@ static NSArray<NSString *> *EnsureArrayOfStrings(id obj) {
 
 /// The hard-coded path to the sync state file.
 NSString *const kSyncStateFilePath = @"/var/db/santa/sync-state.plist";
+
+/// The hard-coded path to the stats state file.
+NSString *const kStatsStateFilePath = @"/var/db/santa/stats-state.plist";
+
+/// Keys associated with the stats state file.
+static NSString *const kLastStatsSubmissionAttemptKey = @"LastAttempt";
+static NSString *const kLastStatsSubmissionVersionKey = @"LastVersion";
 
 #ifdef DEBUG
 NSString *const kConfigOverrideFilePath = @"/var/db/santa/config-overrides.plist";
@@ -181,14 +191,21 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 
 - (instancetype)init {
   return [self initWithSyncStateFile:kSyncStateFilePath
-           syncStateAccessAuthorizer:^BOOL() {
-             // Only access the sync state if a sync server is configured and running as root
-             return self.syncBaseURL != nil && geteuid() == 0;
-           }];
+      statsStateFile:kStatsStateFilePath
+      syncStateAccessAuthorizer:^BOOL() {
+        // Only access the sync state if a sync server is configured and running as root
+        return self.syncBaseURL != nil && geteuid() == 0;
+      }
+      statsStateAccessAuthorizer:^BOOL() {
+        NSLog(@"Check stat state auth - euid: %d (%s)", geteuid(), getprogname());
+        return geteuid() == 0;
+      }];
 }
 
 - (instancetype)initWithSyncStateFile:(NSString *)syncStateFilePath
-            syncStateAccessAuthorizer:(BOOL (^)(void))syncStateAccessAuthorizer {
+                       statsStateFile:(NSString *)statsStateFilePath
+            syncStateAccessAuthorizer:(StateFileAccessAuthorizer)syncStateAccessAuthorizer
+           statsStateAccessAuthorizer:(StateFileAccessAuthorizer)statsStateAccessAuthorizer {
   self = [super init];
   if (self) {
     Class number = [NSNumber class];
@@ -302,6 +319,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
     };
 
     _syncStateFilePath = syncStateFilePath;
+    _statsStateFilePath = statsStateFilePath;
     _syncStateAccessAuthorizerBlock = syncStateAccessAuthorizer;
 
     // This is used to keep KVO on changes, but we use `CFPreferences*` for reading.
@@ -316,6 +334,8 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
       // Save the updated sync state if any keys were migrated.
       [self saveSyncStateToDisk];
     }
+
+    [self readStatsStateFromDisk:statsStateAccessAuthorizer];
 
     _debugFlag = [[NSProcessInfo processInfo].arguments containsObject:@"--debug"];
     [self startWatchingDefaults];
@@ -1353,6 +1373,33 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (NSArray *)entitlementsTeamIDFilter {
   return EnsureArrayOfStrings(self.configState[kEntitlementsTeamIDFilterKey]);
+}
+
+- (void)readStatsStateFromDisk:(StateFileAccessAuthorizer)statsStateAccessAuthorizerBlock {
+  if (!statsStateAccessAuthorizerBlock()) {
+    return;
+  }
+
+  NSDictionary *state = [NSDictionary dictionaryWithContentsOfFile:self.statsStateFilePath];
+
+  if ([state[kLastStatsSubmissionAttemptKey] isKindOfClass:[NSDate class]]) {
+    _lastStatsSubmissionTimestamp = state[kLastStatsSubmissionAttemptKey];
+  }
+
+  if ([state[kLastStatsSubmissionVersionKey] isKindOfClass:[NSString class]]) {
+    _lastStatsSubmissionVersion = state[kLastStatsSubmissionVersionKey];
+  }
+}
+
+- (void)saveStatsSubmissionAttemptTime:(NSDate *)timestamp version:(NSString *)version {
+  NSMutableDictionary *state = [[NSMutableDictionary alloc] init];
+  state[kLastStatsSubmissionAttemptKey] = timestamp;
+  state[kLastStatsSubmissionVersionKey] = version;
+
+  [state writeToFile:self.statsStateFilePath atomically:YES];
+
+  _lastStatsSubmissionTimestamp = timestamp;
+  _lastStatsSubmissionVersion = version;
 }
 
 #pragma mark - Private Defaults Methods

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -197,7 +197,6 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
         return self.syncBaseURL != nil && geteuid() == 0;
       }
       statsStateAccessAuthorizer:^BOOL() {
-        NSLog(@"Check stat state auth - euid: %d (%s)", geteuid(), getprogname());
         return geteuid() == 0;
       }];
 }

--- a/Source/common/SNTConfiguratorTest.m
+++ b/Source/common/SNTConfiguratorTest.m
@@ -18,9 +18,13 @@
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigurator.h"
 
+typedef BOOL (^StateFileAccessAuthorizer)(void);
+
 @interface SNTConfigurator (Testing)
 - (instancetype)initWithSyncStateFile:(NSString *)syncStateFilePath
-            syncStateAccessAuthorizer:(BOOL (^)(void))syncStateAccessAuthorizer;
+                       statsStateFile:(NSString *)statsStateFilePath
+            syncStateAccessAuthorizer:(StateFileAccessAuthorizer)syncStateAccessAuthorizer
+           statsStateAccessAuthorizer:(StateFileAccessAuthorizer)statsStateAccessAuthorizer;
 
 @property NSDictionary *syncState;
 @end
@@ -55,10 +59,14 @@
   XCTAssertTrue([syncStatePlist writeToFile:syncStatePlistPath atomically:YES]);
 
   SNTConfigurator *cfg = [[SNTConfigurator alloc] initWithSyncStateFile:syncStatePlistPath
-                                              syncStateAccessAuthorizer:^{
-                                                // Allow all access to the test plist
-                                                return YES;
-                                              }];
+      statsStateFile:@"/does/not/need/to/exist"
+      syncStateAccessAuthorizer:^{
+        // Allow all access to the test plist
+        return YES;
+      }
+      statsStateAccessAuthorizer:^BOOL {
+        return NO;
+      }];
 
   NSLog(@"sync state: %@", cfg.syncState);
 

--- a/Source/common/SNTConfiguratorTest.m
+++ b/Source/common/SNTConfiguratorTest.m
@@ -68,8 +68,6 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
         return NO;
       }];
 
-  NSLog(@"sync state: %@", cfg.syncState);
-
   verifierBlock(cfg);
 
   XCTAssertTrue([self.fileMgr removeItemAtPath:syncStatePlistPath error:nil]);

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -54,6 +54,10 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
 ///
 - (void)postRuleSyncNotificationForApplication:(NSString *)app reply:(void (^)(void))reply;
 - (void)requestAPNSToken:(void (^)(NSString *))reply;
+// Retrieve saved stats state info from santad
+- (void)retrieveStatsState:(void (^)(NSDate *, NSString *))reply;
+// Have santad save the latest stats state information
+- (void)saveStatsSubmissionAttemptTime:(NSDate *)timestamp version:(NSString *)version;
 
 ///
 /// Control Ops

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -325,6 +325,15 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
+- (void)retrieveStatsState:(void (^)(NSDate *, NSString *))reply {
+  reply([[SNTConfigurator configurator] lastStatsSubmissionTimestamp],
+        [[SNTConfigurator configurator] lastStatsSubmissionVersion]);
+}
+
+- (void)saveStatsSubmissionAttemptTime:(NSDate *)timestamp version:(NSString *)version {
+  [[SNTConfigurator configurator] saveStatsSubmissionAttemptTime:timestamp version:version];
+}
+
 #pragma mark Metrics Ops
 
 - (void)metrics:(void (^)(NSDictionary *))reply {

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -222,6 +222,7 @@ objc_library(
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTDropRootPrivs",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTStrengthify",
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCSyncServiceInterface",
     ],

--- a/Source/santasyncservice/SNTSyncService.mm
+++ b/Source/santasyncservice/SNTSyncService.mm
@@ -146,7 +146,7 @@
       DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
 
   // Trigger a stats collection attempt every hour, however stats will only be
-  // submitted once every 24 hours. The OS is given a 5 minuute scheduling leeway.
+  // submitted once every 24 hours. The OS is given a 5 minute scheduling leeway.
   dispatch_source_set_timer(self.statsSubmissionTimer, DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC,
                             0 * NSEC_PER_SEC);
 
@@ -168,7 +168,7 @@
     NSTimeInterval timeSinceLastOp =
         [[NSDate date] timeIntervalSinceDate:self.lastStatsSubmissionAttempt];
 
-    // Skip submission if the version didn't change or
+    // Skip submission if the version didn't change or the last submission was <23.5h ago
     if ([self.lastStatsSubmissionVersion isEqualToString:self.currentVersion] &&
         timeSinceLastOp < minSubmissionInterval) {
       return;

--- a/Source/santasyncservice/SNTSyncService.mm
+++ b/Source/santasyncservice/SNTSyncService.mm
@@ -147,8 +147,8 @@
 
   // Trigger a stats collection attempt every hour, however stats will only be
   // submitted once every 24 hours. The OS is given a 5 minute scheduling leeway.
-  dispatch_source_set_timer(self.statsSubmissionTimer, DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC,
-                            0 * NSEC_PER_SEC);
+  dispatch_source_set_timer(self.statsSubmissionTimer, DISPATCH_TIME_NOW, 3600 * NSEC_PER_SEC,
+                            300 * NSEC_PER_SEC);
 
   WEAKIFY(self);
   dispatch_source_set_event_handler(self.statsSubmissionTimer, ^{


### PR DESCRIPTION
This changes Santa to persist last stats upload attempt information to help reduce the number of times stats uploads occur. Previously, the sync service would upload on every start and 24 hours later. But if the system rebooted (or even if the service was crash looping) we'd end up uploading far more times than desired.

**Note:** Stats are still opt-in, nothing in this PR changes that.