### PR TITLE
build: fix clangd visibility for generated code

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("//:helper.bzl", "run_command")
 
 package(
@@ -225,4 +226,14 @@ test_suite(
         "//Source/santametricservice:unit_tests",
         "//Source/santasyncservice:unit_tests",
     ],
+)
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    # Only compile targets under //Source, the :release and other genrule
+    # targets cause issues when constructing compile commands for generated
+    # code.
+    targets = {
+        "//Source/...": "",
+    },
 )

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ realclean:
 	bazel clean --expunge
 
 compile_commands:
-	bazel run @hedron_compile_commands//:refresh_all
+	# Build all targets under source so any generated code will be emitted and
+	# available for compile command construction.
+	bazel build //Source/...
+	bazel run :refresh_compile_commands
 
 .PHONY: fmt build test reload clean realclean compile_commands


### PR DESCRIPTION
This CL reliably produces compile commands for Santa's source files, including for generated code. This allows clangd to be aware of the various generated interfaces for .proto files, enabling autocomplete and xref links.

https://github.com/user-attachments/assets/d818498a-eecf-4665-a3b2-fe1b1f1bc9c0

