### PR TITLE
Clean up citation and add extra location for Spotlight importers

### DIFF
--- a/docs/docs/cookbook/faa.md
+++ b/docs/docs/cookbook/faa.md
@@ -100,8 +100,7 @@ except sudo itself. With this installed, users will have to use
 ## Lockdown Spotlight Importers
 
 Spotlight importers have been used as [a persistence trick for a
-while](https://theevilbit.github.io/beyond/beyond_0011/) and were
-recently used in the
+while](https://theevilbit.github.io/beyond/beyond_0011/), going back to [Patrick Wardle](https://x.com/patrickwardle)'s [talks in 2015](https://www.blackhat.com/docs/us-15/materials/us-15-Wardle-Writing-Bad-A-Malware-For-OS-X.pdf). This was recently used in the
 [Sploitlight exploit](https://www.microsoft.com/en-us/security/blog/2025/07/28/sploitlight-analyzing-a-spotlight-based-macos-tcc-vulnerability/).
 
 ```xml
@@ -113,6 +112,12 @@ recently used in the
 		<dict>
 			<key>Path</key>
 			<string>/Users/*/Library/Spotlight</string>
+			<key>IsPrefix</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Path</key>
+			<string>/Library/Spotlight</string>
 			<key>IsPrefix</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Per conversations on [X/Twitter](https://x.com/yo_yo_yo_jbo/status/1950377956842569942) the cookbook rule is missing a location where you could put Spotlight importers even though this directory does not exist on macOS 15.5+. 

Best to cover anyway.

Also added a proper citation for Patrick Wardle's 2015 BH talk where he discussed this technique.

