### PR TITLE
rule download: add support for notification app name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "xxhash", version = "0.8.2")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpole_protos")
 git_override(
     module_name = "protos",
-    commit = "01a55a67d389577a7a2c6ed731e611f7384a5137",
+    commit = "48894b41f26b445079306ae05f8d0b2f39a3a6a4",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -218,7 +218,8 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   NSString *appName = StringToNSString(protoRule->notification_app_name());
   if (appName.length) {
     // If notification_app_name is set but this is a clean sync, return early. We don't want to
-    // continue processing with deprecated behavior.
+    // spam users with notifications for many apps that might be included in a clean sync, and
+    // we don't want to fallback to the deprecated behavior
     if (self.syncState.syncType != SNTSyncTypeNormal) return;
     [[SNTPushNotificationsTracker tracker]
         addNotification:[@{kFileName : appName, kFileBundleBinaryCount : @(0)} mutableCopy]

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -219,7 +219,7 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   if (appName.length) {
     // If notification_app_name is set but this is a clean sync, return early. We don't want to
     // spam users with notifications for many apps that might be included in a clean sync, and
-    // we don't want to fallback to the deprecated behavior
+    // we don't want to fallback to the deprecated behavior.
     if (self.syncState.syncType != SNTSyncTypeNormal) return;
     [[SNTPushNotificationsTracker tracker]
         addNotification:[@{kFileName : appName, kFileBundleBinaryCount : @(0)} mutableCopy]

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -214,6 +214,24 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 
 - (void)processBundleNotificationsForRule:(SNTRule *)rule
                             fromProtoRule:(const ::pbv1::Rule *)protoRule {
+  // Display a system notification if notification_app_name is set and this is not a clean sync.
+  NSString *appName = StringToNSString(protoRule->notification_app_name());
+  if (appName.length) {
+    // If notification_app_name is set but this is a clean sync, return early. We don't want to
+    // continue processing with deprecated behavior.
+    if (self.syncState.syncType != SNTSyncTypeNormal) return;
+    [[SNTPushNotificationsTracker tracker]
+        addNotification:[@{kFileName : appName, kFileBundleBinaryCount : @(0)} mutableCopy]
+                forHash:rule.identifier];
+    return;
+  }
+
+  // If notification_app_name is not set, continue processing with deprecated behavior.
+  [self processDeprecatedBundleNotificationsForRule:rule fromProtoRule:protoRule];
+}
+
+- (void)processDeprecatedBundleNotificationsForRule:(SNTRule *)rule
+                                      fromProtoRule:(const ::pbv1::Rule *)protoRule {
   // Check rule for extra notification related info.
   if (rule.state == SNTRuleStateAllow || rule.state == SNTRuleStateAllowCompiler) {
     // primaryHash is the bundle hash if there was a bundle hash included in the rule, otherwise

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -825,6 +825,8 @@
                ruleCleanup:SNTRuleCleanupNone
                     source:SNTRuleAddSourceSyncService
                      reply:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
+  OCMStub([self.daemonConnRop postRuleSyncNotificationForApplication:[OCMArg any]
+                                                               reply:([OCMArg invokeBlock])]);
   [sut sync];
 
   NSArray *rules = @[
@@ -836,6 +838,9 @@
         initWithIdentifier:@"46f8c706d0533a54554af5fc163eea704f10c08b30f8a5db12bfdc04fb382fc3"
                      state:SNTRuleStateAllow
                       type:SNTRuleTypeCertificate],
+    [[SNTRule alloc] initWithIdentifier:@"platform:com.apple.yes"
+                                  state:SNTRuleStateAllow
+                                   type:SNTRuleTypeSigningID],
     [[SNTRule alloc]
         initWithIdentifier:@"7846698e47ef41be80b83fb9e2b98fa6dc46c9188b068bff323c302955a00142"
                      state:SNTRuleStateBlock
@@ -853,6 +858,7 @@
                                          ruleCleanup:SNTRuleCleanupNone
                                               source:SNTRuleAddSourceSyncService
                                                reply:OCMOCK_ANY]);
+  OCMVerify([self.daemonConnRop postRuleSyncNotificationForApplication:@"yes" reply:OCMOCK_ANY]);
 }
 
 #pragma mark - SNTSyncPostflight Tests

--- a/Source/santasyncservice/testdata/sync_ruledownload_batch1.json
+++ b/Source/santasyncservice/testdata/sync_ruledownload_batch1.json
@@ -1,1 +1,23 @@
-{"rules": [{"rule_type": "BINARY", "policy": "BLOCKLIST", "sha256": "ee382e199f7eda58863a93a7854b930ade35798bc6856ee8e6ab6ce9277f0eab", "custom_msg": ""},{"rule_type": "CERTIFICATE", "policy": "ALLOWLIST", "sha256": "46f8c706d0533a54554af5fc163eea704f10c08b30f8a5db12bfdc04fb382fc3", "custom_msg": ""}],"cursor": "this-is-a-cursor="}
+{
+  "rules": [
+    {
+      "rule_type": "BINARY",
+      "policy": "BLOCKLIST",
+      "sha256": "ee382e199f7eda58863a93a7854b930ade35798bc6856ee8e6ab6ce9277f0eab",
+      "custom_msg": ""
+    },
+    {
+      "rule_type": "CERTIFICATE",
+      "policy": "ALLOWLIST",
+      "sha256": "46f8c706d0533a54554af5fc163eea704f10c08b30f8a5db12bfdc04fb382fc3",
+      "custom_msg": ""
+    },
+    {
+      "rule_type": "SIGNINGID",
+      "policy": "ALLOWLIST",
+      "identifier": "platform:com.apple.yes",
+      "notification_app_name": "yes"
+    }
+  ],
+  "cursor": "this-is-a-cursor="
+}

--- a/Source/santasyncservice/testdata/sync_ruledownload_batch2.json
+++ b/Source/santasyncservice/testdata/sync_ruledownload_batch2.json
@@ -1,1 +1,16 @@
-{"rules": [{"rule_type": "CERTIFICATE", "policy": "BLACKLIST", "sha256": "7846698e47ef41be80b83fb9e2b98fa6dc46c9188b068bff323c302955a00142", "custom_msg": "Hi There"},{"rule_type":"TEAMID", "policy":"BLOCKLIST", "identifier": "AAAAAAAAAA", "custom_msg": "Banned team ID"}]}
+{
+  "rules": [
+    {
+      "rule_type": "CERTIFICATE",
+      "policy": "BLACKLIST",
+      "sha256": "7846698e47ef41be80b83fb9e2b98fa6dc46c9188b068bff323c302955a00142",
+      "custom_msg": "Hi There"
+    },
+    {
+      "rule_type": "TEAMID",
+      "policy": "BLOCKLIST",
+      "identifier": "AAAAAAAAAA",
+      "custom_msg": "Banned team ID"
+    }
+  ]
+}


### PR DESCRIPTION
This CL adds support for the new notification_app_name field during rule download.