### PR TITLE
Add Defer implementation

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -251,6 +251,20 @@ santa_unit_test(
 )
 
 objc_library(
+    name = "Defer",
+    hdrs = ["Defer.h"],
+)
+
+santa_unit_test(
+    name = "DeferTest",
+    srcs = ["DeferTest.mm"],
+    deps = [
+        ":Defer",
+        ":TestUtils",
+    ],
+)
+
+objc_library(
     name = "TelemetryEventMap",
     srcs = ["TelemetryEventMap.mm"],
     hdrs = ["TelemetryEventMap.h"],

--- a/Source/common/Defer.h
+++ b/Source/common/Defer.h
@@ -1,0 +1,75 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA__COMMON__DEFER_H
+#define SANTA__COMMON__DEFER_H
+
+#include <utility>
+
+namespace santa {
+
+/// Defer executes a block on destruction
+template <typename F>
+class Defer {
+ public:
+  explicit Defer(F&& block)
+      : cleanup_block_(std::forward<F>(block)), should_execute_(true) {}
+
+  ~Defer() {
+    if (should_execute_) {
+      cleanup_block_();
+    }
+  }
+
+  Defer(Defer&& other) noexcept
+      : cleanup_block_(std::move(other.cleanup_block_)),
+        should_execute_(other.should_execute_) {
+    other.should_execute_ = false;
+  }
+
+  Defer& operator=(Defer&& other) noexcept {
+    if (this != &other) {
+      // Call our block before moving from other
+      if (should_execute_) {
+        cleanup_block_();
+      }
+      cleanup_block_ = std::move(other.cleanup_block_);
+      should_execute_ = other.should_execute_;
+      other.should_execute_ = false;
+    }
+    return *this;
+  }
+
+  // Not copyable
+  Defer(const Defer&) = delete;
+  Defer& operator=(const Defer&) = delete;
+
+  void Cancel() { should_execute_ = false; }
+
+  // Execute early, will not be called again upon destruction
+  void Execute() {
+    if (should_execute_) {
+      cleanup_block_();
+      should_execute_ = false;
+    }
+  }
+
+ private:
+  F cleanup_block_;
+  bool should_execute_;
+};
+
+}  // namespace santa
+
+#endif  // SANTA__COMMON__DEFER_H

--- a/Source/common/DeferTest.mm
+++ b/Source/common/DeferTest.mm
@@ -1,0 +1,76 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/Defer.h"
+
+#include <Foundation/Foundation.h>
+#include <XCTest/XCTest.h>
+#include <dispatch/dispatch.h>
+
+#include "Source/common/TestUtils.h"
+
+using santa::Defer;
+
+@interface DeferTest : XCTestCase
+@property dispatch_semaphore_t sema;
+@end
+
+@implementation DeferTest
+
+- (void)setUp {
+  self.sema = dispatch_semaphore_create(0);
+}
+
+- (void)testBasic {
+  (void)Defer(^{
+    dispatch_semaphore_signal(self.sema);
+  });
+
+  XCTAssertSemaTrue(self.sema, 0, "Defer was not destructed");
+
+  {
+    Defer d(^{
+      dispatch_semaphore_signal(self.sema);
+    });
+  }
+
+  XCTAssertSemaTrue(self.sema, 0, "Defer was not destructed");
+}
+
+- (void)testCancel {
+  {
+    Defer d(^{
+      dispatch_semaphore_signal(self.sema);
+    });
+
+    d.Cancel();
+  }
+
+  XCTAssertSemaFalse(self.sema, "Defer was unexpectedly destructed");
+}
+
+- (void)testExecute {
+  {
+    Defer d(^{
+      dispatch_semaphore_signal(self.sema);
+    });
+
+    d.Execute();
+    XCTAssertSemaTrue(self.sema, 0, "Defer was not executed early");
+  }
+
+  XCTAssertSemaFalse(self.sema, "Defer was destructed more than once");
+}
+
+@end


### PR DESCRIPTION
Adds a Defer object to run code on destruction. The primary purpose is to better ensure cleanup operations (closing files, freeing memory, etc.) are performed in functions that have many return paths.