### PR TITLE
santad: Move StaticRule processing into SNTRuleTable.

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -73,10 +73,8 @@
 ///    </dict>
 ///  </array>
 ///
-///  The return of this property is a dictionary where the keys are the
-///  identifiers of each rule, with the SNTRule as a value
 ///
-@property(nullable, readonly, nonatomic) NSDictionary<NSString *, SNTRule *> *staticRules;
+@property(nullable, readonly, nonatomic) NSArray<NSDictionary *> *staticRules;
 
 ///
 ///  The regex of allowed paths. Regexes are specified in ICU format.

--- a/Source/common/SNTRule.h
+++ b/Source/common/SNTRule.h
@@ -24,27 +24,27 @@
 ///
 ///  The hash of the object this rule is for
 ///
-@property(copy) NSString *identifier;
+@property(readonly, copy) NSString *identifier;
 
 ///
 ///  The state of this rule
 ///
-@property SNTRuleState state;
+@property(readonly) SNTRuleState state;
 
 ///
 ///  The type of object this rule is for (binary, certificate)
 ///
-@property SNTRuleType type;
+@property(readonly) SNTRuleType type;
 
 ///
 ///  A custom message that will be displayed if this rule blocks a binary from executing
 ///
-@property(copy) NSString *customMsg;
+@property(readonly, copy) NSString *customMsg;
 
 ///
 ///  A custom URL to take the user to when this binary is blocked from executing.
 ///
-@property(copy) NSString *customURL;
+@property(readonly, copy) NSString *customURL;
 
 ///
 ///  The time when this rule was last retrieved from the rules database, if rule is transitive.
@@ -55,12 +55,12 @@
 ///
 ///  A comment attached to this rule. This is intended only for local rules.
 ///
-@property(copy) NSString *comment;
+@property(readonly, copy) NSString *comment;
 
 ///
 ///  A CEL expression for this rule, required if the state is SNTRuleStateCEL.
 ///
-@property(copy) NSString *celExpr;
+@property(readonly, copy) NSString *celExpr;
 
 ///
 ///  Whether this rule is a static rule.

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -28,6 +28,11 @@ static const NSUInteger kExpectedTeamIDLength = 10;
 
 @interface SNTRule ()
 @property(readwrite) NSUInteger timestamp;
+@property(readwrite) SNTRuleState state;
+@property(readwrite) SNTRuleType type;
+@property(readwrite) NSString *customMsg;
+@property(readwrite) NSString *identifier;
+@property(readwrite) NSString *celExpr;
 @end
 
 @implementation SNTRule

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -31,6 +31,8 @@ static const NSUInteger kExpectedTeamIDLength = 10;
 @property(readwrite) SNTRuleState state;
 @property(readwrite) SNTRuleType type;
 @property(readwrite) NSString *customMsg;
+@property(readwrite) NSString *customURL;
+@property(readwrite) NSString *comment;
 @property(readwrite) NSString *identifier;
 @property(readwrite) NSString *celExpr;
 @end

--- a/Source/common/SNTRuleTest.mm
+++ b/Source/common/SNTRuleTest.mm
@@ -23,7 +23,10 @@
 #import "Source/common/SNTRule.h"
 
 @interface SNTRule ()
+// Making these properties readwrite makes some tests much easier to write.
 @property(readwrite) NSUInteger timestamp;
+@property(readwrite) SNTRuleState state;
+@property(readwrite) SNTRuleType type;
 @end
 
 @interface SNTRuleTest : XCTestCase

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -327,7 +327,7 @@ REGISTER_COMMAND_NAME(@"rule")
                                                    error:nil];
 
   if (check) {
-    if (!identifier) return [self printErrorUsageAndExit:@"--check requires --identifier"];
+    if (!newRule.identifier) return [self printErrorUsageAndExit:@"--check requires --identifier"];
     return [self printStateOfRule:newRule daemonConnection:self.daemonConn];
   }
 

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -116,6 +116,11 @@
 - (void)updateStaticRules:(NSArray<NSDictionary *> *)staticRules;
 
 ///
+///  Cached static rules.
+///
+@property(readonly) NSDictionary<NSString *, SNTRule *> *cachedStaticRules;
+
+///
 ///  A map of a file hashes to cached decisions. This is used to pre-validate and whitelist
 ///  certain critical system binaries that are integral to Santa's functionality.
 ///

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -111,6 +111,11 @@
 - (NSArray<SNTRule *> *)retrieveAllRules;
 
 ///
+///  Update the static rules from the configuration.
+///
+- (void)updateStaticRules:(NSArray<NSDictionary *> *)staticRules;
+
+///
 ///  A map of a file hashes to cached decisions. This is used to pre-validate and whitelist
 ///  certain critical system binaries that are integral to Santa's functionality.
 ///

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -79,7 +79,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
 @property NSDate *lastTransitiveRuleCulling;
 @property NSDictionary *criticalSystemBinaries;
 @property(readonly) NSArray *criticalSystemBinaryPaths;
-@property NSDictionary<NSString *, SNTRule *> *cachedStaticRules;
+@property(readwrite) NSDictionary<NSString *, SNTRule *> *cachedStaticRules;
 @end
 
 @implementation SNTRuleTable

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -382,7 +382,6 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
 
     rule = staticRules[identifiers.signingID];
     if (rule.type == SNTRuleTypeSigningID) {
-      LOGD(@"Found static rule for signing ID %@: %@", identifiers.signingID, rule);
       return rule;
     }
 

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -79,6 +79,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
 @property NSDate *lastTransitiveRuleCulling;
 @property NSDictionary *criticalSystemBinaries;
 @property(readonly) NSArray *criticalSystemBinaryPaths;
+@property NSDictionary<NSString *, SNTRule *> *cachedStaticRules;
 @end
 
 @implementation SNTRuleTable
@@ -287,6 +288,9 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
   // Setup critical system binaries
   [self setupSystemCriticalBinaries];
 
+  // Prime the cached static rules.
+  [self updateStaticRules:[[SNTConfigurator configurator] staticRules]];
+
   return newVersion;
 }
 
@@ -362,7 +366,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
   __block SNTRule *rule;
 
   // Look for a static rule that matches.
-  NSDictionary *staticRules = [[SNTConfigurator configurator] staticRules];
+  NSDictionary *staticRules = self.cachedStaticRules;
   if (staticRules.count) {
     // IMPORTANT: The order static rules are checked here should be the same
     // order as given by the SQL query for the rules database.
@@ -378,6 +382,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
 
     rule = staticRules[identifiers.signingID];
     if (rule.type == SNTRuleTypeSigningID) {
+      LOGD(@"Found static rule for signing ID %@: %@", identifiers.signingID, rule);
       return rule;
     }
 
@@ -624,6 +629,39 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     [rs close];
   }];
   return rules;
+}
+
+#pragma mark Caching Static Rules
+
+- (void)updateStaticRules:(NSArray<NSDictionary *> *)staticRules {
+  if (![staticRules isKindOfClass:[NSArray class]]) {
+    self.cachedStaticRules = nil;
+    return;
+  }
+
+  NSMutableDictionary<NSString *, SNTRule *> *rules =
+      [NSMutableDictionary dictionaryWithCapacity:staticRules.count];
+  for (id rule in staticRules) {
+    if (![rule isKindOfClass:[NSDictionary class]]) continue;
+    NSError *error;
+    SNTRule *r = [[SNTRule alloc] initStaticRuleWithDictionary:rule error:&error];
+    if (error) {
+      LOGE(@"Failed to initialize static rule %@: %@", rule, error);
+    }
+    if (!r) continue;
+
+    if (r.state == SNTRuleStateCEL && _celEvaluator) {
+      auto celExpr = _celEvaluator->Compile(santa::NSStringToUTF8StringView(r.celExpr));
+      if (!celExpr.ok()) {
+        LOGE(@"Failed to compile CEL expression for static rule %@: %s", r.identifier,
+             std::string(celExpr.status().message()).c_str());
+        continue;
+      }
+    }
+
+    rules[r.identifier] = r;
+  }
+  self.cachedStaticRules = [rules copy];
 }
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -35,6 +35,15 @@
 @property id mockConfigurator;
 @end
 
+@interface SNTRule ()
+// Making these properties readwrite makes some tests much easier to write.
+@property(readwrite) SNTRuleState state;
+@property(readwrite) SNTRuleType type;
+@property(readwrite) NSString *customMsg;
+@property(readwrite) NSString *identifier;
+@property(readwrite) NSString *celExpr;
+@end
+
 @implementation SNTRuleTableTest
 
 - (void)setUp {

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -116,12 +116,9 @@ double watchdogRAMPeak = 0;
   };
 
   // Update counts with data from StaticRules configuration
-  [[[SNTConfigurator configurator] staticRules]
-      enumerateObjectsUsingBlock:^(NSDictionary *rule, NSUInteger idx, BOOL *stop) {
-        SNTRule *r = [[SNTRule alloc] initStaticRuleWithDictionary:rule error:nil];
-        if (!r) return;
-
-        switch (r.type) {
+  [[rdb cachedStaticRules]
+      enumerateKeysAndObjectsUsingBlock:^(NSString *key, SNTRule *rule, BOOL *stop) {
+        switch (rule.type) {
           case SNTRuleTypeCDHash: ruleCounts.cdhash++; break;
           case SNTRuleTypeBinary: ruleCounts.binary++; break;
           case SNTRuleTypeSigningID: ruleCounts.signingID++; break;
@@ -131,7 +128,7 @@ double watchdogRAMPeak = 0;
         }
 
         // Note: Transitive rules cannot come from static rules
-        switch (r.state) {
+        switch (rule.state) {
           case SNTRuleStateAllowCompiler: ruleCounts.compiler++; break;
           default: break;
         }

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -117,8 +117,11 @@ double watchdogRAMPeak = 0;
 
   // Update counts with data from StaticRules configuration
   [[[SNTConfigurator configurator] staticRules]
-      enumerateKeysAndObjectsUsingBlock:^(NSString *key, SNTRule *rule, BOOL *stop) {
-        switch (rule.type) {
+      enumerateObjectsUsingBlock:^(NSDictionary *rule, NSUInteger idx, BOOL *stop) {
+        SNTRule *r = [[SNTRule alloc] initStaticRuleWithDictionary:rule error:nil];
+        if (!r) return;
+
+        switch (r.type) {
           case SNTRuleTypeCDHash: ruleCounts.cdhash++; break;
           case SNTRuleTypeBinary: ruleCounts.binary++; break;
           case SNTRuleTypeSigningID: ruleCounts.signingID++; break;
@@ -128,7 +131,7 @@ double watchdogRAMPeak = 0;
         }
 
         // Note: Transitive rules cannot come from static rules
-        switch (rule.state) {
+        switch (r.state) {
           case SNTRuleStateAllowCompiler: ruleCounts.compiler++; break;
           default: break;
         }

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -104,4 +104,6 @@ const static NSString *kBlockLongPath = @"BlockLongPath";
 - (void)updateEntitlementsPrefixFilter:(NSArray<NSString *> *)filter;
 - (void)updateEntitlementsTeamIDFilter:(NSArray<NSString *> *)filter;
 
+@property(nonatomic, readonly) SNTRuleTable *ruleTable;
+
 @end

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -86,7 +86,7 @@ void UpdatePrefixFilterLocked(std::unique_ptr<PrefixTree<Unit>> &tree,
 @property SNTEventTable *eventTable;
 @property SNTNotificationQueue *notifierQueue;
 @property SNTPolicyProcessor *policyProcessor;
-@property SNTRuleTable *ruleTable;
+@property(readwrite) SNTRuleTable *ruleTable;
 @property SNTSyncdQueue *syncdQueue;
 @property SNTMetricCounter *events;
 @property santa::ProcessControlBlock processControlBlock;

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -51,6 +51,13 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
   };
 };
 
+@interface SNTRule ()
+// Making these properties readwrite makes some tests much easier to write.
+@property(readwrite) SNTRuleState state;
+@property(readwrite) SNTRuleType type;
+@property(readwrite) NSString *customMsg;
+@end
+
 @interface SNTExecutionControllerTest : XCTestCase
 @property id mockDecisionCache;
 @property id mockConfigurator;

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -170,7 +170,7 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision *cd) {
     return NO;
   }
 
-  switch (rule.state) {
+  switch (state) {
     case SNTRuleStateSilentBlock: cd.silentBlock = YES; break;
     case SNTRuleStateAllowCompiler:
       if (!enableTransitiveRules) {

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -174,7 +174,7 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision *cd) {
     case SNTRuleStateSilentBlock: cd.silentBlock = YES; break;
     case SNTRuleStateAllowCompiler:
       if (!enableTransitiveRules) {
-        switch (rule.type) {
+        switch (type) {
           case SNTRuleTypeCDHash: cd.decision = SNTEventStateAllowCDHash; break;
           case SNTRuleTypeBinary: cd.decision = SNTEventStateAllowBinary; break;
           case SNTRuleTypeSigningID: cd.decision = SNTEventStateAllowSigningID; break;

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -539,17 +539,10 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 
 // Transitive allowlist rules
 - (void)testDecisionForTransitiveAllowlistRuleMatches {
-  NSMutableDictionary *d = [@{
-    @"rule_type" : @"BINARY",
-    @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-    @"policy" : @"ALLOWLIST"
-  } mutableCopy];
-
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:d error:nil];
-  XCTAssertNotNil(rule, "invalid test rule dictionary");
-
-  d[@"policy"] = @"ALLOWLIST_TRANSITIVE";
-  rule = [[SNTRule alloc] initWithDictionary:d error:nil];
+  SNTRule *rule = [[SNTRule alloc]
+      initWithIdentifier:@"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                   state:SNTRuleStateAllowTransitive
+                    type:SNTRuleTypeBinary];
 
   [self testRule:rule
        transitiveRules:YES

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -539,16 +539,17 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 
 // Transitive allowlist rules
 - (void)testDecisionForTransitiveAllowlistRuleMatches {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
+  NSMutableDictionary *d = [@{
     @"rule_type" : @"BINARY",
     @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     @"policy" : @"ALLOWLIST"
-  }
-                                                error:nil];
+  } mutableCopy];
 
+  SNTRule *rule = [[SNTRule alloc] initWithDictionary:d error:nil];
   XCTAssertNotNil(rule, "invalid test rule dictionary");
 
-  rule.state = SNTRuleStateAllowTransitive;
+  d[@"policy"] = @"ALLOWLIST_TRANSITIVE";
+  rule = [[SNTRule alloc] initWithDictionary:d error:nil];
 
   [self testRule:rule
        transitiveRules:YES
@@ -567,16 +568,11 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 }
 
 - (void)testEnsureANonMatchingRuleResultsInUnknown {
-  SNTRule *rule = [[SNTRule alloc] initWithDictionary:@{
-    @"rule_type" : @"BINARY",
-    @"identifier" : @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-    @"policy" : @"ALLOWLIST"
-  }
-                                                error:nil];
-
-  XCTAssertNotNil(rule, "invalid test rule dictionary");
-
-  rule.state = static_cast<SNTRuleState>(88888);  // Set to an invalid state
+  // Set to an invalid state
+  SNTRule *rule = [[SNTRule alloc]
+      initWithIdentifier:@"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                   state:static_cast<SNTRuleState>(88888)
+                    type:SNTRuleTypeBinary];
 
   [self testRule:rule
        transitiveRules:YES

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -27,6 +27,7 @@
 #import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/common/SNTXPCSyncServiceInterface.h"
 #include "Source/common/TelemetryEventMap.h"
+#include "Source/santad/DataLayer/SNTRuleTable.h"
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #include "Source/santad/DataLayer/WatchItems.h"
 #include "Source/santad/EventProviders/AuthResultCache.h"
@@ -371,11 +372,13 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                  }],
     [[SNTKVOManager alloc] initWithObject:configurator
                                  selector:@selector(staticRules)
-                                     type:[NSDictionary class]
-                                 callback:^(NSDictionary *oldValue, NSDictionary *newValue) {
-                                   if ([oldValue isEqualToDictionary:newValue]) {
+                                     type:[NSArray class]
+                                 callback:^(NSArray *oldValue, NSArray *newValue) {
+                                   if ([oldValue isEqualToArray:newValue]) {
                                      return;
                                    }
+
+                                   [exec_controller.ruleTable updateStaticRules:newValue];
 
                                    LOGI(@"StaticRules changed. Flushing caches.");
                                    auth_result_cache->FlushCache(


### PR DESCRIPTION
Use this move to allow checking CEL rules at update time.