### PR TITLE
common: Add CEL evaluator

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,7 @@ build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
 build --copt=-Werror
 build --copt=-Wall
 build --copt=-Wno-error=deprecated-declarations
+build --copt=-Wno-error=nullability-completeness
 build --copt=-Wreorder-init-list
 build --copt=-Wc99-designator
 build --copt=-Wno-c++20-designator
@@ -13,6 +14,12 @@ build --copt=-Wno-error=deprecated-non-prototype
 build --per_file_copt=.*\.mm\$@-std=c++20
 build --cxxopt=-std=c++20
 build --host_cxxopt=-std=c++20
+
+# cel-cpp has lots of warnings that we don't need to see (and definitely don't
+# want to be treated as errors).
+build --per_file_copt=.*cel-cpp.*@-Wno-deprecated-declarations
+build --per_file_copt=.*cel-cpp.*@-Wno-nullability-completeness
+build --per_file_copt=.*cel-cpp.*@-Wno-unused-function
 
 build --copt=-DSANTA_OPEN_SOURCE=1
 build --cxxopt=-DSANTA_OPEN_SOURCE=1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,16 @@ git_override(
     remote = "https://github.com/northpolesec/protos",
 )
 
+# cel-cpp
+# The 0.11.0 release has a bug in it that was fixed a few weeks later but hasn't
+# been released yet.
+bazel_dep(name = "cel-cpp", version = "0.11.0")
+git_override(
+    module_name = "cel-cpp",
+    commit = "dbf9eff24a835193fae8eec27540ddbb6464e63a",
+    remote = "https://github.com/google/cel-cpp.git",
+)
+
 # FMDB
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "FMDB")

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -60,6 +60,14 @@ cc_library(
     ],
 )
 
+santa_unit_test(
+    name = "SantaCacheTest",
+    srcs = ["SantaCacheTest.mm"],
+    deps = [
+        ":SantaCache",
+    ],
+)
+
 cc_library(
     name = "SantaSetCache",
     hdrs = ["SantaSetCache.h"],
@@ -72,24 +80,73 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "AuditUtilities",
-    hdrs = ["AuditUtilities.h"],
-)
-
-santa_unit_test(
-    name = "SantaCacheTest",
-    srcs = ["SantaCacheTest.mm"],
-    deps = [
-        ":SantaCache",
-    ],
-)
-
 santa_unit_test(
     name = "SantaSetCacheTest",
     srcs = ["SantaSetCacheTest.mm"],
     deps = [
         ":SantaSetCache",
+    ],
+)
+
+cc_library(
+    name = "AuditUtilities",
+    hdrs = ["AuditUtilities.h"],
+)
+
+proto_library(
+    name = "cel_proto",
+    srcs = ["CEL.proto"],
+    deps = [
+        "@protobuf//:timestamp_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "cel_cc_proto",
+    deps = [":cel_proto"],
+)
+
+objc_library(
+    name = "CEL",
+    srcs = ["CEL.cc"],
+    hdrs = ["CEL.h"],
+    deps = [
+        ":cel_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@cel-cpp//checker:validation_result",
+        "@cel-cpp//common:ast_proto",
+        "@cel-cpp//common:function_descriptor",
+        "@cel-cpp//compiler",
+        "@cel-cpp//compiler:compiler_factory",
+        "@cel-cpp//compiler:standard_library",
+        "@cel-cpp//eval/public:activation",
+        "@cel-cpp//eval/public:activation_bind_helper",
+        "@cel-cpp//eval/public:builtin_func_registrar",
+        "@cel-cpp//eval/public:cel_expr_builder_factory",
+        "@cel-cpp//eval/public:cel_expression",
+        "@cel-cpp//eval/public:cel_function",
+        "@cel-cpp//eval/public:cel_function_adapter",
+        "@cel-cpp//eval/public:cel_options",
+        "@cel-cpp//eval/public:cel_value",
+        "@cel-cpp//eval/public/containers:field_access",
+        "@cel-cpp//eval/public/structs:cel_proto_wrapper",
+        "@cel-cpp//internal:status_macros",
+        "@cel-cpp//parser",
+        "@northpolesec_protos//sync:v1_cc_proto",
+    ],
+)
+
+santa_unit_test(
+    name = "CELTest",
+    srcs = ["CELTest.mm"],
+    deps = [
+        ":CEL",
+        ":cel_cc_proto",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@northpolesec_protos//sync:v1_cc_proto",
     ],
 )
 
@@ -701,6 +758,7 @@ santa_unit_test(
 test_suite(
     name = "unit_tests",
     tests = [
+        ":CELTest",
         ":EncodeEntitlementsTest",
         ":MOLAuthenticatingURLSessionTest",
         ":MOLCertificateTest",

--- a/Source/common/CEL.cc
+++ b/Source/common/CEL.cc
@@ -1,0 +1,236 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/CEL.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "cel/expr/checked.pb.h"
+#include "common/ast_proto.h"
+#include "compiler/compiler_factory.h"
+#include "compiler/standard_library.h"
+#include "eval/public/activation_bind_helper.h"
+#include "eval/public/builtin_func_registrar.h"
+#include "eval/public/cel_expr_builder_factory.h"
+#include "eval/public/cel_function_adapter.h"
+
+namespace cel_runtime = ::google::api::expr::runtime;
+namespace syncv1 = ::santa::sync::v1;
+namespace pbv1 = ::santa::cel::v1;
+
+namespace santa {
+
+// Creates a CEL Activation with the static and dynamic contexts attached
+// appropriately.
+absl::StatusOr<cel_runtime::Activation> CreateActivation(
+    ::pbv1::CELStaticContext *static_context,
+    ::pbv1::CELDynamicContext * (^dynamicBlock)(
+        ::google::protobuf::Arena *arena)) {
+  cel_runtime::Activation activation;
+
+  if (dynamicBlock) {
+    absl::StatusOr<std::unique_ptr<cel_runtime::CelFunction>> getArgsFunction =
+        cel_runtime::FunctionAdapter<::pbv1::CELDynamicContext *>::Create(
+            "getDynamic", false,
+            std::function<::pbv1::CELDynamicContext *(
+                ::google::protobuf::Arena *)>(
+                [dynamicBlock](::google::protobuf::Arena *arena)
+                    -> ::pbv1::CELDynamicContext * {
+                  return dynamicBlock(arena);
+                }));
+    if (!getArgsFunction.ok()) {
+      return getArgsFunction.status();
+    }
+
+    if (auto result =
+            activation.InsertFunction(std::move(getArgsFunction.value()));
+        !result.ok()) {
+      return result;
+    }
+  }
+
+  google::protobuf::Arena arena;
+  if (auto result = BindProtoToActivation(
+          static_context, &arena, &activation,
+          cel_runtime::ProtoUnsetFieldOptions::kBindDefault);
+      !result.ok()) {
+    return result;
+  }
+
+  return activation;
+}
+
+absl::Status CELEvaluator::Initialize() {
+  // Link the reflection for needed messages to that the CEL compiler can
+  // recognize them.
+  google::protobuf::LinkMessageReflection<::pbv1::CELStaticContext>();
+  google::protobuf::LinkMessageReflection<::pbv1::CELDynamicContext>();
+  // We need the Policy enum to be linked in and the library doesn't seem to
+  // have a way to force enum reflection to be linked, so we're using the Rule
+  // message as that contains a field that uses Policy.
+  google::protobuf::LinkMessageReflection<::syncv1::Rule>();
+
+  // Create a compiler builder with the generated descriptor pool for protos.
+  absl::StatusOr<std::unique_ptr<::cel::CompilerBuilder>> builderStatus =
+      ::cel::NewCompilerBuilder(
+          google::protobuf::DescriptorPool::generated_pool());
+  if (!builderStatus.ok()) {
+    return builderStatus.status();
+  }
+  auto builder = std::move(builderStatus.value());
+
+  // Add the standard library.
+  if (auto result = builder->AddLibrary(::cel::StandardCompilerLibrary());
+      !result.ok()) {
+    return result;
+  }
+
+  ::cel::TypeCheckerBuilder &checker_builder = builder->GetCheckerBuilder();
+
+  // Add the static context type. The value will be bound during activation.
+  if (auto result = checker_builder.AddContextDeclaration(
+          ::pbv1::CELStaticContext::descriptor()->full_name());
+      !result.ok()) {
+    return result;
+  }
+
+  // Add the single getDynamic function overload.
+  // The implementation will be bound during activation.
+  absl::StatusOr<::cel::FunctionDecl> decl = ::cel::MakeFunctionDecl(
+      "getDynamic",
+      ::cel::MakeOverloadDecl(
+          "getDynamic",
+          ::cel::MessageType(::pbv1::CELDynamicContext::descriptor())));
+  if (!decl.ok()) {
+    return decl.status();
+  }
+  if (absl::Status result = checker_builder.MergeFunction(decl.value());
+      !result.ok()) {
+    return result;
+  }
+
+  // Build and store the compiler.
+  absl::StatusOr<std::unique_ptr<::cel::Compiler>> compiler = builder->Build();
+  if (!compiler.ok()) {
+    return compiler.status();
+  }
+  compiler_ = std::move(compiler.value());
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<::cel_runtime::CelExpression>>
+CELEvaluator::Compile(absl::string_view expr) {
+  if (!compiler_) {
+    return absl::InvalidArgumentError(
+        "CELEvaluator::Initialize() must be called before Compile()");
+  }
+
+  // Compile the expression.
+  absl::StatusOr<::cel::ValidationResult> result = compiler_->Compile(expr);
+  if (!result.ok()) {
+    return absl::Status(std::move(result.status()));
+  }
+  if (!result.value().IsValid() || result.value().GetAst() == nullptr) {
+    return absl::InvalidArgumentError(result.value().FormatError());
+  }
+
+  // Check the AST for correctness.
+  ::cel::expr::CheckedExpr cel_expr;
+  if (absl::Status status =
+          ::cel::AstToCheckedExpr(*result.value().GetAst(), &cel_expr);
+      !status.ok()) {
+    return status;
+  }
+
+  // Setup a default environment for building expressions.
+  cel_runtime::InterpreterOptions options;
+  std::unique_ptr<cel_runtime::CelExpressionBuilder> builder =
+      CreateCelExpressionBuilder(
+          google::protobuf::DescriptorPool::generated_pool(),
+          google::protobuf::MessageFactory::generated_factory(), options);
+
+  // Register the builtin functions.
+  if (auto result = RegisterBuiltinFunctions(builder->GetRegistry(), options);
+      !result.ok()) {
+    return result;
+  }
+
+  // Register the getDynamic function.
+  if (auto result = builder->GetRegistry()->RegisterLazyFunction(
+          ::cel::FunctionDescriptor("getDynamic", false, {}));
+      !result.ok()) {
+    return result;
+  }
+
+  // Create an expression plan with the checked expression.
+  absl::StatusOr<std::unique_ptr<cel_runtime::CelExpression>> expression_plan =
+      builder->CreateExpression(&cel_expr);
+  return expression_plan;
+};
+
+absl::StatusOr<::santa::sync::v1::Policy> CELEvaluator::Evaluate(
+    const ::cel_runtime::CelExpression *expression_plan,
+    ::pbv1::CELStaticContext *static_context,
+    ::pbv1::CELDynamicContext * (^dynamicBlock)(
+        ::google::protobuf::Arena *arena)) {
+  // Create an activation with the static and dynamic contexts.
+  absl::StatusOr<cel_runtime::Activation> activation =
+      CreateActivation(static_context, dynamicBlock);
+  if (!activation.ok()) {
+    return activation.status();
+  }
+  // Evaluate the parsed expression.
+  google::protobuf::Arena arena;
+  absl::StatusOr<cel_runtime::CelValue> result =
+      expression_plan->Evaluate(std::move(activation.value()), &arena);
+  if (!result.ok()) {
+    return result.status();
+  }
+
+  // Check the result type.
+  // A bool value will return ALLOWLIST for true and BLOCKLIST for false.
+  // A Policy value will be returned as-is
+  // Everything else is an error.
+  if (bool value; result.value().GetValue(&value)) {
+    if (value) {
+      return syncv1::ALLOWLIST;
+    }
+    return syncv1::BLOCKLIST;
+  } else if (int64_t value; result.value().GetValue(&value) &&
+                            syncv1::Policy_IsValid((int)value)) {
+    auto policy = static_cast<syncv1::Policy>(value);
+    return policy;
+  } else if (const cel_runtime::CelError * value;
+             result.value().GetValue(&value)) {
+    return *value;
+  } else {
+    return absl::InvalidArgumentError(
+        absl::StrCat("expected 'santa.sync.v1.Policy' result got '",
+                     result.value().DebugString(), "'"));
+  }
+}
+
+absl::StatusOr<::santa::sync::v1::Policy> CELEvaluator::CompileAndEvaluate(
+    absl::string_view cel_expr, ::pbv1::CELStaticContext *static_context,
+    ::pbv1::CELDynamicContext * (^dynamicBlock)(
+        ::google::protobuf::Arena *arena)) {
+  absl::StatusOr<std::unique_ptr<::cel_runtime::CelExpression>> expr =
+      Compile(cel_expr);
+  if (!expr.ok()) {
+    return expr.status();
+  }
+  return Evaluate(expr.value().get(), static_context, dynamicBlock);
+}
+
+}  // namespace santa

--- a/Source/common/CEL.h
+++ b/Source/common/CEL.h
@@ -1,0 +1,83 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA__COMMON__CEL_H
+#define SANTA__COMMON__CEL_H
+
+#include "Source/common/CEL.pb.h"
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "sync/v1.pb.h"
+
+// CEL headers have warnings and our config turns them into errors.
+// For some reason these can't be disabled with --per_file_copt.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#include "cel/expr/checked.pb.h"
+#include "compiler/compiler.h"
+#include "eval/public/cel_expression.h"
+#pragma clang diagnostic pop
+
+namespace santa {
+
+class CELEvaluator {
+ public:
+  // Initialize the evaluator. This must be called before any other methods as
+  // it initializes the CEL compiler.
+  absl::Status Initialize();
+
+  // Compile a CEL expression from a string into an expression plan
+  // ready for evaluation. These expression plans could be cached.
+  absl::StatusOr<std::unique_ptr<::google::api::expr::runtime::CelExpression>> Compile(
+      absl::string_view cel_expr);
+
+  // Evaluate an expression plan against a static and dynamic context.
+  //
+  // The static context is all of the fields that will not change between
+  // executions of a given binary and can safely be cached.
+  //
+  // If the optional `dynamicBlock` block is provided and the expression uses
+  // uses the `getDynamic` function, the block will be called to retireve the
+  // dynamic context. Evaluations that make use of this dynamic context should
+  // not be cached.
+  absl::StatusOr<::santa::sync::v1::Policy> Evaluate(
+      ::google::api::expr::runtime::CelExpression const *expression_plan,
+      ::santa::cel::v1::CELStaticContext *static_context,
+      ::santa::cel::v1::CELDynamicContext * (^dynamicBlock)(::google::protobuf::Arena *arena));
+
+  // Convenience method that combines Compile() and Evaluate() into a single call.
+  absl::StatusOr<::santa::sync::v1::Policy> CompileAndEvaluate(
+      absl::string_view cel_expr, ::santa::cel::v1::CELStaticContext *static_context,
+      ::santa::cel::v1::CELDynamicContext * (^dynamicBlock)(::google::protobuf::Arena *arena));
+
+  CELEvaluator() = default;
+  ~CELEvaluator() = default;
+
+  CELEvaluator(CELEvaluator &&other) = default;
+  CELEvaluator &operator=(CELEvaluator &&rhs) = default;
+
+  // Could be safe to implement these, but not currently needed
+  CELEvaluator(const CELEvaluator &other) = delete;
+  CELEvaluator &operator=(const CELEvaluator &other) = delete;
+
+ private:
+  std::unique_ptr<::cel::Compiler> compiler_;
+};
+
+}  // namespace santa
+
+#endif  // SANTA__COMMON__CEL_H

--- a/Source/common/CEL.proto
+++ b/Source/common/CEL.proto
@@ -1,0 +1,34 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+syntax = "proto3";
+
+package santa.cel.v1;
+
+import "google/protobuf/timestamp.proto";
+
+message CELStaticContext {
+  message Binary {
+    optional google.protobuf.Timestamp signing_timestamp = 1;
+  }
+  Binary binary = 1;
+}
+
+message CELDynamicContext {
+  message Process {
+    repeated string args = 1;
+    repeated string envs = 2;
+  }
+  Process process = 1;
+}

--- a/Source/common/CELTest.mm
+++ b/Source/common/CELTest.mm
@@ -1,0 +1,130 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/CEL.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include <optional>
+
+#include "Source/common/CEL.pb.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "google/protobuf/arena.h"
+#include "sync/v1.pb.h"
+
+namespace syncv1 = ::santa::sync::v1;
+namespace pbv1 = ::santa::cel::v1;
+
+@interface CELTest : XCTestCase
+@end
+
+@implementation CELTest
+
+- (void)testBasic {
+  google::protobuf::Arena arena;
+  auto e = google::protobuf::Arena::Create<::pbv1::CELStaticContext>(&arena);
+
+  e->mutable_binary()->mutable_signing_timestamp()->set_seconds(1748436989);
+
+  santa::CELEvaluator sut;
+  if (auto result = sut.Initialize(); !result.ok()) {
+    XCTFail("Failed to initialize: %s", result.message().data());
+  }
+
+  {
+    // Test bad expression.
+    auto result = sut.CompileAndEvaluate("foo", e, nil);
+    if (result.ok()) XCTFail("Expected failure to evaluate, got ok!");
+  }
+  {
+    // Timestamp comparison by seconds.
+    auto result =
+        sut.CompileAndEvaluate("binary.signing_timestamp >= timestamp(1748436989)", e, nil);
+    if (!result.ok()) {
+      XCTFail(@"Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value(), syncv1::Policy::ALLOWLIST);
+    }
+  }
+  {
+    // Timestamp comparison by date string.
+    auto result = sut.CompileAndEvaluate(
+        "binary.signing_timestamp >= timestamp('2025-05-28T12:00:00Z')", e, nil);
+    if (!result.ok()) {
+      XCTFail(@"Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value(), syncv1::Policy::ALLOWLIST);
+    }
+  }
+  {
+    // Re-use of a compiled expression.
+    auto expr = sut.Compile("binary.signing_timestamp >= timestamp('2025-05-28T12:00:00Z')");
+    if (!expr.ok()) {
+      XCTFail("Failed to compile: %s", expr.status().message().data());
+    }
+
+    auto result = sut.Evaluate(expr.value().get(), e, nil);
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value(), syncv1::Policy::ALLOWLIST);
+    }
+
+    ::pbv1::CELStaticContext *e2 =
+        google::protobuf::Arena::Create<::pbv1::CELStaticContext>(&arena);
+    e2->mutable_binary()->mutable_signing_timestamp()->set_seconds(1716916129);
+    auto result2 = sut.Evaluate(expr.value().get(), e2, nil);
+    if (!result2.ok()) {
+      XCTFail("Failed to evaluate: %s", result2.status().message().data());
+    } else {
+      XCTAssertEqual(result2.value(), syncv1::Policy::BLOCKLIST);
+    }
+  }
+  {
+    // Dynamic - process args
+    auto result = sut.CompileAndEvaluate(
+        "getDynamic().process.args[0] == 'hello'", e,
+        ^::pbv1::CELDynamicContext *(google::protobuf::Arena *arena) {
+          auto dyn = google::protobuf::Arena::Create<::pbv1::CELDynamicContext>(arena);
+          dyn->mutable_process()->mutable_args()->Add("hello");
+          dyn->mutable_process()->mutable_args()->Add("world");
+          return dyn;
+        });
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value(), syncv1::Policy::ALLOWLIST);
+    }
+  }
+  {
+    // Dynamic, env vars, ternary
+    auto result = sut.CompileAndEvaluate(
+        "'DYLD_INSERT_LIBRARIES=1' in getDynamic().process.envs ? santa.sync.v1.Policy.ALLOWLIST : "
+        "santa.sync.v1.Policy.BLOCKLIST",
+        e, ^::pbv1::CELDynamicContext *(google::protobuf::Arena *arena) {
+          auto dyn = google::protobuf::Arena::Create<::pbv1::CELDynamicContext>(arena);
+          dyn->mutable_process()->mutable_envs()->Add("DYLD_INSERT_LIBRARIES=1");
+          return dyn;
+        });
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value(), syncv1::Policy::ALLOWLIST);
+    }
+  }
+}
+
+@end


### PR DESCRIPTION
This is the first part of implementing CEL rules (as a means to complete #15, and google/santa#1200).

This PR adds the necessary dependencies and a new CELEvaluator class that holds a configured compiler. The evaluator can compile CEL expressions into a re-usable expression plan and then evaluate it using static per-binary data (e.g. signing timestamp) and a block to retrieve dynamic per-process data (e.g. command-line args). 

This new library is as yet unused and won't be compiled in. The next PR will add the ability to use CEL rules during execution.