### PR TITLE
build: Fix multi-arch builds for rust

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,5 @@
 build --apple_generate_dsym
 build --define=apple.propagate_embedded_extra_outputs=yes
-# Needed to enable multi-arch builds across compiler toolchains (e.g. Rust)
-build --incompatible_enable_apple_toolchain_resolution
 
 build --copt=-Werror
 build --copt=-Wall

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,9 +7,23 @@ bazel_dep(name = "protobuf", version = "31.1")
 bazel_dep(name = "rules_apple", version = "3.21.0")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
+bazel_dep(name = "rules_rust", version = "0.61.0")
 bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(name = "rules_swift", version = "2.8.2")
 bazel_dep(name = "xxhash", version = "0.8.2")
+
+# Load rules_rust dependencies needed for rednose.
+# The edition/version must match what's needed by the dependency.
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2024",
+    versions = ["1.86.0"],
+    extra_target_triples = [
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
+    ],
+)
+use_repo(rust, "rust_toolchains")
 
 # North Pole Protos
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")


### PR DESCRIPTION
This is an almost clean revert of #461. `--incompatible_enable_apple_toolchain_resolution` seems to neuter the `--macos_cpus` flag such that our builds are no longer multi-arch. Until we find a better solution, defining the rust toolchains inside this repo and reverting that flag is the easiest fix.