### PR TITLE
Support export batches

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -268,12 +268,42 @@
 @property(readonly) BOOL enableTelemetryExport;
 
 ///
-///  If enableTelemetryExport is true, this defined how often telemetry export is performed.
+///  If enableTelemetryExport is true, this defines how often telemetry export is performed.
 ///  Defaults to 900 (15 minutes). Minimum allowed value is 60.
 ///
 ///  @note: This property is KVO compliant.
 ///
 @property(readonly) uint32_t telemetryExportIntervalSec;
+
+///
+///  When exporting telemetry, this defines how long Santa will wait for a given batch to upload.
+///  Defaults to 300 (5 minutes). Minimum allowed value is 60.
+///
+///  @note: This property is KVO compliant.
+///
+@property(readonly) uint32_t telemetryExportTimeoutSec;
+
+///
+///  This configuration key sets the threshold size in megabytes for grouping telemetry files
+///  into export batches. When the accumulated size of files in a batch reaches or exceeds
+///  this threshold, the batch is considered complete and ready for export.
+///  Note: All files in a batch are written as a single combined file at the destination.
+///  See also: TelemetryExportMaxFilesPerBatch
+///  Defaults to 500.
+///
+///  @note: This property is KVO compliant.
+///
+@property(readonly) uint32_t telemetryExportBatchThresholdSizeMB;
+
+///
+///  Sets the maximum number of individual telemetry files that can be grouped into a single
+///  export batch.
+///  Note: All files in a batch are written as a single combined file at the destination.
+///  See also: TelemetryExportBatchThresholdSizeMB
+///
+///  @note: This property is KVO compliant.
+///
+@property(readonly) uint32_t telemetryExportMaxFilesPerBatch;
 
 ///
 ///  If set, contains the filesystem access policy configuration.

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -142,6 +142,10 @@ static NSString *const kFileAccessPolicyUpdateIntervalSec = @"FileAccessPolicyUp
 
 static NSString *const kEnableTelemetryExport = @"EnableTelemetryExport";
 static NSString *const kTelemetryExportIntervalSec = @"TelemetryExportIntervalSec";
+static NSString *const kTelemetryExportTimeoutSec = @"TelemetryExportTimeoutSec";
+static NSString *const kTelemetryExportBatchThresholdSizeMB =
+    @"TelemetryExportBatchThresholdSizeMB";
+static NSString *const kTelemetryExportMaxFilesPerBatch = @"TelemetryExportMaxFilesPerBatch";
 
 static NSString *const kEnableMachineIDDecoration = @"EnableMachineIDDecoration";
 
@@ -303,6 +307,9 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
       kFileAccessPolicyUpdateIntervalSec : number,
       kEnableTelemetryExport : number,
       kTelemetryExportIntervalSec : number,
+      kTelemetryExportTimeoutSec : number,
+      kTelemetryExportBatchThresholdSizeMB : number,
+      kTelemetryExportMaxFilesPerBatch : number,
       kEnableMachineIDDecoration : number,
       kEnableForkAndExitLogging : number,
       kIgnoreOtherEndpointSecurityClients : number,
@@ -687,6 +694,18 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 + (NSSet *)keyPathsForValuesAffectingTelemetryExportIntervalSec {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingTelemetryExportTimeoutSec {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingTelemetryExportBatchThresholdSizeMB {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingTelemetryExportMaxFilesPerBatch {
   return [self configStateSet];
 }
 
@@ -1166,6 +1185,24 @@ static SNTConfigurator *sharedConfigurator = nil;
   return self.configState[kTelemetryExportIntervalSec]
              ? [self.configState[kTelemetryExportIntervalSec] unsignedIntValue]
              : 60 * 15;
+}
+
+- (uint32_t)telemetryExportTimeoutSec {
+  return self.configState[kTelemetryExportTimeoutSec]
+             ? [self.configState[kTelemetryExportTimeoutSec] unsignedIntValue]
+             : (5 * 60);
+}
+
+- (uint32_t)telemetryExportMaxFileUploadSizeMB {
+  return self.configState[kTelemetryExportBatchThresholdSizeMB]
+             ? [self.configState[kTelemetryExportBatchThresholdSizeMB] unsignedIntValue]
+             : 500;
+}
+
+- (uint32_t)telemetryExportMaxOpenedFiles {
+  return self.configState[kTelemetryExportMaxFilesPerBatch]
+             ? [self.configState[kTelemetryExportMaxFilesPerBatch] unsignedIntValue]
+             : 50;
 }
 
 - (BOOL)enableMachineIDDecoration {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1341,7 +1341,6 @@ santa_unit_test(
         "EndpointSecurity",
     ],
     deps = [
-        ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
         ":EndpointSecuritySerializer",
@@ -1354,7 +1353,9 @@ santa_unit_test(
         ":EndpointSecurityWriterSpool",
         ":EndpointSecurityWriterSyslog",
         ":MockEndpointSecurityAPI",
+        ":SNTSyncdQueue",
         "//Source/common:SNTCommonEnums",
+        "//Source/common:SNTExportConfiguration",
         "//Source/common:TelemetryEventMap",
         "//Source/common:TestUtils",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:SpoolBatchers",

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -18,6 +18,9 @@
 #include <Foundation/Foundation.h>
 #include <sys/stat.h>
 
+#include <algorithm>
+#include <atomic>
+#include <memory>
 #include <utility>
 
 #import "Source/common/SNTCommonEnums.h"
@@ -52,10 +55,6 @@ static constexpr size_t kMaxExpectedWriteSizeBytes = 4096;
 // Minimum allowable telemetry export frequency.
 // Semi-arbitrary. Goal is to protect against too much strain on the export path.
 static constexpr uint32_t kMinTelemetryExportIntervalSecs = 60;
-// Max time to wait for the sync service to export a file.
-// Should be slightly smaller than kMinTelemetryExportIntervalSecs to
-// prevent overlapping runs.
-static constexpr uint32_t kMinTelemetryExportTimeoutSecs = kMinTelemetryExportIntervalSecs - 2;
 
 // Translate configured log type to appropriate Serializer/Writer pairs
 std::unique_ptr<Logger> Logger::Create(
@@ -63,7 +62,9 @@ std::unique_ptr<Logger> Logger::Create(
     GetExportConfigBlock getExportConfigBlock, TelemetryEvent telemetry_mask,
     SNTEventLogType log_type, SNTDecisionCache *decision_cache, NSString *event_log_path,
     NSString *spool_log_path, size_t spool_dir_size_threshold, size_t spool_file_size_threshold,
-    uint64_t spool_flush_timeout_ms, uint32_t telemetry_export_seconds) {
+    uint64_t spool_flush_timeout_ms, uint32_t telemetry_export_seconds,
+    uint32_t telemetry_export_timeout_seconds, uint32_t telemetry_export_batch_threshold_size_mb,
+    uint32_t telemetry_export_max_files_per_batch) {
   std::shared_ptr<santa::Serializer> serializer;
   std::shared_ptr<santa::Writer> writer;
 
@@ -119,23 +120,31 @@ std::unique_ptr<Logger> Logger::Create(
     default: LOGE(@"Invalid log type: %ld", log_type); return nullptr;
   }
 
-  auto logger = std::make_unique<Logger>(syncd_queue, getExportConfigBlock, telemetry_mask,
-                                         std::move(serializer), std::move(writer));
+  auto logger = std::make_unique<Logger>(
+      syncd_queue, getExportConfigBlock, telemetry_mask, telemetry_export_timeout_seconds,
+      telemetry_export_batch_threshold_size_mb, telemetry_export_max_files_per_batch,
+      std::move(serializer), std::move(writer));
+
   logger->SetTimerInterval(telemetry_export_seconds);
 
   return logger;
 }
 
 Logger::Logger(SNTSyncdQueue *syncd_queue, GetExportConfigBlock get_export_config_block,
-               TelemetryEvent telemetry_mask, std::shared_ptr<santa::Serializer> serializer,
-               std::shared_ptr<santa::Writer> writer)
-    : Timer<Logger>(kMinTelemetryExportIntervalSecs),
+               TelemetryEvent telemetry_mask, uint32_t telemetry_export_timeout_seconds,
+               uint32_t telemetry_export_batch_threshold_size_mb,
+               uint32_t telemetry_export_max_files_per_batch,
+               std::shared_ptr<santa::Serializer> serializer, std::shared_ptr<santa::Writer> writer)
+    : Timer<Logger>(kMinTelemetryExportIntervalSecs, Logger::Mode::kSingleShot),
       syncd_queue_(syncd_queue),
       get_export_config_block_(get_export_config_block),
       telemetry_mask_(telemetry_mask),
       serializer_(std::move(serializer)),
       writer_(std::move(writer)),
-      tracker_(ExportTracker::Create()) {
+      tracker_(ExportTracker::Create()),
+      export_batch_threshold_size_bytes_(std::make_unique<std::atomic_uint64_t>()),
+      export_max_files_per_batch_(std::make_unique<std::atomic_uint32_t>()),
+      export_timeout_secs_(std::make_unique<std::atomic_uint32_t>()) {
   // Provide a default block instead of leaving nil
   if (get_export_config_block_ == nil) {
     get_export_config_block_ = ^SNTExportConfiguration *() {
@@ -145,10 +154,91 @@ Logger::Logger(SNTSyncdQueue *syncd_queue, GetExportConfigBlock get_export_confi
 
   export_queue_ = dispatch_queue_create("com.northpolesec.santa.daemon.export",
                                         DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+
+  SetBatchThresholdSizeMB(telemetry_export_batch_threshold_size_mb);
+  SetMaxFilesPerBatch(telemetry_export_max_files_per_batch);
+  SetTelmetryExportTimeoutSecs(telemetry_export_timeout_seconds);
+}
+
+void Logger::SetBatchThresholdSizeMB(uint32_t val) {
+  // Limit between 10 MB to 5 GB
+  constexpr uint64_t mb_multiplier = 1024 * 1024;
+  constexpr uint32_t upload_mb_min = 1;
+  constexpr uint32_t upload_mb_max = 5120;
+
+  uint32_t new_val = std::clamp(val, upload_mb_min, upload_mb_max);
+  if (new_val != val) {
+    LOGW(@"Export batch threshold size must be between %u and %u MB. Clamped to: %u", upload_mb_min,
+         upload_mb_max, new_val);
+  }
+
+  export_batch_threshold_size_bytes_->store(new_val * mb_multiplier, std::memory_order_relaxed);
+}
+
+void Logger::SetMaxFilesPerBatch(uint32_t val) {
+  // Ensure a sane max in order to limit the number of simultaneously opened files.
+  // Limit between 1 to 100
+  static constexpr uint32_t opened_min = 1;
+  static constexpr uint32_t opened_max = 100;
+
+  uint32_t new_val = std::clamp(val, opened_min, opened_max);
+
+  if (new_val != val) {
+    LOGW(@"Export max files per batch must be between %u and %u. Clamped to: %u", opened_min,
+         opened_max, new_val);
+  }
+
+  export_max_files_per_batch_->store(new_val, std::memory_order_relaxed);
+}
+
+void Logger::SetTelmetryExportTimeoutSecs(uint32_t val) {
+  static constexpr uint32_t timeout_min = 1;
+  static constexpr uint32_t timeout_max = 600;
+
+  uint32_t new_val = std::clamp(val, timeout_min, timeout_max);
+
+  if (new_val != val) {
+    LOGW(@"Export timeout must be between %u and %u seconds. Clamped to: %u", timeout_min,
+         timeout_max, new_val);
+  }
+
+  export_timeout_secs_->store(new_val, std::memory_order_relaxed);
 }
 
 void Logger::SetTelemetryMask(TelemetryEvent mask) {
   telemetry_mask_ = mask;
+}
+
+Logger::ExportLogType Logger::GetLogType(NSFileHandle *handle, NSString *path) {
+  static constexpr NSUInteger kMagicLength = sizeof(uint32_t);
+  NSError *err;
+  NSData *magic_bytes = [handle readDataUpToLength:kMagicLength error:&err];
+  [handle seekToFileOffset:0];
+  if (magic_bytes.length != kMagicLength) {
+    LOGW(@"Unable to determine log file type: %@", path);
+    return ExportLogType::kUnknown;
+  }
+
+  uint32_t magic = *(uint32_t *)(magic_bytes.bytes);
+  if (magic == ::fsspool::kStreamBatcherMagic) {
+    return ExportLogType::kUncompressedStream;
+  } else if (magic == 0xfd2fb528) {
+    return ExportLogType::kZstdStream;
+  } else if ((magic & 0xffff) == 0x8b1f) {
+    return ExportLogType::kGzipStream;
+  } else {
+    LOGW(@"Unsupported log file type: %@ (magic: 0x%08x)", path, magic);
+    return ExportLogType::kUnknown;
+  }
+}
+
+std::pair<NSString *, NSString *> Logger::GetContentTypeAndExtension(ExportLogType log_type) {
+  switch (log_type) {
+    case ExportLogType::kUncompressedStream: return {@"application/octet-stream", @".stream"};
+    case ExportLogType::kGzipStream: return {@"application/gzip", @".gz"};
+    case ExportLogType::kZstdStream: return {@"application/zstd", @".zst"};
+    default: return {nil, nil};
+  }
 }
 
 void Logger::OnTimer() {
@@ -169,58 +259,129 @@ void Logger::ExportTelemetrySerialized() {
     return;
   }
 
-  while (std::optional<std::string> file_to_export = writer_->NextFileToExport()) {
-    NSString *path = @((*file_to_export).c_str());
+  uint32_t max_opened_files = export_max_files_per_batch_->load(std::memory_order_relaxed);
+  uint64_t max_file_upload_size_bytes =
+      export_batch_threshold_size_bytes_->load(std::memory_order_relaxed);
+  __block BOOL reply_block_success = YES;
+  BOOL process_another_batch = YES;
 
-    NSFileHandle *handle = [NSFileHandle fileHandleForReadingAtPath:path];
-    if (!handle) {
-      LOGW(@"Failed to get a file handle for telemetry file to export: %@", path);
-      tracker_.AckCompleted(*file_to_export);
-      continue;
+  while (reply_block_success && process_another_batch) {
+    uint64_t total_bytes_opened = 0;
+    ExportLogType cur_log_type = ExportLogType::kUnknown;
+    NSMutableDictionary<NSString *, NSFileHandle *> *pathsToHandles =
+        [[NSMutableDictionary alloc] initWithCapacity:max_opened_files];
+
+    process_another_batch = NO;
+
+    while (std::optional<std::string> file_to_export = writer_->NextFileToExport()) {
+      NSString *path = @((*file_to_export).c_str());
+
+      NSFileHandle *handle = [NSFileHandle fileHandleForReadingAtPath:path];
+      if (!handle) {
+        LOGW(@"Failed to get a file handle for telemetry file to export: %@", path);
+        tracker_.AckCompleted(*file_to_export);
+        continue;
+      }
+
+      struct stat sb;
+      if (fstat(handle.fileDescriptor, &sb) != 0) {
+        LOGW(@"Failed to stat telemetry file to export: %@", path);
+        tracker_.AckCompleted(*file_to_export);
+        continue;
+      }
+
+      if (!S_ISREG(sb.st_mode)) {
+        LOGW(@"Telemetry file to export is not a regular file: %@", path);
+        tracker_.AckCompleted(*file_to_export);
+        continue;
+      }
+
+      ExportLogType log_type = GetLogType(handle, path);
+      if (log_type == ExportLogType::kUnknown) {
+        LOGI(@"Unsupported log type, removing: %@", path);
+        tracker_.AckCompleted(*file_to_export);
+        continue;
+      }
+
+      // Track all files as initially unsuccessfully processed
+      // in case the export times out.
+      tracker_.Track(*file_to_export);
+
+      if (cur_log_type == ExportLogType::kUnknown || cur_log_type == log_type) {
+        cur_log_type = log_type;
+        total_bytes_opened += sb.st_size;
+        [pathsToHandles setObject:handle forKey:path];
+      } else {
+        // This is a different supported log type. It will be "tracked" in the tracker, until the
+        // next batch, but can be closed as no other operations will be performed on the file in
+        // this current batch.
+        [handle closeFile];
+        process_another_batch = YES;
+      }
+
+      if (pathsToHandles.count >= max_opened_files ||
+          total_bytes_opened >= max_file_upload_size_bytes) {
+        // Current batch is full
+        process_another_batch = YES;
+        break;
+      }
     }
 
-    struct stat sb;
-    if (fstat(handle.fileDescriptor, &sb) != 0) {
-      LOGW(@"Failed to stat telemetry file to export: %@", path);
-      tracker_.AckCompleted(*file_to_export);
-      continue;
+    if (pathsToHandles.count == 0) {
+      // Nothing left to process
+      break;
     }
 
-    if (!S_ISREG(sb.st_mode)) {
-      LOGW(@"Telemetry file to export is not a regular file: %@", path);
-      tracker_.AckCompleted(*file_to_export);
-      continue;
-    }
+    auto [contentType, extension] = GetContentTypeAndExtension(cur_log_type);
+    // We should always have a valid content type and extension
+    assert(contentType != nil);
+    assert(extension != nil);
 
-    // Track all files as initially unsuccessfully processed
-    // in case the export times out.
-    tracker_.Track(*file_to_export);
+    NSString *fileName = [NSString stringWithFormat:@"%@-%@.%@", [SNTSystemInfo bootSessionUUID],
+                                                    [[NSUUID UUID] UUIDString], extension];
 
-    NSString *fileName = [NSString
-        stringWithFormat:@"%@-%@", [SNTSystemInfo bootSessionUUID], [path lastPathComponent]];
+    dispatch_semaphore_t semaProcessingBlockCompleted = dispatch_semaphore_create(0);
+    dispatch_semaphore_t semaProcessingBlockExecuted = dispatch_semaphore_create(0);
 
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    // TODO: Support multiple telemetry files.
-    [syncd_queue_ exportTelemetryFiles:@[ handle ]
+    dispatch_semaphore_signal(semaProcessingBlockExecuted);
+
+    void (^exportReplyBlock)(BOOL success) = ^void(BOOL success) {
+      if (dispatch_semaphore_wait(semaProcessingBlockExecuted, DISPATCH_TIME_NOW) != 0) {
+        // Block has already executed, nothing to do.
+        return;
+      }
+
+      reply_block_success = success;
+
+      [pathsToHandles
+          enumerateKeysAndObjectsUsingBlock:^(NSString *path, NSFileHandle *handle, BOOL *stop) {
+            [handle closeFile];
+
+            if (success) {
+              tracker_.AckCompleted(path.UTF8String);
+            }
+          }];
+
+      dispatch_semaphore_signal(semaProcessingBlockCompleted);
+    };
+
+    [syncd_queue_ exportTelemetryFiles:[pathsToHandles allValues]
                               fileName:fileName
-                             totalSize:sb.st_size
-                           contentType:@"application/octet-stream"  // TODO: Update when compressing
+                             totalSize:total_bytes_opened
+                           contentType:contentType
                                 config:export_config
-                                 reply:^(BOOL success) {
-                                   [handle closeFile];
-                                   if (success) {
-                                     tracker_.AckCompleted(*file_to_export);
-                                   }
-                                   dispatch_semaphore_signal(sema);
-                                 }];
-    if (dispatch_semaphore_wait(
-            sema,
-            dispatch_time(DISPATCH_TIME_NOW, kMinTelemetryExportTimeoutSecs * NSEC_PER_SEC))) {
-      LOGW(@"Timed out waiting for telemetry to export.");
-    }
-  }
+                                 reply:exportReplyBlock];
 
-  writer_->FilesExported(tracker_.Drain());
+    if (dispatch_semaphore_wait(
+            semaProcessingBlockCompleted,
+            dispatch_time(DISPATCH_TIME_NOW,
+                          export_timeout_secs_->load(std::memory_order_relaxed) * NSEC_PER_SEC))) {
+      LOGW(@"Timed out waiting for telemetry to export.");
+      exportReplyBlock(FALSE);
+    }
+
+    writer_->FilesExported(tracker_.Drain());
+  }
 }
 
 void Logger::Log(std::unique_ptr<EnrichedMessage> msg) {

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -22,9 +22,11 @@
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #import "Source/common/SNTCommonEnums.h"
+#include "Source/common/SNTExportConfiguration.h"
 #include "Source/common/TelemetryEventMap.h"
 #include "Source/common/TestUtils.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
@@ -42,6 +44,7 @@
 #include "Source/santad/Logs/EndpointSecurity/Writers/Spool.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Syslog.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
+#import "Source/santad/SNTSyncdQueue.h"
 
 using santa::BasicString;
 using santa::Empty;
@@ -57,19 +60,30 @@ using santa::Protobuf;
 using santa::Spool;
 using santa::Syslog;
 using santa::TelemetryEvent;
+using testing::Pair;
+using testing::Return;
+using testing::UnorderedElementsAre;
+using ExportLogType = ::santa::Logger::ExportLogType;
 
 namespace santa {
 
 class LoggerPeer : public Logger {
  public:
   // Make base class constructors and members visible
+  using Logger::export_batch_threshold_size_bytes_;
+  using Logger::export_max_files_per_batch_;
+  using Logger::export_timeout_secs_;
+  using Logger::ExportTelemetrySerialized;
   using Logger::Logger;
   using Logger::serializer_;
   using Logger::tracker_;
   using Logger::writer_;
 
   LoggerPeer(std::unique_ptr<Logger> l)
-      : Logger(nil, nil, TelemetryEvent::kEverything, l->serializer_, l->writer_) {}
+      : Logger(nil, nil, TelemetryEvent::kEverything, l->export_timeout_secs_->load(),
+               static_cast<uint32_t>(l->export_batch_threshold_size_bytes_->load() / 1024 / 1024),
+               l->export_max_files_per_batch_->load(), std::move(l->serializer_),
+               std::move(l->writer_)) {}
 
   absl::flat_hash_map<std::string, bool> TrackerState() { return tracker_.file_state_; }
 };
@@ -102,15 +116,76 @@ class MockSerializer : public Empty {
               (override));
 };
 
-class MockWriter : public Null {
+class MockWriter : public santa::Writer {
  public:
-  MOCK_METHOD(void, Write, (std::vector<uint8_t> && bytes));
+  MOCK_METHOD(void, Write, (std::vector<uint8_t> && bytes), (override));
+  MOCK_METHOD(void, Flush, (), (override));
+  MOCK_METHOD(std::optional<std::string>, NextFileToExport, (), (override));
+  MOCK_METHOD(void, FilesExported, ((absl::flat_hash_map<std::string, bool> files_exported)),
+              (override));
 };
 
 @interface LoggerTest : XCTestCase
+@property NSFileManager *fileMgr;
+@property NSString *testDir;
+@property id mockSyncdQueue;
+@property SNTExportConfiguration * (^exportConfigBlock)(void);
 @end
 
 @implementation LoggerTest
+
+- (void)setUp {
+  self.fileMgr = [NSFileManager defaultManager];
+  self.testDir =
+      [NSString stringWithFormat:@"%@santa-logger-test-%d", NSTemporaryDirectory(), getpid()];
+
+  XCTAssertTrue([self.fileMgr createDirectoryAtPath:self.testDir
+                        withIntermediateDirectories:YES
+                                         attributes:nil
+                                              error:nil]);
+
+  self.mockSyncdQueue = OCMClassMock([SNTSyncdQueue class]);
+  self.exportConfigBlock = ^{
+    return [[SNTExportConfiguration alloc] init];
+  };
+}
+
+- (void)tearDown {
+  NSError *err;
+  XCTAssertTrue([self.fileMgr removeItemAtPath:self.testDir error:&err]);
+  if (err) {
+    XCTFail(@"Test dir cleanup failed: %@", err);
+  }
+
+  [self.mockSyncdQueue stopMocking];
+}
+
+- (NSString *)createTestFile:(NSString *)name
+                 contentSize:(NSUInteger)contentSize
+                        type:(ExportLogType)fileType {
+  static uint32_t magic = 0x0;
+  XCTAssertGreaterThanOrEqual(contentSize, sizeof(magic));
+  switch (fileType) {
+    case ExportLogType::kUnknown: magic = 0x0a; break;
+    case ExportLogType::kUncompressedStream: magic = ::fsspool::kStreamBatcherMagic; break;
+    case ExportLogType::kGzipStream: magic = 0x8b1f; break;
+    case ExportLogType::kZstdStream: magic = 0xfd2fb528; break;
+    default: XCTFail("Creating unsupported file type: %d", fileType); break;
+  }
+
+  NSMutableData *d = [[NSMutableData alloc] initWithBytes:&magic length:sizeof(magic)];
+  NSString *content = RepeatedString(@"A", contentSize - sizeof(magic));
+  [d appendBytes:content.UTF8String length:content.length];
+
+  NSString *path = [NSString stringWithFormat:@"%@/%@", self.testDir, name];
+  XCTAssertTrue([d writeToFile:path atomically:YES]);
+
+  return path;
+}
+
+- (NSString *)createTestFile:(NSString *)name contentSize:(NSUInteger)contentSize {
+  return [self createTestFile:name contentSize:contentSize type:ExportLogType::kUnknown];
+}
 
 - (void)testCreate {
   // Ensure that the factory method creates expected serializers/writers pairs
@@ -118,57 +193,57 @@ class MockWriter : public Null {
 
   XCTAssertEqual(nullptr, Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                          (SNTEventLogType)123, nil, @"/tmp/temppy", @"/tmp/spool",
-                                         1, 1, 1, 1));
+                                         1, 1, 1, 1, 1, 1, 1));
 
   LoggerPeer logger(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                    SNTEventLogTypeFilelog, nil, @"/tmp/temppy", @"/tmp/spool", 1, 1,
-                                   1, 1));
+                                   1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<BasicString>(logger.serializer_));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<File>(logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeSyslog, nil, @"/tmp/temppy", @"/tmp/spool", 1,
-                                     1, 1, 1));
+                                     1, 1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<BasicString>(logger.serializer_));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Syslog>(logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeNull, nil, @"/tmp/temppy", @"/tmp/spool", 1, 1,
-                                     1, 1));
+                                     1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Empty>(logger.serializer_));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Null>(logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeProtobuf, nil, @"/tmp/temppy", @"/tmp/spool", 1,
-                                     1, 1, 1));
+                                     1, 1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.serializer_));
   XCTAssertNotEqual(nullptr,
                     std::dynamic_pointer_cast<Spool<::fsspool::AnyBatcher>>(logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeProtobufStream, nil, @"/tmp/temppy",
-                                     @"/tmp/spool", 1, 1, 1, 1));
+                                     @"/tmp/spool", 1, 1, 1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.serializer_));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Spool<::fsspool::UncompressedStreamBatcher>>(
                                  logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeProtobufStreamGzip, nil, @"/tmp/temppy",
-                                     @"/tmp/spool", 1, 1, 1, 1));
+                                     @"/tmp/spool", 1, 1, 1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.serializer_));
   XCTAssertNotEqual(nullptr,
                     std::dynamic_pointer_cast<Spool<::fsspool::GzipStreamBatcher>>(logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeProtobufStreamZstd, nil, @"/tmp/temppy",
-                                     @"/tmp/spool", 1, 1, 1, 1));
+                                     @"/tmp/spool", 1, 1, 1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.serializer_));
   XCTAssertNotEqual(nullptr,
                     std::dynamic_pointer_cast<Spool<::fsspool::ZstdStreamBatcher>>(logger.writer_));
 
   logger = LoggerPeer(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
                                      SNTEventLogTypeJSON, nil, @"/tmp/temppy", @"/tmp/spool", 1, 1,
-                                     1, 1));
+                                     1, 1, 1, 1, 1));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<Protobuf>(logger.serializer_));
   XCTAssertNotEqual(nullptr, std::dynamic_pointer_cast<File>(logger.writer_));
 }
@@ -193,7 +268,7 @@ class MockWriter : public Null {
     EXPECT_CALL(*mockSerializer, SerializeMessage(testing::A<const EnrichedClose &>())).Times(1);
     EXPECT_CALL(*mockWriter, Write).Times(1);
 
-    Logger(nil, nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
+    Logger(nil, nil, TelemetryEvent::kEverything, 1, 1, 1, mockSerializer, mockWriter)
         .Log(std::move(enrichedMsg));
   }
 
@@ -213,7 +288,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeAllowlist(testing::_, hash));
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(nil, nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
+  Logger(nil, nil, TelemetryEvent::kEverything, 1, 1, 1, mockSerializer, mockWriter)
       .LogAllowlist(Message(mockESApi, &msg), hash);
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
@@ -229,7 +304,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeBundleHashingEvent).Times((int)[events count]);
   EXPECT_CALL(*mockWriter, Write).Times((int)[events count]);
 
-  Logger(nil, nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
+  Logger(nil, nil, TelemetryEvent::kEverything, 1, 1, 1, mockSerializer, mockWriter)
       .LogBundleHashingEvents(events);
 
   XCTBubbleMockVerifyAndClearExpectations(mockSerializer.get());
@@ -243,9 +318,8 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeDiskAppeared);
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(nil, nil, TelemetryEvent::kEverything, mockSerializer, mockWriter).LogDiskAppeared(@{
-    @"key" : @"value"
-  });
+  Logger(nil, nil, TelemetryEvent::kEverything, 1, 1, 1, mockSerializer, mockWriter)
+      .LogDiskAppeared(@{@"key" : @"value"});
 
   XCTBubbleMockVerifyAndClearExpectations(mockSerializer.get());
   XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
@@ -258,9 +332,8 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeDiskDisappeared);
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(nil, nil, TelemetryEvent::kEverything, mockSerializer, mockWriter).LogDiskDisappeared(@{
-    @"key" : @"value"
-  });
+  Logger(nil, nil, TelemetryEvent::kEverything, 1, 1, 1, mockSerializer, mockWriter)
+      .LogDiskDisappeared(@{@"key" : @"value"});
 
   XCTBubbleMockVerifyAndClearExpectations(mockSerializer.get());
   XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
@@ -277,7 +350,7 @@ class MockWriter : public Null {
   EXPECT_CALL(*mockSerializer, SerializeFileAccess(_, _, _, _, _, _));
   EXPECT_CALL(*mockWriter, Write);
 
-  Logger(nil, nil, TelemetryEvent::kEverything, mockSerializer, mockWriter)
+  Logger(nil, nil, TelemetryEvent::kEverything, 1, 1, 1, mockSerializer, mockWriter)
       .LogFileAccess(
           "v1", "name", Message(mockESApi, &msg),
           EnrichedProcess(std::nullopt, std::nullopt, std::nullopt, std::nullopt,
@@ -291,7 +364,7 @@ class MockWriter : public Null {
 - (void)testExportTracker {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   LoggerPeer logger(Logger::Create(mockESApi, nil, nil, TelemetryEvent::kEverything,
-                                   SNTEventLogTypeNull, nil, @"", @"", 1, 1, 1, 1));
+                                   SNTEventLogTypeNull, nil, @"", @"", 1, 1, 1, 1, 1, 1, 1));
 
   // Nothing in the map initially
   auto map = logger.tracker_.Drain();
@@ -342,6 +415,281 @@ class MockWriter : public Null {
   XCTAssertEqual(map.size(), 2);
   XCTAssertEqual(map.at("baz"), false);
   XCTAssertEqual(map.at("qaz"), true);
+}
+
+- (void)setExportExpectationSize:(NSUInteger)totalSize success:(BOOL)success {
+  OCMExpect([self.mockSyncdQueue
+      exportTelemetryFiles:OCMOCK_ANY
+                  fileName:OCMOCK_ANY
+                 totalSize:totalSize
+               contentType:OCMOCK_ANY
+                    config:OCMOCK_ANY
+                     reply:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(success), nil])]);
+}
+
+- (void)testExportSuccessWithSupportedTypeAndUnknownFile {
+  auto mockWriter = std::make_shared<MockWriter>();
+
+  [self setExportExpectationSize:25 success:YES];
+
+  // Only f2 and f3 will be exported (total 25 bytes)
+  NSString *f1 = [self createTestFile:@"f1" contentSize:5];
+  NSString *f2 = [self createTestFile:@"f2" contentSize:10 type:ExportLogType::kZstdStream];
+  NSString *f3 = [self createTestFile:@"f3" contentSize:15 type:ExportLogType::kZstdStream];
+
+  LoggerPeer l(self.mockSyncdQueue, self.exportConfigBlock, TelemetryEvent::kEverything, 5, 1, 10,
+               nullptr, mockWriter);
+
+  EXPECT_CALL(*mockWriter, NextFileToExport)
+      .WillOnce(Return(f1.UTF8String))
+      .WillOnce(Return(f2.UTF8String))
+      .WillOnce(Return(f3.UTF8String))
+      .WillOnce(Return(std::nullopt));
+
+  // All 3 files should be marked true - The zstd files were successfully
+  // exported and the unknown file will be cleaned up.
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f1.UTF8String, true),
+                                                              Pair(f2.UTF8String, true),
+                                                              Pair(f3.UTF8String, true))));
+
+  l.ExportTelemetrySerialized();
+
+  XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
+  XCTAssertTrue(OCMVerifyAll(self.mockSyncdQueue));
+}
+
+- (void)testExportFailWithSupportedTypeAndUnknownFile {
+  auto mockWriter = std::make_shared<MockWriter>();
+
+  // Only f2 and f3 will be exported (total 25 bytes)
+  NSString *f1 = [self createTestFile:@"f1" contentSize:5];
+  NSString *f2 = [self createTestFile:@"f2" contentSize:10 type:ExportLogType::kZstdStream];
+  NSString *f3 = [self createTestFile:@"f3" contentSize:15 type:ExportLogType::kZstdStream];
+
+  [self setExportExpectationSize:25 success:NO];
+
+  LoggerPeer l(self.mockSyncdQueue, self.exportConfigBlock, TelemetryEvent::kEverything, 5, 1, 10,
+               nullptr, mockWriter);
+
+  EXPECT_CALL(*mockWriter, NextFileToExport)
+      .WillOnce(Return(f1.UTF8String))
+      .WillOnce(Return(f2.UTF8String))
+      .WillOnce(Return(f3.UTF8String))
+      .WillOnce(Return(std::nullopt));
+
+  // The one unknown file will be marked true so it gets removed, but the two files that
+  // failed to send will be marked false.
+  // exported and the unknown file will be cleaned up.
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f1.UTF8String, true),
+                                                              Pair(f2.UTF8String, false),
+                                                              Pair(f3.UTF8String, false))));
+
+  l.ExportTelemetrySerialized();
+
+  XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
+  XCTAssertTrue(OCMVerifyAll(self.mockSyncdQueue));
+}
+
+- (void)testExportWithMultipleSupportedTypes {
+  auto mockWriter = std::make_shared<MockWriter>();
+
+  // Only f1 and f2 will be exported in the first batch (total 25 bytes).
+  // Files f3 and f4 will be "visited" during the first batch scan, but not
+  // uploaded until the second batch.
+  NSString *f1 = [self createTestFile:@"f1" contentSize:5 type:ExportLogType::kZstdStream];
+  NSString *f2 = [self createTestFile:@"f2" contentSize:10 type:ExportLogType::kZstdStream];
+  NSString *f3 = [self createTestFile:@"f3" contentSize:30 type:ExportLogType::kGzipStream];
+  NSString *f4 = [self createTestFile:@"f4" contentSize:40 type:ExportLogType::kGzipStream];
+
+  [self setExportExpectationSize:15 success:YES];
+  [self setExportExpectationSize:70 success:YES];
+
+  LoggerPeer l(self.mockSyncdQueue, self.exportConfigBlock, TelemetryEvent::kEverything, 5, 1, 10,
+               nullptr, mockWriter);
+
+  EXPECT_CALL(*mockWriter, NextFileToExport)
+      .WillOnce(Return(f1.UTF8String))
+      .WillOnce(Return(f2.UTF8String))
+      .WillOnce(Return(f3.UTF8String))
+      .WillOnce(Return(f4.UTF8String))
+      .WillOnce(Return(std::nullopt))
+      .WillOnce(Return(f3.UTF8String))
+      .WillOnce(Return(f4.UTF8String))
+      .WillOnce(Return(std::nullopt));
+
+  // Ensure only 2/4 files are sent the first time, and only the 2 remaining files
+  // are sent the second time.
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f3.UTF8String, true),
+                                                              Pair(f4.UTF8String, true))))
+      .After(
+          EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(
+                                       Pair(f1.UTF8String, true), Pair(f2.UTF8String, true),
+                                       Pair(f3.UTF8String, false), Pair(f4.UTF8String, false)))));
+
+  l.ExportTelemetrySerialized();
+
+  XCTAssertTrue(OCMVerifyAll(self.mockSyncdQueue));
+  XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
+}
+
+- (void)testExportMaxOpenedFiles {
+  auto mockWriter = std::make_shared<MockWriter>();
+
+  // Only f1, f2, and f3 will be exported in the first batch (total 30 bytes).
+  // File f4 will not be visited because of the limit being reached, but will
+  // be exported in the second batch.
+  NSString *f1 = [self createTestFile:@"f1" contentSize:5 type:ExportLogType::kZstdStream];
+  NSString *f2 = [self createTestFile:@"f2" contentSize:10 type:ExportLogType::kZstdStream];
+  NSString *f3 = [self createTestFile:@"f3" contentSize:15 type:ExportLogType::kZstdStream];
+  NSString *f4 = [self createTestFile:@"f4" contentSize:40 type:ExportLogType::kZstdStream];
+
+  [self setExportExpectationSize:30 success:YES];
+  [self setExportExpectationSize:40 success:YES];
+
+  // Limit to 3 opened files
+  LoggerPeer l(self.mockSyncdQueue, self.exportConfigBlock, TelemetryEvent::kEverything, 5, 1, 3,
+               nullptr, mockWriter);
+
+  EXPECT_CALL(*mockWriter, NextFileToExport)
+      .WillOnce(Return(f1.UTF8String))
+      .WillOnce(Return(f2.UTF8String))
+      .WillOnce(Return(f3.UTF8String))
+      .WillOnce(Return(f4.UTF8String))
+      .WillOnce(Return(std::nullopt));
+
+  // Ensure only 3/4 files are sent the first time because of the open file limit
+  // are sent the second time.
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f4.UTF8String, true))))
+      .After(EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(
+                                          Pair(f1.UTF8String, true), Pair(f2.UTF8String, true),
+                                          Pair(f3.UTF8String, true)))));
+
+  l.ExportTelemetrySerialized();
+
+  XCTAssertTrue(OCMVerifyAll(self.mockSyncdQueue));
+  XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
+}
+
+- (void)testExportMaxBatchSize {
+  auto mockWriter = std::make_shared<MockWriter>();
+
+  // Files f1 and f2 will be exported in the first batch.
+  // File f3 will go alone in the second batch.
+  // Files f4 and f5 will go in the third batch.
+  static constexpr NSUInteger oneMB = 1024 * 1024;
+  NSString *f1 = [self createTestFile:@"f1"
+                          contentSize:(oneMB - 1)
+                                 type:ExportLogType::kZstdStream];
+  NSString *f2 = [self createTestFile:@"f2" contentSize:10 type:ExportLogType::kZstdStream];
+  NSString *f3 = [self createTestFile:@"f3" contentSize:oneMB type:ExportLogType::kZstdStream];
+  NSString *f4 = [self createTestFile:@"f4" contentSize:40 type:ExportLogType::kZstdStream];
+  NSString *f5 = [self createTestFile:@"f5" contentSize:oneMB type:ExportLogType::kZstdStream];
+
+  [self setExportExpectationSize:((oneMB - 1) + 10) success:YES];
+  [self setExportExpectationSize:oneMB success:YES];
+  [self setExportExpectationSize:(40 + oneMB) success:YES];
+
+  // Limit to 3 opened files
+  LoggerPeer l(self.mockSyncdQueue, self.exportConfigBlock, TelemetryEvent::kEverything, 5, 1, 10,
+               nullptr, mockWriter);
+
+  EXPECT_CALL(*mockWriter, NextFileToExport)
+      .WillOnce(Return(f1.UTF8String))
+      .WillOnce(Return(f2.UTF8String))
+      .WillOnce(Return(f3.UTF8String))
+      .WillOnce(Return(f4.UTF8String))
+      .WillOnce(Return(f5.UTF8String))
+      .WillOnce(Return(std::nullopt));
+
+  // Ensure the batches happen in the expected order
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f4.UTF8String, true),
+                                                              Pair(f5.UTF8String, true))))
+      .After(
+          EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f3.UTF8String, true)))))
+      .After(EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(
+                                          Pair(f1.UTF8String, true), Pair(f2.UTF8String, true)))));
+
+  l.ExportTelemetrySerialized();
+
+  XCTAssertTrue(OCMVerifyAll(self.mockSyncdQueue));
+  XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
+}
+
+- (void)testExportNoMoreBatchesAfterFailedExport {
+  auto mockWriter = std::make_shared<MockWriter>();
+
+  // Only f1 and f2 will be sent in the first batch due to opened file limitations.
+  NSString *f1 = [self createTestFile:@"f1" contentSize:5 type:ExportLogType::kZstdStream];
+  NSString *f2 = [self createTestFile:@"f2" contentSize:10 type:ExportLogType::kZstdStream];
+
+  // Simulate failed export in the reply block
+  [self setExportExpectationSize:15 success:NO];
+
+  // Limit to 2 opened files
+  LoggerPeer l(self.mockSyncdQueue, self.exportConfigBlock, TelemetryEvent::kEverything, 5, 1, 2,
+               nullptr, mockWriter);
+
+  // Note: std::nullopt is never returned as the export loops don't continue
+  EXPECT_CALL(*mockWriter, NextFileToExport)
+      .WillOnce(Return(f1.UTF8String))
+      .WillOnce(Return(f2.UTF8String));
+
+  // Ensure only 3/4 files are sent the first time because of the open file limit
+  // are sent the second time.
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f1.UTF8String, false),
+                                                              Pair(f2.UTF8String, false))));
+
+  l.ExportTelemetrySerialized();
+
+  XCTAssertTrue(OCMVerifyAll(self.mockSyncdQueue));
+  XCTBubbleMockVerifyAndClearExpectations(mockWriter.get());
+}
+
+- (void)testGetContentTypeAndExtension {
+  auto typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kUnknown);
+  XCTAssertNil(typeAndExt.first);
+  XCTAssertNil(typeAndExt.second);
+
+  typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kUncompressedStream);
+  XCTAssertEqualObjects(typeAndExt.first, @"application/octet-stream");
+  XCTAssertEqualObjects(typeAndExt.second, @".stream");
+
+  typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kGzipStream);
+  XCTAssertEqualObjects(typeAndExt.first, @"application/gzip");
+  XCTAssertEqualObjects(typeAndExt.second, @".gz");
+
+  typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kZstdStream);
+  XCTAssertEqualObjects(typeAndExt.first, @"application/zstd");
+  XCTAssertEqualObjects(typeAndExt.second, @".zst");
+}
+
+- (void)testExportSettingsClamp {
+  LoggerPeer l(nil, self.exportConfigBlock, TelemetryEvent::kNone, 5, 1, 2, nullptr, nullptr);
+
+  // Export batch threshold size must be between 1 and 5120 MB
+  constexpr uint64_t mb_multiplier = 1024 * 1024;
+  l.SetBatchThresholdSizeMB(0);
+  XCTAssertEqual(l.export_batch_threshold_size_bytes_->load(), 1 * mb_multiplier);
+  l.SetBatchThresholdSizeMB(20000);
+  XCTAssertEqual(l.export_batch_threshold_size_bytes_->load(), 5120 * mb_multiplier);
+  l.SetBatchThresholdSizeMB(75);
+  XCTAssertEqual(l.export_batch_threshold_size_bytes_->load(), 75 * mb_multiplier);
+
+  // Max filesper batch must be between 1 and 100
+  l.SetMaxFilesPerBatch(0);
+  XCTAssertEqual(l.export_max_files_per_batch_->load(), 1);
+  l.SetMaxFilesPerBatch(200);
+  XCTAssertEqual(l.export_max_files_per_batch_->load(), 100);
+  l.SetMaxFilesPerBatch(60);
+  XCTAssertEqual(l.export_max_files_per_batch_->load(), 60);
+
+  // Telemetry export timeout must be between 1 and 600 seconds
+  l.SetTelmetryExportTimeoutSecs(0);
+  XCTAssertEqual(l.export_timeout_secs_->load(), 1);
+  l.SetTelmetryExportTimeoutSecs(1000);
+  XCTAssertEqual(l.export_timeout_secs_->load(), 600);
+  l.SetTelmetryExportTimeoutSecs(250);
+  XCTAssertEqual(l.export_timeout_secs_->load(), 250);
 }
 
 @end

--- a/Source/santad/Logs/EndpointSecurity/MockLogger.h
+++ b/Source/santad/Logs/EndpointSecurity/MockLogger.h
@@ -29,8 +29,8 @@ class MockLogger : public santa::Logger {
   using Logger::Logger;
 
   MockLogger()
-      : Logger(nil, nil, santa::TelemetryEvent::kEverything, nullptr, nullptr) {
-  }
+      : Logger(nil, nil, santa::TelemetryEvent::kEverything, 0, 0, 0, nullptr,
+               nullptr) {}
 
   MOCK_METHOD(void, Log, (std::unique_ptr<santa::EnrichedMessage>));
 

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -139,7 +139,9 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
       TelemetryConfigToBitmask([configurator telemetry], [configurator enableAllEventUpload]),
       [configurator eventLogType], [SNTDecisionCache sharedCache], [configurator eventLogPath],
       [configurator spoolDirectory], spool_dir_threshold_bytes, spool_file_threshold_bytes,
-      spool_flush_timeout_ms, telemetry_export_frequency_secs);
+      spool_flush_timeout_ms, telemetry_export_frequency_secs,
+      [configurator telemetryExportTimeoutSec], [configurator telemetryExportBatchThresholdSizeMB],
+      [configurator telemetryExportMaxFilesPerBatch]);
   if (!logger) {
     LOGE(@"Failed to create logger.");
     exit(EXIT_FAILURE);


### PR DESCRIPTION
Supports exporting batches of telemetry files as a single operation as well as new supporting configuration keys. Also supports handling spools that switch between event log types and will independently batch files of the different types.