### PR TITLE
Support compressed stream in santactl printlog

### DIFF
--- a/Source/common/ScopedFile.h
+++ b/Source/common/ScopedFile.h
@@ -24,11 +24,6 @@
 #import "Source/common/SNTLogging.h"
 #include "absl/status/statusor.h"
 
-// Forward declarations
-namespace santa {
-class ScopedFilePeer;
-}  // namespace santa
-
 namespace santa {
 
 class ScopedFile {
@@ -75,7 +70,7 @@ class ScopedFile {
     return ScopedFile(fd);
   }
 
-  ScopedFile(int fd) : fd_(fd) {}
+  explicit ScopedFile(int fd) : fd_(fd) {}
 
   ~ScopedFile() {
     if (fd_ >= 0) {
@@ -107,7 +102,10 @@ class ScopedFile {
     return [[NSFileHandle alloc] initWithFileDescriptor:dup(fd_) closeOnDealloc:YES];
   }
 
-  friend class ScopedFilePeer;
+  // Some consumers need access to the raw file descriptor. But usaage must be
+  // carefully evaluated to ensure usage of the returned file descriptor
+  // doesn't outlast the lifetime of this object.
+  int UnsafeFD() const { return fd_; }
 
  private:
   int fd_ = -1;

--- a/Source/common/ScopedFile.h
+++ b/Source/common/ScopedFile.h
@@ -102,7 +102,7 @@ class ScopedFile {
     return [[NSFileHandle alloc] initWithFileDescriptor:dup(fd_) closeOnDealloc:YES];
   }
 
-  // Some consumers need access to the raw file descriptor. But usaage must be
+  // Some consumers need access to the raw file descriptor. But usage must be
   // carefully evaluated to ensure usage of the returned file descriptor
   // doesn't outlast the lifetime of this object.
   int UnsafeFD() const { return fd_; }

--- a/Source/common/ScopedFileTest.mm
+++ b/Source/common/ScopedFileTest.mm
@@ -21,15 +21,6 @@
 #include "Source/common/TestUtils.h"
 #include "absl/status/statusor.h"
 
-namespace santa {
-
-class ScopedFilePeer : public ScopedFile {
- public:
-  using ScopedFile::fd_;
-};
-
-}  // namespace santa
-
 @interface ScopedFileTest : XCTestCase
 @end
 
@@ -41,8 +32,7 @@ class ScopedFilePeer : public ScopedFile {
     auto file = santa::ScopedFile::CreateTemporary();
     XCTAssertStatusOk(file);
 
-    santa::ScopedFilePeer *peer = static_cast<santa::ScopedFilePeer *>(&(*file));
-    savedFD = peer->fd_;
+    savedFD = file->UnsafeFD();
   }
 
   XCTAssertLessThan(close(savedFD), 0);

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -26,12 +26,16 @@ objc_library(
     srcs = ["Commands/SNTCommandPrintLog.mm"],
     deps = [
         ":santactl_cmd",
+        "//Source/common:NSData+Zlib",
         "//Source/common:SNTLogging",
         "//Source/common:SNTXxhash",
+        "//Source/common:ScopedFile",
         "//Source/common:santa_cc_proto_library_wrapper",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:SpoolBatchers",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:binaryproto_cc_proto_library_wrapper",
+        "@abseil-cpp//absl/status:statusor",
         "@protobuf//src/google/protobuf/json",
+        "@zstd",
     ],
 )
 

--- a/Source/santactl/Commands/SNTCommandPrintLog.mm
+++ b/Source/santactl/Commands/SNTCommandPrintLog.mm
@@ -265,6 +265,9 @@ absl::StatusOr<std::unique_ptr<MessageSource>> HandleZstdFileSource(ScopedFile s
                                                ZSTD_getErrorName(bytes_decompressed)));
   }
 
+  // Clamp the length now that we know the true size
+  decompressed.length = bytes_decompressed;
+
   return CreateStreamSource(decompressed);
 }
 


### PR DESCRIPTION
This PR extends `santactl printlog` to first determine if any of the given files were compressed, and decompress them before deserializing.