### PR TITLE
santad: Fix 'UNIQUE constraint failed' and 'Unable to compute hash' errors

### DIFF
--- a/Source/santad/DataLayer/SNTEventTable.m
+++ b/Source/santad/DataLayer/SNTEventTable.m
@@ -133,8 +133,10 @@ static const uint32_t kEventTableCurrentVersion = 4;
   [self inTransaction:^(FMDatabase *db, BOOL *rollback) {
     [eventsData
         enumerateKeysAndObjectsUsingBlock:^(NSData *eventData, SNTStoredEvent *event, BOOL *stop) {
-          success = [db executeUpdate:@"INSERT OR IGNORE INTO 'events' (idx, filesha256, eventdata) VALUES (?, ?, ?)",
-                                      event.idx, event.fileSHA256, eventData];
+          success = [db
+              executeUpdate:
+                  @"INSERT OR IGNORE INTO 'events' (idx, filesha256, eventdata) VALUES (?, ?, ?)",
+                  event.idx, event.fileSHA256, eventData];
           if (!success) *stop = YES;
         }];
   }];

--- a/Source/santad/DataLayer/SNTEventTable.m
+++ b/Source/santad/DataLayer/SNTEventTable.m
@@ -133,8 +133,7 @@ static const uint32_t kEventTableCurrentVersion = 4;
   [self inTransaction:^(FMDatabase *db, BOOL *rollback) {
     [eventsData
         enumerateKeysAndObjectsUsingBlock:^(NSData *eventData, SNTStoredEvent *event, BOOL *stop) {
-          success = [db executeUpdate:@"INSERT INTO 'events' (idx, filesha256, eventdata)"
-                                      @"VALUES (?, ?, ?)",
+          success = [db executeUpdate:@"INSERT OR IGNORE INTO 'events' (idx, filesha256, eventdata) VALUES (?, ?, ?)",
                                       event.idx, event.fileSHA256, eventData];
           if (!success) *stop = YES;
         }];

--- a/Source/santad/DataLayer/SNTEventTable.m
+++ b/Source/santad/DataLayer/SNTEventTable.m
@@ -133,10 +133,10 @@ static const uint32_t kEventTableCurrentVersion = 4;
   [self inTransaction:^(FMDatabase *db, BOOL *rollback) {
     [eventsData
         enumerateKeysAndObjectsUsingBlock:^(NSData *eventData, SNTStoredEvent *event, BOOL *stop) {
-          success = [db
-              executeUpdate:
-                  @"INSERT OR IGNORE INTO 'events' (idx, filesha256, eventdata) VALUES (?, ?, ?)",
-                  event.idx, event.fileSHA256, eventData];
+          success = [db executeUpdate:@"INSERT INTO 'events' (idx, filesha256, eventdata) "
+                                      @"VALUES (?, ?, ?) "
+                                      @"ON CONFLICT(filesha256) DO NOTHING",
+                                      event.idx, event.fileSHA256, eventData];
           if (!success) *stop = YES;
         }];
   }];

--- a/Source/santad/DataLayer/SNTEventTableTest.m
+++ b/Source/santad/DataLayer/SNTEventTableTest.m
@@ -94,19 +94,24 @@ NSString *GenerateRandomHexStringWithSHA256Length() {
 
   SNTStoredEvent *event = [self createTestEvent];
   XCTAssertTrue([self.sut addStoredEvent:event]);
+  XCTAssertEqual(self.sut.pendingEventsCount, 1);
 
-  // Attempt to add an event with the same file hash fails because of non-unique filehash256 column
+  // Attempt to add an event with the same file hash succeeds despite
+  // non-unique filehash256 column
   event.idx = @(arc4random());
-  XCTAssertFalse([self.sut addStoredEvent:event]);
+  XCTAssertTrue([self.sut addStoredEvent:event]);
+  XCTAssertEqual(self.sut.pendingEventsCount, 1);
 
   // Create a new hash and re-insert
   event.idx = @(arc4random());
   event.fileSHA256 = GenerateRandomHexStringWithSHA256Length();
   XCTAssertTrue([self.sut addStoredEvent:event]);
+  XCTAssertEqual(self.sut.pendingEventsCount, 2);
 
   // Attempting to add an event with a non-unique idx fails
   event.fileSHA256 = GenerateRandomHexStringWithSHA256Length();
   XCTAssertFalse([self.sut addStoredEvent:event]);
+  XCTAssertEqual(self.sut.pendingEventsCount, 2);
 }
 
 - (void)testRetrieveEvent {

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -139,7 +139,6 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     if (!binInfo.SHA256) {
       // If there isn't a hash, no need to compute the other info here.
       // Just continue on to the next binary.
-      LOGW(@"Unable to compute hash for critical system binary %@.", path);
       continue;
     }
     MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:NULL];

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -139,6 +139,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     if (!binInfo.SHA256) {
       // If there isn't a hash, no need to compute the other info here.
       // Just continue on to the next binary.
+      LOGD(@"Unable to compute hash for critical system binary %@.", path);
       continue;
     }
     MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:NULL];


### PR DESCRIPTION
This fixes the following 2 errors, which are both appearing frequently from santad:

```
default	11:38:26.799802-0400	com.northpolesec.santa.daemon	Unknown error calling sqlite3_step (19: UNIQUE constraint failed: events.filesha256) rs
```

```
default	11:38:27.456329-0400	com.northpolesec.santa.daemon	W com.northpolesec.santa.daemon: Unable to compute hash for critical system binary /System/Library/PrivateFrameworks/TCC.framework/Versions/A/Resources/tccd.
```

The first error is because of the unique constraint added in #337 - this causes the transaction to fail if an event is added for a binary that already has a pending event. The desired behavior is that the insert failing is ignored, so adding `ON CONFLICT(filesha256) DO NOTHING` fixes this. `INSERT OR IGNORE` would also work but that silently ignores *all* constraints, including `NOT NULL`

The second error is because the location of `tccd` has moved from inside the framework version to a support folder in some prior release of macOS. Both paths are in the list of critical binaries but only 1 will ever match. Logging these warnings could be confusing and the failure to compute will never cause any problems.