### PR TITLE
Add a make target for making dev releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 test:
 	bazel test --define=SANTA_BUILD_TYPE=adhoc --test_output=errors //:unit_tests
 
+devrelease:
+	bazel build -c opt --apple_generate_dsym --macos_cpus=arm64,x86_64 //:release
+
 reload:
 	bazel run //:reload
 

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ compile_commands:
 	bazel build //Source/...
 	bazel run :refresh_compile_commands
 
-.PHONY: fmt build test reload clean realclean compile_commands
+.PHONY: fmt build test devrelease reload clean realclean compile_commands


### PR DESCRIPTION
This adds a new build target `devrelease` to the Makefile for quickly building a development package for testing install.sh