### PR TITLE
santad: Stop logging failure to create signing ID for adhoc binaries

### DIFF
--- a/Source/common/SigningIDHelpers.mm
+++ b/Source/common/SigningIDHelpers.mm
@@ -26,8 +26,6 @@ NSString *FormatSigningID(MOLCodesignChecker *csc) {
     if (csc.platformBinary) {
       return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
     } else {
-      LOGD(@"unable to format signing ID missing team ID for non-platform binary: %@",
-           csc.signingID);
       return nil;
     }
   }


### PR DESCRIPTION
This line gets printed every time we encounter an adhoc binary and it's not really telling us anything useful.