### PR TITLE
Set type URL in AnyBatcher before first write

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/AnyBatcher.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/AnyBatcher.h
@@ -27,7 +27,7 @@ class AnyBatcher {
  public:
   AnyBatcher() = default;
 
-  inline bool ShouldInitializeBeforeWrite() { return false; }
+  inline bool ShouldInitializeBeforeWrite() { return true; }
   absl::Status InitializeBatch(int fd);
   bool NeedToOpenFile();
   absl::Status Write(std::vector<uint8_t> bytes);


### PR DESCRIPTION
Without this change, the `type_url` on some of the Any protos isn't set, which causes problems with unmarshalling.