### PR TITLE
santactl,sync: Add signing timestamp

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "xxhash", version = "0.8.2")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "f4587ecd0c2e34c2bc764da56838cfa22d5f19b4",
+    commit = "126060741a2b6d7bb4fa439869fbf35c39aadeb6",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/MOLCodesignChecker.h
+++ b/Source/common/MOLCodesignChecker.h
@@ -83,6 +83,13 @@
 /** The entitlements encoded in this binary. */
 @property(readonly) NSDictionary *entitlements;
 
+/** The timestamp of when the binary was signed.
+
+  This timestamp is the secure timestamp that was certified by Apple's timestamp
+  authority service and can be trusted.
+*/
+@property(readonly) NSDate *signingTimestamp;
+
 /**
   Designated initializer
 

--- a/Source/common/MOLCodesignChecker.m
+++ b/Source/common/MOLCodesignChecker.m
@@ -300,6 +300,10 @@ static NSString *const kErrorDomain = @"com.google.molcodesignchecker";
   return self.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict];
 }
 
+- (NSDate *)signingTimestamp {
+  return self.signingInformation[(__bridge NSString *)kSecCodeInfoTimestamp];
+}
+
 - (BOOL)signingInformationMatches:(MOLCodesignChecker *)otherChecker {
   return [self.certificates isEqual:otherChecker.certificates];
 }

--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -45,6 +45,7 @@
 @property BOOL entitlementsFiltered;
 @property uint32_t codesigningFlags;
 @property SNTSigningStatus signingStatus;
+@property NSDate *signingTimestamp;
 
 @property NSString *quarantineURL;
 

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -194,4 +194,11 @@
 ///
 @property BOOL entitlementsFiltered;
 
+///
+/// The timestamp of when the binary was signed. This timestamp is the secure
+/// timestamp that was certified by Apple's timestamp authority service and can
+/// be trusted.
+///
+@property NSDate *signingTimestamp;
+
 @end

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -49,6 +49,7 @@
   ENCODE_BOXABLE(coder, signingStatus);
   ENCODE(coder, entitlements);
   ENCODE_BOXABLE(coder, entitlementsFiltered);
+  ENCODE(coder, signingTimestamp);
 
   ENCODE(coder, executingUser);
   ENCODE(coder, occurrenceDate);
@@ -100,6 +101,7 @@
     DECODE_SELECTOR(decoder, signingStatus, NSNumber, integerValue);
     DECODE_DICT(decoder, entitlements);
     DECODE_SELECTOR(decoder, entitlementsFiltered, NSNumber, boolValue);
+    DECODE(decoder, signingTimestamp, NSDate);
 
     DECODE(decoder, executingUser, NSString);
     DECODE(decoder, occurrenceDate, NSDate);

--- a/Source/common/StoredEventHelpers.mm
+++ b/Source/common/StoredEventHelpers.mm
@@ -35,6 +35,7 @@ SNTStoredEvent *StoredEventFromFileInfo(SNTFileInfo *fileInfo) {
   se.teamID = cs.teamID;
   se.signingID = FormatSigningID(cs);
   se.entitlements = cs.entitlements;
+  se.signingTimestamp = cs.signingTimestamp;
   if (cs.signatureFlags & kSecCodeSignatureAdhoc) {
     se.signingStatus = SNTSigningStatusAdhoc;
   } else if (IsDevelopmentCert(cs.leafCertificate)) {

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -50,6 +50,7 @@ static NSString *const kTeamID = @"Team ID";
 static NSString *const kSigningID = @"Signing ID";
 static NSString *const kCDHash = @"CDHash";
 static NSString *const kEntitlements = @"Entitlements";
+static NSString *const kSigningTimestamp = @"Signing Timestamp";
 
 // signing chain keys
 static NSString *const kCommonName = @"Common Name";
@@ -138,6 +139,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 @property(readonly, copy, nonatomic) SNTAttributeBlock signingChain;
 @property(readonly, copy, nonatomic) SNTAttributeBlock universalSigningChain;
 @property(readonly, copy, nonatomic) SNTAttributeBlock entitlements;
+@property(readonly, copy, nonatomic) SNTAttributeBlock signingTimestamp;
 
 // Mapping between property string keys and SNTAttributeBlocks
 @property(nonatomic) NSDictionary<NSString *, SNTAttributeBlock> *propertyMap;
@@ -230,6 +232,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     kType,
     kPageZero,
     kCodeSigned,
+    kSigningTimestamp,
     kRule,
     kEntitlements,
     kSigningChain,
@@ -269,6 +272,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       kSigningID : self.signingID,
       kCDHash : self.cdhash,
       kEntitlements : self.entitlements,
+      kSigningTimestamp : self.signingTimestamp,
     };
 
     _printQueue =
@@ -533,6 +537,13 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
     return csc.entitlements ?: @{};
+  };
+}
+
+- (SNTAttributeBlock)signingTimestamp {
+  return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
+    return [cmd.dateFormatter stringFromDate:csc.signingTimestamp];
   };
 }
 

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -164,6 +164,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     cd.sha256 = binInfo.SHA256;
     cd.signingID = FormatSigningID(csInfo);
     cd.cdhash = csInfo.cdhash;
+    cd.signingTimestamp = csInfo.signingTimestamp;
     cd.signingStatus = IsDevelopmentCert(csInfo.leafCertificate) ? SNTSigningStatusDevelopment
                                                                  : SNTSigningStatusProduction;
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -374,6 +374,7 @@ static NSString *const kPrinterProxyPostMonterey =
     se.parentName = @(esMsg.ParentProcessName().c_str());
     se.entitlements = cd.entitlements;
     se.entitlementsFiltered = cd.entitlementsFiltered;
+    se.signingTimestamp = cd.signingTimestamp;
 
     // Bundle data
     se.fileBundleID = [binInfo bundleIdentifier];

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -226,6 +226,8 @@ static void UpdateCachedDecisionSigningInfo(
     cd.entitlements = [entitlements sntDeepCopy];
     cd.entitlementsFiltered = NO;
   }
+
+  cd.signingTimestamp = csInfo.signingTimestamp;
 }
 
 - (nonnull SNTCachedDecision *)

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -200,6 +200,7 @@ using santa::NSStringToUTF8StringView;
   e->set_signing_id(NSStringToUTF8String(event.signingID));
   e->set_cdhash(NSStringToUTF8String(event.cdhash));
   e->set_cs_flags(event.codesigningFlags);
+  e->set_signing_timestamp([event.signingTimestamp timeIntervalSince1970]);
 
   switch (event.signingStatus) {
     case SNTSigningStatusUnsigned: e->set_signing_status(::pbv1::SIGNING_STATUS_UNSIGNED); break;


### PR DESCRIPTION
Output secure signing timestamps in `santactl fileinfo` output and upload in events sent to a sync server.

```
» santactl fileinfo /Applications/Google\ Chrome.app
Path                   : /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
SHA-256                : d226e4ae13441f7b3a5f4bda2fbc627bc3ee73b255138fc4f11de08ef2e32379
SHA-1                  : 57fe53fed74b865ade0b78b6c8f918bbe8303bbd
Bundle Name            : Google Chrome
Bundle Version         : 7151.56
Bundle Version Str     : 137.0.7151.56
Team ID                : EQHXZ8M8AV
Signing ID             : EQHXZ8M8AV:com.google.Chrome
CDHash                 : 360106ba5e5b351b36549dfafd3791a8a792582c
Type                   : Executable (arm64, x86_64)
Code-signed            : Yes
Signing Timestamp      : 2025/05/26 16:23:13 -0400
Rule                   : Allowed (TeamID)
```