### PR TITLE
gui: Fix minor UI issue when an app sets empty bundle name

### DIFF
--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -436,9 +436,20 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
   return [[self.infoPlist objectForKey:@"CFBundleIdentifier"] description];
 }
 
+///
+///  Return either CFBundleDisplayName or CFBundleName, or nil if those
+///  keys are not set or are empty strings.
+///
 - (NSString *)bundleName {
-  return [[self.infoPlist objectForKey:@"CFBundleDisplayName"] description]
-             ?: [[self.infoPlist objectForKey:@"CFBundleName"] description];
+  NSString *name = [[self.infoPlist objectForKey:@"CFBundleDisplayName"] description];
+  if (name.length == 0) {
+    name = [[self.infoPlist objectForKey:@"CFBundleName"] description];
+    if (name.length == 0) {
+      return nil;
+    }
+  }
+
+  return name;
 }
 
 - (NSString *)bundleVersion {

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -57,7 +57,7 @@ import santa_gui_SNTMessageView
 }
 
 func copyDetailsToClipboard(e: SNTStoredEvent?, customURL: String?) {
-  var s = "Santa blocked \(e?.fileBundleName ?? "an application:")"
+  var s = "Santa blocked \((e?.fileBundleName?.isEmpty == false) ? e!.fileBundleName! : "an application")"
   if let publisher = e?.publisherInfo {
     s += "\nPublisher  : \(publisher)"
   }
@@ -203,7 +203,7 @@ struct SNTBinaryMessageEventView: View {
       Divider()
 
       VStack(alignment: .leading, spacing: 10.0) {
-        if let bundleName = e?.fileBundleName {
+        if let bundleName = e?.fileBundleName, !bundleName.isEmpty {
           TextWithLimit(bundleName)
         } else if let filePath = e?.filePath {
           TextWithLimit((filePath as NSString).lastPathComponent)


### PR DESCRIPTION
This is a minor UI issue only that is rare and caused by an app developer intentionally setting their bundle name to an empty string. This issue only affects what data Santa chooses to show in the UI, and could result in labels having missing values. There is no missing data in sync events or telemetry.