### PR TITLE
sync: Fix rare issue causing event upload to skip

### DIFF
--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -101,8 +101,7 @@ using santa::NSStringToUTF8StringView;
     if (event.idx) [eventIds addObject:event.idx];
 
     std::optional<::pbv1::Event> e = [self messageForEvent:event withArena:pArena];
-    if (!e.has_value()) return;
-    uploadEvents->Add(*std::move(e));
+    if (e.has_value()) uploadEvents->Add(*std::move(e));
 
     if (uploadEvents->size() >= self.syncState.eventBatchSize || idx == finalIdx) {
       if (![self performRequest:req]) {


### PR DESCRIPTION
Previously, if the last event available in the database is one that should be skipped (e.g it's transitive or locally approved) the entire batch is skipped and the pending events are deleted