### PR TITLE
readme: Update shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Santa
 
-[![license](https://img.shields.io/github/license/northpolesec/santa)](https://github.com/northpolesec/santa/blob/main/LICENSE)
-[![CI](https://github.com/northpolesec/santa/actions/workflows/ci.yml/badge.svg)](https://github.com/northpolesec/santa/actions/workflows/ci.yml)
-[![latest release](https://img.shields.io/github/v/release/northpolesec/santa.svg)](https://github.com/northpolesec/santa/releases/latest)
-[![latest release date](https://img.shields.io/github/release-date/northpolesec/santa.svg)](https://github.com/northpolesec/santa/releases/latest)
-[![downloads](https://img.shields.io/github/downloads/northpolesec/santa/latest/total)](https://github.com/northpolesec/santa/releases/latest)
+[![license](https://img.shields.io/github/license/northpolesec/santa?style=flat-square&color=lightgray)](https://github.com/northpolesec/santa/blob/main/LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/northpolesec/santa/ci.yml?style=flat-square&label=CI)](https://github.com/northpolesec/santa/actions/workflows/ci.yml)
+[![latest release](https://img.shields.io/github/v/release/northpolesec/santa.svg?style=flat-square)](https://github.com/northpolesec/santa/releases/latest)
+[![latest release date](https://img.shields.io/github/release-date/northpolesec/santa?display_date=published_at&style=flat-square&color=007ec6)](https://github.com/northpolesec/santa/releases/latest)
+[![downloads](https://img.shields.io/github/downloads/northpolesec/santa/latest/total?style=flat-square&color=007ec6)](https://github.com/northpolesec/santa/releases/latest)
 
 <p align="center">
     <img src="./docs/static/img/nps-logo-256.png" height="128" alt="Santa Icon" />


### PR DESCRIPTION
Switch CI to use shields.io style, update all to flat-square style, update coloring for more consistency. Release related shields are all blue, license is light gray, CI remains green/red based on status.

![image](https://github.com/user-attachments/assets/244e9b96-b77c-49c6-9399-e108542ce80a)
