### PR TITLE
Keychain wrapper implementation

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -219,6 +219,29 @@ santa_unit_test(
 )
 
 objc_library(
+    name = "Keychain",
+    srcs = ["Keychain.mm"],
+    hdrs = ["Keychain.h"],
+    sdk_frameworks = [
+        "Security",
+    ],
+    deps = [
+        ":SNTLogging",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+    ],
+)
+
+santa_unit_test(
+    name = "KeychainTest",
+    srcs = ["KeychainTest.mm"],
+    deps = [
+        ":Keychain",
+        ":TestUtils",
+    ],
+)
+
+objc_library(
     name = "TelemetryEventMap",
     srcs = ["TelemetryEventMap.mm"],
     hdrs = ["TelemetryEventMap.h"],

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -238,6 +238,8 @@ santa_unit_test(
     deps = [
         ":Keychain",
         ":TestUtils",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
     ],
 )
 

--- a/Source/common/Keychain.h
+++ b/Source/common/Keychain.h
@@ -1,0 +1,81 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA__COMMON__KEYCHAIN_H
+#define SANTA__COMMON__KEYCHAIN_H
+
+#include <Foundation/Foundation.h>
+#include <Security/Security.h>
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace santa {
+
+namespace keychain_utils {
+
+// Validation helpers with semi-arbitrary length checks.
+bool IsValidServiceName(NSString *service);
+bool IsValidAccountName(NSString *account);
+bool IsValidDescription(NSString *description);
+
+absl::Status SecurityOSStatusToAbslStatus(OSStatus status);
+
+}  // namespace keychain_utils
+
+class KeychainItem;
+
+class KeychainManager {
+ public:
+  static std::unique_ptr<KeychainManager> Create(NSString *service, SecPreferencesDomain domain);
+  KeychainManager(NSString *service, SecKeychainRef keychain_ref);
+  ~KeychainManager();
+
+  KeychainManager(KeychainManager &&other);
+  KeychainManager &operator=(KeychainManager &&other);
+
+  // Could be safe to implement, but not currently needed
+  KeychainManager(KeychainManager &other) = delete;
+  KeychainManager &operator=(KeychainManager &other) = delete;
+
+  std::unique_ptr<KeychainItem> CreateItem(NSString *account, NSString *description);
+
+ private:
+  NSString *service_;
+  SecKeychainRef keychain_;
+};
+
+class KeychainItem {
+ public:
+  // Note: The given keychain is retained
+  KeychainItem(NSString *service, NSString *account, NSString *description,
+               SecKeychainRef keychain);
+  ~KeychainItem();
+
+  absl::Status Store(NSData *data);
+  absl::Status Delete();
+  absl::StatusOr<NSData *> Get();
+
+ private:
+  NSString *service_;
+  NSString *account_;
+  NSString *description_;
+  SecKeychainRef keychain_;
+};
+
+}  // namespace santa
+
+#endif  // SANTA__COMMON__KEYCHAIN_H

--- a/Source/common/Keychain.h
+++ b/Source/common/Keychain.h
@@ -15,8 +15,8 @@
 #ifndef SANTA__COMMON__KEYCHAIN_H
 #define SANTA__COMMON__KEYCHAIN_H
 
-#include <Foundation/Foundation.h>
-#include <Security/Security.h>
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
 
 #include <memory>
 

--- a/Source/common/Keychain.h
+++ b/Source/common/Keychain.h
@@ -24,8 +24,7 @@
 #include "absl/status/statusor.h"
 
 namespace santa {
-
-namespace keychain_utils {
+namespace keychain {
 
 // Validation helpers with semi-arbitrary length checks.
 bool IsValidServiceName(NSString *service);
@@ -34,36 +33,33 @@ bool IsValidDescription(NSString *description);
 
 absl::Status SecurityOSStatusToAbslStatus(OSStatus status);
 
-}  // namespace keychain_utils
+class Item;
 
-class KeychainItem;
-
-class KeychainManager {
+class Manager {
  public:
-  static std::unique_ptr<KeychainManager> Create(NSString *service, SecPreferencesDomain domain);
-  KeychainManager(NSString *service, SecKeychainRef keychain_ref);
-  ~KeychainManager();
+  static std::unique_ptr<Manager> Create(NSString *service, SecPreferencesDomain domain);
+  Manager(NSString *service, SecKeychainRef keychain_ref);
+  ~Manager();
 
-  KeychainManager(KeychainManager &&other);
-  KeychainManager &operator=(KeychainManager &&other);
+  Manager(Manager &&other);
+  Manager &operator=(Manager &&other);
 
   // Could be safe to implement, but not currently needed
-  KeychainManager(KeychainManager &other) = delete;
-  KeychainManager &operator=(KeychainManager &other) = delete;
+  Manager(Manager &other) = delete;
+  Manager &operator=(Manager &other) = delete;
 
-  std::unique_ptr<KeychainItem> CreateItem(NSString *account, NSString *description);
+  std::unique_ptr<Item> CreateItem(NSString *account, NSString *description);
 
  private:
   NSString *service_;
   SecKeychainRef keychain_;
 };
 
-class KeychainItem {
+class Item {
  public:
   // Note: The given keychain is retained
-  KeychainItem(NSString *service, NSString *account, NSString *description,
-               SecKeychainRef keychain);
-  ~KeychainItem();
+  Item(NSString *service, NSString *account, NSString *description, SecKeychainRef keychain);
+  ~Item();
 
   absl::Status Store(NSData *data);
   absl::Status Delete();
@@ -76,6 +72,7 @@ class KeychainItem {
   SecKeychainRef keychain_;
 };
 
+}  // namespace keychain
 }  // namespace santa
 
 #endif  // SANTA__COMMON__KEYCHAIN_H

--- a/Source/common/Keychain.mm
+++ b/Source/common/Keychain.mm
@@ -1,0 +1,217 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/Keychain.h"
+
+#include <Security/SecBase.h>
+#include <Security/SecItem.h>
+#include <errno.h>
+
+#include "Source/common/SNTLogging.h"
+
+namespace santa {
+
+namespace keychain_utils {
+bool IsValidServiceName(NSString *service) {
+  return service.length > 0 && service.length <= 128;
+}
+
+bool IsValidAccountName(NSString *account) {
+  return account.length > 0 && account.length <= 128;
+}
+
+bool IsValidDescription(NSString *description) {
+  return description.length > 0 && description.length <= 255;
+}
+
+inline absl::StatusCode OSStatusToAbslStatusCode(OSStatus status) {
+  switch (status) {
+    case errSecItemNotFound: return absl::StatusCode::kNotFound;
+    case errSecMissingEntitlement: [[fallthrough]];
+    case errSecAuthFailed: [[fallthrough]];
+    case errSecWrPerm: [[fallthrough]];
+    case errSecInteractionNotAllowed: return absl::StatusCode::kPermissionDenied;
+    case errSecNoSuchKeychain: return absl::StatusCode::kNotFound;
+    case errSecNoSuchAttr: [[fallthrough]];
+    case errSecParam: return absl::StatusCode::kInvalidArgument;
+    case errSecDuplicateItem: return absl::StatusCode::kAlreadyExists;
+
+    default: return absl::StatusCode::kUnknown;  // Or kUnknown
+  }
+}
+
+absl::Status SecurityOSStatusToAbslStatus(OSStatus status) {
+  if (status == errSecSuccess) {
+    return absl::OkStatus();
+  }
+
+  NSString *msg = CFBridgingRelease(SecCopyErrorMessageString(status, NULL));
+  return absl::Status(OSStatusToAbslStatusCode(status), msg.UTF8String);
+}
+
+}  // namespace keychain_utils
+
+std::unique_ptr<KeychainManager> KeychainManager::Create(NSString *service,
+                                                         SecPreferencesDomain domain) {
+  if (!keychain_utils::IsValidServiceName(service)) {
+    return nullptr;
+  }
+
+  SecKeychainRef keychain = NULL;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  OSStatus status = SecKeychainCopyDomainDefault(domain, &keychain);
+#pragma clang diagnostic pop
+  if (status != errSecSuccess || keychain == nullptr) {
+    LOGE(@"Failed to get desired keychain. Domain: %d, status: %d", domain, status);
+    return nullptr;
+  }
+
+  return std::make_unique<KeychainManager>(service, keychain);
+}
+
+KeychainManager::KeychainManager(NSString *service, SecKeychainRef keychain)
+    : service_(service), keychain_(keychain) {
+  assert(keychain_ != nullptr);
+}
+
+KeychainManager::~KeychainManager() {
+  if (keychain_ != nullptr) {
+    CFRelease(keychain_);
+  }
+}
+
+KeychainManager::KeychainManager(KeychainManager &&other)
+    : service_(std::move(other.service_)), keychain_(other.keychain_) {
+  other.service_ = nil;
+  other.keychain_ = nullptr;
+}
+
+KeychainManager &KeychainManager::operator=(KeychainManager &&other) {
+  if (this != &other) {
+    if (keychain_ != nullptr) {
+      CFRelease(keychain_);
+    }
+
+    service_ = std::move(other.service_);
+    keychain_ = other.keychain_;
+
+    other.service_ = nil;
+    other.keychain_ = nullptr;
+  }
+  return *this;
+}
+
+std::unique_ptr<KeychainItem> KeychainManager::CreateItem(NSString *account,
+                                                          NSString *description) {
+  if (!keychain_utils::IsValidAccountName(account)) {
+    LOGE(@"Invalid account name for keychain item: %@", account);
+    return nullptr;
+  }
+
+  if (!keychain_utils::IsValidDescription(description)) {
+    LOGE(@"Invalid description for keychain item: %@", description);
+    return nullptr;
+  }
+
+  return std::make_unique<KeychainItem>(service_, account, description, keychain_);
+}
+
+KeychainItem::KeychainItem(NSString *service, NSString *account, NSString *description,
+                           SecKeychainRef keychain)
+    : service_(service), account_(account), description_(description), keychain_(keychain) {
+  assert(keychain_ != nullptr);
+  // Retain the keychain reference for ourselves
+  CFRetain(keychain_);
+}
+
+KeychainItem::~KeychainItem() {
+  if (keychain_ != nullptr) {
+    CFRelease(keychain_);
+  }
+}
+
+absl::Status KeychainItem::Store(NSData *data) {
+  if (data.length == 0) {
+    return absl::ErrnoToStatus(EINVAL, "No data to store");
+  }
+
+  if (auto status = Delete(); !status.ok()) {
+    LOGE(@"Failed to remove previous value. %s", status.message().data());
+    return status;
+  }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  NSDictionary *attributes = @{
+    (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
+    (__bridge id)kSecAttrService : service_,
+    (__bridge id)kSecAttrAccount : account_,
+    (__bridge id)kSecValueData : data,
+    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly,
+    (__bridge id)kSecAttrSynchronizable : @(NO),
+    (__bridge id)kSecAttrDescription : description_,
+    (__bridge id)kSecReturnAttributes : @(NO),
+    (__bridge id)kSecUseKeychain : (__bridge id)keychain_,
+  };
+#pragma clang diagnostic pop
+
+  OSStatus status = SecItemAdd((__bridge CFDictionaryRef)attributes, NULL);
+  if (status != errSecSuccess) {
+    return keychain_utils::SecurityOSStatusToAbslStatus(status);
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status KeychainItem::Delete() {
+  NSDictionary *query = @{
+    (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
+    (__bridge id)kSecAttrService : service_,
+    (__bridge id)kSecAttrAccount : account_,
+    (__bridge id)kSecReturnData : @(NO),
+    (__bridge id)kSecMatchSearchList : @[ (__bridge id)keychain_ ],
+  };
+
+  OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
+
+  // Don't consider it an error if the item didn't exist
+  if (status != errSecSuccess && status != errSecItemNotFound) {
+    return keychain_utils::SecurityOSStatusToAbslStatus(status);
+  }
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<NSData *> KeychainItem::Get() {
+  NSDictionary *query = @{
+    (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
+    (__bridge id)kSecAttrService : service_,
+    (__bridge id)kSecAttrAccount : account_,
+    (__bridge id)kSecMatchSearchList : @[ (__bridge id)keychain_ ],
+    (__bridge id)kSecReturnData : @(YES),
+    (__bridge id)kSecMatchLimit : (__bridge id)kSecMatchLimitOne,
+  };
+
+  CFTypeRef result = NULL;
+  OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+
+  if (status != errSecSuccess) {
+    return keychain_utils::SecurityOSStatusToAbslStatus(status);
+  }
+
+  return CFBridgingRelease(result);
+}
+
+}  // namespace santa

--- a/Source/common/Keychain.mm
+++ b/Source/common/Keychain.mm
@@ -14,11 +14,9 @@
 
 #include "Source/common/Keychain.h"
 
-#include <Security/SecBase.h>
-#include <Security/SecItem.h>
 #include <errno.h>
 
-#include "Source/common/SNTLogging.h"
+#import "Source/common/SNTLogging.h"
 
 namespace santa {
 
@@ -152,20 +150,20 @@ absl::Status KeychainItem::Store(NSData *data) {
     return status;
   }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSDictionary *attributes = @{
     (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
     (__bridge id)kSecAttrService : service_,
     (__bridge id)kSecAttrAccount : account_,
     (__bridge id)kSecValueData : data,
-    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly,
     (__bridge id)kSecAttrSynchronizable : @(NO),
     (__bridge id)kSecAttrDescription : description_,
     (__bridge id)kSecReturnAttributes : @(NO),
     (__bridge id)kSecUseKeychain : (__bridge id)keychain_,
-  };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly,
 #pragma clang diagnostic pop
+  };
 
   OSStatus status = SecItemAdd((__bridge CFDictionaryRef)attributes, NULL);
   if (status != errSecSuccess) {

--- a/Source/common/KeychainTest.mm
+++ b/Source/common/KeychainTest.mm
@@ -22,10 +22,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
-using santa::keychain_utils::IsValidAccountName;
-using santa::keychain_utils::IsValidDescription;
-using santa::keychain_utils::IsValidServiceName;
-using santa::keychain_utils::SecurityOSStatusToAbslStatus;
+namespace keychain = ::santa::keychain;
 
 @interface KeychainTest : XCTestCase
 @property NSString *testKeychainPath;
@@ -43,31 +40,31 @@ using santa::keychain_utils::SecurityOSStatusToAbslStatus;
 }
 
 - (void)testValidationUtils {
-  XCTAssertFalse(IsValidAccountName(nil));
-  XCTAssertFalse(IsValidAccountName(RepeatedString(@"A", 512)));
-  XCTAssertTrue(IsValidAccountName(RepeatedString(@"A", 64)));
+  XCTAssertFalse(keychain::IsValidAccountName(nil));
+  XCTAssertFalse(keychain::IsValidAccountName(RepeatedString(@"A", 512)));
+  XCTAssertTrue(keychain::IsValidAccountName(RepeatedString(@"A", 64)));
 
-  XCTAssertFalse(IsValidDescription(nil));
-  XCTAssertFalse(IsValidDescription(RepeatedString(@"A", 512)));
-  XCTAssertTrue(IsValidDescription(RepeatedString(@"A", 64)));
+  XCTAssertFalse(keychain::IsValidDescription(nil));
+  XCTAssertFalse(keychain::IsValidDescription(RepeatedString(@"A", 512)));
+  XCTAssertTrue(keychain::IsValidDescription(RepeatedString(@"A", 64)));
 
-  XCTAssertFalse(IsValidServiceName(nil));
-  XCTAssertFalse(IsValidServiceName(RepeatedString(@"A", 512)));
-  XCTAssertTrue(IsValidServiceName(RepeatedString(@"A", 64)));
+  XCTAssertFalse(keychain::IsValidServiceName(nil));
+  XCTAssertFalse(keychain::IsValidServiceName(RepeatedString(@"A", 512)));
+  XCTAssertTrue(keychain::IsValidServiceName(RepeatedString(@"A", 64)));
 }
 
 - (void)testSecurityOSStatusToAbslStatus {
   absl::Status s;
 
-  s = SecurityOSStatusToAbslStatus(errSecSuccess);
+  s = keychain::SecurityOSStatusToAbslStatus(errSecSuccess);
   XCTAssertTrue(s.ok());
 
-  s = SecurityOSStatusToAbslStatus(errSecDuplicateItem);
+  s = keychain::SecurityOSStatusToAbslStatus(errSecDuplicateItem);
   XCTAssertFalse(s.ok());
 }
 
 - (void)testFactoryFailure {
-  santa::KeychainManager::Create(nil, kSecPreferencesDomainSystem);
+  keychain::Manager::Create(nil, kSecPreferencesDomainSystem);
 }
 
 - (void)testKeychainItem {
@@ -86,11 +83,9 @@ using santa::keychain_utils::SecurityOSStatusToAbslStatus;
   }
   XCTAssertNotEqual(keychain, nullptr);
 
-  santa::KeychainManager mgr(@"com.norhpolesec.test.service", keychain);
-  std::unique_ptr<santa::KeychainItem> item1 =
-      mgr.CreateItem(@"TestAccount1", @"Test keychain item");
-  std::unique_ptr<santa::KeychainItem> item2 =
-      mgr.CreateItem(@"TestAccount2", @"Test keychain item");
+  keychain::Manager mgr(@"com.norhpolesec.test.service", keychain);
+  std::unique_ptr<keychain::Item> item1 = mgr.CreateItem(@"TestAccount1", @"Test keychain item");
+  std::unique_ptr<keychain::Item> item2 = mgr.CreateItem(@"TestAccount2", @"Test keychain item");
 
   NSData *testData1 = [@"hello1" dataUsingEncoding:NSUTF8StringEncoding];
   NSData *testData2 = [@"hello2" dataUsingEncoding:NSUTF8StringEncoding];

--- a/Source/common/KeychainTest.mm
+++ b/Source/common/KeychainTest.mm
@@ -1,0 +1,61 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/Keychain.h"
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/TestUtils.h"
+
+using santa::keychain_utils::IsValidAccountName;
+using santa::keychain_utils::IsValidDescription;
+using santa::keychain_utils::IsValidServiceName;
+using santa::keychain_utils::SecurityOSStatusToAbslStatus;
+
+@interface KeychainTest : XCTestCase
+@end
+
+@implementation KeychainTest
+
+- (void)testValidationUtils {
+  XCTAssertFalse(IsValidAccountName(nil));
+  XCTAssertFalse(IsValidAccountName(RepeatedString(@"A", 512)));
+  XCTAssertTrue(IsValidAccountName(RepeatedString(@"A", 64)));
+
+  XCTAssertFalse(IsValidDescription(nil));
+  XCTAssertFalse(IsValidDescription(RepeatedString(@"A", 512)));
+  XCTAssertTrue(IsValidDescription(RepeatedString(@"A", 64)));
+
+  XCTAssertFalse(IsValidServiceName(nil));
+  XCTAssertFalse(IsValidServiceName(RepeatedString(@"A", 512)));
+  XCTAssertTrue(IsValidServiceName(RepeatedString(@"A", 64)));
+}
+
+- (void)testSecurityOSStatusToAbslStatus {
+  absl::Status s;
+
+  s = SecurityOSStatusToAbslStatus(errSecSuccess);
+  XCTAssertTrue(s.ok());
+
+  s = SecurityOSStatusToAbslStatus(errSecDuplicateItem);
+  XCTAssertFalse(s.ok());
+}
+
+- (void)testFactoryFailure {
+  santa::KeychainManager::Create(nil, kSecPreferencesDomainSystem);
+}
+
+@end


### PR DESCRIPTION
This adds objects for Santa to manage store/get/delete operations for keychain items.

The `KeychainManager` is the main class. This will typically be used like a singleton. For Santa's purposes, it will be injected when needed. Consumers of the `KeychainManager` can create `KeychainItem`s for themselves. The `KeychainItem` object then allows users to perform keychain operations for that item.