### PR TITLE
sync: add support for primary user groups

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "xxhash", version = "0.8.2")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "bd61ba67c96bb8983e1b1ecf51f0af0d9308ac63",
+    commit = "704246489aa55e6e2b60b47133a8668bc3656105",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -497,6 +497,11 @@
 @property(nullable, readonly, nonatomic) NSString *machineOwner;
 
 ///
+///  The machine owner's groups.
+///
+@property(nullable, readonly, nonatomic) NSArray<NSString *> *machineOwnerGroups;
+
+///
 ///  The last date of a successful full sync.
 ///
 @property(nullable, nonatomic) NSDate *fullSyncLastSuccess;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -95,9 +95,11 @@ static NSString *const kEnableStatsCollectionKey = @"EnableStatsCollection";
 static NSString *const kStatsOrganizationID = @"StatsOrganizationID";
 
 static NSString *const kMachineOwnerKey = @"MachineOwner";
+static NSString *const kMachineOwnerGroupsKey = @"MachineOwnerGroups";
 static NSString *const kMachineIDKey = @"MachineID";
 static NSString *const kMachineOwnerPlistFileKey = @"MachineOwnerPlist";
 static NSString *const kMachineOwnerPlistKeyKey = @"MachineOwnerKey";
+static NSString *const kMachineOwnerGroupsPlistKeyKey = @"MachineOwnerGroupsKey";
 static NSString *const kMachineIDPlistFileKey = @"MachineIDPlist";
 static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
@@ -284,9 +286,11 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
       kEnableStatsCollectionKey : number,
       kStatsOrganizationID : string,
       kMachineOwnerKey : string,
+      kMachineOwnerGroupsKey : array,
       kMachineIDKey : string,
       kMachineOwnerPlistFileKey : string,
       kMachineOwnerPlistKeyKey : string,
+      kMachineOwnerGroupsPlistKeyKey : string,
       kMachineIDPlistFileKey : string,
       kMachineIDPlistKeyKey : string,
       kEventLogType : string,
@@ -539,6 +543,10 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 + (NSSet *)keyPathsForValuesAffectingMachineOwner {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingMachineOwnerGroups {
   return [self configStateSet];
 }
 
@@ -1037,6 +1045,26 @@ static SNTConfigurator *sharedConfigurator = nil;
   }
 
   return machineOwner ?: @"";
+}
+
+- (NSArray<NSString *> *)machineOwnerGroups {
+  NSArray<NSString *> *machineOwnerGroups = self.configState[kMachineOwnerGroupsKey];
+  if (machineOwnerGroups.count) return machineOwnerGroups;
+
+  NSString *plistPath = self.configState[kMachineOwnerPlistFileKey];
+  NSString *plistKey = self.configState[kMachineOwnerGroupsPlistKeyKey];
+  if (plistPath && plistKey) {
+    NSDictionary *plist = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+    machineOwnerGroups = [plist[plistKey] isKindOfClass:[NSArray class]] ? plist[plistKey] : nil;
+    for (NSString *group in machineOwnerGroups) {
+      if (![group isKindOfClass:[NSString class]]) {
+        machineOwnerGroups = nil;
+        break;
+      }
+    }
+  }
+
+  return machineOwnerGroups;
 }
 
 - (NSString *)machineID {

--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -398,6 +398,7 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     syncState.machineOwner = @"";
     SLOGW(@"Missing Machine Owner.");
   }
+  syncState.machineOwnerGroups = config.machineOwnerGroups;
 
   syncState.xsrfToken = self.xsrfToken;
   syncState.xsrfTokenHeader = self.xsrfTokenHeader;

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -92,6 +92,12 @@ The following table expands upon the above logic to list most of the permutation
   req->set_model_identifier(NSStringToUTF8String([SNTSystemInfo modelIdentifier]));
   req->set_santa_version(NSStringToUTF8String([SNTSystemInfo santaFullVersion]));
   req->set_primary_user(NSStringToUTF8String(self.syncState.machineOwner));
+  if (self.syncState.machineOwnerGroups.count) {
+    google::protobuf::RepeatedPtrField<std::string> *groups = req->mutable_primary_user_groups();
+    for (NSString *group in self.syncState.machineOwnerGroups) {
+      groups->Add(NSStringToUTF8String(group));
+    }
+  }
   req->set_sip_status([SNTSIPStatus currentStatus]);
 
   if (self.syncState.pushNotificationsToken) {

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -58,6 +58,7 @@
 /// Machine identifier and owner.
 @property(copy) NSString *machineID;
 @property(copy) NSString *machineOwner;
+@property(copy) NSArray<NSString *> *machineOwnerGroups;
 
 /// Settings sent from server during preflight that are set during postflight.
 @property SNTClientMode clientMode;


### PR DESCRIPTION
If defined, primary user groups are uploaded during preflight.