### PR TITLE
Add secure signing timestamp and signing timestamp

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -333,6 +333,18 @@ message Execution {
 
   // Entitlement information about the target executbale
   optional EntitlementInfo entitlement_info = 16;
+
+  // The secure timestamp of when this binary was signed, as provided by the
+  // timestamp service. Not populated for unsigned or ad-hoc signed binaries,
+  // or if the secure timestamp is missing.
+  // Number of seconds since UNIX epoch.
+  uint32 secure_signing_time = 32;
+
+  // The timestamp provided by the developer when this binary was signed.
+  // It is possible for developers to set this to whatever they wish when signing
+  // unlike the secure_signing_time.
+  // Number of seconds since UNIX epoch.
+  uint32 signing_time = 33;
 }
 
 // Information about a fork event

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -568,6 +568,14 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg, SNTCach
   pb_exec->set_reason(GetReasonEnum(cd.decision));
   pb_exec->set_mode(GetModeEnum(cd.decisionClientMode));
 
+  if (cd.secureSigningTime) {
+    pb_exec->set_secure_signing_time([cd.secureSigningTime timeIntervalSince1970]);
+  }
+
+  if (cd.signingTime) {
+    pb_exec->set_signing_time([cd.signingTime timeIntervalSince1970]);
+  }
+
   if (cd.certSHA256 || cd.certCommonName) {
     EncodeCertificateInfo(pb_exec->mutable_certificate_info(), cd.certSHA256, cd.certCommonName);
   }


### PR DESCRIPTION
Add secure signing timestamp and signing timestamp to the telemetry feed.