### PR TITLE
Cookbook: Add CEL rule to prevent users from disabling gatekeeper

### DIFF
--- a/docs/docs/cookbook/cel.md
+++ b/docs/docs/cookbook/cel.md
@@ -17,5 +17,5 @@ target.signing_time >= timestamp('2025-05-31T00:00:00Z')
 Create a signing ID rule for `platform:com.apple.spctl` and attach the following CEL program
 
 ```clike
-['--global-disable', '--disable', '--remove'].exists(flag, flag in args) ? BLOCKLIST : ALLOWLIST
+['--global-disable', '--master-disable','--disable', '--add', '--remove'].exists(flag, flag in args) ? BLOCKLIST : ALLOWLIST
 ```

--- a/docs/docs/cookbook/cel.md
+++ b/docs/docs/cookbook/cel.md
@@ -17,5 +17,5 @@ target.signing_time >= timestamp('2025-05-31T00:00:00Z')
 Create a signing ID rule for `platform:com.apple.spctl` and attach the following CEL program
 
 ```clike
-['--global-disable', '--disable', '--remove'].exists(flag, flag in args) : BLOCKLIST ? ALLOWLIST
+['--global-disable', '--disable', '--remove'].exists(flag, flag in args) ? BLOCKLIST : ALLOWLIST
 ```

--- a/docs/docs/cookbook/cel.md
+++ b/docs/docs/cookbook/cel.md
@@ -12,3 +12,10 @@ before the provided date. This is particularly useful when attached to a
 target.signing_time >= timestamp('2025-05-31T00:00:00Z')
 ```
 
+## Prevent users from disabling gatekeeper
+
+Create a signing ID rule for `platform:com.apple.spctl` and attach the following CEL program
+
+```clike
+['--global-disable', '--disable', '--remove'].exists(flag, flag in args) : BLOCKLIST ? ALLOWLIST
+```


### PR DESCRIPTION
This adds a rule for preventing users from disabling gatekeeper via spctl.