### PR TITLE
docs: update UUIDs in example profiles to be different than the old Google Santa profiles

### DIFF
--- a/docs/docs/deployment/profile-system-extension.md
+++ b/docs/docs/deployment/profile-system-extension.md
@@ -50,13 +50,13 @@ example as a template.
 <dict>
 	<!-- See https://developer.apple.com/documentation/devicemanagement/systemextensions for payload descriptions -->
 	<key>PayloadUUID</key>
-	<string>40C19D5B-76D7-4C1C-BC9D-2F7EB29CFF4D</string>
+	<string>CAA3F5F6-4519-410D-960B-FDC323FA08E2</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadOrganization</key>
 	<string>My Company</string>
 	<key>PayloadIdentifier</key>
-	<string>com.mycompany.santa.sysx-policy.40C19D5B-76D7-4C1C-BC9D-2F7EB29CFF4D</string>
+	<string>com.mycompany.santa.sysx-policy.CAA3F5F6-4519-410D-960B-FDC323FA08E2</string>
 	<key>PayloadDisplayName</key>
 	<string>Santa: System Extension</string>
 	<key>PayloadDescription</key>
@@ -73,13 +73,13 @@ example as a template.
 	<array>
 		<dict>
 			<key>PayloadUUID</key>
-			<string>98D01A7B-ADC1-43C8-AB8E-8BDC25FCA3C9</string>
+			<string>67EF74B6-F4FB-49FC-A086-5DE3E61B838A</string>
 			<key>PayloadType</key>
 			<string>com.apple.system-extension-policy</string>
 			<key>PayloadOrganization</key>
 			<string>My Company</string>
 			<key>PayloadIdentifier</key>
-			<string>com.mycompany.santa.sysx-policy.98D01A7B-ADC1-43C8-AB8E-8BDC25FCA3C9</string>
+			<string>com.mycompany.santa.sysx-policy.67EF74B6-F4FB-49FC-A086-5DE3E61B838A</string>
 			<key>PayloadDisplayName</key>
 			<string>Sysx</string>
 			<key>PayloadDescription</key>

--- a/docs/docs/deployment/profile-tcc.md
+++ b/docs/docs/deployment/profile-tcc.md
@@ -62,13 +62,13 @@ for deploying custom profiles, you can use the following example as a template.
 <plist version="1.0">
 <dict>
 	<key>PayloadUUID</key>
-	<string>089CBCFB-F2AA-407C-9F2A-A12967FE20BC</string>
+	<string>9622A065-8AA4-4294-BDA3-71AA5C15BD93</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadOrganization</key>
 	<string>My Company</string>
 	<key>PayloadIdentifier</key>
-	<string>com.mycompany.santa.tcc-policy.089CBCFB-F2AA-407C-9F2A-A12967FE20BC</string>
+	<string>com.mycompany.santa.tcc-policy.9622A065-8AA4-4294-BDA3-71AA5C15BD93</string>
 	<key>PayloadDisplayName</key>
 	<string>Santa: TCC</string>
 	<key>PayloadDescription</key>
@@ -85,13 +85,13 @@ for deploying custom profiles, you can use the following example as a template.
 	<array>
 		<dict>
 			<key>PayloadUUID</key>
-			<string>2416BA4B-CBFC-4719-B02F-20251B881D6F</string>
+			<string>8339162A-75E7-4E07-91DC-45DC939A4764</string>
 			<key>PayloadType</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
 			<key>PayloadOrganization</key>
 			<string>My Company</string>
 			<key>PayloadIdentifier</key>
-			<string>com.mycompany.santa.tcc-policy.2416BA4B-CBFC-4719-B02F-20251B881D6F</string>
+			<string>com.mycompany.santa.tcc-policy.8339162A-75E7-4E07-91DC-45DC939A4764</string>
 			<key>PayloadDisplayName</key>
 			<string>TCC</string>
 			<key>PayloadDescription</key>


### PR DESCRIPTION
This PR updates the UUIDs in the example profiles for the system extension and the TCC profile. 

Related to #379 