### PR TITLE
bundle service: Adaptive priority

### DIFF
--- a/Conf/com.northpolesec.santa.bundleservice.plist
+++ b/Conf/com.northpolesec.santa.bundleservice.plist
@@ -19,7 +19,7 @@
 	<key>KeepAlive</key>
 	<false/>
 	<key>ProcessType</key>
-	<string>Interactive</string>
+	<string>Adaptive</string>
 	<key>ThrottleInterval</key>
 	<integer>0</integer>
 	<key>EnablePressuredExit</key>


### PR DESCRIPTION
From reading the docs, it seems like this is the correct priority - though in practice I have not noticed a difference in performance or EnablePressuredExit when under load. Doesn't seem to hurt, so let's go for it.