### PR TITLE
Remove unnecessary build macro

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,9 +24,6 @@ build --per_file_copt=.*cel-cpp.*@-Wno-deprecated-declarations
 build --per_file_copt=.*cel-cpp.*@-Wno-nullability-completeness
 build --per_file_copt=.*cel-cpp.*@-Wno-unused-function
 
-build --copt=-DSANTA_OPEN_SOURCE=1
-build --cxxopt=-DSANTA_OPEN_SOURCE=1
-
 # Many config options for sanitizers pulled from
 # https://github.com/protocolbuffers/protobuf/blob/main/.bazelrc
 build:san-common --strip=never

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/AnyBatcher.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/AnyBatcher.mm
@@ -38,11 +38,7 @@ bool AnyBatcher::NeedToOpenFile() {
 
 absl::Status AnyBatcher::Write(std::vector<uint8_t> bytes) {
   google::protobuf::Any any;
-#if SANTA_OPEN_SOURCE
-  any.set_value(bytes.data(), bytes.size());
-#else
   any.set_value(absl::string_view((const char *)bytes.data(), bytes.size()));
-#endif
   any.set_type_url(type_url_);
 
   *cache_.mutable_records()->Add() = any;


### PR DESCRIPTION
The `SANTA_OPEN_SOURCE` macro is a vestige of supporting older protobuf library versions in different build environments and is no longer necessary.