### PR TITLE
Remove run time and compile time checks for macOS 13

### DIFF
--- a/Source/common/MOLXPCConnection.h
+++ b/Source/common/MOLXPCConnection.h
@@ -119,8 +119,7 @@
  @note If the connection to the server failed, this will be nil, so you can safely send messages
  and rely on the invalidationHandler for handling the failure.
  */
-@property(readonly, nonatomic, nullable) id synchronousRemoteObjectProxy API_AVAILABLE(macos(10.11))
-    ;
+@property(readonly, nonatomic, nullable) id synchronousRemoteObjectProxy;
 
 /**
  The privileged interface this object exports. (server)

--- a/Source/common/Platform.h
+++ b/Source/common/Platform.h
@@ -18,13 +18,6 @@
 
 #include <Availability.h>
 
-#if defined(MAC_OS_VERSION_13_0) && \
-    MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_13_0
-#define HAVE_MACOS_13 1
-#else
-#undef HAVE_MACOS_13
-#endif
-
 #if defined(MAC_OS_VERSION_14_0) && \
     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_14_0
 #define HAVE_MACOS_14 1

--- a/Source/common/SNTFileInfoTest.m
+++ b/Source/common/SNTFileInfoTest.m
@@ -34,12 +34,8 @@
 - (void)testPathStandardizing {
   SNTFileInfo *sut = [[SNTFileInfo alloc] initWithPath:@"/Applications/Safari.app"];
   XCTAssertNotNil(sut);
-  if (@available(macOS 13.0, *)) {
-    XCTAssertEqualObjects(sut.path, @"/System/Volumes/Preboot/Cryptexes/App/System/Applications/"
-                                    @"Safari.app/Contents/MacOS/Safari");
-  } else {
-    XCTAssertEqualObjects(sut.path, @"/Applications/Safari.app/Contents/MacOS/Safari");
-  }
+  XCTAssertEqualObjects(sut.path, @"/System/Volumes/Preboot/Cryptexes/App/System/Applications/"
+                                  @"Safari.app/Contents/MacOS/Safari");
 
   sut = [[SNTFileInfo alloc] initWithPath:@"../../../../../../../../../../../../../../../bin/ls"];
   XCTAssertEqualObjects(sut.path, @"/bin/ls");
@@ -96,20 +92,6 @@
 
 - (void)testKext {
   // Skip this test on macOS 13 as KEXTs have moved into the kernelcache.
-  if (@available(macOS 13.0, *)) {
-    return;
-  }
-
-  SNTFileInfo *sut = [[SNTFileInfo alloc]
-      initWithPath:@"/System/Library/Extensions/AppleAPIC.kext/Contents/MacOS/AppleAPIC"];
-
-  XCTAssertTrue(sut.isMachO);
-  XCTAssertTrue(sut.isKext);
-
-  XCTAssertFalse(sut.isDylib);
-  XCTAssertFalse(sut.isExecutable);
-  XCTAssertFalse(sut.isFat);
-  XCTAssertFalse(sut.isScript);
 }
 
 - (void)testDylibs {

--- a/Source/common/SNTFileInfoTest.m
+++ b/Source/common/SNTFileInfoTest.m
@@ -90,10 +90,6 @@
   XCTAssertFalse(sut.isMissingPageZero);
 }
 
-- (void)testKext {
-  // Skip this test on macOS 13 as KEXTs have moved into the kernelcache.
-}
-
 - (void)testDylibs {
   SNTFileInfo *sut = [[SNTFileInfo alloc] initWithPath:@"/usr/lib/system/libsystem_platform.dylib"];
 

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -35,7 +35,7 @@
                           customMessage:(NSString *)message
                               customURL:(NSString *)url
                              customText:(NSString *)text
-                            configState:(SNTConfigState *)configState API_AVAILABLE(macos(13.0));
+                            configState:(SNTConfigState *)configState;
 - (void)postClientModeNotification:(SNTClientMode)clientmode;
 - (void)postRuleSyncNotificationForApplication:(NSString *)app;
 - (void)updateCountsForEvent:(SNTStoredEvent *)event

--- a/Source/common/TestUtils.mm
+++ b/Source/common/TestUtils.mm
@@ -270,7 +270,6 @@ uint32_t MinSupportedESMessageVersion(es_event_type_t event_type) {
     case ES_EVENT_TYPE_AUTH_COPYFILE:
     case ES_EVENT_TYPE_NOTIFY_COPYFILE: return 4;
 
-#if HAVE_MACOS_13
     // The following events are available beginning in macOS 13.0
     case ES_EVENT_TYPE_NOTIFY_AUTHENTICATION:
     case ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED:
@@ -287,7 +286,6 @@ uint32_t MinSupportedESMessageVersion(es_event_type_t event_type) {
     case ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT:
     case ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD:
     case ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE: return 6;
-#endif
 
 #if HAVE_MACOS_14
     // The following events are available beginning in macOS 14.0

--- a/Source/gui/SNTFileAccessMessageWindowController.h
+++ b/Source/gui/SNTFileAccessMessageWindowController.h
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 ///  Controller for a single message window.
 ///
-API_AVAILABLE(macos(13.0))
 @interface SNTFileAccessMessageWindowController : SNTMessageWindowController <NSWindowDelegate>
 
 - (instancetype)initWithEvent:(SNTFileAccessEvent *)event

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -20,7 +20,6 @@ import santa_common_SNTConfigState
 import santa_common_SNTFileAccessEvent
 import santa_gui_SNTMessageView
 
-@available(macOS 13, *)
 @objc public class SNTFileAccessMessageWindowViewFactory: NSObject {
   @objc public static func createWith(
     window: NSWindow,

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -408,7 +408,7 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
                           customMessage:(NSString *)message
                               customURL:(NSString *)url
                              customText:(NSString *)text
-                            configState:(SNTConfigState *)configState API_AVAILABLE(macos(13.0)) {
+                            configState:(SNTConfigState *)configState {
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -57,62 +57,31 @@ bool EndpointSecurityAPI::UnmuteAllPaths(const Client &client) {
 }
 
 bool EndpointSecurityAPI::UnmuteAllTargetPaths(const Client &client) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    return es_unmute_all_target_paths(client.Get()) == ES_RETURN_SUCCESS;
-  }
-#endif
-
-  return true;
+  return es_unmute_all_target_paths(client.Get()) == ES_RETURN_SUCCESS;
 }
 
 bool EndpointSecurityAPI::IsTargetPathMutingInverted(const Client &client) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    return es_muting_inverted(client.Get(), ES_MUTE_INVERSION_TYPE_TARGET_PATH) == ES_MUTE_INVERTED;
-  }
-#endif
-
-  return false;
+  return es_muting_inverted(client.Get(), ES_MUTE_INVERSION_TYPE_TARGET_PATH) == ES_MUTE_INVERTED;
 }
 
 bool EndpointSecurityAPI::InvertTargetPathMuting(const Client &client) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    if (!IsTargetPathMutingInverted(client)) {
-      return es_invert_muting(client.Get(), ES_MUTE_INVERSION_TYPE_TARGET_PATH) ==
-             ES_RETURN_SUCCESS;
-    } else {
-      return true;
-    }
+  if (!IsTargetPathMutingInverted(client)) {
+    return es_invert_muting(client.Get(), ES_MUTE_INVERSION_TYPE_TARGET_PATH) == ES_RETURN_SUCCESS;
+  } else {
+    return true;
   }
-#endif
-
-  return false;
 }
 
 bool EndpointSecurityAPI::IsProcessMutingInverted(const Client &client) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    return es_muting_inverted(client.Get(), ES_MUTE_INVERSION_TYPE_PROCESS) == ES_MUTE_INVERTED;
-  }
-#endif
-
-  return false;
+  return es_muting_inverted(client.Get(), ES_MUTE_INVERSION_TYPE_PROCESS) == ES_MUTE_INVERTED;
 }
 
 bool EndpointSecurityAPI::InvertProcessMuting(const Client &client) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    if (!IsProcessMutingInverted(client)) {
-      return es_invert_muting(client.Get(), ES_MUTE_INVERSION_TYPE_PROCESS) == ES_RETURN_SUCCESS;
-    } else {
-      return true;
-    }
+  if (!IsProcessMutingInverted(client)) {
+    return es_invert_muting(client.Get(), ES_MUTE_INVERSION_TYPE_PROCESS) == ES_RETURN_SUCCESS;
+  } else {
+    return true;
   }
-#endif
-
-  return false;
 }
 
 bool EndpointSecurityAPI::MuteProcess(const Client &client, const audit_token_t *tok) {
@@ -125,30 +94,18 @@ bool EndpointSecurityAPI::UnmuteProcess(const Client &client, const audit_token_
 
 bool EndpointSecurityAPI::MuteTargetPath(const Client &client, std::string_view path,
                                          WatchItemPathType path_type) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    return es_mute_path(client.Get(), path.data(),
-                        path_type == WatchItemPathType::kPrefix
-                            ? ES_MUTE_PATH_TYPE_TARGET_PREFIX
-                            : ES_MUTE_PATH_TYPE_TARGET_LITERAL) == ES_RETURN_SUCCESS;
-  }
-#endif
-
-  return false;
+  return es_mute_path(client.Get(), path.data(),
+                      path_type == WatchItemPathType::kPrefix
+                          ? ES_MUTE_PATH_TYPE_TARGET_PREFIX
+                          : ES_MUTE_PATH_TYPE_TARGET_LITERAL) == ES_RETURN_SUCCESS;
 }
 
 bool EndpointSecurityAPI::UnmuteTargetPath(const Client &client, std::string_view path,
                                            WatchItemPathType path_type) {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    return es_unmute_path(client.Get(), path.data(),
-                          path_type == WatchItemPathType::kPrefix
-                              ? ES_MUTE_PATH_TYPE_TARGET_PREFIX
-                              : ES_MUTE_PATH_TYPE_TARGET_LITERAL) == ES_RETURN_SUCCESS;
-  }
-#endif
-
-  return true;
+  return es_unmute_path(client.Get(), path.data(),
+                        path_type == WatchItemPathType::kPrefix
+                            ? ES_MUTE_PATH_TYPE_TARGET_PREFIX
+                            : ES_MUTE_PATH_TYPE_TARGET_LITERAL) == ES_RETURN_SUCCESS;
 }
 
 bool EndpointSecurityAPI::RespondAuthResult(const Client &client, const Message &msg,

--- a/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
@@ -472,11 +472,7 @@ class EnrichedAuthenticationOD : public EnrichedEventWithInstigator {
   EnrichedAuthenticationOD(EnrichedAuthenticationOD &&) = default;
 
   const es_process_t *EventInstigator() const override {
-#if HAVE_MACOS_13
     return es_msg_->event.authentication->data.od->instigator;
-#else
-    return nullptr;
-#endif
   }
 
   std::optional<audit_token_t> EventInstigatorToken() const override {
@@ -504,11 +500,7 @@ class EnrichedAuthenticationTouchID : public EnrichedEventWithInstigator {
   EnrichedAuthenticationTouchID(EnrichedAuthenticationTouchID &&) = default;
 
   const es_process_t *EventInstigator() const override {
-#if HAVE_MACOS_13
     return es_msg_->event.authentication->data.touchid->instigator;
-#else
-    return nullptr;
-#endif
   }
 
   std::optional<audit_token_t> EventInstigatorToken() const override {
@@ -537,11 +529,7 @@ class EnrichedAuthenticationToken : public EnrichedEventWithInstigator {
   EnrichedAuthenticationToken(EnrichedAuthenticationToken &&) = default;
 
   const es_process_t *EventInstigator() const override {
-#if HAVE_MACOS_13
     return es_msg_->event.authentication->data.token->instigator;
-#else
-    return nullptr;
-#endif
   }
 
   std::optional<audit_token_t> EventInstigatorToken() const override {
@@ -589,15 +577,11 @@ class EnrichedLaunchItem : public EnrichedEventWithInstigator {
   EnrichedLaunchItem(EnrichedLaunchItem &&) = default;
 
   const es_process_t *EventInstigator() const override {
-#if HAVE_MACOS_13
     if (es_msg_->event_type == ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD) {
       return es_msg_->event.btm_launch_item_add->instigator;
     } else {
       return es_msg_->event.btm_launch_item_remove->instigator;
     }
-#else
-    return nullptr;
-#endif
   }
 
   std::optional<audit_token_t> EventInstigatorToken() const override {
@@ -624,15 +608,11 @@ class EnrichedLaunchItem : public EnrichedEventWithInstigator {
   }
 
   const es_process_t *AppRegistrant() const {
-#if HAVE_MACOS_13
     if (es_msg_->event_type == ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD) {
       return es_msg_->event.btm_launch_item_add->app;
     } else {
       return es_msg_->event.btm_launch_item_remove->app;
     }
-#else
-    return nullptr;
-#endif
   }
 
   std::optional<audit_token_t> AppRegistrantToken() const {

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -90,7 +90,6 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
     case ES_EVENT_TYPE_NOTIFY_COPYFILE:
       return std::make_unique<EnrichedMessage>(EnrichedCopyfile(
           std::move(es_msg), Enrich(*es_msg->process), Enrich(*es_msg->event.copyfile.source)));
-#if HAVE_MACOS_13
     case ES_EVENT_TYPE_NOTIFY_AUTHENTICATION:
       switch (es_msg->event.authentication->type) {
         case ES_AUTHENTICATION_TYPE_OD:
@@ -173,7 +172,6 @@ std::unique_ptr<EnrichedMessage> Enricher::Enrich(Message &&es_msg) {
     case ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED:
       return std::make_unique<EnrichedMessage>(
           EnrichedXProtectRemediated(std::move(es_msg), Enrich(*es_msg->process)));
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
     case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE:
       return std::make_unique<EnrichedMessage>(EnrichedGatekeeperOverride(

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -101,7 +101,6 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
     case ES_EVENT_TYPE_NOTIFY_CLOSE: {
       BOOL shouldLogClose = esMsg->event.close.modified;
 
-#if HAVE_MACOS_13
       if (esMsg->version >= 6) {
         // As of macSO 13.0 we have a new field for if a file was mmaped with
         // write permissions on close events. However due to a bug in ES, it
@@ -113,7 +112,6 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
         // account.
         shouldLogClose |= esMsg->event.close.was_mapped_writable;
       }
-#endif
 
       if (!shouldLogClose) {
         // Ignore unmodified files
@@ -209,28 +207,22 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
     ES_EVENT_TYPE_NOTIFY_LINK,
     ES_EVENT_TYPE_NOTIFY_RENAME,
     ES_EVENT_TYPE_NOTIFY_UNLINK,
+    ES_EVENT_TYPE_NOTIFY_AUTHENTICATION,
+    ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN,
+    ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT,
+    ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN,
+    ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT,
+    ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK,
+    ES_EVENT_TYPE_NOTIFY_LW_SESSION_UNLOCK,
+    ES_EVENT_TYPE_NOTIFY_SCREENSHARING_ATTACH,
+    ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH,
+    ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN,
+    ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT,
+    ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD,
+    ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE,
+    ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED,
+    ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED,
   };
-
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    events.insert({
-      ES_EVENT_TYPE_NOTIFY_AUTHENTICATION,
-      ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN,
-      ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT,
-      ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN,
-      ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT,
-      ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK,
-      ES_EVENT_TYPE_NOTIFY_LW_SESSION_UNLOCK,
-      ES_EVENT_TYPE_NOTIFY_SCREENSHARING_ATTACH,
-      ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH,
-      ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN,
-      ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT,
-      ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD,
-      ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE,
-      ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED,
-      ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED});
-  }
-#endif  // HAVE_MACOS_13
 
 #if HAVE_MACOS_15
   if (@available(macOS 15.0, *)) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -81,28 +81,32 @@ class MockAuthResultCache : public AuthResultCache {
 }
 
 - (std::set<es_event_type_t>)expectedSubscriptions {
-  std::set<es_event_type_t> expectedEventSubs{
-      ES_EVENT_TYPE_NOTIFY_CLONE,        ES_EVENT_TYPE_NOTIFY_CLOSE,
-      ES_EVENT_TYPE_NOTIFY_COPYFILE,     ES_EVENT_TYPE_NOTIFY_CS_INVALIDATED,
-      ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA, ES_EVENT_TYPE_NOTIFY_EXEC,
-      ES_EVENT_TYPE_NOTIFY_FORK,         ES_EVENT_TYPE_NOTIFY_EXIT,
-      ES_EVENT_TYPE_NOTIFY_LINK,         ES_EVENT_TYPE_NOTIFY_RENAME,
-      ES_EVENT_TYPE_NOTIFY_UNLINK,
-  };
-
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    expectedEventSubs.insert(
-        {ES_EVENT_TYPE_NOTIFY_AUTHENTICATION, ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN,
-         ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT, ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK,
-         ES_EVENT_TYPE_NOTIFY_LW_SESSION_UNLOCK, ES_EVENT_TYPE_NOTIFY_SCREENSHARING_ATTACH,
-         ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH, ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN,
-         ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT, ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN,
-         ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT, ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD,
-         ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE, ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED,
-         ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED});
-  }
-#endif  // HAVE_MACOS_13
+  std::set<es_event_type_t> expectedEventSubs{ES_EVENT_TYPE_NOTIFY_CLONE,
+                                              ES_EVENT_TYPE_NOTIFY_CLOSE,
+                                              ES_EVENT_TYPE_NOTIFY_COPYFILE,
+                                              ES_EVENT_TYPE_NOTIFY_CS_INVALIDATED,
+                                              ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA,
+                                              ES_EVENT_TYPE_NOTIFY_EXEC,
+                                              ES_EVENT_TYPE_NOTIFY_FORK,
+                                              ES_EVENT_TYPE_NOTIFY_EXIT,
+                                              ES_EVENT_TYPE_NOTIFY_LINK,
+                                              ES_EVENT_TYPE_NOTIFY_RENAME,
+                                              ES_EVENT_TYPE_NOTIFY_UNLINK,
+                                              ES_EVENT_TYPE_NOTIFY_AUTHENTICATION,
+                                              ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGIN,
+                                              ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT,
+                                              ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK,
+                                              ES_EVENT_TYPE_NOTIFY_LW_SESSION_UNLOCK,
+                                              ES_EVENT_TYPE_NOTIFY_SCREENSHARING_ATTACH,
+                                              ES_EVENT_TYPE_NOTIFY_SCREENSHARING_DETACH,
+                                              ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN,
+                                              ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGOUT,
+                                              ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN,
+                                              ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT,
+                                              ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD,
+                                              ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE,
+                                              ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED,
+                                              ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED};
 
 #if HAVE_MACOS_15
   if (@available(macOS 15.0, *)) {
@@ -248,64 +252,56 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 }
 
 - (void)testHandleEventCloseMappedWritableMatchesRegex {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    // CLOSE not modified, but was_mapped_writable, should remove from cache,
-    // and matches fileChangesRegex
-    TestHelperBlock testBlock =
-        ^(es_message_t *esMsg, std::shared_ptr<MockEndpointSecurityAPI> mockESApi, id mockCC,
-          SNTEndpointSecurityRecorder *recorderClient, std::shared_ptr<PrefixTree<Unit>> prefixTree,
-          __autoreleasing dispatch_semaphore_t *sema,
-          __autoreleasing dispatch_semaphore_t *semaMetrics) {
-          esMsg->event_type = ES_EVENT_TYPE_NOTIFY_CLOSE;
-          esMsg->event.close.modified = false;
-          esMsg->event.close.was_mapped_writable = true;
-          esMsg->event.close.target = &targetFileMatchesRegex;
-          Message msg(mockESApi, esMsg);
-
-          OCMExpect([mockCC handleEvent:msg withLogger:nullptr]).ignoringNonObjectArgs();
-
-          XCTAssertNoThrow([recorderClient handleMessage:Message(mockESApi, esMsg)
-                                      recordEventMetrics:^(EventDisposition d) {
-                                        XCTAssertEqual(d, EventDisposition::kProcessed);
-                                        dispatch_semaphore_signal(*semaMetrics);
-                                      }]);
-          XCTAssertSemaTrue(*semaMetrics, 5, "Metrics not recorded within expected window");
-          XCTAssertSemaTrue(*sema, 5, "Log wasn't called within expected time window");
-        };
-
-    [self handleMessageShouldLog:YES shouldRemoveFromCache:YES withBlock:testBlock];
-  }
-#endif
-}
-
-- (void)testHandleEventCloseMappedWritableMissesRegex {
-#if HAVE_MACOS_13
-  if (@available(macOS 13.0, *)) {
-    // CLOSE not modified, but was_mapped_writable, remove from cache, and does not match
-    // fileChangesRegex
-    TestHelperBlock testBlock = ^(
-        es_message_t *esMsg, std::shared_ptr<MockEndpointSecurityAPI> mockESApi, id mockCC,
+  // CLOSE not modified, but was_mapped_writable, should remove from cache,
+  // and matches fileChangesRegex
+  TestHelperBlock testBlock =
+      ^(es_message_t *esMsg, std::shared_ptr<MockEndpointSecurityAPI> mockESApi, id mockCC,
         SNTEndpointSecurityRecorder *recorderClient, std::shared_ptr<PrefixTree<Unit>> prefixTree,
         __autoreleasing dispatch_semaphore_t *sema,
         __autoreleasing dispatch_semaphore_t *semaMetrics) {
-      esMsg->event_type = ES_EVENT_TYPE_NOTIFY_CLOSE;
-      esMsg->event.close.modified = false;
-      esMsg->event.close.was_mapped_writable = true;
-      esMsg->event.close.target = &targetFileMissesRegex;
-      Message msg(mockESApi, esMsg);
+        esMsg->event_type = ES_EVENT_TYPE_NOTIFY_CLOSE;
+        esMsg->event.close.modified = false;
+        esMsg->event.close.was_mapped_writable = true;
+        esMsg->event.close.target = &targetFileMatchesRegex;
+        Message msg(mockESApi, esMsg);
 
-      OCMExpect([mockCC handleEvent:msg withLogger:nullptr]).ignoringNonObjectArgs();
+        OCMExpect([mockCC handleEvent:msg withLogger:nullptr]).ignoringNonObjectArgs();
 
-      XCTAssertNoThrow([recorderClient handleMessage:Message(mockESApi, esMsg)
-                                  recordEventMetrics:^(EventDisposition d) {
-                                    XCTFail("Metrics record callback should not be called here");
-                                  }]);
-    };
+        XCTAssertNoThrow([recorderClient handleMessage:Message(mockESApi, esMsg)
+                                    recordEventMetrics:^(EventDisposition d) {
+                                      XCTAssertEqual(d, EventDisposition::kProcessed);
+                                      dispatch_semaphore_signal(*semaMetrics);
+                                    }]);
+        XCTAssertSemaTrue(*semaMetrics, 5, "Metrics not recorded within expected window");
+        XCTAssertSemaTrue(*sema, 5, "Log wasn't called within expected time window");
+      };
 
-    [self handleMessageShouldLog:NO shouldRemoveFromCache:YES withBlock:testBlock];
-  }
-#endif
+  [self handleMessageShouldLog:YES shouldRemoveFromCache:YES withBlock:testBlock];
+}
+
+- (void)testHandleEventCloseMappedWritableMissesRegex {
+  // CLOSE not modified, but was_mapped_writable, remove from cache, and does not match
+  // fileChangesRegex
+  TestHelperBlock testBlock =
+      ^(es_message_t *esMsg, std::shared_ptr<MockEndpointSecurityAPI> mockESApi, id mockCC,
+        SNTEndpointSecurityRecorder *recorderClient, std::shared_ptr<PrefixTree<Unit>> prefixTree,
+        __autoreleasing dispatch_semaphore_t *sema,
+        __autoreleasing dispatch_semaphore_t *semaMetrics) {
+        esMsg->event_type = ES_EVENT_TYPE_NOTIFY_CLOSE;
+        esMsg->event.close.modified = false;
+        esMsg->event.close.was_mapped_writable = true;
+        esMsg->event.close.target = &targetFileMissesRegex;
+        Message msg(mockESApi, esMsg);
+
+        OCMExpect([mockCC handleEvent:msg withLogger:nullptr]).ignoringNonObjectArgs();
+
+        XCTAssertNoThrow([recorderClient handleMessage:Message(mockESApi, esMsg)
+                                    recordEventMetrics:^(EventDisposition d) {
+                                      XCTFail("Metrics record callback should not be called here");
+                                    }]);
+      };
+
+  [self handleMessageShouldLog:NO shouldRemoveFromCache:YES withBlock:testBlock];
 }
 
 - (void)testHandleMessage {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -51,7 +51,6 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCSInvalidated &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedClone &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCopyfile &) override;
-#if HAVE_MACOS_13
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLock &) override;
@@ -69,7 +68,6 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLaunchItem &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectDetected &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectRemediated &) override;
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -194,8 +194,6 @@ static inline void AppendInstigator(std::string &str, const EnrichedEventType &e
   AppendInstigator(str, event->process, event.instigator(), prefix);
 }
 
-#if HAVE_MACOS_13
-
 static inline void AppendEventUser(std::string &str,
                                    const std::optional<std::shared_ptr<std::string>> &user,
                                    uid_t uid, const std::string prefix = "event_") {
@@ -243,8 +241,6 @@ static inline std::string GetOpenSSHLoginResult(std::string &str,
     default: return "UNKNOWN";
   }
 }
-
-#endif  // HAVE_MACOS_13
 
 static char *FormattedDateString(char *buf, size_t len) {
   struct timeval tv;
@@ -512,8 +508,6 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedCopyfile &msg) 
 
   return FinalizeString(str);
 }
-
-#if HAVE_MACOS_13
 
 std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedLoginWindowSessionLogin &msg) {
   std::string str = CreateDefaultString();
@@ -940,8 +934,6 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedXProtectRemedia
 
   return FinalizeString(str);
 }
-
-#endif  // HAVE_MACOS_13
 
 #if HAVE_MACOS_15
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -306,8 +306,6 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   XCTAssertCppStringEqual(got, want);
 }
 
-#if HAVE_MACOS_13
-
 - (void)testSerializeMessageLoginWindowSessionLogin {
   es_file_t procFile = MakeESFile("foo");
   es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(12, 34), MakeAuditToken(56, 78));
@@ -1053,8 +1051,6 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 
   XCTAssertCppStringEqual(got, want);
 }
-
-#endif  // HAVE_MACOS_13
 
 #if HAVE_MACOS_15
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -43,7 +43,6 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCSInvalidated &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedClone &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCopyfile &) override;
-#if HAVE_MACOS_13
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLock &) override;
@@ -61,7 +60,6 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLaunchItem &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectDetected &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectRemediated &) override;
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -67,8 +67,6 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedCopyfile &msg) {
   return {};
 }
 
-#if HAVE_MACOS_13
-
 std::vector<uint8_t> Empty::SerializeMessage(const EnrichedLoginWindowSessionLogin &msg) {
   return {};
 }
@@ -136,8 +134,6 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedXProtectDetected &) {
 std::vector<uint8_t> Empty::SerializeMessage(const EnrichedXProtectRemediated &) {
   return {};
 }
-
-#endif  // HAVE_MACOS_13
 
 #if HAVE_MACOS_15
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -50,7 +50,6 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCSInvalidated &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedClone &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedCopyfile &) override;
-#if HAVE_MACOS_13
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogin &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogout &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLock &) override;
@@ -68,7 +67,6 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedLaunchItem &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectDetected &) override;
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectRemediated &) override;
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
   std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) override;
 #endif  // HAVE_MACOS_15

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -683,8 +683,6 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedCopyfile &msg) {
   return FinalizeProto(santa_msg);
 }
 
-#if HAVE_MACOS_13
-
 ::pbv1::SocketAddress::Type GetSocketAddressType(es_address_type_t type) {
   switch (type) {
     case ES_ADDRESS_TYPE_NONE: return ::pbv1::SocketAddress::TYPE_NONE;
@@ -1181,8 +1179,6 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedXProtectRemediated
 
   return FinalizeProto(santa_msg);
 }
-
-#endif  // HAVE_MACOS_13
 
 #if HAVE_MACOS_15
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -70,14 +70,12 @@ extern ::pbv1::Execution::Mode GetModeEnum(SNTClientMode mode);
 extern ::pbv1::FileDescriptor::FDType GetFileDescriptorType(uint32_t fdtype);
 extern ::pbv1::FileAccess::AccessType GetAccessType(es_event_type_t event_type);
 extern ::pbv1::FileAccess::PolicyDecision GetPolicyDecision(FileAccessPolicyDecision decision);
-#if HAVE_MACOS_13
 extern ::pbv1::SocketAddress::Type GetSocketAddressType(es_address_type_t type);
 extern ::pbv1::OpenSSHLogin::Result GetOpenSSHLoginResultType(es_openssh_login_result_type_t type);
 extern ::pbv1::AuthenticationTouchID::Mode GetAuthenticationTouchIDMode(es_touchid_mode_t mode);
 extern ::pbv1::AuthenticationAutoUnlock::Type GetAuthenticationAutoUnlockType(
     es_auto_unlock_type_t type);
 extern ::pbv1::LaunchItem::ItemType GetBTMLaunchItemType(es_btm_item_type_t item_type);
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15_4
 extern ::pbv1::TCCModification::IdentityType GetTCCIdentityType(es_tcc_identity_type_t id_type);
 extern ::pbv1::TCCModification::EventType GetTCCEventType(es_tcc_event_type_t event_type);
@@ -893,8 +891,6 @@ void SerializeAndCheckNonESEvents(
                   }];
 }
 
-#if HAVE_MACOS_13
-
 - (void)testSerializeMessageLoginWindowSessionLogin {
   __block es_event_lw_session_login_t lwLogin = {
       .username = MakeESStringToken("daemon"),
@@ -1496,8 +1492,6 @@ void SerializeAndCheckNonESEvents(
                   }
                        variant:@"null_token"];
 }
-
-#endif  // HAVE_MACOS_13
 
 #if HAVE_MACOS_15
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -64,7 +64,6 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedCSInvalidated &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedClone &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedCopyfile &) = 0;
-#if HAVE_MACOS_13
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedLoginWindowSessionLogin &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(
       const santa::EnrichedLoginWindowSessionLogout &) = 0;
@@ -85,7 +84,6 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedLaunchItem &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectDetected &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedXProtectRemediated &) = 0;
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
   virtual std::vector<uint8_t> SerializeMessage(const santa::EnrichedGatekeeperOverride &) = 0;
 #endif  // HAVE_MACOS_15

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -59,7 +59,6 @@ static NSString *const kEventTypeNotifyRename = @"NotifyRename";
 static NSString *const kEventTypeNotifyUnlink = @"NotifyUnlink";
 static NSString *const kEventTypeNotifyUnmount = @"NotifyUnmount";
 static NSString *const kPseudoEventTypeGlobal = @"Global";
-#if HAVE_MACOS_13
 static NSString *const kEventTypeNotifyAuthentication = @"NotifyAuthentication";
 static NSString *const kEventTypeNotifyLoginLogin = @"NotifyLoginLogin";
 static NSString *const kEventTypeNotifyLoginLogout = @"NotifyLoginLogout";
@@ -75,7 +74,6 @@ static NSString *const kEventTypeNotifyLaunchItemAdd = @"NotifyLaunchItemAdd";
 static NSString *const kEventTypeNotifyLaunchItemRemove = @"NotifyLaunchItemRemove";
 static NSString *const kEventTypeNotifyXProtectDetected = @"NotifyXProtectDetected";
 static NSString *const kEventTypeNotifyXProtectRemediated = @"NotifyXProtectRemediated";
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
 static NSString *const kEventTypeNotifyGatekeeperOverride = @"NotifyGatekeeperOverride";
 #endif  // HAVE_MACOS_15
@@ -150,7 +148,6 @@ NSString *const EventTypeToString(es_event_type_t eventType) {
     case ES_EVENT_TYPE_NOTIFY_RENAME: return kEventTypeNotifyRename;
     case ES_EVENT_TYPE_NOTIFY_UNLINK: return kEventTypeNotifyUnlink;
     case ES_EVENT_TYPE_NOTIFY_UNMOUNT: return kEventTypeNotifyUnmount;
-#if HAVE_MACOS_13
     case ES_EVENT_TYPE_NOTIFY_AUTHENTICATION: return kEventTypeNotifyAuthentication;
     case ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN: return kEventTypeNotifyLoginLogin;
     case ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT: return kEventTypeNotifyLoginLogout;
@@ -166,7 +163,6 @@ NSString *const EventTypeToString(es_event_type_t eventType) {
     case ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE: return kEventTypeNotifyLaunchItemRemove;
     case ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED: return kEventTypeNotifyXProtectDetected;
     case ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED: return kEventTypeNotifyXProtectRemediated;
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
     case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE: return kEventTypeNotifyGatekeeperOverride;
 #endif  // HAVE_MACOS_15

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -186,7 +186,6 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
       {ES_EVENT_TYPE_NOTIFY_RENAME, @"NotifyRename"},
       {ES_EVENT_TYPE_NOTIFY_UNLINK, @"NotifyUnlink"},
       {ES_EVENT_TYPE_NOTIFY_UNMOUNT, @"NotifyUnmount"},
-#if HAVE_MACOS_13
       {ES_EVENT_TYPE_NOTIFY_AUTHENTICATION, @"NotifyAuthentication"},
       {ES_EVENT_TYPE_NOTIFY_LOGIN_LOGIN, @"NotifyLoginLogin"},
       {ES_EVENT_TYPE_NOTIFY_LOGIN_LOGOUT, @"NotifyLoginLogout"},
@@ -202,7 +201,6 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
       {ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_REMOVE, @"NotifyLaunchItemRemove"},
       {ES_EVENT_TYPE_NOTIFY_XP_MALWARE_DETECTED, @"NotifyXProtectDetected"},
       {ES_EVENT_TYPE_NOTIFY_XP_MALWARE_REMEDIATED, @"NotifyXProtectRemediated"},
-#endif  // HAVE_MACOS_13
 #if HAVE_MACOS_15
       {ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE, @"NotifyGatekeeperOverride"},
 #endif  // HAVE_MACOS_15


### PR DESCRIPTION
Since we bumped our min supported version to macOS 13, we can remove the runtime and compile time checks for macOS 13 from the codebase.

macOS 12 support dropped here: #399 