### PR TITLE
gui: change button behavior during hashing

### DIFF
--- a/Source/gui/SNTMessageView.swift
+++ b/Source/gui/SNTMessageView.swift
@@ -141,7 +141,11 @@ public func MoreDetailsButton(_ showDetails: Binding<Bool>) -> some View {
   .help("⌘ m")
 }
 
-public func OpenEventButton(customText: String? = nil, action: @escaping () -> Void) -> some View {
+public func OpenEventButton(
+  customText: String? = nil,
+  disabled: Bool? = false,
+  action: @escaping () -> Void
+) -> some View {
   Button(
     action: action,
     label: {
@@ -149,6 +153,7 @@ public func OpenEventButton(customText: String? = nil, action: @escaping () -> V
       Text(t).frame(maxWidth: 200.0)
     }
   )
+  .disabled(disabled ?? false)
   .keyboardShortcut(.return, modifiers: .command)
   .help("⌘ Return")
 }


### PR DESCRIPTION
1. During bundle hashing the Dismiss button will now show up as "Cancel".
2. During hashing the Open button _will_ be shown but will be disabled, instead of not showing at all.
3. I removed the `bundleProgress` variable from subviews that do not need it