### PR TITLE
Support sending FAA rules over XPC from sync service to daemon

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -537,6 +537,9 @@ objc_library(
     name = "SNTFileAccessRule",
     srcs = ["SNTFileAccessRule.mm"],
     hdrs = ["SNTFileAccessRule.h"],
+    deps = [
+        ":CoderMacros",
+    ],
 )
 
 santa_unit_test(
@@ -713,6 +716,7 @@ objc_library(
         ":SNTCommonEnums",
         ":SNTConfigBundle",
         ":SNTConfigurator",
+        ":SNTFileAccessRule",
         ":SNTRule",
         ":SNTRuleIdentifiers",
         ":SNTStoredEvent",

--- a/Source/common/SNTFileAccessRule.h
+++ b/Source/common/SNTFileAccessRule.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSInteger, SNTFileAccessRuleState) {
   SNTFileAccessRuleStateRemove,
 };
 
-@interface SNTFileAccessRule : NSObject
+@interface SNTFileAccessRule : NSObject <NSSecureCoding>
 
 @property SNTFileAccessRuleState state;
 @property(copy) NSString *name;

--- a/Source/common/SNTFileAccessRule.mm
+++ b/Source/common/SNTFileAccessRule.mm
@@ -14,6 +14,8 @@
 
 #include "Source/common/SNTFileAccessRule.h"
 
+#import "Source/common/CoderMacros.h"
+
 @implementation SNTFileAccessRule
 
 - (instancetype)initWithState:(SNTFileAccessRuleState)state {
@@ -24,6 +26,26 @@
   self = [super init];
   if (self) {
     _state = state;
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  ENCODE_BOXABLE(coder, state);
+  ENCODE(coder, name);
+  ENCODE(coder, details);
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  self = [super init];
+  if (self) {
+    DECODE_SELECTOR(decoder, state, NSNumber, intValue);
+    DECODE(decoder, name, NSString);
+    DECODE_DICT(decoder, details);
   }
   return self;
 }

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -14,6 +14,8 @@
 /// limitations under the License.
 
 #import "Source/common/SNTConfigBundle.h"
+#import "Source/common/SNTFileAccessRule.h"
+#import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCUnprivilegedControlInterface.h"
 
@@ -36,10 +38,11 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
   SNTRuleAddSourceSyncService,
   SNTRuleAddSourceSantactl,
 };
-- (void)databaseRuleAddRules:(NSArray *)rules
-                 ruleCleanup:(SNTRuleCleanup)cleanupType
-                      source:(SNTRuleAddSource)source
-                       reply:(void (^)(NSError *error))reply;
+- (void)databaseRuleAddExecutionRules:(NSArray<SNTRule *> *)executionRules
+                      fileAccessRules:(NSArray<SNTFileAccessRule *> *)fileAccessRules
+                          ruleCleanup:(SNTRuleCleanup)cleanupType
+                               source:(SNTRuleAddSource)source
+                                reply:(void (^)(NSError *error))reply;
 - (void)databaseEventsPending:(void (^)(NSArray<SNTStoredEvent *> *events))reply;
 - (void)databaseRemoveEventsWithIDs:(NSArray *)ids;
 - (void)retrieveAllRules:(void (^)(NSArray<SNTRule *> *rules, NSError *error))reply;

--- a/Source/common/SNTXPCControlInterface.mm
+++ b/Source/common/SNTXPCControlInterface.mm
@@ -51,8 +51,15 @@ NSString *const kBundleID = @"com.northpolesec.santa.daemon";
             ofReply:YES];
 
   [r setClasses:[NSSet setWithObjects:[NSArray class], [SNTRule class], nil]
-        forSelector:@selector(databaseRuleAddRules:ruleCleanup:source:reply:)
+        forSelector:@selector(databaseRuleAddExecutionRules:
+                                            fileAccessRules:ruleCleanup:source:reply:)
       argumentIndex:0
+            ofReply:NO];
+
+  [r setClasses:[NSSet setWithObjects:[NSArray class], [SNTFileAccessRule class], nil]
+        forSelector:@selector(databaseRuleAddExecutionRules:
+                                            fileAccessRules:ruleCleanup:source:reply:)
+      argumentIndex:1
             ofReply:NO];
 
   [r setClasses:[NSSet setWithObjects:[NSArray class], [SNTRule class], nil]

--- a/Source/santactl/Commands/SNTCommandRule.mm
+++ b/Source/santactl/Commands/SNTCommandRule.mm
@@ -244,13 +244,15 @@ REGISTER_COMMAND_NAME(@"rule")
 
   if (!importRules && cleanupType != SNTRuleCleanupNone) {
     [[self.daemonConn remoteObjectProxy]
-        databaseRuleAddRules:@[]
-                 ruleCleanup:cleanupType
-                      source:SNTRuleAddSourceSantactl
-                       reply:^(NSError *error) {
-                         TEE_LOGE(@"Failed to delete rules: %@\n", error.localizedDescription);
-                         exit(EXIT_FAILURE);
-                       }];
+        databaseRuleAddExecutionRules:@[]
+                      fileAccessRules:nil
+                          ruleCleanup:cleanupType
+                               source:SNTRuleAddSourceSantactl
+                                reply:^(NSError *error) {
+                                  TEE_LOGE(@"Failed to delete rules: %@\n",
+                                           error.localizedDescription);
+                                  exit(EXIT_FAILURE);
+                                }];
     exit(EXIT_SUCCESS);
   }
 
@@ -339,45 +341,49 @@ REGISTER_COMMAND_NAME(@"rule")
   }
 
   [[self.daemonConn remoteObjectProxy]
-      databaseRuleAddRules:@[ newRule ]
-               ruleCleanup:SNTRuleCleanupNone
-                    source:SNTRuleAddSourceSantactl
-                     reply:^(NSError *error) {
-                       if (error) {
-                         TEE_LOGE(@"Failed to modify rules: %@", error.localizedFailureReason);
-                         exit(1);
-                       } else {
-                         NSString *ruleType;
-                         switch (newRule.type) {
-                           case SNTRuleTypeCertificate: ruleType = @"Certificate SHA-256"; break;
-                           case SNTRuleTypeBinary: {
-                             ruleType = @"SHA-256";
-                             break;
-                           }
-                           case SNTRuleTypeTeamID: {
-                             ruleType = @"Team ID";
-                             break;
-                           }
-                           case SNTRuleTypeSigningID: {
-                             ruleType = @"Signing ID";
-                             break;
-                           }
-                           case SNTRuleTypeCDHash: {
-                             ruleType = @"CDHash";
-                             break;
-                           }
-                           default: ruleType = @"(Unknown type)";
-                         }
-                         if (newRule.state == SNTRuleStateRemove) {
-                           printf("Removed rule for %s: %s.\n", [ruleType UTF8String],
-                                  [newRule.identifier UTF8String]);
-                         } else {
-                           printf("Added rule for %s: %s.\n", [ruleType UTF8String],
-                                  [newRule.identifier UTF8String]);
-                         }
-                         exit(0);
-                       }
-                     }];
+      databaseRuleAddExecutionRules:@[ newRule ]
+                    fileAccessRules:nil
+                        ruleCleanup:SNTRuleCleanupNone
+                             source:SNTRuleAddSourceSantactl
+                              reply:^(NSError *error) {
+                                if (error) {
+                                  TEE_LOGE(@"Failed to modify rules: %@",
+                                           error.localizedFailureReason);
+                                  exit(1);
+                                } else {
+                                  NSString *ruleType;
+                                  switch (newRule.type) {
+                                    case SNTRuleTypeCertificate:
+                                      ruleType = @"Certificate SHA-256";
+                                      break;
+                                    case SNTRuleTypeBinary: {
+                                      ruleType = @"SHA-256";
+                                      break;
+                                    }
+                                    case SNTRuleTypeTeamID: {
+                                      ruleType = @"Team ID";
+                                      break;
+                                    }
+                                    case SNTRuleTypeSigningID: {
+                                      ruleType = @"Signing ID";
+                                      break;
+                                    }
+                                    case SNTRuleTypeCDHash: {
+                                      ruleType = @"CDHash";
+                                      break;
+                                    }
+                                    default: ruleType = @"(Unknown type)";
+                                  }
+                                  if (newRule.state == SNTRuleStateRemove) {
+                                    printf("Removed rule for %s: %s.\n", [ruleType UTF8String],
+                                           [newRule.identifier UTF8String]);
+                                  } else {
+                                    printf("Added rule for %s: %s.\n", [ruleType UTF8String],
+                                           [newRule.identifier UTF8String]);
+                                  }
+                                  exit(0);
+                                }
+                              }];
 }
 
 - (void)printStateOfRule:(SNTRule *)rule daemonConnection:(MOLXPCConnection *)daemonConn {
@@ -439,16 +445,18 @@ REGISTER_COMMAND_NAME(@"rule")
   }
 
   [[self.daemonConn remoteObjectProxy]
-      databaseRuleAddRules:parsedRules
-               ruleCleanup:cleanupType
-                    source:SNTRuleAddSourceSantactl
-                     reply:^(NSError *error) {
-                       if (error) {
-                         TEE_LOGE(@"Failed to modify rules: %@", error.localizedFailureReason);
-                         exit(1);
-                       }
-                       exit(0);
-                     }];
+      databaseRuleAddExecutionRules:parsedRules
+                    fileAccessRules:nil
+                        ruleCleanup:cleanupType
+                             source:SNTRuleAddSourceSantactl
+                              reply:^(NSError *error) {
+                                if (error) {
+                                  TEE_LOGE(@"Failed to modify rules: %@",
+                                           error.localizedFailureReason);
+                                  exit(1);
+                                }
+                                exit(0);
+                              }];
 }
 
 - (void)exportJSONFile:(NSString *)jsonFilePath {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -815,6 +815,7 @@ objc_library(
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTError",
+        "//Source/common:SNTFileAccessRule",
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -26,6 +26,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTError.h"
 #import "Source/common/SNTExportConfiguration.h"
+#import "Source/common/SNTFileAccessRule.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTRule.h"
@@ -137,10 +138,11 @@ double watchdogRAMPeak = 0;
   reply(ruleCounts);
 }
 
-- (void)databaseRuleAddRules:(NSArray *)rules
-                 ruleCleanup:(SNTRuleCleanup)cleanupType
-                      source:(SNTRuleAddSource)source
-                       reply:(void (^)(NSError *error))reply {
+- (void)databaseRuleAddExecutionRules:(NSArray<SNTRule *> *)executionRules
+                      fileAccessRules:(NSArray<SNTFileAccessRule *> *)fileAccessRules
+                          ruleCleanup:(SNTRuleCleanup)cleanupType
+                               source:(SNTRuleAddSource)source
+                                reply:(void (^)(NSError *error))reply {
 #ifndef DEBUG
   SNTConfigurator *config = [SNTConfigurator configurator];
   if (source == SNTRuleAddSourceSantactl && (config.syncBaseURL || config.staticRules.count > 0)) {
@@ -159,11 +161,11 @@ double watchdogRAMPeak = 0;
   // If any rules are added that are not plain allowlist rules, then flush decision cache.
   // In particular, the addition of allowlist compiler rules should cause a cache flush.
   // We also flush cache if a allowlist compiler rule is replaced with a allowlist rule.
-  BOOL flushCache =
-      ((cleanupType != SNTRuleCleanupNone) || [ruleTable addedRulesShouldFlushDecisionCache:rules]);
+  BOOL flushCache = ((cleanupType != SNTRuleCleanupNone) ||
+                     [ruleTable addedRulesShouldFlushDecisionCache:executionRules]);
 
   NSError *error;
-  [ruleTable addRules:rules ruleCleanup:cleanupType error:&error];
+  [ruleTable addRules:executionRules ruleCleanup:cleanupType error:&error];
 
   // Whenever we add rules, we can also check for and remove outdated transitive rules.
   [ruleTable removeOutdatedTransitiveRules];

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -867,10 +867,11 @@
 
   // Stub out the call to invoke the block, verification of the input is later
   OCMStub([self.daemonConnRop
-      databaseRuleAddRules:OCMOCK_ANY
-               ruleCleanup:SNTRuleCleanupNone
-                    source:SNTRuleAddSourceSyncService
-                     reply:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
+      databaseRuleAddExecutionRules:OCMOCK_ANY
+                    fileAccessRules:OCMOCK_ANY
+                        ruleCleanup:SNTRuleCleanupNone
+                             source:SNTRuleAddSourceSyncService
+                              reply:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
   OCMStub([self.daemonConnRop postRuleSyncNotificationForApplication:[OCMArg any]
                                                                reply:([OCMArg invokeBlock])]);
   [sut sync];
@@ -902,10 +903,11 @@
                                 celExpr:nil],
   ];
 
-  OCMVerify([self.daemonConnRop databaseRuleAddRules:rules
-                                         ruleCleanup:SNTRuleCleanupNone
-                                              source:SNTRuleAddSourceSyncService
-                                               reply:OCMOCK_ANY]);
+  OCMVerify([self.daemonConnRop databaseRuleAddExecutionRules:rules
+                                              fileAccessRules:OCMOCK_ANY
+                                                  ruleCleanup:SNTRuleCleanupNone
+                                                       source:SNTRuleAddSourceSyncService
+                                                        reply:OCMOCK_ANY]);
   OCMVerify([self.daemonConnRop postRuleSyncNotificationForApplication:@"yes" reply:OCMOCK_ANY]);
 }
 
@@ -917,10 +919,11 @@
 
   // Stub out the call to invoke the block, verification of the input is later
   OCMStub([self.daemonConnRop
-      databaseRuleAddRules:OCMOCK_ANY
-               ruleCleanup:SNTRuleCleanupNone
-                    source:SNTRuleAddSourceSyncService
-                     reply:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
+      databaseRuleAddExecutionRules:OCMOCK_ANY
+                    fileAccessRules:OCMOCK_ANY
+                        ruleCleanup:SNTRuleCleanupNone
+                             source:SNTRuleAddSourceSyncService
+                              reply:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
   OCMStub([self.daemonConnRop postRuleSyncNotificationForApplication:[OCMArg any]
                                                                reply:([OCMArg invokeBlock])]);
   [sut sync];
@@ -942,10 +945,11 @@
                                 celExpr:@"this is an invalid expression"],
   ];
 
-  OCMVerify([self.daemonConnRop databaseRuleAddRules:rules
-                                         ruleCleanup:SNTRuleCleanupNone
-                                              source:SNTRuleAddSourceSyncService
-                                               reply:OCMOCK_ANY]);
+  OCMVerify([self.daemonConnRop databaseRuleAddExecutionRules:rules
+                                              fileAccessRules:OCMOCK_ANY
+                                                  ruleCleanup:SNTRuleCleanupNone
+                                                       source:SNTRuleAddSourceSyncService
+                                                        reply:OCMOCK_ANY]);
 }
 
 #pragma mark - SNTSyncPostflight Tests


### PR DESCRIPTION
This PR sets up the plumbing to get the newly parsed FAA rules over to the daemon.