### PR TITLE
Fix version issue with last events table upgrade

### DIFF
--- a/Source/santad/DataLayer/SNTDatabaseTable.mm
+++ b/Source/santad/DataLayer/SNTDatabaseTable.mm
@@ -92,6 +92,9 @@
   [self inTransaction:^(FMDatabase *db, BOOL *rollback) {
     uint32_t currentVersion = [db userVersion];
     uint32_t newVersion = [self initializeDatabase:db fromVersion:currentVersion];
+    // For debug builds, assert that the returned new version matches what is expected.
+    // Version 0 is allowed since that means no upgrade was necessary.
+    assert(newVersion == 0 || newVersion == [self currentSupportedVersion]);
     if (newVersion < 1) return;
 
     LOGI(@"Updated %@ from version %d to %d", [self className], currentVersion, newVersion);

--- a/Source/santad/DataLayer/SNTEventTable.mm
+++ b/Source/santad/DataLayer/SNTEventTable.mm
@@ -79,7 +79,7 @@ static const uint32_t kEventTableCurrentVersion = 5;
     [db executeUpdate:@"DROP INDEX filesha256"];
     [db executeUpdate:@"ALTER TABLE events RENAME COLUMN filesha256 TO uniqueid"];
     [db executeUpdate:@"CREATE UNIQUE INDEX uniqueid ON events (uniqueid)"];
-    newVersion = 4;
+    newVersion = 5;
   }
 
   return newVersion;


### PR DESCRIPTION
Bug was not part of a release, introduced the other day in #569 - https://github.com/northpolesec/santa/pull/569/files#diff-9236068babaeecd117a8944c96d84288c9896248a83ef71155d64ae1a543484fR82