### PR TITLE
Ensure to ack files even when all spool files are unsupported

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -329,6 +329,8 @@ void Logger::ExportTelemetrySerialized() {
 
     if (pathsToHandles.count == 0) {
       // Nothing left to process
+      // Drain the tracker in case there were non-uploadable files encountered
+      writer_->FilesExported(tracker_.Drain());
       break;
     }
 


### PR DESCRIPTION
If a spool was full on unsupported file types when exporting telemetry, they would never get marked as acked and never removed. Meaning the spool would stay full and no new telemetry would get written.