### PR TITLE
docs: highlight santa profile content, update sizing

### DIFF
--- a/docs/docs/deployment/profile-configuration.md
+++ b/docs/docs/deployment/profile-configuration.md
@@ -44,6 +44,7 @@ available.
 						<dict>
 							<key>mcx_preference_settings</key>
 							<dict>
+<!-- highlight-start -->
 								<key>ClientMode</key>
 								<integer>1</integer>
 								<key>EnableSilentMode</key>
@@ -91,6 +92,7 @@ available.
 								</array>
 								<key>SyncBaseURL</key>
 								<string>https://sync-server-hostname/api/santa/</string>
+<!-- highlight-end -->
 							</dict>
 						</dict>
 					</array>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -142,6 +142,8 @@
   --ifm-navbar-padding-vertical: 1rem;
   --ifm-navbar-padding-horizontal: 1.75rem;
   --ifm-navbar-height: 90px;
+
+  --ifm-container-width-xl: 80%;
 }
 
 html[data-theme="dark"] {
@@ -210,5 +212,9 @@ html[data-theme="dark"] {
 }
 .theme-doc-sidebar-item-link-level-2 {
   font-size: 14px;
+}
+
+pre {
+  tab-size: 2;
 }
 


### PR DESCRIPTION
On the "Profile: Santa Configuration" page, highlight the part of the profile that is _unique_ to Santa, to make it clearer where to put the keys that we document.

While here, also update the container width so that wider windows don't leave half the screen empty and update the "tab width" to 2 spaces so that XML profiles can actually fit on a reasonable size screen.

![image](https://github.com/user-attachments/assets/671ac552-87d6-4faf-87cf-b036f702a472)
