### PR TITLE
Add binary digest method to SNTXxhash

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -291,6 +291,7 @@ santa_unit_test(
     srcs = ["SNTXxhashTest.mm"],
     deps = [
         ":SNTXxhash",
+        ":String",
         ":TestUtils",
     ],
 )

--- a/Source/common/SNTXxhash.h
+++ b/Source/common/SNTXxhash.h
@@ -15,9 +15,10 @@
 #ifndef SANTA__COMMON__XXHASH_H
 #define SANTA__COMMON__XXHASH_H
 
-#define XXH_STATIC_LINKING_ONLY
+#include <functional>
 #include <string>
 
+#define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"
 
 namespace santa {
@@ -64,7 +65,16 @@ class Xxhash {
     XxhashFuncPtrs::Update(&state_, data, size);
   }
 
-  std::string Digest() {
+  void Digest(std::function<void(const uint8_t *, size_t)> callback) {
+    hash_type hash = XxhashFuncPtrs::Digest(&state_);
+    canonical_type canonical_hash;
+    XxhashFuncPtrs::CanonicalFromHash(&canonical_hash, hash);
+
+    callback(reinterpret_cast<const uint8_t *>(&canonical_hash),
+             sizeof(canonical_hash));
+  }
+
+  std::string HexDigest() {
     hash_type hash = XxhashFuncPtrs::Digest(&state_);
     canonical_type canonical_hash;
     XxhashFuncPtrs::CanonicalFromHash(&canonical_hash, hash);

--- a/Source/common/SNTXxhashTest.mm
+++ b/Source/common/SNTXxhashTest.mm
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#include "Source/common/String.h"
 #include "Source/common/TestUtils.h"
 
 #include <string>
@@ -29,62 +30,102 @@
   santa::Xxhash64 state;
 
   state.Update("hello", 5);
-  XCTAssertCppStringEqual(state.Digest(), "9555e8555c62dcfd");
+  XCTAssertCppStringEqual(state.HexDigest(), "9555e8555c62dcfd");
 
   state.Update("world", 5);
-  XCTAssertCppStringEqual(state.Digest(), "ffdcce9d0e1f7d46");
+  XCTAssertCppStringEqual(state.HexDigest(), "ffdcce9d0e1f7d46");
+
+  std::vector<uint8_t> want = santa::HexStringToBuf(state.HexDigest());
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  state.Digest(^(const uint8_t *buf, size_t length) {
+    XCTAssertEqual(want.size(), length);
+    XCTAssertEqual(0, memcmp(want.data(), buf, length));
+    dispatch_semaphore_signal(sema);
+  });
+
+  XCTAssertSemaTrue(sema, 0, "Digest callback block was not called");
 }
 
 - (void)testXxhashCopyState64 {
   santa::Xxhash64 state;
   state.Update("hello", 5);
-  XCTAssertCppStringEqual(state.Digest(), "9555e8555c62dcfd");
+  XCTAssertCppStringEqual(state.HexDigest(), "9555e8555c62dcfd");
 
   // Check that the copying of existing state works.
   santa::Xxhash64 state2(state);
-  XCTAssertCppStringEqual(state2.Digest(), "9555e8555c62dcfd");
+  XCTAssertCppStringEqual(state2.HexDigest(), "9555e8555c62dcfd");
   state2.Update("bye", 3);
-  XCTAssertCppStringEqual(state2.Digest(), "0a20389200c43514");
+  XCTAssertCppStringEqual(state2.HexDigest(), "0a20389200c43514");
 
   // Ensure that the original state is not modified
-  XCTAssertCppStringEqual(state.Digest(), "9555e8555c62dcfd");
+  XCTAssertCppStringEqual(state.HexDigest(), "9555e8555c62dcfd");
 
   // Ensure that a second copy has identical results to the first.
   santa::Xxhash64 state3(state);
-  XCTAssertCppStringEqual(state3.Digest(), "9555e8555c62dcfd");
+  XCTAssertCppStringEqual(state3.HexDigest(), "9555e8555c62dcfd");
   state3.Update("bye", 3);
-  XCTAssertCppStringEqual(state3.Digest(), "0a20389200c43514");
+  XCTAssertCppStringEqual(state3.HexDigest(), "0a20389200c43514");
+
+  std::vector<uint8_t> want = santa::HexStringToBuf(state.HexDigest());
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  state.Digest(^(const uint8_t *buf, size_t length) {
+    XCTAssertEqual(want.size(), length);
+    XCTAssertEqual(0, memcmp(want.data(), buf, length));
+    dispatch_semaphore_signal(sema);
+  });
+
+  XCTAssertSemaTrue(sema, 0, "Digest callback block was not called");
 }
 
 - (void)testXxhash128 {
   santa::Xxhash128 state;
 
   state.Update("hello", 5);
-  XCTAssertCppStringEqual(state.Digest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
+  XCTAssertCppStringEqual(state.HexDigest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
 
   state.Update("world", 5);
-  XCTAssertCppStringEqual(state.Digest(), "ddf7ff67be2b60f50f178df33653476f");
+  XCTAssertCppStringEqual(state.HexDigest(), "ddf7ff67be2b60f50f178df33653476f");
+
+  std::vector<uint8_t> want = santa::HexStringToBuf(state.HexDigest());
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  state.Digest(^(const uint8_t *buf, size_t length) {
+    XCTAssertEqual(want.size(), length);
+    XCTAssertEqual(0, memcmp(want.data(), buf, length));
+    dispatch_semaphore_signal(sema);
+  });
+
+  XCTAssertSemaTrue(sema, 0, "Digest callback block was not called");
 }
 
 - (void)testXxhashCopyState128 {
   santa::Xxhash128 state;
   state.Update("hello", 5);
-  XCTAssertCppStringEqual(state.Digest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
+  XCTAssertCppStringEqual(state.HexDigest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
 
   // Check that the copying of existing state works.
   santa::Xxhash128 state2(state);
-  XCTAssertCppStringEqual(state2.Digest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
+  XCTAssertCppStringEqual(state2.HexDigest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
   state2.Update("bye", 3);
-  XCTAssertCppStringEqual(state2.Digest(), "a02b1c0f54414e59c9cb785db0a4cfc8");
+  XCTAssertCppStringEqual(state2.HexDigest(), "a02b1c0f54414e59c9cb785db0a4cfc8");
 
   // Ensure that the original state is not modified
-  XCTAssertCppStringEqual(state.Digest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
+  XCTAssertCppStringEqual(state.HexDigest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
 
   // Ensure that a second copy has identical results to the first.
   santa::Xxhash128 state3(state);
-  XCTAssertCppStringEqual(state3.Digest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
+  XCTAssertCppStringEqual(state3.HexDigest(), "b5e9c1ad071b3e7fc779cfaa5e523818");
   state3.Update("bye", 3);
-  XCTAssertCppStringEqual(state3.Digest(), "a02b1c0f54414e59c9cb785db0a4cfc8");
+  XCTAssertCppStringEqual(state3.HexDigest(), "a02b1c0f54414e59c9cb785db0a4cfc8");
+
+  std::vector<uint8_t> want = santa::HexStringToBuf(state.HexDigest());
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  state.Digest(^(const uint8_t *buf, size_t length) {
+    XCTAssertEqual(want.size(), length);
+    XCTAssertEqual(0, memcmp(want.data(), buf, length));
+    dispatch_semaphore_signal(sema);
+  });
+
+  XCTAssertSemaTrue(sema, 0, "Digest callback block was not called");
 }
 
 @end

--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace santa {
 
@@ -78,6 +79,27 @@ static inline std::string BufToHexString(const uint8_t *buf, size_t bufsize) {
 
 static inline std::string BufToHexString(NSData *data) {
   return BufToHexString(static_cast<const uint8_t *>(data.bytes), data.length);
+}
+
+static inline std::vector<uint8_t> HexStringToBuf(std::string_view str) {
+  std::vector<uint8_t> bytes;
+  bytes.reserve(str.length() / 2);
+
+  char cur_byte[3];
+  cur_byte[2] = '\0';
+
+  for (int i = 0; i < str.length() / 2; i++) {
+    cur_byte[0] = str[i * 2];
+    cur_byte[1] = str[i * 2 + 1];
+
+    bytes.push_back(std::strtoul(cur_byte, nullptr, 16));
+  }
+
+  return bytes;
+}
+
+static inline std::vector<uint8_t> HexStringToBuf(NSString *str) {
+  return HexStringToBuf(NSStringToUTF8StringView(str));
 }
 
 }  // namespace santa

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -698,7 +698,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
     }
     [rs close];
 
-    digest = santa::StringToNSString(hash.Digest());
+    digest = santa::StringToNSString(hash.HexDigest());
     self.rulesHash = digest;
   }];
   return digest;

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -115,27 +115,6 @@ bool ConfirmValidHexString(NSString *str, size_t expected_length) {
   return true;
 }
 
-static std::vector<uint8_t> HexStringToBytes(NSString *str) {
-  if (!str) {
-    return std::vector<uint8_t>{};
-  }
-
-  std::vector<uint8_t> bytes;
-  bytes.reserve(str.length / 2);
-
-  char cur_byte[3];
-  cur_byte[2] = '\0';
-
-  for (int i = 0; i < str.length / 2; i++) {
-    cur_byte[0] = [str characterAtIndex:(i * 2)];
-    cur_byte[1] = [str characterAtIndex:(i * 2 + 1)];
-
-    bytes.push_back(std::strtoul(cur_byte, nullptr, 16));
-  }
-
-  return bytes;
-}
-
 static inline bool GetBoolValue(NSDictionary *options, NSString *key, bool default_value) {
   return options[key] ? [options[key] boolValue] : default_value;
 }
@@ -406,7 +385,7 @@ std::variant<Unit, SetWatchItemProcess> VerifyConfigWatchItemProcesses(NSDiction
                 NSStringToUTF8String(process[kWatchItemConfigKeyProcessesBinaryPath] ?: @""),
                 NSStringToUTF8String(process[kWatchItemConfigKeyProcessesSigningID] ?: @""),
                 NSStringToUTF8String(process[kWatchItemConfigKeyProcessesTeamID] ?: @""),
-                HexStringToBytes(process[kWatchItemConfigKeyProcessesCDHash]),
+                HexStringToBuf(process[kWatchItemConfigKeyProcessesCDHash]),
                 NSStringToUTF8String(process[kWatchItemConfigKeyProcessesCertificateSha256] ?: @""),
                 process[kWatchItemConfigKeyProcessesPlatformBinary]
                     ? std::make_optional(

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -108,7 +108,7 @@ std::vector<uint8_t> Serializer::SerializeFileAccess(const std::string &policy_v
   state.Update(&operation_id_data, sizeof(operation_id_data));
 
   return SerializeFileAccess(policy_version, policy_name, msg, enriched_process, target, decision,
-                             state.Digest());
+                             state.HexDigest());
 }
 
 };  // namespace santa


### PR DESCRIPTION
Rename the existing `Digest` method to `HexDigest`. Add a new `Digest` method that provides to the callers callback method the big endian canonical binary digest.