### PR TITLE
Add single Single Shot mode to Timer mixin class

### DIFF
--- a/Source/common/Timer.h
+++ b/Source/common/Timer.h
@@ -26,9 +26,14 @@ namespace santa {
 template <typename T>
 class Timer {
  public:
-  explicit Timer(NSTimeInterval minimum_interval,
+  enum class Mode {
+    kContinuous,  // Default: timer fires repeatedly at intervals
+    kSingleShot,  // Timer is cancelled while OnTimer fires and restarted once complete
+  };
+
+  explicit Timer(NSTimeInterval minimum_interval, Mode mode = Mode::kContinuous,
                  dispatch_qos_class_t qos_class = QOS_CLASS_UTILITY)
-      : interval_seconds_(minimum_interval), minimum_interval_(minimum_interval) {
+      : interval_seconds_(minimum_interval), minimum_interval_(minimum_interval), mode_(mode) {
     static_assert(
         requires(T t) { t.OnTimer(); }, "Classes using Timer<T> must implement 'void OnTimer()'");
 
@@ -38,21 +43,7 @@ class Timer {
   virtual ~Timer() { StopTimer(); }
 
   /// Start a new timer if not already running.
-  void StartTimer() {
-    if (timer_source_) {
-      return;  // No-op if already running
-    }
-
-    timer_source_ = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, timer_queue_);
-
-    dispatch_source_set_event_handler(timer_source_, ^{
-      TimerCallback();
-    });
-
-    UpdateTimingParameters();
-
-    dispatch_resume(timer_source_);
-  }
+  void StartTimer() { StartTimer(false); }
 
   /// Stop the timer if running.
   void StopTimer() {
@@ -66,21 +57,66 @@ class Timer {
   /// Set new timer parameters. If the timer is running, it will fire immediately.
   void SetTimerInterval(NSTimeInterval interval_seconds) {
     interval_seconds_ = std::max(interval_seconds, minimum_interval_);
-    UpdateTimingParameters();
+    UpdateTimingParameters(false);
   }
 
-  void TimerCallback() { static_cast<T *>(this)->OnTimer(); }
+  void TimerCallback() {
+    if (mode_ == Mode::kSingleShot) {
+      // In SingleShot mode, call OnTimer between cancelling and restarting the timer
+      ReleaseTimerSource();
+      static_cast<T *>(this)->OnTimer();
+      StartTimer(true);
+    } else {
+      // Continuous mode - just call OnTimer
+      static_cast<T *>(this)->OnTimer();
+    }
+  }
 
  private:
-  /// Update the timer firing settings. If a timer is currently active, will
-  /// result in it firing in 10 seconds and then again at the current interval.
-  /// The 10 second delay is to allow the sync service to launch and settle
-  /// since it is often launched around the same time this timer is started.
-  void UpdateTimingParameters() {
+  void StartTimer(bool is_restart) {
     if (timer_source_) {
-      dispatch_source_set_timer(timer_source_,
-                                dispatch_time(DISPATCH_WALLTIME_NOW, 10 * NSEC_PER_SEC),
-                                interval_seconds_ * NSEC_PER_SEC, 0);
+      return;  // No-op if already running
+    }
+
+    timer_source_ = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, timer_queue_);
+
+    dispatch_source_set_event_handler(timer_source_, ^{
+      TimerCallback();
+    });
+
+    UpdateTimingParameters(is_restart);
+
+    dispatch_resume(timer_source_);
+  }
+
+  /// Update the timer firing settings.
+  /// In SingleShot Mode:
+  ///   If the update is from a restart, will wait a full interval cycle.
+  ///   Otherwise, will use a 10 second "startup" value to allow changes to settle.
+  /// In Continuous Mode:
+  ///   An initial 10 second "startup" value is used to allow the system to settle
+  ///   and will then fire continuously on every interval cycle.
+  void UpdateTimingParameters(bool is_restart) {
+    if (!timer_source_) {
+      return;
+    }
+
+    dispatch_time_t start_time;
+
+    if (is_restart && mode_ == Mode::kSingleShot) {
+      // On restart in SingleShot mode, use the normal interval as the start time argument
+      start_time = dispatch_time(DISPATCH_WALLTIME_NOW, interval_seconds_ * NSEC_PER_SEC);
+    } else {
+      // On initial start or timing interval changes, use 10 second delay
+      start_time = dispatch_time(DISPATCH_WALLTIME_NOW, 10 * NSEC_PER_SEC);
+    }
+
+    if (mode_ == Mode::kSingleShot) {
+      // For single-shot mode, set up a one-time timer
+      dispatch_source_set_timer(timer_source_, start_time, DISPATCH_TIME_FOREVER, 0);
+    } else {
+      // For continuous mode, set up repeating timer
+      dispatch_source_set_timer(timer_source_, start_time, interval_seconds_ * NSEC_PER_SEC, 0);
     }
   }
 
@@ -96,6 +132,7 @@ class Timer {
   dispatch_source_t timer_source_{nullptr};
   NSTimeInterval interval_seconds_;
   NSTimeInterval minimum_interval_;
+  Mode mode_;
 };
 
 }  // namespace santa


### PR DESCRIPTION
Adds a new mode to the Timer mixin class called "SingleShot" that derived classes can use. In this new mode, the timer is only fired once, and then immediately cancelled while the OnTimer method is called. Upon return, the timer is rescheduled.

This can be used by classes that might be performing long running operations during the OnTimer callback and want to wait a full interval before the operation is rescheduled.