### PR TITLE
Add nullability to stored events. Fix unwrap of missing data.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,8 +4,8 @@ build --define=apple.propagate_embedded_extra_outputs=yes
 build --copt=-Werror
 build --copt=-Wall
 build --copt=-Wformat-security
+build --copt=-Wnullability-completeness
 build --copt=-Wno-error=deprecated-declarations
-build --copt=-Wno-error=nullability-completeness
 build --copt=-Wreorder-init-list
 build --copt=-Wsemicolon-before-method-body
 build --copt=-Wc99-designator

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -19,10 +19,10 @@
 @interface SNTStoredEvent : NSObject <NSSecureCoding>
 
 /// The date and time the execution request was received by santad.
-@property (nonnull) NSDate *occurrenceDate;
+@property(nonnull) NSDate *occurrenceDate;
 
 /// An index for this event, randomly generated during initialization.
-@property (nonnull) NSNumber *idx;
+@property(nonnull) NSNumber *idx;
 
 // Subclasses are required to define: `hashForEvent`.
 // The base class implementation will throw an exception.

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -19,13 +19,13 @@
 @interface SNTStoredEvent : NSObject <NSSecureCoding>
 
 /// The date and time the execution request was received by santad.
-@property NSDate *occurrenceDate;
+@property (nonnull) NSDate *occurrenceDate;
 
 /// An index for this event, randomly generated during initialization.
-@property NSNumber *idx;
+@property (nonnull) NSNumber *idx;
 
 // Subclasses are required to define: `hashForEvent`.
 // The base class implementation will throw an exception.
-- (NSString *)hashForEvent;
+- (nullable NSString *)hashForEvent;
 
 @end

--- a/Source/common/SNTStoredExecutionEvent.h
+++ b/Source/common/SNTStoredExecutionEvent.h
@@ -23,13 +23,13 @@
 /// Represents an execution event stored in the events database.
 @interface SNTStoredExecutionEvent : SNTStoredEvent <NSSecureCoding>
 
-- (instancetype)initWithFileInfo:(SNTFileInfo *)fileInfo;
+- (nullable instancetype)initWithFileInfo:(nullable SNTFileInfo *)fileInfo;
 
 /// The SHA-256 of the executed file.
-@property NSString *fileSHA256;
+@property(nullable) NSString *fileSHA256;
 
 /// The full path of the executed file.
-@property NSString *filePath;
+@property(nullable) NSString *filePath;
 
 /// Set to YES if the event is a part of a bundle. When an event is passed to SantaGUI this propery
 /// will be used as an indicator to to kick off bundle hashing as necessary. Default value is NO.
@@ -37,45 +37,45 @@
 
 /// If the executed file was part of a bundle, this is the calculated hash of all the nested
 /// executables within the bundle.
-@property NSString *fileBundleHash;
+@property(nullable) NSString *fileBundleHash;
 
 /// If the executed file was part of a bundle, this is the time in ms it took to hash the bundle.
-@property NSNumber *fileBundleHashMilliseconds;
+@property(nullable) NSNumber *fileBundleHashMilliseconds;
 
 /// If the executed file was part of a bundle, this is the total count of related mach-o binaries.
-@property NSNumber *fileBundleBinaryCount;
+@property(nullable) NSNumber *fileBundleBinaryCount;
 
 /// If the executed file was part of the bundle, this is the CFBundleDisplayName, if it exists
 /// or the CFBundleName if not.
-@property NSString *fileBundleName;
+@property(nullable) NSString *fileBundleName;
 
 /// If the executed file was part of the bundle, this is the path to the bundle.
-@property NSString *fileBundlePath;
+@property(nullable) NSString *fileBundlePath;
 
 /// The relative path to the bundle's main executable.
-@property NSString *fileBundleExecutableRelPath;
+@property(nullable) NSString *fileBundleExecutableRelPath;
 
 /// If the executed file was part of the bundle, this is the CFBundleID.
-@property NSString *fileBundleID;
+@property(nullable) NSString *fileBundleID;
 
 /// If the executed file was part of the bundle, this is the CFBundleVersion.
-@property NSString *fileBundleVersion;
+@property(nullable) NSString *fileBundleVersion;
 
 /// If the executed file was part of the bundle, this is the CFBundleShortVersionString.
-@property NSString *fileBundleVersionString;
+@property(nullable) NSString *fileBundleVersionString;
 
 /// If the executed file was signed, this is an NSArray of MOLCertificate's
 /// representing the signing chain.
-@property NSArray<MOLCertificate *> *signingChain;
+@property(nullable) NSArray<MOLCertificate *> *signingChain;
 
 /// If the executed file was signed, this is the Team ID if present in the signature information.
-@property NSString *teamID;
+@property(nullable) NSString *teamID;
 
 /// If the executed file was signed, this is the Signing ID if present in the signature information.
-@property NSString *signingID;
+@property(nullable) NSString *signingID;
 
 /// If the executed file was signed, this is the CDHash of the binary.
-@property NSString *cdhash;
+@property(nullable) NSString *cdhash;
 
 /// Codesigning flags for the process (from `<Kernel/kern/cs_blobs.h>`)
 @property uint32_t codesigningFlags;
@@ -84,43 +84,43 @@
 @property SNTSigningStatus signingStatus;
 
 /// The user who executed the binary.
-@property NSString *executingUser;
+@property(nullable) NSString *executingUser;
 
 /// The decision santad returned.
 @property SNTEventState decision;
 
 /// NSArray of logged in users when the decision was made.
-@property NSArray *loggedInUsers;
+@property(nullable) NSArray *loggedInUsers;
 
 /// NSArray of sessions when the decision was made (e.g. nobody@console, nobody@ttys000).
-@property NSArray *currentSessions;
+@property(nullable) NSArray *currentSessions;
 
 /// The process ID of the binary being executed.
-@property NSNumber *pid;
+@property(nullable) NSNumber *pid;
 
 /// The parent process ID of the binary being executed.
-@property NSNumber *ppid;
+@property(nullable) NSNumber *ppid;
 
 /// The name of the parent process.
-@property NSString *parentName;
+@property(nullable) NSString *parentName;
 
 /// Quarantine data about the executed file, if any.
-@property NSString *quarantineDataURL;
-@property NSString *quarantineRefererURL;
-@property NSDate *quarantineTimestamp;
-@property NSString *quarantineAgentBundleID;
+@property(nullable) NSString *quarantineDataURL;
+@property(nullable) NSString *quarantineRefererURL;
+@property(nullable) NSDate *quarantineTimestamp;
+@property(nullable) NSString *quarantineAgentBundleID;
 
 /// A generated string representing the publisher based on the signingChain
-@property(readonly) NSString *publisherInfo;
+@property(readonly, nullable) NSString *publisherInfo;
 
 /// Return an array of the underlying SecCertificateRef's of the signingChain
 ///
 /// WARNING: If the refs need to be used for a long time be careful to properly
 /// CFRetain/CFRelease the returned items.
-@property(readonly) NSArray *signingChainCertRefs;
+@property(readonly, nullable) NSArray *signingChainCertRefs;
 
 /// If the executed file was entitled, this is the set of key/value pairs of entitlements
-@property NSDictionary *entitlements;
+@property(nullable) NSDictionary *entitlements;
 
 /// Whether or not the set of entitlements were filtered (e.g. due to configuration)
 @property BOOL entitlementsFiltered;
@@ -128,11 +128,11 @@
 /// The timestamp of when the binary was signed. This timestamp is the secure
 /// timestamp that was certified by Apple's timestamp authority service and can
 /// be trusted.
-@property NSDate *secureSigningTime;
+@property(nullable) NSDate *secureSigningTime;
 
 /// The timestamp of when the binary was signed. This timestamp is the insecure
 /// timestamp provided by the developer during signing. It has not been validated
 /// and could be spoofed.
-@property NSDate *signingTime;
+@property(nullable) NSDate *signingTime;
 
 @end

--- a/Source/common/SNTStoredExecutionEvent.mm
+++ b/Source/common/SNTStoredExecutionEvent.mm
@@ -23,7 +23,7 @@
 
 @implementation SNTStoredExecutionEvent
 
-- (instancetype)initWithFileInfo:(SNTFileInfo *)fileInfo {
+- (nullable instancetype)initWithFileInfo:(nullable SNTFileInfo *)fileInfo {
   self = [super init];
   if (self) {
     _filePath = fileInfo.path;

--- a/Source/common/SNTStoredFileAccessEvent.h
+++ b/Source/common/SNTStoredFileAccessEvent.h
@@ -23,46 +23,46 @@
 @interface SNTStoredFileAccessEvent : SNTStoredEvent <NSSecureCoding>
 
 /// The rule version that was violated.
-@property NSString *ruleVersion;
+@property(nullable) NSString *ruleVersion;
 
 /// The rule name that was violated.
-@property NSString *ruleName;
+@property(nullable) NSString *ruleName;
 
 /// The watched path that was accessed.
-@property NSString *accessedPath;
+@property(nullable) NSString *accessedPath;
 
-@property SNTStoredFileAccessProcess *process;
+@property(nullable) SNTStoredFileAccessProcess *process;
 
 @end
 
 @interface SNTStoredFileAccessProcess : NSObject <NSSecureCoding>
 
 /// The full path of the process's executable file.
-@property NSString *filePath;
+@property(nullable) NSString *filePath;
 
 /// If the process was signed, this is the CDHash of the binary.
-@property NSString *cdhash;
+@property(nullable) NSString *cdhash;
 
 /// The SHA-256 of the executed file.
-@property NSString *fileSHA256;
+@property(nullable) NSString *fileSHA256;
 
 /// If the process was signed, this is the Signing ID if present in the signature information.
-@property NSString *signingID;
+@property(nullable) NSString *signingID;
 
 /// If the executed file was signed, this is an NSArray of MOLCertificate's
 /// representing the signing chain.
-@property NSArray<MOLCertificate *> *signingChain;
+@property(nullable) NSArray<MOLCertificate *> *signingChain;
 
 /// If the process was signed, this is the Team ID if present in the signature information.
-@property NSString *teamID;
+@property(nullable) NSString *teamID;
 
 /// The process ID of the binary being executed.
-@property NSNumber *pid;
+@property(nullable) NSNumber *pid;
 
 /// The user who executed the binary.
-@property NSString *executingUser;
+@property(nullable) NSString *executingUser;
 
 /// Information about this process's parent
-@property SNTStoredFileAccessProcess *parent;
+@property(nullable) SNTStoredFileAccessProcess *parent;
 
 @end

--- a/Source/common/SNTStoredFileAccessEvent.mm
+++ b/Source/common/SNTStoredFileAccessEvent.mm
@@ -15,6 +15,7 @@
 #import "Source/common/SNTStoredFileAccessEvent.h"
 
 #import "Source/common/CoderMacros.h"
+#import "Source/common/MOLCertificate.h"
 
 @implementation SNTStoredFileAccessEvent
 
@@ -34,6 +35,7 @@
   ENCODE(coder, accessedPath);
   ENCODE(coder, ruleVersion);
   ENCODE(coder, ruleName);
+  ENCODE(coder, process);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
@@ -83,7 +85,7 @@
     DECODE(decoder, cdhash, NSString);
     DECODE(decoder, fileSHA256, NSString);
     DECODE(decoder, signingID, NSString);
-    DECODE(decoder, signingChain, NSString);
+    DECODE_ARRAY(decoder, signingChain, MOLCertificate);
     DECODE(decoder, teamID, NSString);
     DECODE(decoder, pid, NSNumber);
     DECODE(decoder, executingUser, NSString);

--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -74,7 +74,7 @@ func copyDetailsToClipboard(e: SNTStoredExecutionEvent?, customURL: String?) {
     s += "\nCDHash     : \(cdhash)"
   }
   s += "\nSHA-256    : \(e?.fileSHA256 ?? "unknown")"
-  s += "\nParent     : \(e?.parentName ?? "") (\(String(format: "%d", e?.ppid.intValue ?? 0)))"
+  s += "\nParent     : \(e?.parentName ?? "") (\(String(format: "%d", e?.ppid?.intValue ?? 0)))"
 
   let url = SNTBlockMessage.eventDetailURL(for: e, customURL: customURL as String?)
   s += "\nURL        : \(url?.absoluteString ?? "unknown")"
@@ -148,7 +148,7 @@ struct MoreDetailsView: View {
 
         addLabel {
           Text("Parent").bold().font(Font.system(size: 12.0))
-          Text(verbatim: "\(e?.parentName ?? "") (\(e?.ppid.stringValue ?? "unknown"))")
+          Text(verbatim: "\(e?.parentName ?? "") (\(e?.ppid?.stringValue ?? "unknown"))")
             .textSelection(.enabled)
         }
 

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -66,19 +66,19 @@ struct MoreDetailsView: View {
         Spacer()
         addLabel {
           Text("Accessed Path").bold().font(Font.system(size: 12.0))
-          Text(e.accessedPath).font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
+          Text(e.accessedPath ?? "").font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
         }
 
         Divider()
 
         addLabel {
           Text("Binary Path").bold().font(Font.system(size: 12.0))
-          Text(e.process.filePath).font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
+          Text(e.process?.filePath ?? "").font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
         }
 
         Divider()
 
-        if let signingID = e.process.signingID {
+        if let signingID = e.process?.signingID {
           addLabel {
             Text("Signing ID").bold().font(Font.system(size: 12.0))
             Text(signingID).font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
@@ -86,7 +86,7 @@ struct MoreDetailsView: View {
           Divider()
         }
 
-        if let cdHash = e.process.cdhash {
+        if let cdHash = e.process?.cdhash {
           addLabel {
             Text("CDHash").bold().font(Font.system(size: 12.0))
             Text(cdHash).font(Font.system(size: 12.0).monospaced()).textSelection(.enabled)
@@ -97,7 +97,7 @@ struct MoreDetailsView: View {
         addLabel {
           Text("SHA-256").bold().font(Font.system(size: 12.0))
           // Fix the max width of this to 240px so that the SHA-256 splits across 2 lines evenly.
-          Text(e.process.fileSHA256).font(Font.system(size: 12.0).monospaced()).frame(width: 240)
+          Text(e.process?.fileSHA256 ?? "").font(Font.system(size: 12.0).monospaced()).frame(width: 240)
             .textSelection(.enabled)
         }
 
@@ -151,11 +151,11 @@ struct Event: View {
       Divider()
 
       VStack(alignment: .leading, spacing: 10.0) {
-        TextWithLimit(e.accessedPath).textSelection(.enabled)
-        TextWithLimit((e.process?.parent?.filePath as NSString?)?.lastPathComponent ?? "").textSelection(.enabled)
-        TextWithLimit(e.process?.executingUser ?? "unknown").textSelection(.enabled)
-        TextWithLimit(e.ruleName).textSelection(.enabled)
-        TextWithLimit(e.ruleVersion).textSelection(.enabled)
+        TextWithLimit(e.accessedPath ?? "<unknown>").textSelection(.enabled)
+        TextWithLimit((e.process?.filePath as NSString?)?.lastPathComponent ?? "").textSelection(.enabled)
+        TextWithLimit(e.process?.executingUser ?? "<unknown>").textSelection(.enabled)
+        TextWithLimit(e.ruleName ?? "<unknown>").textSelection(.enabled)
+        TextWithLimit(e.ruleVersion ?? "<unknown>").textSelection(.enabled)
 
       }
     }.sheet(isPresented: $isShowingDetails) {


### PR DESCRIPTION
This fixes a crash that could occur in the FAA block dialog. This issue was introduced during development of the .7 release and was never part of a release.