### PR TITLE
Collect, open, and send telemetry files to sync service for processing

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1107,7 +1107,12 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 - (BOOL)enableTelemetryExport {
+  // Temporarily only enable for debug builds
+#ifdef DEBUG
   return [self.configState[kEnableTelemetryExport] boolValue];
+#else
+  return NO;
+#endif
 }
 
 - (uint32_t)telemetryExportIntervalSec {

--- a/Source/common/SNTXPCSyncServiceInterface.h
+++ b/Source/common/SNTXPCSyncServiceInterface.h
@@ -29,6 +29,7 @@
 - (void)postBundleEventToSyncServer:(SNTStoredEvent *)event
                               reply:(void (^)(SNTBundleEventAction))reply;
 - (void)pushNotificationStatus:(void (^)(SNTPushNotificationStatus))reply;
+- (void)exportTelemetryFile:(NSFileHandle *)fd reply:(void (^)(BOOL))reply;
 
 // The syncservice regularly syncs with a configured sync server. Use this method to sync out of
 // band. The syncservice ensures syncs do not run concurrently.

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -98,6 +98,11 @@ struct RuleCounts {
 ///
 - (void)syncBundleEvent:(SNTStoredEvent *)event relatedEvents:(NSArray<SNTStoredEvent *> *)events;
 
+///
+///  Telemetry Ops
+///
+- (void)exportTelemetryWithReply:(void (^)(BOOL))reply;
+
 @end
 
 @interface SNTXPCUnprivilegedControlInterface : NSObject

--- a/Source/common/Timer.h
+++ b/Source/common/Timer.h
@@ -73,10 +73,13 @@ class Timer {
 
  private:
   /// Update the timer firing settings. If a timer is currently active, will
-  /// result in it immediately firing and then again at the current interval.
+  /// result in it firing in 10 seconds and then again at the current interval.
+  /// The 10 second delay is to allow the sync service to launch and settle
+  /// since it is often launched around the same time this timer is started.
   void UpdateTimingParameters() {
     if (timer_source_) {
-      dispatch_source_set_timer(timer_source_, DISPATCH_WALLTIME_NOW,
+      dispatch_source_set_timer(timer_source_,
+                                dispatch_time(DISPATCH_WALLTIME_NOW, 10 * NSEC_PER_SEC),
                                 interval_seconds_ * NSEC_PER_SEC, 0);
     }
   }

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -44,6 +44,17 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTCommandTelemetry",
+    srcs = ["Commands/SNTCommandTelemetry.mm"],
+    deps = [
+        ":santactl_cmd",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTXPCControlInterface",
+    ],
+)
+
+objc_library(
     name = "santactl_lib",
     srcs = [
         "Commands/SNTCommandCheckCache.m",
@@ -69,6 +80,7 @@ objc_library(
     deps = [
         ":SNTCommandInstall",
         ":SNTCommandPrintLog",
+        ":SNTCommandTelemetry",
         ":santactl_cmd",
         "//Source/common:MOLCertificate",
         "//Source/common:MOLCodesignChecker",

--- a/Source/santactl/Commands/SNTCommandTelemetry.mm
+++ b/Source/santactl/Commands/SNTCommandTelemetry.mm
@@ -1,0 +1,111 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+// This command currently only exists in debug builds
+#ifdef DEBUG
+
+#import "Source/santactl/SNTCommand.h"
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTXPCControlInterface.h"
+#import "Source/santactl/SNTCommandController.h"
+
+@interface SNTCommandTelemetry : SNTCommand <SNTCommandProtocol>
+@end
+
+@implementation SNTCommandTelemetry
+
+REGISTER_COMMAND_NAME(@"telemetry")
+
++ (BOOL)requiresRoot {
+  return NO;
+}
+
++ (BOOL)requiresDaemonConn {
+  return YES;
+}
+
++ (NSString *)shortHelpText {
+  return @"Interact with Santa telemetry.";
+}
+
++ (NSString *)longHelpText {
+  return (@"Usage: santactl telemetry [options]\n"
+          @"  One of:\n"
+          @"    --export: Export current telemetry.\n"
+          @"\n");
+}
+
+- (void)runWithArguments:(NSArray *)arguments {
+  if (!arguments.count) {
+    [self printErrorUsageAndExit:@"No arguments"];
+  }
+
+  enum class TelemetryOperation {
+    kUnknown,
+    kExport,
+  };
+
+  TelemetryOperation operation = TelemetryOperation::kUnknown;
+
+  // Parse arguments
+  for (NSUInteger i = 0; i < arguments.count; ++i) {
+    NSString *arg = arguments[i];
+
+    if ([arg caseInsensitiveCompare:@"--export"] == NSOrderedSame) {
+      operation = TelemetryOperation::kExport;
+    } else {
+      [self printErrorUsageAndExit:[@"Unknown argument: " stringByAppendingString:arg]];
+    }
+  }
+
+  switch (operation) {
+    case TelemetryOperation::kExport: {
+      [self exportTelemetry];
+      break;
+    }
+    default: [self printErrorUsageAndExit:@"No operation provided"];
+  }
+
+  // Individual operation handlers control exiting with success or failure
+  exit(EXIT_FAILURE);
+}
+
+- (void)exportTelemetry {
+  int64_t secondsToWait = 300;
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+  [[self.daemonConn synchronousRemoteObjectProxy] exportTelemetryWithReply:^(BOOL success) {
+    if (success) {
+      LOGI(@"Telemetry exported successfully.");
+    } else {
+      LOGI(@"Telemetry export failed. Please consult logs for more information.");
+    }
+
+    dispatch_semaphore_signal(sema);
+  }];
+
+  if (dispatch_semaphore_wait(sema,
+                              dispatch_time(DISPATCH_TIME_NOW, secondsToWait * NSEC_PER_SEC)) > 0) {
+    LOGW(@"Timed out waiting for export to complete.");
+    exit(EXIT_FAILURE);
+  }
+
+  exit(EXIT_SUCCESS);
+}
+
+@end
+
+#endif  // DEBUG

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -719,6 +719,10 @@ objc_library(
 objc_library(
     name = "EndpointSecurityWriter",
     hdrs = ["Logs/EndpointSecurity/Writers/Writer.h"],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+    ],
 )
 
 objc_library(
@@ -750,6 +754,8 @@ objc_library(
         "//Source/common:santa_cc_proto_library_wrapper",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool_log_batch_writer",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -781,11 +787,14 @@ objc_library(
         ":EndpointSecurityWriterSpool",
         ":EndpointSecurityWriterSyslog",
         ":SNTDecisionCache",
+        ":SNTSyncdQueue",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredEvent",
         "//Source/common:TelemetryEventMap",
         "//Source/common:Timer",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -64,7 +64,7 @@ class LoggerPeer : public Logger {
   using Logger::Logger;
 
   LoggerPeer(std::unique_ptr<Logger> l)
-      : Logger(TelemetryEvent::kEverything, l->serializer_, l->writer_) {}
+      : Logger(nil, TelemetryEvent::kEverything, l->serializer_, l->writer_) {}
 
   std::shared_ptr<santa::Serializer> Serializer() { return serializer_; }
 
@@ -114,32 +114,36 @@ class MockWriter : public Null {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
 
   XCTAssertEqual(nullptr,
-                 Logger::Create(mockESApi, TelemetryEvent::kEverything, (SNTEventLogType)123, nil,
-                                @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
+                 Logger::Create(mockESApi, nil, TelemetryEvent::kEverything, (SNTEventLogType)123,
+                                nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
 
-  LoggerPeer logger(Logger::Create(mockESApi, TelemetryEvent::kEverything, SNTEventLogTypeFilelog,
-                                   nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
+  LoggerPeer logger(Logger::Create(mockESApi, nil, TelemetryEvent::kEverything,
+                                   SNTEventLogTypeFilelog, nil, @"/tmp/temppy", @"/tmp/spool", 1, 1,
+                                   1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<BasicString>(logger.Serializer()));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<File>(logger.Writer()));
 
-  logger = LoggerPeer(Logger::Create(mockESApi, TelemetryEvent::kEverything, SNTEventLogTypeSyslog,
-                                     nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
+  logger =
+      LoggerPeer(Logger::Create(mockESApi, nil, TelemetryEvent::kEverything, SNTEventLogTypeSyslog,
+                                nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<BasicString>(logger.Serializer()));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Syslog>(logger.Writer()));
 
-  logger = LoggerPeer(Logger::Create(mockESApi, TelemetryEvent::kEverything, SNTEventLogTypeNull,
-                                     nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
+  logger =
+      LoggerPeer(Logger::Create(mockESApi, nil, TelemetryEvent::kEverything, SNTEventLogTypeNull,
+                                nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Empty>(logger.Serializer()));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Null>(logger.Writer()));
 
-  logger =
-      LoggerPeer(Logger::Create(mockESApi, TelemetryEvent::kEverything, SNTEventLogTypeProtobuf,
-                                nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
+  logger = LoggerPeer(Logger::Create(mockESApi, nil, TelemetryEvent::kEverything,
+                                     SNTEventLogTypeProtobuf, nil, @"/tmp/temppy", @"/tmp/spool", 1,
+                                     1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.Serializer()));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Spool>(logger.Writer()));
 
-  logger = LoggerPeer(Logger::Create(mockESApi, TelemetryEvent::kEverything, SNTEventLogTypeJSON,
-                                     nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
+  logger =
+      LoggerPeer(Logger::Create(mockESApi, nil, TelemetryEvent::kEverything, SNTEventLogTypeJSON,
+                                nil, @"/tmp/temppy", @"/tmp/spool", 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.Serializer()));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<File>(logger.Writer()));
 }
@@ -164,7 +168,8 @@ class MockWriter : public Null {
     EXPECT_CALL(*mockSerializer, SerializeMessage(testing::A<const EnrichedClose &>())).Times(1);
     EXPECT_CALL(*mockWriter, Write).Times(1);
 
-    Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter).Log(std::move(enrichedMsg));
+    Logger(nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
+        .Log(std::move(enrichedMsg));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
@@ -183,7 +188,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeAllowlist(testing::_, hash));
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter)
+  Logger(nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
       .LogAllowlist(Message(mockESApi, &msg), hash);
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
@@ -199,7 +204,8 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeBundleHashingEvent).Times((int)[events count]);
   EXPECT_CALL(*mockWriter, Write).Times((int)[events count]);
 
-  Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter).LogBundleHashingEvents(events);
+  Logger(nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
+      .LogBundleHashingEvents(events);
 
   XCTBubbleMockVerifyAndClearExpectations(mockSerializer.get());
   XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
@@ -212,7 +218,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeDiskAppeared);
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter).LogDiskAppeared(@{
+  Logger(nil, TelemetryEvent::kEverything, mockSerializer, mockWriter).LogDiskAppeared(@{
     @"key" : @"value"
   });
 
@@ -227,7 +233,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeDiskDisappeared);
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter).LogDiskDisappeared(@{
+  Logger(nil, TelemetryEvent::kEverything, mockSerializer, mockWriter).LogDiskDisappeared(@{
     @"key" : @"value"
   });
 
@@ -246,7 +252,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeFileAccess(_, _, _, _, _, _));
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(TelemetryEvent::kEverything, mockSerializer, mockWriter)
+  Logger(nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
       .LogFileAccess(
           "v1", "name", Message(mockESApi, &msg),
           EnrichedProcess(std::nullopt, std::nullopt, std::nullopt, std::nullopt,

--- a/Source/santad/Logs/EndpointSecurity/MockLogger.h
+++ b/Source/santad/Logs/EndpointSecurity/MockLogger.h
@@ -28,7 +28,8 @@ class MockLogger : public santa::Logger {
  public:
   using Logger::Logger;
 
-  MockLogger() : Logger(santa::TelemetryEvent::kEverything, nullptr, nullptr) {}
+  MockLogger()
+      : Logger(nil, santa::TelemetryEvent::kEverything, nullptr, nullptr) {}
 
   MOCK_METHOD(void, Log, (std::unique_ptr<santa::EnrichedMessage>));
 

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -99,9 +100,11 @@ class FsSpoolWriter {
 class FsSpoolReader {
  public:
   explicit FsSpoolReader(absl::string_view base_directory);
-  absl::Status AckMessage(const std::string& message_path);
+  absl::Status AckMessage(const std::string& message_path, bool delete_file);
   // Returns absl::NotFoundError in case the FsSpool is empty.
   absl::StatusOr<std::string> NextMessagePath();
+  absl::StatusOr<absl::flat_hash_set<std::string>> BatchMessagePaths(
+      size_t count);
   int NumberOfUnackedMessages() const;
 
  private:

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_nowindows.cc
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_nowindows.cc
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -53,7 +54,8 @@ int Open(const char* filename, int flags, mode_t mode) {
 int Close(int fd) { return close(fd); }
 
 absl::Status IterateDirectory(
-    const std::string& dir, std::function<void(const std::string&)> callback) {
+    const std::string& dir,
+    std::function<void(const std::string&, bool*)> callback) {
   if (!IsDirectory(dir)) {
     return absl::InvalidArgumentError(
         absl::StrFormat("%s is not a directory", dir));
@@ -63,8 +65,9 @@ absl::Status IterateDirectory(
     return absl::ErrnoToStatus(errno, absl::StrCat("failed to open ", dir));
   }
   struct dirent* ep;
-  while ((ep = readdir(dp)) != nullptr) {
-    callback(ep->d_name);
+  bool stop = false;
+  while (!stop && ((ep = readdir(dp)) != nullptr)) {
+    callback(ep->d_name, &stop);
   }
   closedir(dp);
   return absl::OkStatus();

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -34,8 +35,9 @@ bool StatIsReg(mode_t mode);
 int Unlink(const char* pathname);
 int Write(int fd, absl::string_view buf);
 
-absl::Status IterateDirectory(const std::string& dir,
-                              std::function<void(const std::string&)> callback);
+absl::Status IterateDirectory(
+    const std::string& dir,
+    std::function<void(const std::string&, bool*)> callback);
 
 }  // namespace fsspool
 

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
@@ -1,4 +1,5 @@
 /// Copyright 2022 Google LLC
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@
 #include <dispatch/dispatch.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -26,6 +28,8 @@
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_log_batch_writer.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 
 // Forward declarations
 namespace santa {
@@ -48,6 +52,10 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   void Write(std::vector<uint8_t> &&bytes) override;
   void Flush() override;
 
+  std::optional<absl::flat_hash_set<std::string>> GetFilesToExport(size_t max_count) override;
+  std::optional<std::string> NextFileToExport() override;
+  void FilesExported(absl::flat_hash_map<std::string, bool> files_exported) override;
+
   void BeginFlushTask();
 
   // Peer class for testing
@@ -58,6 +66,7 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
 
   dispatch_queue_t q_ = NULL;
   dispatch_source_t timer_source_ = NULL;
+  ::fsspool::FsSpoolReader spool_reader_;
   ::fsspool::FsSpoolWriter spool_writer_;
   ::fsspool::FsSpoolLogBatchWriter log_batch_writer_;
   const size_t spool_file_size_threshold_;

--- a/Source/santad/Logs/EndpointSecurity/Writers/Writer.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Writer.h
@@ -1,21 +1,27 @@
 /// Copyright 2022 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///
-///    http://www.apache.org/licenses/LICENSE-2.0
+///     https://www.apache.org/licenses/LICENSE-2.0
 ///
-///    Unless required by applicable law or agreed to in writing, software
-///    distributed under the License is distributed on an "AS IS" BASIS,
-///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-///    See the License for the specific language governing permissions and
-///    limitations under the License.
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #ifndef SANTA__SANTAD__LOGS_ENDPOINTSECURITY_WRITERS_WRITER_H
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_WRITERS_WRITER_H
 
+#include <optional>
+#include <utility>
 #include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 
 namespace santa {
 
@@ -23,8 +29,20 @@ class Writer {
  public:
   virtual ~Writer() = default;
 
-  virtual void Write(std::vector<uint8_t>&& bytes) = 0;
+  virtual void Write(std::vector<uint8_t> &&bytes) = 0;
   virtual void Flush() = 0;
+
+  virtual std::optional<absl::flat_hash_set<std::string>> GetFilesToExport(
+      size_t max_count) {
+    return std::nullopt;
+  }
+
+  virtual std::optional<std::string> NextFileToExport() { return std::nullopt; }
+
+  virtual void FilesExported(
+      absl::flat_hash_map<std::string, bool> files_exported) {
+    // no-op
+  }
 };
 
 }  // namespace santa

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -514,4 +514,9 @@ double watchdogRAMPeak = 0;
   [self reloadSystemExtension];
 }
 
+- (void)exportTelemetryWithReply:(void (^)(BOOL))reply {
+  _logger->ExportTelemetry();
+  reply(YES);
+}
+
 @end

--- a/Source/santad/SNTSyncdQueue.h
+++ b/Source/santad/SNTSyncdQueue.h
@@ -22,8 +22,11 @@
 @interface SNTSyncdQueue : NSObject
 
 - (void)reassessSyncServiceConnection;
+- (void)reassessSyncServiceConnectionImmediately;
 
 - (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle;
 - (void)addBundleEvent:(SNTStoredEvent *)event reply:(void (^)(SNTBundleEventAction))reply;
+- (void)exportTelemetryFile:(NSFileHandle *)telemetryFile
+          completionHandler:(void (^)(BOOL))completionHandler;
 
 @end

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -197,7 +197,6 @@
 
 - (void)exportTelemetryFile:(NSFileHandle *)telemetryFile
           completionHandler:(void (^)(BOOL))completionHandler {
-  LOGE(@"Syncd queue, about to dispatch...");
   [self dispatchBlockOnSyncdQueue:^{
     if (self.syncConnection.remoteObjectProxy) {
       [self.syncConnection.remoteObjectProxy exportTelemetryFile:telemetryFile

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -27,7 +27,7 @@
 
 @interface SNTSyncdQueue ()
 @property dispatch_queue_t syncdQueue;
-@property(nonatomic) MOLXPCConnection *syncConnection;
+@property MOLXPCConnection *syncConnection;
 @property dispatch_source_t timer;
 @property NSURL *previousSyncBaseURL;
 @property BOOL syncServiceConnected;
@@ -57,6 +57,13 @@
 /// state, as well as relevant config deltas, to determine whether the sync
 /// service should be started, bounced, or stopped.
 - (void)reassessSyncServiceConnection {
+  [self reassessSyncServiceConnectionWithDelay:1];
+}
+- (void)reassessSyncServiceConnectionImmediately {
+  [self reassessSyncServiceConnectionWithDelay:0];
+}
+
+- (void)reassessSyncServiceConnectionWithDelay:(uint32_t)seconds {
   WEAKIFY(self);
   dispatch_sync(self.syncdQueue, ^{
     if (self.timer) {
@@ -64,9 +71,8 @@
     }
 
     self.timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.syncdQueue);
-    dispatch_source_set_timer(self.timer,
-                              dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC),  // 1 second delay
-                              DISPATCH_TIME_FOREVER,                               // won't repeat
+    dispatch_source_set_timer(self.timer, dispatch_time(DISPATCH_TIME_NOW, seconds * NSEC_PER_SEC),
+                              DISPATCH_TIME_FOREVER,  // won't repeat
                               100 * NSEC_PER_MSEC);
 
     // WEAKIFY(self);
@@ -76,6 +82,7 @@
 
       NSURL *newSyncBaseURL = [configurator syncBaseURL];
       BOOL statsCollectionEnabled = [configurator enableStatsCollection];
+      BOOL telemetryExportEnabled = [configurator enableTelemetryExport];
 
       // If the SyncBaseURL was added or changed, and a connection already
       // exists, it must be bounced.
@@ -90,15 +97,18 @@
       self.previousSyncBaseURL = newSyncBaseURL;
 
       // If newSyncBaseURL or statsCollectionEnabled is set, start the sync service
-      if (newSyncBaseURL || statsCollectionEnabled) {
+      if (newSyncBaseURL || statsCollectionEnabled || telemetryExportEnabled) {
         if (!self.syncServiceConnected) {
           [self establishSyncServiceConnectionSerialized];
         }
 
-        // Ensure any pending requests to clear sync state are cancelled.
-        [NSObject cancelPreviousPerformRequestsWithTarget:[SNTConfigurator configurator]
-                                                 selector:@selector(clearSyncState)
-                                                   object:nil];
+        // Ensure any pending requests to clear sync state are cancelled, but
+        // only if there is a sync base URL set
+        if (newSyncBaseURL) {
+          [NSObject cancelPreviousPerformRequestsWithTarget:[SNTConfigurator configurator]
+                                                   selector:@selector(clearSyncState)
+                                                     object:nil];
+        }
       } else {
         if (self.syncServiceConnected) {
           // Note: Only teardown the connection if we're connected. This helps
@@ -183,6 +193,20 @@
   dispatch_async(self.syncdQueue, ^{
     block();
   });
+}
+
+- (void)exportTelemetryFile:(NSFileHandle *)telemetryFile
+          completionHandler:(void (^)(BOOL))completionHandler {
+  LOGE(@"Syncd queue, about to dispatch...");
+  [self dispatchBlockOnSyncdQueue:^{
+    if (self.syncConnection.remoteObjectProxy) {
+      [self.syncConnection.remoteObjectProxy exportTelemetryFile:telemetryFile
+                                                           reply:completionHandler];
+    } else {
+      // Unable to send to sync service, but still must call the completion handler
+      completionHandler(NO);
+    }
+  }];
 }
 
 // The event upload is skipped if an event has been initiated for it in the last 10 minutes.

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -189,7 +189,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
     [authorizer_client registerAuthExecProbe:proc_faa_client];
   }
 
-  [syncd_queue reassessSyncServiceConnection];
+  [syncd_queue reassessSyncServiceConnectionImmediately];
 
   NSMutableArray<SNTKVOManager *> *kvoObservers = [[NSMutableArray alloc] init];
   [kvoObservers addObjectsFromArray:@[
@@ -560,6 +560,8 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
                                    LOGI(@"EnableTelemetryExport changed: %d -> %d", oldBool,
                                         newBool);
+
+                                   [syncd_queue reassessSyncServiceConnectionImmediately];
 
                                    if (newBool) {
                                      logger->StartTimer();

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -133,7 +133,7 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
   uint32_t telemetry_export_frequency_secs = [configurator telemetryExportIntervalSec];
 
   std::unique_ptr<::Logger> logger = Logger::Create(
-      esapi,
+      esapi, syncd_queue,
       TelemetryConfigToBitmask([configurator telemetry], [configurator enableAllEventUpload]),
       [configurator eventLogType], [SNTDecisionCache sharedCache], [configurator eventLogPath],
       [configurator spoolDirectory], spool_dir_threshold_bytes, spool_file_threshold_bytes,

--- a/Source/santasyncservice/SNTSyncService.mm
+++ b/Source/santasyncservice/SNTSyncService.mm
@@ -97,6 +97,12 @@
   [self.syncManager pushNotificationStatus:reply];
 }
 
+- (void)exportTelemetryFile:(NSFileHandle *)fd reply:(void (^)(BOOL))reply {
+  // Note: For now, reply false so that spool files are not removed
+  LOGD(@"SNTSyncService: exportTelemetryFile:reply: - Got file descriptor: %@", fd);
+  reply(NO);
+}
+
 // TODO(bur): Add support for santactl sync --debug to enable debug logging for that sync.
 - (void)syncWithLogListener:(NSXPCListenerEndpoint *)logListener
                    syncType:(SNTSyncType)syncType


### PR DESCRIPTION
The PR starts many of the foundational pieces for eventual support for exporting telemetry.

The overall flow is:
1. Export is triggered via a timer in `santad`, or a new `santactl telemetry` command
    1.1. If triggered via `santactl`, an XPC message is sent to `santad` to start exporting
2. `santad` will query the configured writer (based on the `EventLogType`) for files to export
    1.1.  For each telemetry file, it is first opened
    1.2. The file descriptor is sent to the sync service to perform the actual export
    * The file descriptor is passed because the sync service doesn't have permissions to read the log files and also ensures logic for handling log files is kept within the daemon
3. When `santad` receives a response from the sync service, it will inform the writer whether or not the action was successful so it can do appropriate cleanup.

This currently can only be enabled in debug builds, including the new `santactl telemetry` command.