### PR TITLE
Fix up SNTFileInfo and MOLCodeSignChecker to always use the same FDs

### DIFF
--- a/Source/common/SNTFileInfo.mm
+++ b/Source/common/SNTFileInfo.mm
@@ -796,7 +796,10 @@
 - (MOLCodesignChecker *)codesignCheckerWithError:(NSError **)error {
   if (!self.cachedCodesignChecker && !self.codesignCheckerError) {
     NSError *e;
-    self.cachedCodesignChecker = [[MOLCodesignChecker alloc] initWithBinaryPath:self.path error:&e];
+    self.cachedCodesignChecker =
+        [[MOLCodesignChecker alloc] initWithBinaryPath:self.path
+                                        fileDescriptor:self.fileHandle.fileDescriptor
+                                                 error:&e];
     self.codesignCheckerError = e;
   }
   if (error) *error = self.codesignCheckerError;

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -1,4 +1,5 @@
 /// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2025 North Pole Security, Inc. All rights reserved.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santactl/Commands/SNTCommandFileInfoTest.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfoTest.mm
@@ -127,7 +127,9 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 
 - (void)testCodeSignedNo {
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSUnsigned userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  // Get actual file descriptor value from the file info object
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), @"No");
 }
@@ -135,7 +137,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedSignatureFailed {
   NSString *expected = @"Yes, but code/signature changed/unverifiable";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSSignatureFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -143,7 +146,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedStaticCodeChanged {
   NSString *expected = @"Yes, but code/signature changed/unverifiable";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSStaticCodeChanged userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -151,7 +155,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedSignatureNotVerifiable {
   NSString *expected = @"Yes, but code/signature changed/unverifiable";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSSignatureNotVerifiable userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -159,7 +164,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedSignatureUnsupported {
   NSString *expected = @"Yes, but code/signature changed/unverifiable";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSSignatureUnsupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -167,7 +173,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedResourceDirectoryFailed {
   NSString *expected = @"Yes, but resources invalid";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourceDirectoryFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -175,7 +182,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedResourceNotSupported {
   NSString *expected = @"Yes, but resources invalid";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourceNotSupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -183,7 +191,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedResourceRulesInvalid {
   NSString *expected = @"Yes, but resources invalid";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourceRulesInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -191,7 +200,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedResourcesInvalid {
   NSString *expected = @"Yes, but resources invalid";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourcesInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -199,7 +209,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedResourcesNotFound {
   NSString *expected = @"Yes, but resources invalid";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotFound userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -207,7 +218,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedResourcesNotSealed {
   NSString *expected = @"Yes, but resources invalid";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotSealed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -215,7 +227,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedReqFailed {
   NSString *expected = @"Yes, but failed requirement validation";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSReqFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -223,7 +236,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedReqInvalid {
   NSString *expected = @"Yes, but failed requirement validation";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSReqInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -231,7 +245,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedReqUnsupported {
   NSString *expected = @"Yes, but failed requirement validation";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSReqUnsupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -239,7 +254,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedInfoPlistFailed {
   NSString *expected = @"Yes, but can't validate as the Info.plist has been modified";
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSInfoPlistFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -247,7 +263,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 - (void)testCodeSignedDefault {
   NSString *expected = @"Yes, but failed to validate (999)";
   NSError *err = [NSError errorWithDomain:@"" code:999 userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  int actualFD = self.fileInfo.fileHandle.fileDescriptor;
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:actualFD error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }


### PR DESCRIPTION
This PR ensures that SNTFileInfo and MOLCodeSignChecker always get the same view of a file once opened. In some rare scenarios it may be possible for these to get a different view.  

In which case we'll report the team ID from the es event but not correctly evaluate because of a code signing failure that's the result of swapping a file.

## Related Issues

- #556 