### PR TITLE
Cookbook: Update slack rules to better handle helper binaries

### DIFF
--- a/docs/docs/cookbook/faa.md
+++ b/docs/docs/cookbook/faa.md
@@ -74,6 +74,18 @@ The utility of this was highlighted by SpecterOps in their talk
 				<key>IsPrefix</key>
 				<true/>
 			</dict>
+			<dict>
+				<key>Path</key>
+				<string>/Users/*/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack/Cookies</string>
+				<key>IsPrefix</key>
+				<true/>
+			</dict>
+			<dict>
+				<key>Path</key>
+				<string>/Users/*/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack/StaleCookies</string>
+				<key>IsPrefix</key>
+				<true/>
+			</dict>
 		</array>
 		<key>Options</key>
 		<dict>

--- a/docs/docs/cookbook/faa.md
+++ b/docs/docs/cookbook/faa.md
@@ -88,7 +88,7 @@ The utility of this was highlighted by SpecterOps in their talk
 		<array>
 				<dict>
 					<key>SigningID</key>
-					<string>com.tinyspeck.slackmacgap</string>
+					<string>com.tinyspeck.slackmacgap*</string>
 					<key>TeamID</key>
 					<string>BQR82RBBHL</string>
 				</dict>


### PR DESCRIPTION
Update cookbook rules for blocking access to Slack cookies to include the helper binary and alternate paths for the cookies.

https://github.com/user-attachments/assets/1f82c617-9684-472c-8095-3f90ae7b3b87