### PR TITLE
Support changing FAA rate limiting variables via configuration

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -343,6 +343,30 @@
 @property(readonly, nonatomic) uint32_t fileAccessPolicyUpdateIntervalSec;
 
 ///
+///  Sets the average logs per second that will be emitted by File Access
+///  Authorization rule violations.
+///  @note: Set to 0 to disable log rate limiting.
+///  @note: Rate limiting only applies to logging. FAA rules that are not
+///         audit only will still block operations that violate the rule.
+///  @note: This property is KVO compliant.
+///  See also: FileAccessGlobalWindowSizeSec
+///  Defaults to 60.
+///
+@property(readonly) uint32_t fileAccessGlobalLogsPerSec;
+
+///
+///  Sets the window size over which the fileAccessGlobalLogsPerSec
+///  setting is applied in order to allow for burts of logs.
+///  @note: Set to 0 to disable log rate limiting.
+///  @note: Rate limiting only applies to logging. FAA rules that are not
+///         audit only will still block operations that violate the rule.
+///  @note: This property is KVO compliant.
+///  See also: FileAccessGlobalLogsPerSec
+///  Defaults to 15.
+///
+@property(readonly) uint32_t fileAccessGlobalWindowSizeSec;
+
+///
 /// Enabling this appends the Santa machine ID to the end of each log line. If nothing
 /// has been overridden, this is the host's UUID.
 /// Defaults to NO.

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -139,6 +139,8 @@ static NSString *const kFileAccessPolicy = @"FileAccessPolicy";
 static NSString *const kFileAccessPolicyPlist = @"FileAccessPolicyPlist";
 static NSString *const kFileAccessBlockMessage = @"FileAccessBlockMessage";
 static NSString *const kFileAccessPolicyUpdateIntervalSec = @"FileAccessPolicyUpdateIntervalSec";
+static NSString *const kFileAccessGlobalLogsPerSec = @"FileAccessGlobalLogsPerSec";
+static NSString *const kFileAccessGlobalWindowSizeSec = @"FileAccessGlobalWindowSizeSec";
 
 static NSString *const kEnableTelemetryExport = @"EnableTelemetryExport";
 static NSString *const kTelemetryExportIntervalSec = @"TelemetryExportIntervalSec";
@@ -305,6 +307,8 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
       kFileAccessPolicyPlist : string,
       kFileAccessBlockMessage : string,
       kFileAccessPolicyUpdateIntervalSec : number,
+      kFileAccessGlobalWindowSizeSec : number,
+      kFileAccessGlobalLogsPerSec : number,
       kEnableTelemetryExport : number,
       kTelemetryExportIntervalSec : number,
       kTelemetryExportTimeoutSec : number,
@@ -602,6 +606,14 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 + (NSSet *)keyPathsForValuesAffectingFileAccessPolicyUpdateIntervalSec {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingFileAccessGlobalLogsPerSec {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingFileAccessGlobalWindowSizeSec {
   return [self configStateSet];
 }
 
@@ -1170,6 +1182,18 @@ static SNTConfigurator *sharedConfigurator = nil;
   return self.configState[kFileAccessPolicyUpdateIntervalSec]
              ? [self.configState[kFileAccessPolicyUpdateIntervalSec] unsignedIntValue]
              : 60 * 10;
+}
+
+- (uint32_t)fileAccessGlobalLogsPerSec {
+  return self.configState[kFileAccessGlobalLogsPerSec]
+             ? [self.configState[kFileAccessGlobalLogsPerSec] unsignedIntValue]
+             : 60;
+}
+
+- (uint32_t)fileAccessGlobalWindowSizeSec {
+  return self.configState[kFileAccessGlobalWindowSizeSec]
+             ? [self.configState[kFileAccessGlobalWindowSizeSec] unsignedIntValue]
+             : 15;
 }
 
 - (BOOL)enableTelemetryExport {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -543,6 +543,7 @@ objc_library(
     deps = [
         ":Metrics",
         "//Source/common:BranchPrediction",
+        "//Source/common:SNTLogging",
         "//Source/common:SystemResources",
     ],
 )

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -99,7 +99,8 @@ class FAAPolicyProcessor {
 
   FAAPolicyProcessor(SNTDecisionCache *decision_cache, std::shared_ptr<Enricher> enricher,
                      std::shared_ptr<Logger> logger, std::shared_ptr<TTYWriter> tty_writer,
-                     std::shared_ptr<Metrics> metrics,
+                     std::shared_ptr<Metrics> metrics, uint32_t rate_limit_logs_per_sec,
+                     uint32_t rate_limit_window_size_sec,
                      GenerateEventDetailLinkBlock generate_event_detail_link_block,
                      StoreAccessEventBlock store_access_event_block);
 
@@ -109,6 +110,8 @@ class FAAPolicyProcessor {
                                     const es_process_t *es_proc);
 
   virtual SNTCachedDecision *__strong GetCachedDecision(const struct stat &stat_buf);
+
+  virtual void ModifyRateLimiterSettings(uint32_t logs_per_sec, uint32_t window_size_sec);
 
   static std::vector<FAAPolicyProcessor::PathTarget> PathTargets(const Message &msg);
 

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -208,8 +208,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   auto policy = std::make_shared<santa::WatchItemPolicyBase>("foo_policy", "ver", "/foo");
   FAAPolicyProcessor::PathTarget target = {.path = "/some/random/path", .is_readable = true};
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil,
-                                            nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
 
   EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
       .WillRepeatedly([&faaPolicyProcessor](const Message &msg,
@@ -309,8 +309,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil,
-                                            nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
   EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
       .WillRepeatedly(testing::Return(false));
 
@@ -495,8 +495,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   NSString *want;
   id certMock = OCMClassMock([MOLCertificate class]);
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil,
-                                            nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
 
   EXPECT_CALL(faaPolicyProcessor, GetCertificateHash)
       .WillRepeatedly([&faaPolicyProcessor](const es_file_t *es_file) {
@@ -583,8 +583,8 @@ static inline std::pair<dev_t, ino_t> FileID(const es_file_t &file) {
   SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
   cd.certSHA256 = @(instigatingCertHash);
 
-  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, nil,
-                                            nil);
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
 
   EXPECT_CALL(faaPolicyProcessor, PolicyMatchesProcess)
       .WillRepeatedly([&faaPolicyProcessor](const WatchItemProcess &policy_proc,

--- a/Source/santad/EventProviders/MockFAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/MockFAAPolicyProcessor.h
@@ -37,10 +37,12 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
   MockFAAPolicyProcessor(
       SNTDecisionCache *dc, std::shared_ptr<Enricher> enricher, std::shared_ptr<Logger> logger,
       std::shared_ptr<TTYWriter> tty_writer, std::shared_ptr<Metrics> metrics,
+      uint32_t rate_limit_logs_per_sec, uint32_t rate_limit_window_size_sec,
       FAAPolicyProcessor::GenerateEventDetailLinkBlock generate_event_detail_link_block,
       FAAPolicyProcessor::StoreAccessEventBlock store_access_event_block)
       : FAAPolicyProcessor(dc, std::move(enricher), std::move(logger), std::move(tty_writer),
-                           std::move(metrics), std::move(generate_event_detail_link_block),
+                           std::move(metrics), rate_limit_logs_per_sec, rate_limit_window_size_sec,
+                           std::move(generate_event_detail_link_block),
                            std::move(store_access_event_block)) {}
   virtual ~MockFAAPolicyProcessor() {}
 

--- a/Source/santad/EventProviders/RateLimiter.h
+++ b/Source/santad/EventProviders/RateLimiter.h
@@ -17,7 +17,6 @@
 
 #import <Foundation/Foundation.h>
 
-#include <atomic>
 #include <memory>
 
 #include "Source/santad/Metrics.h"
@@ -38,12 +37,11 @@ namespace santa {
 class RateLimiter {
  public:
   // Factory
-  static RateLimiter Create(
-      std::shared_ptr<santa::Metrics> metrics, uint16_t max_qps,
-      NSTimeInterval reset_duration = kDefaultResetDuration);
+  static RateLimiter Create(std::shared_ptr<santa::Metrics> metrics,
+                            uint32_t logs_per_sec, uint32_t window_size_sec);
 
-  RateLimiter(std::shared_ptr<santa::Metrics> metrics, uint16_t max_qps,
-              NSTimeInterval reset_duration);
+  RateLimiter(std::shared_ptr<santa::Metrics> metrics, uint32_t logs_per_sec,
+              uint32_t window_size_sec);
 
   enum class Decision {
     kRateLimited = 0,
@@ -52,14 +50,16 @@ class RateLimiter {
 
   Decision Decide(uint64_t cur_mach_time);
 
+  void ModifySettings(uint32_t logs_per_sec, uint32_t window_size_sec);
+
   friend class santa::RateLimiterPeer;
 
  private:
+  void ModifySettingsSerialized(uint32_t logs_per_sec,
+                                uint32_t window_size_sec);
   bool ShouldRateLimitSerialized();
   size_t EventsRateLimitedSerialized();
   void TryResetSerialized(uint64_t cur_mach_time);
-
-  static constexpr NSTimeInterval kDefaultResetDuration = 15.0;
 
   std::shared_ptr<santa::Metrics> metrics_;
   size_t log_count_total_ = 0;

--- a/Source/santad/EventProviders/RateLimiter.h
+++ b/Source/santad/EventProviders/RateLimiter.h
@@ -41,7 +41,7 @@ class RateLimiter {
                             uint32_t logs_per_sec, uint32_t window_size_sec);
 
   RateLimiter(std::shared_ptr<santa::Metrics> metrics, uint32_t logs_per_sec,
-              uint32_t window_size_sec);
+              uint32_t window_size_sec, uint32_t max_window_size = 3600);
 
   enum class Decision {
     kRateLimited = 0,
@@ -62,6 +62,7 @@ class RateLimiter {
   void TryResetSerialized(uint64_t cur_mach_time);
 
   std::shared_ptr<santa::Metrics> metrics_;
+  const uint32_t max_window_size_;
   size_t log_count_total_ = 0;
   size_t max_log_count_total_;
   uint64_t reset_mach_time_;

--- a/Source/santad/EventProviders/RateLimiter.mm
+++ b/Source/santad/EventProviders/RateLimiter.mm
@@ -13,6 +13,7 @@
 /// limitations under the License.
 
 #include "Source/santad/EventProviders/RateLimiter.h"
+
 #include <limits>
 
 #include "Source/common/BranchPrediction.h"

--- a/Source/santad/EventProviders/RateLimiter.mm
+++ b/Source/santad/EventProviders/RateLimiter.mm
@@ -41,8 +41,8 @@ void RateLimiter::ModifySettingsSerialized(uint32_t logs_per_sec, uint32_t windo
   // Semi-arbitrary window size limit of 1 hour
   if (window_size_sec > max_window_size_) {
     window_size_sec = max_window_size_;
-    LOGW(@"FileAccessGlobalWindowSizeSec must be between 0 and %u. Clamped to: %u",
-         max_window_size_, window_size_sec);
+    LOGW(@"Window size must be between 0 and %u. Clamped to: %u", max_window_size_,
+         window_size_sec);
   }
 
   if (logs_per_sec == 0 || window_size_sec == 0) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
@@ -72,8 +72,8 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
                  .WillOnce(testing::Return(true)))
       .WillOnce(testing::Return(true));
 
-  auto mockFAA =
-      std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nullptr, nil, nil);
+  auto mockFAA = std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nullptr,
+                                                          0, 0, nil, nil);
   auto mockFAAProxy = std::make_shared<santa::ProcessFAAPolicyProcessorProxy>(mockFAA);
 
   SNTEndpointSecurityProcessFileAccessAuthorizer *procFAAClient =
@@ -105,8 +105,8 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
   SetExpectationsForProcessFileAccessAuthorizerInit(mockESApi);
 
   // First call will not match, second call will match
-  auto mockFAA =
-      std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nullptr, nil, nil);
+  auto mockFAA = std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nullptr,
+                                                          0, 0, nil, nil);
   EXPECT_CALL(*mockFAA, PolicyMatchesProcess)
       .WillOnce(testing::Return(false))
       .WillOnce(testing::Return(true));

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -630,6 +630,24 @@ changes in the release notes of any future release that changes them.`,
         },
       ],
     },
+    {
+      key: "FileAccessGlobalLogsPerSec",
+      description: `Sets the average logs per second that will be emitted by File Access
+        Authorization rule violations. Setting to 0 will disable log rate limiting. Rate
+        limiting only applies to logging. FAA rules that are not audit only will still
+        block operations that violate the rule.`,
+      type: "integer",
+      defaultValue: 60,
+    },
+    {
+      key: "FileAccessGlobalWindowSizeSec",
+      description: `Sets the window size over which the fileAccessGlobalLogsPerSec setting
+        is applied in order to allow for burts of logs. Setting to 0 will disable log rate
+        limiting. Rate limiting only applies to logging. FAA rules that are not audit only
+        will still block operations that violate the rule.`,
+      type: "integer",
+      defaultValue: 15,
+    },
   ],
   usb: [
     {

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -641,7 +641,7 @@ changes in the release notes of any future release that changes them.`,
     },
     {
       key: "FileAccessGlobalWindowSizeSec",
-      description: `Sets the window size over which the fileAccessGlobalLogsPerSec setting
+      description: `Sets the window size over which the FileAccessGlobalLogsPerSec setting
         is applied in order to allow for burts of logs. Setting to 0 will disable log rate
         limiting. Rate limiting only applies to logging. FAA rules that are not audit only
         will still block operations that violate the rule.`,


### PR DESCRIPTION
Adds two new configuration values to control rate limiting for logs emitted from FAA rule violations:
* `FileAccessGlobalLogsPerSec` (default: 60)
* `FileAccessGlobalWindowSizeSec` (default: 15)

This replaces the previously hard coed values.

Fixes #566 