### PR TITLE
Add FAA rules received and processed counts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "zstd", version = "1.5.7")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "acbb8b92c170095c00e3f283d2d9c801fb61569a",
+    commit = "ac102ef6724298a8dbc70a73d0303189bafd6b3f",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -42,6 +42,10 @@ using santa::NSStringToUTF8String;
   req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
   req->set_rules_received(static_cast<uint32_t>(self.syncState.rulesReceived));
   req->set_rules_processed(static_cast<uint32_t>(self.syncState.rulesProcessed));
+  req->set_file_access_rules_received(
+      static_cast<uint32_t>(self.syncState.fileAccessRulesReceived));
+  req->set_file_access_rules_processed(
+      static_cast<uint32_t>(self.syncState.fileAccessRulesProcessed));
 
   switch (self.syncState.syncType) {
     case SNTSyncTypeNormal: req->set_sync_type(::pbv1::NORMAL); break;

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -136,6 +136,7 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   google::protobuf::Arena arena;
 
   self.syncState.rulesReceived = 0;
+  self.syncState.fileAccessRulesReceived = 0;
   NSMutableArray<SNTRule *> *newRules = [NSMutableArray array];
   NSMutableArray<SNTFileAccessRule *> *newFileAccessRules = [NSMutableArray array];
   std::string cursor;
@@ -180,10 +181,12 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
       cursor = response.cursor();
       SLOGI(@"Received %lu rules", (unsigned long)response.rules_size());
       self.syncState.rulesReceived += response.rules_size();
+      self.syncState.fileAccessRulesReceived += response.file_access_rules_size();
     }
   } while (!cursor.empty());
 
   self.syncState.rulesProcessed = newRules.count;
+  self.syncState.fileAccessRulesProcessed = newFileAccessRules.count;
 
   return [[SNTDownloadedRuleSets alloc] initWithExecutionRules:newRules
                                                fileAccessRules:newFileAccessRules];

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -86,9 +86,11 @@
 /// The content-encoding to use for the client uploads during the sync session.
 @property SNTSyncContentEncoding contentEncoding;
 
-/// Counts of rules received and processed during rule download.
+/// Counts of execution and file access rules received and processed during rule download.
 @property NSUInteger rulesReceived;
 @property NSUInteger rulesProcessed;
+@property NSUInteger fileAccessRulesReceived;
+@property NSUInteger fileAccessRulesProcessed;
 
 @property BOOL preflightOnly;
 @property BOOL pushNotificationSync;


### PR DESCRIPTION
This provides matching functionality to existing execution rule counts