### PR TITLE
Update how MOLXPCConnection tracks connections, vends proxy objects

### DIFF
--- a/Source/common/MOLXPCConnection.h
+++ b/Source/common/MOLXPCConnection.h
@@ -132,13 +132,6 @@
 @property(retain, nullable) NSXPCInterface *unprivilegedInterface;
 
 /**
-  Old interface property, please update to use privilegedExportedInterface and/or
-  unprivilegedExportedInterface instead.
- */
-@property(retain, nullable) NSXPCInterface *exportedInterface
-    __attribute__((deprecated("Use privilegedInterface and / or unprivilegedInterface instead.")));
-
-/**
  The object that responds to messages from the other end. (server)
  */
 @property(retain, nullable) id exportedObject;
@@ -152,6 +145,11 @@
  A block to run when a/the connection is invalidated/interrupted/rejected.
  */
 @property(copy, nullable) void (^invalidationHandler)(void);
+
+/**
+ Whether or not the XPC connection is currently established.
+ */
+@property(readonly) BOOL isConnected;
 
 @end
 

--- a/Source/common/MOLXPCConnection.m
+++ b/Source/common/MOLXPCConnection.m
@@ -124,6 +124,7 @@
     self.currentConnection.remoteObjectInterface = self.validationInterface;
     self.currentConnection.interruptionHandler = self.currentConnection.invalidationHandler = ^{
       STRONGIFY(self);
+      self.currentConnection.remoteObjectInterface = nil;
       if (self.invalidationHandler) self.invalidationHandler();
     };
     [self.currentConnection resume];
@@ -158,15 +159,6 @@
     interface = self.privilegedInterface;
   } else {
     interface = self.unprivilegedInterface;
-  }
-
-  // TODO(any): Remove 1-2 releases after exportedInterface was marked deprecated.
-  if (!interface) {
-    // Silence warning about using exportedInterface temporarily until this is removed.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    interface = self.exportedInterface;
-#pragma clang diagnostic pop
   }
 
   if (!interface) return NO;
@@ -205,8 +197,7 @@
 }
 
 - (id)remoteObjectProxy {
-  if (self.currentConnection.remoteObjectInterface &&
-      self.currentConnection.remoteObjectInterface != self.validationInterface) {
+  if (self.isConnected) {
     return [self.currentConnection remoteObjectProxyWithErrorHandler:^(NSError *error) {
       [self.currentConnection invalidate];
     }];
@@ -215,13 +206,17 @@
 }
 
 - (id)synchronousRemoteObjectProxy {
-  if (self.currentConnection.remoteObjectInterface &&
-      self.currentConnection.remoteObjectInterface != self.validationInterface) {
+  if (self.isConnected) {
     return [self.currentConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError *error) {
       [self.currentConnection invalidate];
     }];
   }
   return nil;
+}
+
+- (BOOL)isConnected {
+  return self.currentConnection.remoteObjectInterface &&
+      self.currentConnection.remoteObjectInterface == self.remoteInterface;
 }
 
 #pragma mark Connection tear-down

--- a/Source/common/MOLXPCConnection.m
+++ b/Source/common/MOLXPCConnection.m
@@ -216,7 +216,7 @@
 
 - (BOOL)isConnected {
   return self.currentConnection.remoteObjectInterface &&
-      self.currentConnection.remoteObjectInterface == self.remoteInterface;
+         self.currentConnection.remoteObjectInterface == self.remoteInterface;
 }
 
 #pragma mark Connection tear-down

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -559,7 +559,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                    LOGI(@"EnableTelemetryExport changed: %d -> %d", oldBool,
                                         newBool);
 
-                                   [syncd_queue reassessSyncServiceConnectionImmediately];
+                                   [syncd_queue reassessSyncServiceConnection];
 
                                    if (newBool) {
                                      logger->StartTimer();


### PR DESCRIPTION
Also removes deprecated `exportedInterface` that is no longer used.