### PR TITLE
telemetry export: remove extra dot from file extension

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -234,9 +234,9 @@ Logger::ExportLogType Logger::GetLogType(NSFileHandle *handle, NSString *path) {
 
 std::pair<NSString *, NSString *> Logger::GetContentTypeAndExtension(ExportLogType log_type) {
   switch (log_type) {
-    case ExportLogType::kUncompressedStream: return {@"application/octet-stream", @".stream"};
-    case ExportLogType::kGzipStream: return {@"application/gzip", @".gz"};
-    case ExportLogType::kZstdStream: return {@"application/zstd", @".zst"};
+    case ExportLogType::kUncompressedStream: return {@"application/octet-stream", @"stream"};
+    case ExportLogType::kGzipStream: return {@"application/gzip", @"gz"};
+    case ExportLogType::kZstdStream: return {@"application/zstd", @"zst"};
     default: return {nil, nil};
   }
 }

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -652,15 +652,15 @@ class MockWriter : public santa::Writer {
 
   typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kUncompressedStream);
   XCTAssertEqualObjects(typeAndExt.first, @"application/octet-stream");
-  XCTAssertEqualObjects(typeAndExt.second, @".stream");
+  XCTAssertEqualObjects(typeAndExt.second, @"stream");
 
   typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kGzipStream);
   XCTAssertEqualObjects(typeAndExt.first, @"application/gzip");
-  XCTAssertEqualObjects(typeAndExt.second, @".gz");
+  XCTAssertEqualObjects(typeAndExt.second, @"gz");
 
   typeAndExt = Logger::GetContentTypeAndExtension(ExportLogType::kZstdStream);
   XCTAssertEqualObjects(typeAndExt.first, @"application/zstd");
-  XCTAssertEqualObjects(typeAndExt.second, @".zst");
+  XCTAssertEqualObjects(typeAndExt.second, @"zst");
 }
 
 - (void)testExportSettingsClamp {


### PR DESCRIPTION
The dot is added in the format string.