### PR TITLE
santad: Check CEL expression validity before adding to DB

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -20,7 +20,7 @@ objc_library(
 
 objc_library(
     name = "SNTRuleTable",
-    srcs = ["DataLayer/SNTRuleTable.m"],
+    srcs = ["DataLayer/SNTRuleTable.mm"],
     hdrs = ["DataLayer/SNTRuleTable.h"],
     sdk_dylibs = [
         "EndpointSecurity",
@@ -40,6 +40,8 @@ objc_library(
         "//Source/common:SNTRule",
         "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SigningIDHelpers",
+        "//Source/common:String",
+        "//Source/common/cel:CEL",
     ],
 )
 
@@ -1106,7 +1108,7 @@ santa_unit_test(
         "DataLayer/SNTDatabaseTable.h",
         "DataLayer/SNTDatabaseTable.m",
         "DataLayer/SNTRuleTable.h",
-        "DataLayer/SNTRuleTable.m",
+        "DataLayer/SNTRuleTable.mm",
         "DataLayer/SNTRuleTableTest.m",
     ],
     sdk_dylibs = [

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1127,6 +1127,8 @@ santa_unit_test(
         "//Source/common:SNTRule",
         "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SigningIDHelpers",
+        "//Source/common:String",
+        "//Source/common/cel:CEL",
         "@FMDB",
         "@OCMock",
     ],

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -348,8 +348,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
 
 - (SNTRule *)ruleFromResultSet:(FMResultSet *)rs {
   return [[SNTRule alloc] initWithIdentifier:[rs stringForColumn:@"identifier"]
-                                       state:(SNTRuleState)[rs intForColumn:@"state"]
-                                        type:(SNTRuleType)[rs intForColumn:@"type"]
+                                       state:static_cast<SNTRuleState>([rs intForColumn:@"state"])
+                                        type:static_cast<SNTRuleType>([rs intForColumn:@"type"])
                                    customMsg:[rs stringForColumn:@"custommsg"]
                                    customURL:[rs stringForColumn:@"customurl"]
                                    timestamp:[rs intForColumn:@"timestamp"]

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -472,7 +472,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
         auto celExpr = _celEvaluator->Compile(santa::NSStringToUTF8StringView(rule.celExpr));
         if (!celExpr.ok()) {
           [SNTError populateError:&blockErr
-                         withCode:SNTErrorCodeRuleInvalid
+                         withCode:SNTErrorCodeRuleInvalidCELExpression
                           message:@"Rule array contained rule with invalid CEL expression"
                            detail:santa::StringToNSString(std::string(celExpr.status().message()))];
           continue;

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -193,6 +193,18 @@
   XCTAssertEqual(error.code, SNTErrorCodeRuleInvalid);
 }
 
+- (void)testAddInvalidCELExpression {
+  SNTRule *r = [[SNTRule alloc] init];
+  r.identifier = @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258";
+  r.type = SNTRuleTypeCertificate;
+  r.state = SNTRuleStateCEL;
+  r.celExpr = @"this is an invalid expression";
+
+  NSError *error;
+  XCTAssertTrue([self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error]);
+  XCTAssertEqual(error.code, SNTErrorCodeRuleInvalidCELExpression);
+}
+
 - (void)testFetchBinaryRule {
   [self.sut addRules:@[ [self _exampleBinaryRule], [self _exampleCertRule] ]
          ruleCleanup:SNTRuleCleanupNone

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -35,7 +35,6 @@ objc_library(
     deps = [
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTExportConfiguration",
-        "//Source/common/cel:CEL",
     ],
 )
 
@@ -125,7 +124,6 @@ objc_library(
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCSyncServiceInterface",
         "//Source/common:String",
-        "//Source/common/cel:CEL",
         "@northpolesec_protos//sync:v1_cc_proto",
         "@protobuf//src/google/protobuf/json",
     ],
@@ -187,7 +185,6 @@ santa_unit_test(
         "//Source/common:SNTSystemInfo",
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:String",
-        "//Source/common/cel:CEL",
         "@OCMock",
         "@northpolesec_protos//sync:v1_cc_proto",
         "@protobuf//src/google/protobuf/json",

--- a/Source/santasyncservice/SNTSyncManager.mm
+++ b/Source/santasyncservice/SNTSyncManager.mm
@@ -26,7 +26,6 @@
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
-#include "Source/common/cel/Evaluator.h"
 #import "Source/santasyncservice/SNTPushClientAPNS.h"
 #import "Source/santasyncservice/SNTPushClientFCM.h"
 #import "Source/santasyncservice/SNTPushNotifications.h"
@@ -63,9 +62,7 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
 
 @end
 
-@implementation SNTSyncManager {
-  std::unique_ptr<santa::cel::Evaluator> _celEvaluator;
-}
+@implementation SNTSyncManager
 
 #pragma mark init
 
@@ -96,11 +93,6 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     _syncLimiter = dispatch_semaphore_create(kMaxEnqueuedSyncs);
 
     _eventBatchSize = kDefaultEventBatchSize;
-
-    auto celEvaluator = santa::cel::Evaluator::Create();
-    if (celEvaluator.ok()) {
-      _celEvaluator = std::move(celEvaluator.value());
-    }
   }
   return self;
 }
@@ -448,8 +440,6 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
   syncState.daemonConn = self.daemonConn;
   syncState.contentEncoding = config.syncClientContentEncoding;
   syncState.pushNotificationsToken = self.pushNotifications.token;
-
-  syncState.celEvaluator = _celEvaluator.get();
 
   return syncState;
 }

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -21,7 +21,6 @@
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/common/String.h"
-#include "Source/common/cel/Evaluator.h"
 #import "Source/santasyncservice/SNTPushNotificationsTracker.h"
 #import "Source/santasyncservice/SNTSyncConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncLogging.h"
@@ -97,8 +96,7 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 
 // Downloads new rules from server and converts them into SNTRule.
 // Returns an array of all converted rules, or nil if there was a server problem.
-// Note that rules from the server are filtered.  We only keep those whose rule_type
-// is either BINARY or CERTIFICATE.  PACKAGE rules are dropped.
+// Note that rules from the server are filtered.
 - (NSArray<SNTRule *> *)downloadNewRulesFromServer {
   google::protobuf::Arena arena;
 
@@ -185,13 +183,6 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 
   const std::string &cel_expr = rule.cel_expr();
   NSString *celExpr = (!cel_expr.empty()) ? StringToNSString(cel_expr) : nil;
-  if (celExpr && self.syncState.celEvaluator) {
-    auto result = self.syncState.celEvaluator->Compile(cel_expr);
-    if (!result.ok()) {
-      LOGE(@"Failed to compile CEL expression: %s", std::string(result.status().message()).c_str());
-      return nil;
-    }
-  }
 
   return [[SNTRule alloc] initWithIdentifier:identifier
                                        state:state

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -17,7 +17,6 @@
 
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTExportConfiguration.h"
-#include "Source/common/cel/Evaluator.h"
 
 @class SNTSyncManager;
 @class MOLXPCConnection;
@@ -93,7 +92,5 @@
 
 @property BOOL preflightOnly;
 @property BOOL pushNotificationSync;
-
-@property santa::cel::Evaluator *celEvaluator;
 
 @end

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -874,9 +874,6 @@
 }
 
 - (void)testRuleDownloadCel {
-  auto celEvaluator = santa::cel::Evaluator::Create();
-  self.syncState.celEvaluator = celEvaluator->get();
-
   SNTSyncRuleDownload *sut = [[SNTSyncRuleDownload alloc] initWithState:self.syncState];
 
   NSData *respData = [self dataFromFixture:@"sync_ruledownload_with_cel_1.json"];
@@ -898,6 +895,7 @@
                                                                reply:([OCMArg invokeBlock])]);
   [sut sync];
 
+  // Both rules should get sent to the daemon. It will reject the second one.
   NSArray *rules = @[
     [[SNTRule alloc]
         initWithIdentifier:@"AAAAAAAAAA"
@@ -906,6 +904,12 @@
                  customMsg:nil
                  customURL:nil
                    celExpr:@"target.signing_time >= timestamp('2025-05-31T00:00:00Z')"],
+    [[SNTRule alloc] initWithIdentifier:@"BBBBBBBBBB"
+                                  state:SNTRuleStateCEL
+                                   type:SNTRuleTypeTeamID
+                              customMsg:nil
+                              customURL:nil
+                                celExpr:@"this is an invalid expression"],
   ];
 
   OCMVerify([self.daemonConnRop databaseRuleAddRules:rules


### PR DESCRIPTION
Move CEL expression validation from SNTRuleDownload -> SNTRuleTable so that it applies to both `santactl rule` and rule download. This doesn't cover static rules but that will be coming in a future PR.

Output from rule download failures:
```
Failed to add rule(s) to database: Rule array contained rule with invalid CEL expression
Failure reason: ERROR: <input>:1:1: undeclared reference to 'undefined_field' (in container '')
 | undefined_field
 | ^
Rule download failed, aborting run
```

Output from santactl sync failures:
```
» sudo santactl rule --force --signingid --identifier platform:com.apple.say --cel 'test'
Failed to modify rules: ERROR: <input>:1:1: undeclared reference to 'test' (in container '')
 | test
 | ^
```