### PR TITLE
Renaming signing timestamp fields

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "xxhash", version = "0.8.2")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "53cb11003aa6d0637e7fb00acd1af49cdb2e4911",
+    commit = "0a7563cdbc6372ba14e449f9eefc9e3617b6fa78",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/MOLCodesignChecker.h
+++ b/Source/common/MOLCodesignChecker.h
@@ -88,15 +88,17 @@
   This timestamp is the secure timestamp that was certified by Apple's timestamp
   authority service and can be trusted.
 */
-@property(readonly) NSDate *secureTimestamp;
+@property(readonly) NSDate *secureSigningTime;
 
 /**
   The timestamp of when the binary was signed.
 
-  This timestamp is the insecure timestamp provided by the developer during
-  signing. It has not been validated and could be spoofed.
+  This timestamp is provided by the developer when this binary was signed.
+  It is possible for developers to set this to whatever they wish when signing
+  unlike the secureSigningTime. Callers should only trust this as much as they
+  trust the developer.
 */
-@property(readonly) NSDate *insecureTimestamp;
+@property(readonly) NSDate *signingTime;
 
 /**
   Designated initializer

--- a/Source/common/MOLCodesignChecker.m
+++ b/Source/common/MOLCodesignChecker.m
@@ -300,11 +300,11 @@ static NSString *const kErrorDomain = @"com.google.molcodesignchecker";
   return self.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict];
 }
 
-- (NSDate *)secureTimestamp {
+- (NSDate *)secureSigningTime {
   return self.signingInformation[(__bridge NSString *)kSecCodeInfoTimestamp];
 }
 
-- (NSDate *)insecureTimestamp {
+- (NSDate *)signingTime {
   return self.signingInformation[(__bridge NSString *)kSecCodeInfoTime];
 }
 

--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -45,8 +45,8 @@
 @property BOOL entitlementsFiltered;
 @property uint32_t codesigningFlags;
 @property SNTSigningStatus signingStatus;
-@property NSDate *secureTimestamp;
-@property NSDate *insecureTimestamp;
+@property NSDate *secureSigningTime;
+@property NSDate *signingTime;
 
 @property NSString *quarantineURL;
 

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -199,13 +199,13 @@
 /// timestamp that was certified by Apple's timestamp authority service and can
 /// be trusted.
 ///
-@property NSDate *secureTimestamp;
+@property NSDate *secureSigningTime;
 
 ///
 /// The timestamp of when the binary was signed. This timestamp is the insecure
 /// timestamp provided by the developer during signing. It has not been validated
 /// and could be spoofed.
 ///
-@property NSDate *insecureTimestamp;
+@property NSDate *signingTime;
 
 @end

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -49,8 +49,8 @@
   ENCODE_BOXABLE(coder, signingStatus);
   ENCODE(coder, entitlements);
   ENCODE_BOXABLE(coder, entitlementsFiltered);
-  ENCODE(coder, secureTimestamp);
-  ENCODE(coder, insecureTimestamp);
+  ENCODE(coder, secureSigningTime);
+  ENCODE(coder, signingTime);
 
   ENCODE(coder, executingUser);
   ENCODE(coder, occurrenceDate);
@@ -102,8 +102,8 @@
     DECODE_SELECTOR(decoder, signingStatus, NSNumber, integerValue);
     DECODE_DICT(decoder, entitlements);
     DECODE_SELECTOR(decoder, entitlementsFiltered, NSNumber, boolValue);
-    DECODE(decoder, secureTimestamp, NSDate);
-    DECODE(decoder, insecureTimestamp, NSDate);
+    DECODE(decoder, secureSigningTime, NSDate);
+    DECODE(decoder, signingTime, NSDate);
 
     DECODE(decoder, executingUser, NSString);
     DECODE(decoder, occurrenceDate, NSDate);

--- a/Source/common/StoredEventHelpers.mm
+++ b/Source/common/StoredEventHelpers.mm
@@ -35,8 +35,8 @@ SNTStoredEvent *StoredEventFromFileInfo(SNTFileInfo *fileInfo) {
   se.teamID = cs.teamID;
   se.signingID = FormatSigningID(cs);
   se.entitlements = cs.entitlements;
-  se.secureTimestamp = cs.secureTimestamp;
-  se.insecureTimestamp = cs.insecureTimestamp;
+  se.secureSigningTime = cs.secureSigningTime;
+  se.signingTime = cs.signingTime;
   if (cs.signatureFlags & kSecCodeSignatureAdhoc) {
     se.signingStatus = SNTSigningStatusAdhoc;
   } else if (IsDevelopmentCert(cs.leafCertificate)) {

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -50,8 +50,8 @@ static NSString *const kTeamID = @"Team ID";
 static NSString *const kSigningID = @"Signing ID";
 static NSString *const kCDHash = @"CDHash";
 static NSString *const kEntitlements = @"Entitlements";
-static NSString *const kSecureTimestamp = @"Secure Timestamp";
-static NSString *const kInsecureTimestamp = @"Insecure Timestamp";
+static NSString *const kSecureSigningTime = @"Secure Signing Time";
+static NSString *const kSigningTime = @"Signing Time";
 
 // signing chain keys
 static NSString *const kCommonName = @"Common Name";
@@ -140,8 +140,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 @property(readonly, copy, nonatomic) SNTAttributeBlock signingChain;
 @property(readonly, copy, nonatomic) SNTAttributeBlock universalSigningChain;
 @property(readonly, copy, nonatomic) SNTAttributeBlock entitlements;
-@property(readonly, copy, nonatomic) SNTAttributeBlock secureTimestamp;
-@property(readonly, copy, nonatomic) SNTAttributeBlock insecureTimestamp;
+@property(readonly, copy, nonatomic) SNTAttributeBlock secureSigningTime;
+@property(readonly, copy, nonatomic) SNTAttributeBlock signingTime;
 
 // Mapping between property string keys and SNTAttributeBlocks
 @property(nonatomic) NSDictionary<NSString *, SNTAttributeBlock> *propertyMap;
@@ -235,8 +235,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     kType,
     kPageZero,
     kCodeSigned,
-    kSecureTimestamp,
-    kInsecureTimestamp,
+    kSecureSigningTime,
+    kSigningTime,
     kRule,
     kEntitlements,
     kSigningChain,
@@ -277,8 +277,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       kSigningID : self.signingID,
       kCDHash : self.cdhash,
       kEntitlements : self.entitlements,
-      kSecureTimestamp : self.secureTimestamp,
-      kInsecureTimestamp : self.insecureTimestamp,
+      kSecureSigningTime : self.secureSigningTime,
+      kSigningTime : self.signingTime,
     };
 
     _printQueue =
@@ -546,17 +546,17 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   };
 }
 
-- (SNTAttributeBlock)secureTimestamp {
+- (SNTAttributeBlock)secureSigningTime {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    return [cmd.dateFormatter stringFromDate:csc.secureTimestamp] ?: @"None";
+    return [cmd.dateFormatter stringFromDate:csc.secureSigningTime] ?: @"None";
   };
 }
 
-- (SNTAttributeBlock)insecureTimestamp {
+- (SNTAttributeBlock)signingTime {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    return [cmd.dateFormatter stringFromDate:csc.insecureTimestamp] ?: @"None";
+    return [cmd.dateFormatter stringFromDate:csc.signingTime] ?: @"None";
   };
 }
 

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -164,8 +164,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     cd.sha256 = binInfo.SHA256;
     cd.signingID = FormatSigningID(csInfo);
     cd.cdhash = csInfo.cdhash;
-    cd.secureTimestamp = csInfo.secureTimestamp;
-    cd.insecureTimestamp = csInfo.insecureTimestamp;
+    cd.secureSigningTime = csInfo.secureSigningTime;
+    cd.signingTime = csInfo.signingTime;
     cd.signingStatus = IsDevelopmentCert(csInfo.leafCertificate) ? SNTSigningStatusDevelopment
                                                                  : SNTSigningStatusProduction;
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -374,8 +374,8 @@ static NSString *const kPrinterProxyPostMonterey =
     se.parentName = @(esMsg.ParentProcessName().c_str());
     se.entitlements = cd.entitlements;
     se.entitlementsFiltered = cd.entitlementsFiltered;
-    se.secureTimestamp = cd.secureTimestamp;
-    se.insecureTimestamp = cd.insecureTimestamp;
+    se.secureSigningTime = cd.secureSigningTime;
+    se.signingTime = cd.signingTime;
 
     // Bundle data
     se.fileBundleID = [binInfo bundleIdentifier];

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -227,8 +227,8 @@ static void UpdateCachedDecisionSigningInfo(
     cd.entitlementsFiltered = NO;
   }
 
-  cd.secureTimestamp = csInfo.secureTimestamp;
-  cd.insecureTimestamp = csInfo.insecureTimestamp;
+  cd.secureSigningTime = csInfo.secureSigningTime;
+  cd.signingTime = csInfo.signingTime;
 }
 
 - (nonnull SNTCachedDecision *)

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -200,8 +200,8 @@ using santa::NSStringToUTF8StringView;
   e->set_signing_id(NSStringToUTF8String(event.signingID));
   e->set_cdhash(NSStringToUTF8String(event.cdhash));
   e->set_cs_flags(event.codesigningFlags);
-  e->set_secure_timestamp([event.secureSigningTime timeIntervalSince1970]);
-  e->set_insecure_timestamp([event.signingTime timeIntervalSince1970]);
+  e->set_secure_signing_time([event.secureSigningTime timeIntervalSince1970]);
+  e->set_signing_time([event.signingTime timeIntervalSince1970]);
 
   switch (event.signingStatus) {
     case SNTSigningStatusUnsigned: e->set_signing_status(::pbv1::SIGNING_STATUS_UNSIGNED); break;

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -200,8 +200,8 @@ using santa::NSStringToUTF8StringView;
   e->set_signing_id(NSStringToUTF8String(event.signingID));
   e->set_cdhash(NSStringToUTF8String(event.cdhash));
   e->set_cs_flags(event.codesigningFlags);
-  e->set_secure_timestamp([event.secureTimestamp timeIntervalSince1970]);
-  e->set_insecure_timestamp([event.insecureTimestamp timeIntervalSince1970]);
+  e->set_secure_timestamp([event.secureSigningTime timeIntervalSince1970]);
+  e->set_insecure_timestamp([event.signingTime timeIntervalSince1970]);
 
   switch (event.signingStatus) {
     case SNTSigningStatusUnsigned: e->set_signing_status(::pbv1::SIGNING_STATUS_UNSIGNED); break;


### PR DESCRIPTION
Adopt the renamed protos and align the naming.