### PR TITLE
Expand sync service connection state to handle more config keys

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1,5 +1,5 @@
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//:helper.bzl", "santa_unit_test")
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -817,6 +817,7 @@ static SNTConfigurator *sharedConfigurator = nil;
 - (NSURL *)syncBaseURL {
   NSString *urlString = self.configState[kSyncBaseURLKey];
   if (urlString.length == 0) {
+    // Treat empty values as nil. This is depended upon by callers.
     return nil;
   }
   if (![urlString hasSuffix:@"/"]) {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -816,7 +816,12 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (NSURL *)syncBaseURL {
   NSString *urlString = self.configState[kSyncBaseURLKey];
-  if (![urlString hasSuffix:@"/"]) urlString = [urlString stringByAppendingString:@"/"];
+  if (urlString.length == 0) {
+    return nil;
+  }
+  if (![urlString hasSuffix:@"/"]) {
+    urlString = [urlString stringByAppendingString:@"/"];
+  }
   NSURL *url = [NSURL URLWithString:urlString];
   return url;
 }

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -44,8 +44,8 @@ static NSArray<NSString *> *EnsureArrayOfStrings(id obj) {
 @property(readonly, nonatomic) NSDictionary *forcedConfigKeyTypes;
 
 /// Holds the configurations from a sync server and mobileconfig.
-@property NSDictionary *syncState;
-@property NSMutableDictionary *configState;
+@property(atomic) NSDictionary *syncState;
+@property(atomic) NSMutableDictionary *configState;
 
 /// Was --debug passed as an argument to this process?
 @property(readonly, nonatomic) BOOL debugFlag;
@@ -1364,6 +1364,9 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (void)clearSyncState {
   self.syncState = [NSMutableDictionary dictionary];
+  // TODO: Start a timer to flush the state to disk. On startup, Santa should
+  // check for the presence of the state file and, if no SyncBaseURL is
+  // configured, start the timer to clear sync state and flush to disk.
 }
 
 - (NSArray *)entitlementsPrefixFilter {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -225,6 +225,7 @@ objc_library(
     deps = [
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTCommonEnums",
+        "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTXPCSyncServiceInterface",

--- a/Source/santad/SNTSyncdQueue.h
+++ b/Source/santad/SNTSyncdQueue.h
@@ -21,7 +21,7 @@
 
 @interface SNTSyncdQueue : NSObject
 
-@property(nonatomic) MOLXPCConnection *syncConnection;
+- (void)reassessSyncServiceConnection;
 
 - (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle;
 - (void)addBundleEvent:(SNTStoredEvent *)event reply:(void (^)(SNTBundleEventAction))reply;

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -77,11 +77,6 @@
       NSURL *newSyncBaseURL = [configurator syncBaseURL];
       BOOL statsCollectionEnabled = [configurator enableStatsCollection];
 
-      // Don't allow an empty string for the sync base URL
-      if (newSyncBaseURL && newSyncBaseURL.absoluteString.length == 0) {
-        newSyncBaseURL = nil;
-      }
-
       // If the SyncBaseURL was added or changed, and a connection already
       // exists, it must be bounced.
       if (self.previousSyncBaseURL && ![self.previousSyncBaseURL isEqual:newSyncBaseURL] &&

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -84,8 +84,8 @@
 
       // If the SyncBaseURL was added or changed, and a connection already
       // exists, it must be bounced.
-      if (self.previousSyncBaseURL.absoluteString.length &&
-          ![self.previousSyncBaseURL isEqual:newSyncBaseURL] && self.syncServiceConnected) {
+      if (self.previousSyncBaseURL && ![self.previousSyncBaseURL isEqual:newSyncBaseURL] &&
+          self.syncServiceConnected) {
         [self tearDownSyncServiceConnectionSerialized];
         // Return early. When the sync service spins down, it will trigger the
         // invalidation handler which will reassess the connection state.

--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -357,7 +357,12 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
   dispatch_source_t timerQueue =
       dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
                              dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0));
-  dispatch_source_set_event_handler(timerQueue, block);
+  dispatch_source_set_event_handler(timerQueue, ^{
+    // Only trigger the sync event if a syncBaseURL exists
+    if ([[SNTConfigurator configurator] syncBaseURL]) {
+      block();
+    }
+  });
   dispatch_resume(timerQueue);
   return timerQueue;
 }


### PR DESCRIPTION
This changes Santa to ensure the sync service is running if either a SyncBaseURL is set, or stats collection is enabled. The desired state of the sync service is reassessed whenever configuration is changed to determine if the service should be started, bounced, or stopped.