### PR TITLE
gui: Update about window with new design and default text

### DIFF
--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -16,7 +16,10 @@ swift_library(
     name = "SNTAboutWindowView",
     srcs = ["SNTAboutWindowView.swift"],
     generates_header = 1,
-    deps = ["//Source/common:SNTConfigurator"],
+    deps = [
+        ":SNTMessageView",
+        "//Source/common:SNTConfigurator",
+    ],
 )
 
 swift_library(
@@ -161,6 +164,7 @@ swift_library(
     name = "SNTTestGUI_lib",
     srcs = ["SNTTestGUI.swift"],
     deps = [
+        ":SNTAboutWindowView",
         ":SNTBinaryMessageWindowView",
         ":SNTDeviceMessageWindowView",
         ":SNTFileAccessMessageWindowView",

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -7,16 +7,16 @@
 /* No comment provided by engineer. */
 "Accessed Path" = "Aufgerufener Pfad";
 
-/* No comment provided by engineer.  */
-"Approve" = "Genehmigen";
-
 /* No comment provided by engineer. */
 "Application" = "Applikation";
 
-/* No comment provided by engineer. */
+/* Default text for Approve */
+"Approve" = "Genehmigen";
+
+/* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "genehmigen die Ausführung von %@";
 
-/* No comment provided by engineer. */
+/* Authorize execution of an application with name */
 "authorize execution of the application %@" = "Die Ausführung der Anwendung autorisieren %@";
 
 /* No comment provided by engineer. */
@@ -28,7 +28,7 @@
 /* No comment provided by engineer. */
 "CDHash" = "CDHash";
 
-/* Copy Details button to copy all details shown in the More Details dialog */
+/* Copy Details */
 "Copy Details" = "Details kopieren";
 
 /* Dismiss button in more details dialog */
@@ -46,7 +46,7 @@
 /* No comment provided by engineer. */
 "Label before time period picker" = "Benachrichtigungen für diese Applikation unterdrücken für ";
 
-/* More Details button in binary block dialog */
+/* More Details button */
 "More Details" = "Mehr Details";
 
 /* No comment provided by engineer. */
@@ -80,7 +80,10 @@
 "Rule Version" = "Regelversion";
 
 /* Explanation in About view */
-"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa ist ein Applikationskontrollsystem für macOS.\n\nEs gibt keine benutzerkonfigurierbaren Einstellungen.";
+"Santa is a security system providing application,\ndevice, and file-access controls." = "Santa ist ein Sicherheitssystem, das Kontrolle über\nAnwendungen, Geräte und Dateizugriffe bietet";
+
+/* No comment provided by engineer. */
+"Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)\nalong with contributions from our wonderful community" = "Santa wurde mit ❤️ von den Elfen bei [North Pole Security](https://northpole.security) entwickelt,\nzusammen mit Beiträgen unserer wunderbaren Community";
 
 /* No comment provided by engineer. */
 "SHA-256" = "SHA-256";
@@ -114,3 +117,6 @@
 
 /* No comment provided by engineer. */
 "User" = "Benutzer";
+
+/* No comment provided by engineer. */
+"Version **%@**" = "Version **%@**";

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -80,7 +80,10 @@
 "Rule Version" = "Rule Version";
 
 /* Explanation in About view */
-"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa is an application control system for macOS.\n\nThere are no user-configurable settings.";
+"Santa is a security system providing application,\ndevice, and file-access controls." = "Santa is a security system providing application,\ndevice, and file-access controls.";
+
+/* No comment provided by engineer. */
+"Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)\nalong with contributions from our wonderful community" = "Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)\nalong with contributions from our wonderful community";
 
 /* No comment provided by engineer. */
 "SHA-256" = "SHA-256";
@@ -114,4 +117,7 @@
 
 /* No comment provided by engineer. */
 "User" = "User";
+
+/* No comment provided by engineer. */
+"Version **%@**" = "Version **%@**";
 

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -13,11 +13,10 @@
 /* Default text for Approve */
 "Approve" = "許可する";
 
-/* File path
-   Signing ID */
+/* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "%@実行を許可する";
 
-/* Bundle name */
+/* Authorize execution of an application with name */
 "authorize execution of the application %@" = "%@アプリケーションの実行を許可する";
 
 /* No comment provided by engineer. */
@@ -29,7 +28,7 @@
 /* No comment provided by engineer. */
 "CDHash" = "CDハッシュ";
 
-/* Copy Details button to copy all details shown in the More Details dialog */
+/* Copy Details */
 "Copy Details" = "詳細をコピー";
 
 /* Dismiss button in more details dialog */
@@ -47,7 +46,7 @@
 /* No comment provided by engineer. */
 "Label before time period picker" = "このアプリケーションからの通知を";
 
-/* More Details button in binary block dialog */
+/* More Details button */
 "More Details" = "さらに詳細";
 
 /* No comment provided by engineer. */
@@ -81,7 +80,10 @@
 "Rule Version" = "ルールバージョン";
 
 /* Explanation in About view */
-"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "SantaはmacOS向けアプリケーション制御システムです\n\n　ユーザーによる設定項目はありません";
+"Santa is a security system providing application,\ndevice, and file-access controls." = "Santaはアプリケーション、デバイス、\nファイルアクセスの制御を提供するセキュリティシステムです";
+
+/* No comment provided by engineer. */
+"Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)\nalong with contributions from our wonderful community" = "Santaは[North Pole Security](https://northpole.security)のエルフたちが❤️を込めて作り、\n素晴らしいコミュニティの貢献によって支えられています";
 
 /* No comment provided by engineer. */
 "SHA-256" = "SHA-256";
@@ -111,7 +113,10 @@
 "The following device has been remounted with reduced permissions" = "次のデバイスは権限を制限して再マウントされました";
 
 /* No comment provided by engineer. */
-unknown = "不明";
+"unknown" = "不明";
 
 /* No comment provided by engineer. */
-User = "ユーザー";
+"User" = "ユーザー";
+
+/* No comment provided by engineer. */
+"Version **%@**" = "バージョン **%@**";

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -5,18 +5,18 @@
 "Access to a file has been denied" = "Доступ к файлу был запрещен";
 
 /* No comment provided by engineer. */
-"Approve" = "Утвердить";
-
-/* No comment provided by engineer. */
 "Accessed Path" = "Доступный путь";
 
 /* No comment provided by engineer. */
 "Application" = "Приложение";
 
-/* No comment provided by engineer. */
+/* Default text for Approve */
+"Approve" = "Утвердить";
+
+/* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "разрешить исполнение %@";
 
-/* No comment provided by engineer. */
+/* Authorize execution of an application with name */
 "authorize execution of the application %@" = "разрешить выполнение заявки %@";
 
 /* No comment provided by engineer. */
@@ -28,10 +28,10 @@
 /* No comment provided by engineer. */
 "CDHash" = "CDHash";
 
-/* Copy Details button to copy all details shown in the More Details dialog */
+/* Copy Details */
 "Copy Details" = "Копия Подробности";
 
-/* No comment provided by engineer. */
+/* Dismiss button in more details dialog */
 "Dismiss" = "Увольте";
 
 /* No comment provided by engineer. */
@@ -46,7 +46,7 @@
 /* No comment provided by engineer. */
 "Label before time period picker" = "Предотвращение будущих уведомлений для этого приложения для ";
 
-/* More Details button in binary block dialog */
+/* More Details button */
 "More Details" = "Подробнее";
 
 /* No comment provided by engineer. */
@@ -80,7 +80,10 @@
 "Rule Version" = "Версия правил";
 
 /* Explanation in About view */
-"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa - это система управления приложениями для macOS.\n\nНет никаких настраиваемых пользователем параметров.";
+"Santa is a security system providing application,\ndevice, and file-access controls." = "Santa - этo система безопасности, обеспечивающая контроль\nнад приложениями, устройствами и доступом к файлам";
+
+/* No comment provided by engineer. */
+"Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)\nalong with contributions from our wonderful community" = "Santa создана с ❤️ эльфами из [North Pole Security](https://northpole.security)\nвместе с вкладом нашего замечательного сообщества";
 
 /* No comment provided by engineer. */
 "SHA-256" = "SHA-256";
@@ -97,11 +100,11 @@
 /* Client mode change: STANDALONE */
 "Switching into Standalone mode" = "Переход в автономный режим";
 
-/* The default message to show the user when a banned application is blocked */
-"The following application has been blocked from<br />executing because it has been deemed malicious or against policy" = "Следующее приложение было заблокировано для выполнения,<br />потому что она была признана вредоносной или противоречащей политике";
-
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Следующее приложение было заблокировано для выполнения,<br />поскольку его надежность не может быть определена";
+
+/* The default message to show the user when a banned application is blocked */
+"The following application has been blocked from<br />executing because it has been deemed malicious or against policy" = "Следующее приложение было заблокировано для выполнения,<br />потому что она была признана вредоносной или противоречащей политике";
 
 /* The default message to show the user when a USB device is blocked from mounting */
 "The following device has been blocked from mounting" = "Следующее устройство было заблокировано для установки";
@@ -114,3 +117,6 @@
 
 /* No comment provided by engineer. */
 "User" = "Пользователь";
+
+/* No comment provided by engineer. */
+"Version **%@**" = "Версия **%@**";

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -1,8 +1,8 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ тепер можна запускати";
 
-/* No comment provided by engineer. */
-"Approve" = "Затвердити";
+/* The default message to show the user when access to a file is blocked */
+"Access to a file has been denied" = "Відмовлено у доступі до файлу";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Шлях доступу";
@@ -10,10 +10,13 @@
 /* No comment provided by engineer. */
 "Application" = "Заявка";
 
-/* No Comment provided by engineer. */
+/* Default text for Approve */
+"Approve" = "Затвердити";
+
+/* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "дозволити виконання %@";
 
-/* No Comment provided by engineer. */
+/* Authorize execution of an application with name */
 "authorize execution of the application %@" = "дозволити виконання заявки %@";
 
 /* No comment provided by engineer. */
@@ -25,13 +28,10 @@
 /* No comment provided by engineer. */
 "CDHash" = "CDHash";
 
-/* Copy Details button to copy all details shown in the More Details dialog */
+/* Copy Details */
 "Copy Details" = "Деталі копіювання";
 
-/* The default message to show the user when access to a file is blocked */
-"Access to a file has been denied" = "Відмовлено у доступі до файлу";
-
-/* No comment provided by engineer. */
+/* Dismiss button in more details dialog */
 "Dismiss" = "Звільнити";
 
 /* No comment provided by engineer. */
@@ -46,7 +46,7 @@
 /* No comment provided by engineer. */
 "Label before time period picker" = "Запобігти майбутнім сповіщенням для цієї заявки для ";
 
-/* More Details button in binary block dialog */
+/* More Details button */
 "More Details" = "Детальніше";
 
 /* No comment provided by engineer. */
@@ -80,7 +80,10 @@
 "Rule Version" = "Версія правила";
 
 /* Explanation in About view */
-"Santa is an application control system for macOS.\n\nThere are no user-configurable settings." = "Santa - система управління додатками для macOS.\n\nНемає налаштувань, що налаштовуються користувачем.";
+"Santa is a security system providing application,\ndevice, and file-access controls." = "Santa - система безпеки, що забезпечує контроль над\nдодатками,пристроями та доступом до файлів";
+
+/* No comment provided by engineer. */
+"Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)\nalong with contributions from our wonderful community" = "Santa створена з ❤️ ельфами з [North Pole Security](https://northpole.security)\nразом з внеском нашого чудового співтовариства";
 
 /* No comment provided by engineer. */
 "SHA-256" = "SHA-256";
@@ -97,11 +100,11 @@
 /* Client mode change: STANDALONE */
 "Switching into Standalone mode" = "Перехід в автономний режим";
 
-/* The default message to show the user when a banned application is blocked */
-"The following application has been blocked from<br />executing because it has been deemed malicious or against policy" = "Наступну програму було заблоковано для виконання,<br />через те, що вона була визнана шкідливою або такою, що суперечить політиці";
-
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Наступна програма була заблокована для виконання,<br />оскільки не може бути визначена її достовірність";
+
+/* The default message to show the user when a banned application is blocked */
+"The following application has been blocked from<br />executing because it has been deemed malicious or against policy" = "Наступну програму було заблоковано для виконання,<br />через те, що вона була визнана шкідливою або такою, що суперечить політиці";
 
 /* The default message to show the user when a USB device is blocked from mounting */
 "The following device has been blocked from mounting" = "Наступний пристрій заблоковано для встановлення";
@@ -114,3 +117,6 @@
 
 /* No comment provided by engineer. */
 "User" = "Користувач";
+
+/* No comment provided by engineer. */
+"Version **%@**" = "Версія **%@**";

--- a/Source/gui/SNTAboutWindowView.swift
+++ b/Source/gui/SNTAboutWindowView.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
 import santa_common_SNTConfigurator
+import santa_gui_SNTMessageView
 
 @objc public class SNTAboutWindowViewFactory: NSObject {
   @objc public static func createWith(window: NSWindow) -> NSViewController {
     return NSHostingController(
-      rootView: SNTAboutWindowView(w: window).frame(width: 400, height: 200)
+      rootView: SNTAboutWindowView(w: window).fixedSize()
     )
   }
 }
@@ -13,23 +14,25 @@ import santa_common_SNTConfigurator
 struct SNTAboutWindowView: View {
   let w: NSWindow?
   let c = SNTConfigurator.configurator()
+  let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
 
   var body: some View {
-    VStack(spacing: 20.0) {
-      Text(verbatim: "Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
-
+    SNTMessageView() {
       if let t = c.aboutText {
         Text(t).multilineTextAlignment(.center)
       } else {
         Text(
           """
-          Santa is an application control system for macOS.
-
-          There are no user-configurable settings.
+          Santa is a security system providing application,
+          device, and file-access controls.
           """,
           comment: "Explanation in About view"
         ).multilineTextAlignment(.center)
       }
+
+      // Calling .init explicitly to get Markdown rendering
+      let versionString = NSLocalizedString("Version **%@**", comment: "Version in About view")
+      Text(.init(String(format: versionString, v))).padding(10.0)
 
       HStack {
         if c.moreInfoURL?.absoluteString.isEmpty == false {
@@ -44,6 +47,18 @@ struct SNTAboutWindowView: View {
         .keyboardShortcut(.defaultAction)
 
       }.padding(10.0)
+
+      Text(
+        """
+        Santa is made with ❤️ by the elves at [North Pole Security](https://northpole.security)
+        along with contributions from our wonderful community
+        """
+      )
+      .font(.system(size: 10.0, weight: .regular))
+      .padding([.bottom], 10.0)
+      .foregroundColor(.secondary)
+      .multilineTextAlignment(.center)
+      .padding(10.0)
     }
   }
 

--- a/Source/gui/SNTMessageView.swift
+++ b/Source/gui/SNTMessageView.swift
@@ -15,12 +15,12 @@ extension Date {
 }
 
 public struct SNTMessageView<Content: View>: View {
-  let blockMessage: NSAttributedString
+  let blockMessage: NSAttributedString?
   @ViewBuilder let content: Content
 
   let enableFunFonts: Bool = SNTConfigurator.configurator().funFontsOnSpecificDays
 
-  public init(_ blockMessage: NSAttributedString, @ViewBuilder content: () -> Content) {
+  public init(_ blockMessage: NSAttributedString? = nil, @ViewBuilder content: () -> Content) {
     self.content = content()
     self.blockMessage = blockMessage
   }
@@ -57,13 +57,15 @@ public struct SNTMessageView<Content: View>: View {
     }.fixedSize()
 
     VStack(spacing: 10.0) {
-      AttributedText(blockMessage)
-        .multilineTextAlignment(.center)
-        .padding([.leading, .trailing], 15.0)
-        .fixedSize(horizontal: false, vertical: true)
+      if let blockMessage = blockMessage {
+        AttributedText(blockMessage)
+          .multilineTextAlignment(.center)
+          .padding([.leading, .trailing], 15.0)
+          .fixedSize(horizontal: false, vertical: true)
+
+      }
 
       Spacer()
-
       content
     }
     .padding([.leading, .trailing], 40.0)

--- a/Source/gui/SNTTestGUI.swift
+++ b/Source/gui/SNTTestGUI.swift
@@ -7,6 +7,7 @@ import santa_common_SNTDeviceEvent
 import santa_common_SNTStoredEvent
 import Source_gui_SNTDeviceMessageWindowView
 import Source_gui_SNTBinaryMessageWindowView
+import Source_gui_SNTAboutWindowView
 
 func ShowWindow(_ vc: NSViewController, _ window: NSWindow) {
   window.contentRect(forFrameRect: NSMakeRect(0, 0, 0, 0))
@@ -236,12 +237,41 @@ struct DeviceView: View {
   }
 }
 
+struct AboutView: View {
+  @State var dateOverride: SpecialDates = .Nov25
+
+  var body: some View {
+    VStack {
+      HStack {
+        Picker(selection: $dateOverride, label: Text(verbatim: "Date")) {
+          Text(verbatim: "Nov 25").tag(SpecialDates.Nov25)
+          Text(verbatim: "Apr 1").tag(SpecialDates.Apr1)
+          Text(verbatim: "May 4").tag(SpecialDates.May4)
+          Text(verbatim: "Oct 31").tag(SpecialDates.Oct31)
+        }.pickerStyle(.segmented)
+      }
+      Button("Display") {
+        switch dateOverride {
+        case .Apr1: Date.overrideDate = Date(timeIntervalSince1970: 1711980915)
+        case .May4: Date.overrideDate = Date(timeIntervalSince1970: 1714832115)
+        case .Oct31: Date.overrideDate = Date(timeIntervalSince1970: 1730384115)
+        case .Nov25: Date.overrideDate = Date(timeIntervalSince1970: 1732544115)
+        }
+
+        let window = NSWindow()
+        ShowWindow(SNTAboutWindowViewFactory.createWith(window: window), window)
+      }
+    }
+  }
+}
+
 struct ContentView: View {
   var body: some View {
     TabView {
       BinaryView().padding(15.0).tabItem({ Text("Binary") })
       FAAView().padding(15.0).tabItem({ Text("FAA") })
       DeviceView().padding(15.0).tabItem({ Text("Device") })
+      AboutView().padding(15.0).tabItem({ Text("About") })
     }
   }
 }


### PR DESCRIPTION
Also adds the About window to SNTTestGUI for easier testing.

## English
<img width="490" alt="Screenshot 2025-04-25 at 11 25 08 PM" src="https://github.com/user-attachments/assets/e6659ed1-b719-4362-af15-4f474b1ca9b9" />

## German
<img width="545" alt="image" src="https://github.com/user-attachments/assets/90dbc809-bad1-4891-99e3-574f3d84d0c2" />

## Japanese
<img width="529" alt="image" src="https://github.com/user-attachments/assets/00aa6510-70a0-490c-99c1-3f2e970a7c90" />

## Russian
<img width="589" alt="image" src="https://github.com/user-attachments/assets/bcf4ac4e-e8ab-49d0-9eec-03de7aa6cfa5" />

## Ukrainian
<img width="539" alt="image" src="https://github.com/user-attachments/assets/a35cfb04-88ee-42a4-8ff5-d3c6f2f740df" />
