### PR TITLE
santactl/fileinfo: Change how Rule field is populated

### DIFF
--- a/Source/common/SNTRule.h
+++ b/Source/common/SNTRule.h
@@ -104,6 +104,11 @@
 - (instancetype)initWithDictionary:(NSDictionary *)rawDict error:(NSError **)error;
 
 ///
+///  Stringify the rule with optional colorization.
+///
+- (NSString *)stringifyWithColor:(BOOL)colorize;
+
+///
 ///  Sets timestamp of rule to the current time.
 ///
 - (void)resetTimestamp;

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -408,6 +408,85 @@ static const NSUInteger kExpectedTeamIDLength = 10;
                        self.identifier, self.state, self.type, (unsigned long)self.timestamp];
 }
 
+- (NSString *)stringifyWithColor:(BOOL)colorize {
+  NSMutableString *output;
+  // Rule state is saved as eventState for output colorization down below
+  SNTEventState eventState = SNTEventStateUnknown;
+
+  switch (self.state) {
+    case SNTRuleStateUnknown:
+      output = [@"None" mutableCopy];
+      break;
+    case SNTRuleStateAllow: OS_FALLTHROUGH;
+    case SNTRuleStateAllowCompiler: OS_FALLTHROUGH;
+    case SNTRuleStateAllowTransitive:
+      output = [@"Allowed" mutableCopy];
+      eventState = SNTEventStateAllow;
+      break;
+    case SNTRuleStateBlock: OS_FALLTHROUGH;
+    case SNTRuleStateSilentBlock:
+      output = [@"Blocked" mutableCopy];
+      eventState = SNTEventStateBlock;
+      break;
+    case SNTRuleStateCEL:
+      output = [@"CEL" mutableCopy];
+      break;
+    case SNTRuleStateRemove: OS_FALLTHROUGH;
+    default:
+      output = [NSMutableString stringWithFormat:@"Unexpected rule state: %ld", self.state];
+      break;
+  }
+
+  if (self.state == SNTRuleStateUnknown) {
+    // No more output to append
+    return output;
+  }
+
+  [output appendString:@" ("];
+
+  switch (self.type) {
+    case SNTRuleTypeUnknown: [output appendString:@"Unknown"]; break;
+    case SNTRuleTypeCDHash: [output appendString:@"CDHash"]; break;
+    case SNTRuleTypeBinary: [output appendString:@"Binary"]; break;
+    case SNTRuleTypeSigningID: [output appendString:@"SigningID"]; break;
+    case SNTRuleTypeCertificate: [output appendString:@"Certificate"]; break;
+    case SNTRuleTypeTeamID: [output appendString:@"TeamID"]; break;
+    default:
+      output = [NSMutableString stringWithFormat:@"Unexpected rule type: %ld", self.type];
+      break;
+  }
+
+  // Add additional attributes
+  switch (self.state) {
+    case SNTRuleStateAllowCompiler: [output appendString:@", Compiler"]; break;
+    case SNTRuleStateAllowTransitive: [output appendString:@", Transitive"]; break;
+    case SNTRuleStateSilentBlock: [output appendString:@", Silent"]; break;
+    default: break;
+  }
+
+  [output appendString:@")"];
+
+  // Colorize
+  if (colorize) {
+    if ((SNTEventStateAllow & eventState)) {
+      [output insertString:@"\033[32m" atIndex:0];
+      [output appendString:@"\033[0m"];
+    } else if ((SNTEventStateBlock & eventState)) {
+      [output insertString:@"\033[31m" atIndex:0];
+      [output appendString:@"\033[0m"];
+    } else {
+      [output insertString:@"\033[33m" atIndex:0];
+      [output appendString:@"\033[0m"];
+    }
+  }
+
+  if (self.state == SNTRuleStateAllowTransitive) {
+    NSDate *date = [NSDate dateWithTimeIntervalSinceReferenceDate:self.timestamp];
+    [output appendString:[NSString stringWithFormat:@"\nlast access date: %@", [date description]]];
+  }
+  return output;
+}
+
 #pragma mark Last-access Timestamp
 
 - (void)resetTimestamp {

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -40,8 +40,6 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
                        reply:(void (^)(NSError *error))reply;
 - (void)databaseEventsPending:(void (^)(NSArray *events))reply;
 - (void)databaseRemoveEventsWithIDs:(NSArray *)ids;
-- (void)databaseRuleForIdentifiers:(SNTRuleIdentifiers *)identifiers
-                             reply:(void (^)(SNTRule *))reply;
 - (void)retrieveAllRules:(void (^)(NSArray<SNTRule *> *rules, NSError *error))reply;
 
 ///

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -51,18 +51,7 @@ struct RuleCounts {
 - (void)databaseRuleCounts:(void (^)(struct RuleCounts ruleCounts))reply;
 - (void)databaseEventCount:(void (^)(int64_t count))reply;
 - (void)staticRuleCount:(void (^)(int64_t count))reply;
-
-///
-///  Decision ops
-///
-
-///
-///  @param filePath A Path to the file, can be nil.
-///  @param identifiers The various identifiers to be used when making a decision.
-///
-- (void)decisionForFilePath:(NSString *)filePath
-                identifiers:(SNTRuleIdentifiers *)identifiers
-                      reply:(void (^)(SNTEventState))reply;
+- (void)databaseRuleForIdentifiers:(SNTRuleIdentifiers *)identifiers reply:(void (^)(SNTRule *))reply;
 
 ///
 ///  Config ops

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -26,7 +26,7 @@ NSString *FormatSigningID(MOLCodesignChecker *csc) {
     if (csc.platformBinary) {
       return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
     } else {
-      LOGD(@"unable to format signing ID missing team ID for non-platform binary");
+      LOGD(@"unable to format signing ID missing team ID for non-platform binary: %@", csc.signingID);
       return nil;
     }
   }

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -197,14 +197,6 @@ double watchdogRAMPeak = 0;
   reply(rules, nil);
 }
 
-#pragma mark Decision Ops
-
-- (void)decisionForFilePath:(NSString *)filePath
-                identifiers:(SNTRuleIdentifiers *)identifiers
-                      reply:(void (^)(SNTEventState))reply {
-  reply([self.policyProcessor decisionForFilePath:filePath identifiers:identifiers].decision);
-}
-
 #pragma mark Config Ops
 
 - (void)watchdogInfo:(void (^)(uint64_t, uint64_t, double, double))reply {

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -60,15 +60,6 @@ typedef std::unique_ptr<santa::cel::Activation> (^ActivationCallbackBlock)(void)
                                    NSDictionary *_Nullable entitlements))entitlementsFilterCallback;
 
 ///
-///  A wrapper for decisionForFileInfo:fileSHA256:certificateSHA256:. This method is slower as it
-///  has to create the SNTFileInfo object. This is mainly used by the santactl binary because
-///  SNTFileInfo is not SecureCoding compliant. If the SHA256 hash of the file has already been
-///  calculated, use the fileSHA256 parameter to save a second calculation of the hash.
-///
-- (nonnull SNTCachedDecision *)decisionForFilePath:(nonnull NSString *)filePath
-                                       identifiers:(nonnull SNTRuleIdentifiers *)identifiers;
-
-///
 /// Updates a decision for a given file and agent configuration.
 ///
 /// Returns YES if the decision requires no futher processing NO otherwise.


### PR DESCRIPTION
Instead of showing the _decision_ that would (probably) be made by santad, the `Rule` field now shows which rule matches. This more accurately reflects the field name and allows us to show that a CEL rule exists (which largely precludes being able to actually give a decision). If we wanted, we could later expand on this to also 

This involved removing the (now unneeded) `decisionForFilePath:identifiers:reply:` method from the XPC control interface, and moving the `databaseRuleForIdentifiers:reply:` method from the privileged to the unprivileged interface. I also moved a `stringifyRule:withColor:` method that had been in SNTCommandRule into SNTRule itself so it can easily be used by both commands.