### PR TITLE
build: Switch to cc_proto_library from com_google_protobuf

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1,5 +1,6 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "objc_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//:helper.bzl", "santa_unit_test")
 
 # Common is the folder containing all the code that's shared between multiple

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/BUILD
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/BUILD
@@ -1,5 +1,6 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//:helper.bzl", "santa_unit_test")
 
 package(


### PR DESCRIPTION
The `cc_proto_library` rule in rules_cc is deprecated.