### PR TITLE
debug: fix SANTA_STORE_SYNC_JSON

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -171,6 +171,14 @@ objc_library(
     hdrs = ["String.h"],
 )
 
+santa_unit_test(
+    name = "StringTest",
+    srcs = ["StringTest.mm"],
+    deps = [
+        ":String",
+    ],
+)
+
 objc_library(
     name = "CertificateHelpers",
     srcs = ["CertificateHelpers.mm"],
@@ -788,6 +796,7 @@ test_suite(
         ":SantaSetCacheTest",
         ":ScopedCFTypeRefTest",
         ":ScopedIOObjectRefTest",
+        ":StringTest",
         ":TelemetryEventMapTest",
         "//Source/common/cel:CELTest",
     ],

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -286,7 +286,7 @@ NSString *const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 }
 
 - (NSString *)cdhash {
-  return santa::StringToNSString(
+  return santa::UTF8StringToNSString(
       santa::BufToHexString((NSData *)self.signingInformation[(__bridge id)kSecCodeInfoUnique]));
 }
 

--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -33,20 +33,25 @@ static inline std::string NSStringToUTF8String(NSString *str) {
   return std::string(str.UTF8String, [str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
 }
 
-static inline NSString *StringToNSString(const std::string &str) {
+static inline NSString *UTF8StringToNSString(const std::string &str) {
   return [NSString stringWithUTF8String:str.c_str()];
 }
 
-static inline NSString *StringToNSString(const char *str) {
+static inline NSString *UTF8StringToNSString(const char *str) {
   return [NSString stringWithUTF8String:str];
 }
 
-static inline NSString *OptionalStringToNSString(const std::optional<std::string> &optional_str) {
+static inline NSString *UTF8StringToNSString(std::string_view str) {
+  return [NSString stringWithUTF8String:str.data()];
+}
+
+static inline NSString *OptionalUTF8StringToNSString(
+    const std::optional<std::string> &optional_str) {
   std::string str = optional_str.value_or("");
   if (str.length() == 0) {
     return nil;
   } else {
-    return StringToNSString(str);
+    return UTF8StringToNSString(str);
   }
 }
 

--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -42,7 +42,8 @@ static inline NSString *UTF8StringToNSString(const char *str) {
 }
 
 static inline NSString *UTF8StringToNSString(std::string_view str) {
-  return [NSString stringWithUTF8String:str.data()];
+  // Ensure null termination.
+  return [NSString stringWithUTF8String:std::string(str).c_str()];
 }
 
 static inline NSString *OptionalUTF8StringToNSString(

--- a/Source/common/StringTest.mm
+++ b/Source/common/StringTest.mm
@@ -1,0 +1,129 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/String.h"
+
+#include <EndpointSecurity/ESTypes.h>
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include <string>
+#include <string_view>
+
+using namespace santa;
+
+@interface StringTest : XCTestCase
+@end
+
+@implementation StringTest
+
+#pragma mark - NSStringToUTF8StringView Tests
+
+- (void)testNSStringToUTF8StringView_BasicString {
+  NSString *s = @"Hello, World!";
+  std::string_view result = NSStringToUTF8StringView(s);
+  XCTAssertEqual(result.size(), 13);
+  XCTAssertEqual(result, "Hello, World!");
+}
+
+- (void)testNSStringToUTF8StringView_EmptyString {
+  NSString *s = @"";
+  std::string_view result = NSStringToUTF8StringView(s);
+  XCTAssertEqual(result.size(), 0);
+  XCTAssertEqual(result, "");
+}
+
+- (void)testNSStringToUTF8StringView_UnicodeString {
+  NSString *s = @"Hello 🌍";
+  std::string_view result = NSStringToUTF8StringView(s);
+  XCTAssertEqual(result.size(), 10);
+  XCTAssertEqual(result, "Hello 🌍");
+}
+
+#pragma mark - NSStringToUTF8String Tests
+
+- (void)testNSStringToUTF8String_BasicString {
+  NSString *s = @"Hello, World!";
+  std::string result = NSStringToUTF8String(s);
+  XCTAssertEqual(result.size(), 13);
+  XCTAssertEqual(result, "Hello, World!");
+}
+
+- (void)testNSStringToUTF8String_EmptyString {
+  NSString *s = @"";
+  std::string result = NSStringToUTF8String(s);
+  XCTAssertEqual(result.size(), 0);
+  XCTAssertEqual(result, "");
+}
+
+- (void)testNSStringToUTF8String_UnicodeString {
+  NSString *s = @"Hello 🌍";
+  std::string result = NSStringToUTF8String(s);
+
+  XCTAssertEqual(result, "Hello 🌍");
+  XCTAssertEqual(result.size(), 10);
+}
+
+#pragma mark - UTF8StringToNSString Tests
+
+- (void)testUTF8StringToNSString_StdString {
+  std::string s = "Hello, World!";
+  NSString *result = UTF8StringToNSString(s);
+  XCTAssertEqualObjects(result, @"Hello, World!");
+}
+
+- (void)testUTF8StringToNSString_EmptyStdString {
+  std::string s = "";
+  NSString *result = UTF8StringToNSString(s);
+  XCTAssertEqualObjects(result, @"");
+}
+
+- (void)testUTF8StringToNSString_CString {
+  const char *s = "Hello, World!";
+  NSString *result = UTF8StringToNSString(s);
+  XCTAssertEqualObjects(result, @"Hello, World!");
+}
+
+- (void)testUTF8StringToNSString_EmptyCString {
+  const char *s = "";
+  NSString *result = UTF8StringToNSString(s);
+  XCTAssertEqualObjects(result, @"");
+}
+
+- (void)testUTF8StringToNSString_StringView {
+  std::string_view strView = "Hello, World!";
+  NSString *result = UTF8StringToNSString(strView);
+  XCTAssertEqualObjects(result, @"Hello, World!");
+}
+
+- (void)testUTF8StringToNSString_EmptyStringView {
+  std::string_view strView = "";
+  NSString *result = UTF8StringToNSString(strView);
+  XCTAssertEqualObjects(result, @"");
+}
+
+- (void)testUTF8StringToNSString_NoNullTerminator {
+  char data[] = {'H', 'e', 'l', 'l', 'o', ',', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
+  std::string_view s(data, 5);
+  NSString *result = UTF8StringToNSString(s);
+  XCTAssertEqualObjects(result, @"Hello");
+}
+
+- (void)testUTF8StringToNSString_UnicodeContent {
+  std::string s = "Hello 🌍";
+  NSString *result = UTF8StringToNSString(s);
+  XCTAssertEqualObjects(result, @"Hello 🌍");
+}
+
+@end

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -479,7 +479,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
           [SNTError populateError:&blockErr
                          withCode:SNTErrorCodeRuleInvalidCELExpression
                           message:@"Rule array contained rule with invalid CEL expression"
-                           detail:santa::StringToNSString(std::string(celExpr.status().message()))];
+                           detail:santa::UTF8StringToNSString(celExpr.status().message())];
           continue;
         }
       }

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -427,7 +427,7 @@ void FAAPolicyProcessor::LogTTY(SNTFileAccessEvent *event, URLTextPair link_info
 
   NSAttributedString *attrStr = [SNTBlockMessage
       attributedBlockMessageForFileAccessEvent:event
-                                 customMessage:OptionalStringToNSString(policy.custom_message)];
+                                 customMessage:OptionalUTF8StringToNSString(policy.custom_message)];
 
   NSMutableString *blockMsg = [NSMutableString stringWithCapacity:1024];
   // Escape sequences `\033[1m` and `\033[0m` begin/end bold lettering
@@ -472,17 +472,17 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
       SNTCachedDecision *cd = GetCachedDecision(msg->process->executable->stat);
       SNTFileAccessEvent *event = [[SNTFileAccessEvent alloc] init];
 
-      event.accessedPath = StringToNSString(target.path);
-      event.ruleVersion = StringToNSString(policy->version);
-      event.ruleName = StringToNSString(policy->name);
+      event.accessedPath = UTF8StringToNSString(target.path);
+      event.ruleVersion = UTF8StringToNSString(policy->version);
+      event.ruleName = UTF8StringToNSString(policy->name);
       event.fileSHA256 = cd.sha256 ?: @"<unknown sha>";
-      event.filePath = StringToNSString(msg->process->executable->path.data);
+      event.filePath = UTF8StringToNSString(msg->process->executable->path.data);
       event.teamID = cd.teamID ?: @"<unknown team id>";
       event.signingID = cd.signingID ?: @"<unknown signing id>";
       event.cdhash = cd.cdhash ?: @"<unknown CDHash>";
       event.pid = @(audit_token_to_pid(msg->process->audit_token));
       event.ppid = @(audit_token_to_pid(msg->process->parent_audit_token));
-      event.parentName = StringToNSString(msg.ParentProcessName());
+      event.parentName = UTF8StringToNSString(msg.ParentProcessName());
       event.signingChain = cd.certChain;
 
       struct passwd *user = getpwuid(audit_token_to_ruid(msg->process->audit_token));
@@ -494,7 +494,7 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
       }
 
       if (ShouldShowUIForPolicy(policy)) {
-        file_access_denied_block(event, OptionalStringToNSString(policy->custom_message),
+        file_access_denied_block(event, OptionalUTF8StringToNSString(policy->custom_message),
                                  link_info.first, link_info.second);
       }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -153,7 +153,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
       }
 
       // Only log file changes that match the given regex
-      NSString *targetPath = santa::StringToNSString(targetFile->path.data);
+      NSString *targetPath = santa::UTF8StringToNSString(targetFile->path.data);
       if (![[self.configurator fileChangesRegex]
               numberOfMatchesInString:targetPath
                               options:0

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
@@ -100,7 +100,7 @@ NSString *MountFromName(NSString *path) {
     return nil;
   }
 
-  NSString *mntFromName = santa::StringToNSString(sfs.f_mntfromname);
+  NSString *mntFromName = santa::UTF8StringToNSString(sfs.f_mntfromname);
 
   return mntFromName.length > 0 ? mntFromName : nil;
 }

--- a/Source/santad/TTYWriter.mm
+++ b/Source/santad/TTYWriter.mm
@@ -51,7 +51,7 @@ void TTYWriter::Write(const es_process_t *proc, NSString * (^messageCreator)(voi
 
   // Copy the data from the es_process_t so the ES message doesn't
   // need to be retained
-  NSString *tty = santa::StringToNSString(proc->tty->path.data);
+  NSString *tty = santa::UTF8StringToNSString(proc->tty->path.data);
   // Realize the message string before going async so as not to need to worry about
   // lifetimes of objects in the provided block.
   NSString *msg = messageCreator();

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -77,7 +77,7 @@ using santa::NSStringToUTF8StringView;
           [NSMutableArray arrayWithCapacity:response.event_upload_bundle_binaries_size()];
       for (const std::string &bundle_binary : response.event_upload_bundle_binaries()) {
         [(NSMutableArray *)self.syncState.bundleBinaryRequests
-            addObject:santa::StringToNSString(bundle_binary)];
+            addObject:santa::UTF8StringToNSString(bundle_binary)];
       }
     }
     SLOGI(@"Uploaded %d events", req->events_size());

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -34,7 +34,7 @@
 namespace pbv1 = ::santa::sync::v1;
 
 using santa::NSStringToUTF8String;
-using santa::StringToNSString;
+using santa::UTF8StringToNSString;
 
 // Ignoring warning regarding deprecated declarations because of large number of
 // reported issues due to checking deprecated proto fields.
@@ -199,15 +199,15 @@ The following table expands upon the above logic to list most of the permutation
   }
 
   if (resp.has_allowed_path_regex()) {
-    self.syncState.allowlistRegex = StringToNSString(resp.allowed_path_regex());
+    self.syncState.allowlistRegex = UTF8StringToNSString(resp.allowed_path_regex());
   } else if (resp.has_deprecated_whitelist_regex()) {
-    self.syncState.allowlistRegex = StringToNSString(resp.deprecated_whitelist_regex());
+    self.syncState.allowlistRegex = UTF8StringToNSString(resp.deprecated_whitelist_regex());
   }
 
   if (resp.has_blocked_path_regex()) {
-    self.syncState.blocklistRegex = StringToNSString(resp.blocked_path_regex());
+    self.syncState.blocklistRegex = UTF8StringToNSString(resp.blocked_path_regex());
   } else if (resp.has_deprecated_blacklist_regex()) {
-    self.syncState.blocklistRegex = StringToNSString(resp.deprecated_blacklist_regex());
+    self.syncState.blocklistRegex = UTF8StringToNSString(resp.deprecated_blacklist_regex());
   }
 
   if (resp.has_block_usb_mount()) {
@@ -215,7 +215,7 @@ The following table expands upon the above logic to list most of the permutation
 
     self.syncState.remountUSBMode = [NSMutableArray array];
     for (const std::string &mode : resp.remount_usb_mode()) {
-      [(NSMutableArray *)self.syncState.remountUSBMode addObject:StringToNSString(mode)];
+      [(NSMutableArray *)self.syncState.remountUSBMode addObject:UTF8StringToNSString(mode)];
     }
   }
 
@@ -237,19 +237,19 @@ The following table expands upon the above logic to list most of the permutation
       if (!protoAWS.access_key().empty() && !protoAWS.secret_access_key().empty() &&
           !protoAWS.session_token().empty() && !protoAWS.bucket_name().empty()) {
         self.syncState.exportConfig = [[SNTExportConfiguration alloc]
-            initWithAWSAccessKey:StringToNSString(protoAWS.access_key())
-                 secretAccessKey:StringToNSString(protoAWS.secret_access_key())
-                    sessionToken:StringToNSString(protoAWS.session_token())
-                      bucketName:StringToNSString(protoAWS.bucket_name())
-                 objectKeyPrefix:StringToNSString(protoAWS.object_key_prefix())];
+            initWithAWSAccessKey:UTF8StringToNSString(protoAWS.access_key())
+                 secretAccessKey:UTF8StringToNSString(protoAWS.secret_access_key())
+                    sessionToken:UTF8StringToNSString(protoAWS.session_token())
+                      bucketName:UTF8StringToNSString(protoAWS.bucket_name())
+                 objectKeyPrefix:UTF8StringToNSString(protoAWS.object_key_prefix())];
       }
     } else if (protoExportConfig.has_gcp_config()) {
       auto protoGCP = protoExportConfig.gcp_config();
       if (!protoGCP.bearer_token().empty() && !protoGCP.bucket_name().empty()) {
         self.syncState.exportConfig = [[SNTExportConfiguration alloc]
-            initWithGCPBearerToken:StringToNSString(protoGCP.bearer_token())
-                        bucketName:StringToNSString(protoGCP.bucket_name())
-                   objectKeyPrefix:StringToNSString(protoGCP.object_key_prefix())];
+            initWithGCPBearerToken:UTF8StringToNSString(protoGCP.bearer_token())
+                        bucketName:UTF8StringToNSString(protoGCP.bucket_name())
+                   objectKeyPrefix:UTF8StringToNSString(protoGCP.object_key_prefix())];
       }
     }
   }

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -31,7 +31,7 @@
 namespace pbv1 = ::santa::sync::v1;
 
 using santa::NSStringToUTF8String;
-using santa::StringToNSString;
+using santa::UTF8StringToNSString;
 
 SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   switch (syncType) {
@@ -144,10 +144,10 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 }
 
 - (SNTRule *)ruleFromProtoRule:(::pbv1::Rule)rule {
-  NSString *identifier = StringToNSString(rule.identifier());
+  NSString *identifier = UTF8StringToNSString(rule.identifier());
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (!identifier.length) identifier = StringToNSString(rule.deprecated_sha256());
+  if (!identifier.length) identifier = UTF8StringToNSString(rule.deprecated_sha256());
 #pragma clang diagnostic pop
   if (!identifier.length) {
     LOGE(@"Failed to process rule with no identifier");
@@ -176,13 +176,13 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   }
 
   const std::string &custom_msg = rule.custom_msg();
-  NSString *customMsg = (!custom_msg.empty()) ? StringToNSString(custom_msg) : nil;
+  NSString *customMsg = (!custom_msg.empty()) ? UTF8StringToNSString(custom_msg) : nil;
 
   const std::string &custom_url = rule.custom_url();
-  NSString *customURL = (!custom_url.empty()) ? StringToNSString(custom_url) : nil;
+  NSString *customURL = (!custom_url.empty()) ? UTF8StringToNSString(custom_url) : nil;
 
   const std::string &cel_expr = rule.cel_expr();
-  NSString *celExpr = (!cel_expr.empty()) ? StringToNSString(cel_expr) : nil;
+  NSString *celExpr = (!cel_expr.empty()) ? UTF8StringToNSString(cel_expr) : nil;
 
   return [[SNTRule alloc] initWithIdentifier:identifier
                                        state:state
@@ -219,7 +219,7 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 - (void)processBundleNotificationsForRule:(SNTRule *)rule
                             fromProtoRule:(const ::pbv1::Rule *)protoRule {
   // Display a system notification if notification_app_name is set and this is not a clean sync.
-  NSString *appName = StringToNSString(protoRule->notification_app_name());
+  NSString *appName = UTF8StringToNSString(protoRule->notification_app_name());
   if (appName.length) {
     // If notification_app_name is set but this is a clean sync, return early. We don't want to
     // spam users with notifications for many apps that might be included in a clean sync, and
@@ -242,7 +242,7 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   if (rule.state == SNTRuleStateAllow || rule.state == SNTRuleStateAllowCompiler) {
     // primaryHash is the bundle hash if there was a bundle hash included in the rule, otherwise
     // it is simply the binary hash.
-    NSString *primaryHash = StringToNSString(protoRule->file_bundle_hash());
+    NSString *primaryHash = UTF8StringToNSString(protoRule->file_bundle_hash());
     if (primaryHash.length != 64) {
       primaryHash = rule.identifier;
     }

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -93,8 +93,7 @@ using santa::NSStringToUTF8String;
   NSData *data = [NSData dataWithBytes:json.data() length:json.size()];
 
 #ifdef SANTA_STORE_SYNC_JSON
-  [self storeJSON:data
-      withMessageType:santa::StringToNSString(std::string(message->GetTypeName()))];
+  [self storeJSON:data withMessageType:santa::UTF8StringToNSString(message->GetTypeName())];
 #endif
 
   return [self requestWithData:data contentType:@"application/json"];

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -93,7 +93,8 @@ using santa::NSStringToUTF8String;
   NSData *data = [NSData dataWithBytes:json.data() length:json.size()];
 
 #ifdef SANTA_STORE_SYNC_JSON
-  [self storeJSON:data withMessageType:santa::StringToNSString(message->GetTypeName())];
+  [self storeJSON:data
+      withMessageType:santa::StringToNSString(std::string(message->GetTypeName()))];
 #endif
 
   return [self requestWithData:data contentType:@"application/json"];


### PR DESCRIPTION
Santa fails to build with `--define=SANTA_STORE_SYNC_JSON=1` - `santa::StringToNSString` doesn't support taking a `std::string_view`.

I added a variant that takes a string_view. I noticed we are assuming UTF8 input, so I updated the names to reflect this. This matches better with the `santa::NSStringToUTF8StringView` naming.