### PR TITLE
gui: truncate accessed path in FAA dialog, add full path to More Details popup

### DIFF
--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -65,9 +65,15 @@ struct MoreDetailsView: View {
     HStack(spacing: 20.0) {
       VStack(spacing: 20.0) {
         Spacer()
+        addLabel {
+          Text("Accessed Path").bold().font(Font.system(size: 12.0))
+          Text(e.accessedPath).font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
+        }
+
+        Divider()
 
         addLabel {
-          Text("Path").bold().font(Font.system(size: 12.0))
+          Text("Binary Path").bold().font(Font.system(size: 12.0))
           Text(e.filePath).font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
         }
 
@@ -142,7 +148,7 @@ struct Event: View {
       Divider()
 
       VStack(alignment: .leading, spacing: 10.0) {
-        Text(e.accessedPath).textSelection(.enabled)
+        TextWithLimit(e.accessedPath).textSelection(.enabled)
         if let app = e.application {
           TextWithLimit(app).textSelection(.enabled)
         } else {

--- a/Source/gui/SNTMessageView.swift
+++ b/Source/gui/SNTMessageView.swift
@@ -235,7 +235,8 @@ public struct TextWithLimit: View {
 
   public var body: some View {
     if self.text.count > self.limit {
-      Text(verbatim: self.text.prefix(self.limit) + "…").help(self.text)
+      let truncatedText = "\(self.text.prefix(self.limit/2))…\(self.text.suffix(self.limit/2))"
+      Text(verbatim: truncatedText).help(self.text)
     } else {
       Text(self.text)
     }


### PR DESCRIPTION
Also modify TextWithLimit() to truncate the middle of the string instead of the end

![image](https://github.com/user-attachments/assets/a6f564ce-7c17-4255-a5f1-0e1b19cd1457)
![image](https://github.com/user-attachments/assets/f4824e20-7262-4df6-853b-d9a8441efe07)
