### PR TITLE
build: Disable codesign timestamp for dev builds

### DIFF
--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -134,7 +134,6 @@ macos_application(
     bundle_id = "com.northpolesec.santa",
     bundle_name = "Santa",
     codesignopts = [
-        "--timestamp",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -27,7 +27,6 @@ macos_command_line_application(
     name = "santabundleservice",
     bundle_id = "com.northpolesec.santa.bundleservice",
     codesignopts = [
-        "--timestamp",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -99,7 +99,6 @@ macos_command_line_application(
     name = "santactl",
     bundle_id = "com.northpolesec.santa.ctl",
     codesignopts = [
-        "--timestamp",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -978,7 +978,6 @@ macos_bundle(
     bundle_extension = "systemextension",
     bundle_id = "com.northpolesec.santa.daemon",
     codesignopts = [
-        "--timestamp",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -57,7 +57,6 @@ macos_command_line_application(
     name = "santametricservice",
     bundle_id = "com.northpolesec.santa.metricservice",
     codesignopts = [
-        "--timestamp",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -234,7 +234,6 @@ macos_command_line_application(
     name = "santasyncservice",
     bundle_id = "com.northpolesec.santa.syncservice",
     codesignopts = [
-        "--timestamp",
         "--force",
         "--options library,kill,runtime",
     ],


### PR DESCRIPTION
This speeds up the build slightly, especially when the timestamp server is busy or when building on a poor connection.

These timestamps are not needed, given that we re-sign every binary when releasing anyway and that signature has its own timestamp.