### PR TITLE
Fix reason values in exec logs

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -78,12 +78,14 @@ std::string GetDecisionString(SNTEventState event_state) {
 std::string GetReasonString(SNTEventState event_state) {
   switch (event_state) {
     case SNTEventStateAllowBinary: return "BINARY";
+    case SNTEventStateAllowLocalBinary: return "BINARY";
     case SNTEventStateAllowCompilerBinary: return "BINARY";
     case SNTEventStateAllowTransitive: return "TRANSITIVE";
     case SNTEventStateAllowPendingTransitive: return "PENDING_TRANSITIVE";
     case SNTEventStateAllowCertificate: return "CERT";
     case SNTEventStateAllowScope: return "SCOPE";
     case SNTEventStateAllowTeamID: return "TEAMID";
+    case SNTEventStateAllowLocalSigningID: return "SIGNINGID";
     case SNTEventStateAllowSigningID: return "SIGNINGID";
     case SNTEventStateAllowCompilerSigningID: return "SIGNINGID";
     case SNTEventStateAllowCDHash: return "CDHASH";
@@ -97,8 +99,13 @@ std::string GetReasonString(SNTEventState event_state) {
     case SNTEventStateBlockCDHash: return "CDHASH";
     case SNTEventStateBlockLongPath: return "LONG_PATH";
     case SNTEventStateBlockUnknown: return "UNKNOWN";
-    default: return "NOTRUNNING";
+    case SNTEventStateUnknown: return "UNKNOWN";
+    case SNTEventStateAllow: return "UNKNOWN";
+    case SNTEventStateBlock: return "UNKNOWN";
+    case SNTEventStateBundleBinary: return "UNKNOWN";
   }
+
+  return "UNKNOWN";
 }
 
 std::string GetModeString(SNTClientMode mode) {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -1393,33 +1393,40 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 }
 
 - (void)testGetReasonString {
-  std::map<SNTEventState, std::string> stateToReason = {
-      {SNTEventStateUnknown, "NOTRUNNING"},
-      {SNTEventStateBundleBinary, "NOTRUNNING"},
-      {SNTEventStateBlockUnknown, "UNKNOWN"},
-      {SNTEventStateBlockBinary, "BINARY"},
-      {SNTEventStateBlockCertificate, "CERT"},
-      {SNTEventStateBlockScope, "SCOPE"},
-      {SNTEventStateBlockTeamID, "TEAMID"},
-      {SNTEventStateBlockSigningID, "SIGNINGID"},
-      {SNTEventStateBlockCDHash, "CDHASH"},
-      {SNTEventStateBlockLongPath, "LONG_PATH"},
-      {SNTEventStateAllowUnknown, "UNKNOWN"},
-      {SNTEventStateAllowBinary, "BINARY"},
-      {SNTEventStateAllowCertificate, "CERT"},
-      {SNTEventStateAllowScope, "SCOPE"},
-      {SNTEventStateAllowCompilerBinary, "BINARY"},
-      {SNTEventStateAllowCompilerCDHash, "CDHASH"},
-      {SNTEventStateAllowCompilerSigningID, "SIGNINGID"},
-      {SNTEventStateAllowTransitive, "TRANSITIVE"},
-      {SNTEventStateAllowPendingTransitive, "PENDING_TRANSITIVE"},
-      {SNTEventStateAllowTeamID, "TEAMID"},
-      {SNTEventStateAllowSigningID, "SIGNINGID"},
-      {SNTEventStateAllowCDHash, "CDHASH"},
-  };
+  std::string want;
+  for (uint64_t i = 0; i <= 64; i++) {
+    SNTEventState state = static_cast<SNTEventState>(i == 0 ? 0 : 1 << (i - 1));
+    std::string want = "UNKNOWN";
+    switch (state) {
+      case SNTEventStateUnknown: want = "UNKNOWN"; break;
+      case SNTEventStateBundleBinary: want = "UNKNOWN"; break;
+      case SNTEventStateBlockUnknown: want = "UNKNOWN"; break;
+      case SNTEventStateBlockBinary: want = "BINARY"; break;
+      case SNTEventStateBlockCertificate: want = "CERT"; break;
+      case SNTEventStateBlockScope: want = "SCOPE"; break;
+      case SNTEventStateBlockTeamID: want = "TEAMID"; break;
+      case SNTEventStateBlockLongPath: want = "LONG_PATH"; break;
+      case SNTEventStateBlockSigningID: want = "SIGNINGID"; break;
+      case SNTEventStateBlockCDHash: want = "CDHASH"; break;
+      case SNTEventStateAllowUnknown: want = "UNKNOWN"; break;
+      case SNTEventStateAllowBinary: want = "BINARY"; break;
+      case SNTEventStateAllowCertificate: want = "CERT"; break;
+      case SNTEventStateAllowScope: want = "SCOPE"; break;
+      case SNTEventStateAllowCompilerBinary: want = "BINARY"; break;
+      case SNTEventStateAllowTransitive: want = "TRANSITIVE"; break;
+      case SNTEventStateAllowPendingTransitive: want = "PENDING_TRANSITIVE"; break;
+      case SNTEventStateAllowTeamID: want = "TEAMID"; break;
+      case SNTEventStateAllowSigningID: want = "SIGNINGID"; break;
+      case SNTEventStateAllowCDHash: want = "CDHASH"; break;
+      case SNTEventStateAllowLocalBinary: want = "BINARY"; break;
+      case SNTEventStateAllowLocalSigningID: want = "SIGNINGID"; break;
+      case SNTEventStateAllowCompilerSigningID: want = "SIGNINGID"; break;
+      case SNTEventStateAllowCompilerCDHash: want = "CDHASH"; break;
+      case SNTEventStateBlock: want = "UNKNOWN"; break;
+      case SNTEventStateAllow: want = "UNKNOWN"; break;
+    }
 
-  for (const auto &kv : stateToReason) {
-    XCTAssertCppStringEqual(santa::GetReasonString(kv.first), kv.second);
+    XCTAssertCppStringEqual(santa::GetReasonString(state), want);
   }
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -317,12 +317,14 @@ static inline void EncodeCertificateInfo(::pbv1::CertificateInfo *pb_cert_info, 
 ::pbv1::Execution::Reason GetReasonEnum(SNTEventState event_state) {
   switch (event_state) {
     case SNTEventStateAllowBinary: return ::pbv1::Execution::REASON_BINARY;
+    case SNTEventStateAllowLocalBinary: return ::pbv1::Execution::REASON_BINARY;
     case SNTEventStateAllowCompilerBinary: return ::pbv1::Execution::REASON_BINARY;
     case SNTEventStateAllowTransitive: return ::pbv1::Execution::REASON_TRANSITIVE;
     case SNTEventStateAllowPendingTransitive: return ::pbv1::Execution::REASON_PENDING_TRANSITIVE;
     case SNTEventStateAllowCertificate: return ::pbv1::Execution::REASON_CERT;
     case SNTEventStateAllowScope: return ::pbv1::Execution::REASON_SCOPE;
     case SNTEventStateAllowTeamID: return ::pbv1::Execution::REASON_TEAM_ID;
+    case SNTEventStateAllowLocalSigningID: return ::pbv1::Execution::REASON_SIGNING_ID;
     case SNTEventStateAllowSigningID: return ::pbv1::Execution::REASON_SIGNING_ID;
     case SNTEventStateAllowCompilerSigningID: return ::pbv1::Execution::REASON_SIGNING_ID;
     case SNTEventStateAllowCDHash: return ::pbv1::Execution::REASON_CDHASH;
@@ -336,8 +338,13 @@ static inline void EncodeCertificateInfo(::pbv1::CertificateInfo *pb_cert_info, 
     case SNTEventStateBlockCDHash: return ::pbv1::Execution::REASON_CDHASH;
     case SNTEventStateBlockLongPath: return ::pbv1::Execution::REASON_LONG_PATH;
     case SNTEventStateBlockUnknown: return ::pbv1::Execution::REASON_UNKNOWN;
-    default: return ::pbv1::Execution::REASON_NOT_RUNNING;
+    case SNTEventStateUnknown: return ::pbv1::Execution::REASON_UNKNOWN;
+    case SNTEventStateAllow: return ::pbv1::Execution::REASON_UNKNOWN;
+    case SNTEventStateBlock: return ::pbv1::Execution::REASON_UNKNOWN;
+    case SNTEventStateBundleBinary: return ::pbv1::Execution::REASON_UNKNOWN;
   }
+
+  return ::pbv1::Execution::REASON_UNKNOWN;
 }
 
 ::pbv1::Execution::Mode GetModeEnum(SNTClientMode mode) {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -519,34 +519,42 @@ void SerializeAndCheckNonESEvents(
 }
 
 - (void)testGetReasonEnum {
-  std::map<SNTEventState, ::pbv1::Execution::Reason> stateToReason = {
-      {SNTEventStateUnknown, ::pbv1::Execution::REASON_NOT_RUNNING},
-      {SNTEventStateBundleBinary, ::pbv1::Execution::REASON_NOT_RUNNING},
-      {SNTEventStateBlockUnknown, ::pbv1::Execution::REASON_UNKNOWN},
-      {SNTEventStateBlockBinary, ::pbv1::Execution::REASON_BINARY},
-      {SNTEventStateBlockCertificate, ::pbv1::Execution::REASON_CERT},
-      {SNTEventStateBlockScope, ::pbv1::Execution::REASON_SCOPE},
-      {SNTEventStateBlockTeamID, ::pbv1::Execution::REASON_TEAM_ID},
-      {SNTEventStateBlockSigningID, ::pbv1::Execution::REASON_SIGNING_ID},
-      {SNTEventStateBlockCDHash, ::pbv1::Execution::REASON_CDHASH},
-      {SNTEventStateBlockLongPath, ::pbv1::Execution::REASON_LONG_PATH},
-      {SNTEventStateAllowUnknown, ::pbv1::Execution::REASON_UNKNOWN},
-      {SNTEventStateAllowBinary, ::pbv1::Execution::REASON_BINARY},
-      {SNTEventStateAllowCertificate, ::pbv1::Execution::REASON_CERT},
-      {SNTEventStateAllowScope, ::pbv1::Execution::REASON_SCOPE},
-      {SNTEventStateAllowCompilerBinary, ::pbv1::Execution::REASON_BINARY},
-      {SNTEventStateAllowCompilerCDHash, ::pbv1::Execution::REASON_CDHASH},
-      {SNTEventStateAllowCompilerSigningID, ::pbv1::Execution::REASON_SIGNING_ID},
-      {SNTEventStateAllowTransitive, ::pbv1::Execution::REASON_TRANSITIVE},
-      {SNTEventStateAllowPendingTransitive, ::pbv1::Execution::REASON_PENDING_TRANSITIVE},
-      {SNTEventStateAllowTeamID, ::pbv1::Execution::REASON_TEAM_ID},
-      {SNTEventStateAllowSigningID, ::pbv1::Execution::REASON_SIGNING_ID},
-      {SNTEventStateAllowCDHash, ::pbv1::Execution::REASON_CDHASH},
-  };
+  for (uint64_t i = 0; i <= 64; i++) {
+    SNTEventState state = static_cast<SNTEventState>(i == 0 ? 0 : 1 << (i - 1));
+    ::pbv1::Execution::Reason want = ::pbv1::Execution::REASON_UNKNOWN;
+    switch (state) {
+      case SNTEventStateUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+      case SNTEventStateBundleBinary: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+      case SNTEventStateBlockUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+      case SNTEventStateBlockBinary: want = ::pbv1::Execution::REASON_BINARY; break;
+      case SNTEventStateBlockCertificate: want = ::pbv1::Execution::REASON_CERT; break;
+      case SNTEventStateBlockScope: want = ::pbv1::Execution::REASON_SCOPE; break;
+      case SNTEventStateBlockTeamID: want = ::pbv1::Execution::REASON_TEAM_ID; break;
+      case SNTEventStateBlockLongPath: want = ::pbv1::Execution::REASON_LONG_PATH; break;
+      case SNTEventStateBlockSigningID: want = ::pbv1::Execution::REASON_SIGNING_ID; break;
+      case SNTEventStateBlockCDHash: want = ::pbv1::Execution::REASON_CDHASH; break;
+      case SNTEventStateAllowUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+      case SNTEventStateAllowBinary: want = ::pbv1::Execution::REASON_BINARY; break;
+      case SNTEventStateAllowCertificate: want = ::pbv1::Execution::REASON_CERT; break;
+      case SNTEventStateAllowScope: want = ::pbv1::Execution::REASON_SCOPE; break;
+      case SNTEventStateAllowCompilerBinary: want = ::pbv1::Execution::REASON_BINARY; break;
+      case SNTEventStateAllowTransitive: want = ::pbv1::Execution::REASON_TRANSITIVE; break;
+      case SNTEventStateAllowPendingTransitive:
+        want = ::pbv1::Execution::REASON_PENDING_TRANSITIVE;
+        break;
+      case SNTEventStateAllowTeamID: want = ::pbv1::Execution::REASON_TEAM_ID; break;
+      case SNTEventStateAllowSigningID: want = ::pbv1::Execution::REASON_SIGNING_ID; break;
+      case SNTEventStateAllowCDHash: want = ::pbv1::Execution::REASON_CDHASH; break;
+      case SNTEventStateAllowLocalBinary: want = ::pbv1::Execution::REASON_BINARY; break;
+      case SNTEventStateAllowLocalSigningID: want = ::pbv1::Execution::REASON_SIGNING_ID; break;
+      case SNTEventStateAllowCompilerSigningID: want = ::pbv1::Execution::REASON_SIGNING_ID; break;
+      case SNTEventStateAllowCompilerCDHash: want = ::pbv1::Execution::REASON_CDHASH; break;
+      case SNTEventStateBlock: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+      case SNTEventStateAllow: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+    }
 
-  for (const auto &kv : stateToReason) {
-    XCTAssertEqual(santa::GetReasonEnum(kv.first), kv.second, @"Bad reason for state: %llu",
-                   kv.first);
+    XCTAssertEqual(santa::GetReasonEnum(state), want, @"Bad reason for state: %llu (1 << %llu)",
+                   state, i == 0 ? 0 : (i - 1));
   }
 }
 


### PR DESCRIPTION
The "not running" reason has not been valid since the old Santa kext was removed. This fixes reason values so that it isn't emitted and rewrites helper functions so that compiler errors will be emitted when new event states are added without properly updating the helpers and associated tests.