### PR TITLE
Add rule to lockdown spotlight importers

### DIFF
--- a/docs/docs/cookbook/faa.md
+++ b/docs/docs/cookbook/faa.md
@@ -96,3 +96,66 @@ except sudo itself. With this installed, users will have to use
 		</array>
 </dict>
 ```
+
+## Lockdown Spotlight Importers
+
+Spotlight importers have been used as [a persistence trick for a while](https://theevilbit.github.io/beyond/beyond_0011/) and were recently used in the [Sploitlight](https://www.microsoft.com/en-us/security/blog/2025/07/28/sploitlight-analyzing-a-spotlight-based-macos-tcc-vulnerability/).
+
+```xml
+<!-- Block unauthorized Spotlight plugin installations (Sploitlight protection) -->
+                <key>SpotlightImporterProtection</key>
+                <dict>
+                        <key>Paths</key>
+                        <array>
+                                <dict>
+                                        <key>Path</key>
+                                        <string>/Users/*/Library/Spotlight</string>
+                                        <key>IsPrefix</key>
+                                        <true/>
+                                </dict>
+                        </array>
+                        <key>Options</key>
+                        <dict>
+                                <key>AllowReadAccess</key>
+                                <true/>
+                                <key>AuditOnly</key>
+                                <false/>
+                                <key>EnableSilentMode</key>
+                                <true/>
+                        </dict>
+                        <key>Processes</key>
+                        <array>
+                                <dict>
+                                        <key>SigningID</key>
+                                        <string>com.apple.mds</string>
+                                        <key>PlatformBinary</key>
+                                        <true/>
+                                </dict>
+                                <dict>
+                                        <key>SigningID</key>
+                                        <string>com.apple.mdworker</string>
+                                        <key>PlatformBinary</key>
+                                        <true/>
+                                </dict>
+                                <dict>
+                                        <key>SigningID</key>
+                                        <string>com.apple.mdworker_shared</string>
+                                        <key>PlatformBinary</key>
+                                        <true/>
+                                </dict>
+                                <dict>
+                                        <key>SigningID</key>
+                                        <string>com.apple.mdimport</string>
+                                        <key>PlatformBinary</key>
+                                        <true/>
+                                </dict>
+                                <!-- Remove this for more security -->
+                                <dict>
+                                        <key>SigningID</key>
+                                        <string>com.apple.installer</string>
+                                        <key>PlatformBinary</key>
+                                        <true/>
+                                </dict>
+                        </array>
+                </dict>
+```


### PR DESCRIPTION
This adds a rule to lockdown Spotlight importers with an FAA rule.