### PR TITLE
Attempt to repair corrupted databases on startup

### DIFF
--- a/Source/santad/DataLayer/SNTDatabaseTable.mm
+++ b/Source/santad/DataLayer/SNTDatabaseTable.mm
@@ -41,7 +41,8 @@
           bail = YES;
           return;
         }
-        LOGW(@"Unable to create a good connection to the database. Deleting. (%@)", [db databasePath]);
+        LOGW(@"Unable to create a good connection to the database. Deleting. (%@)",
+             [db databasePath]);
         [self closeDeleteReopenDatabase:db];
       } else if ([db userVersion] > [self currentSupportedVersion]) {
         LOGW(@"Database version newer than supported. Deleting. (%@)", [db databasePath]);


### PR DESCRIPTION
This changes Santa to detect DB corruption and attempt repairs. If repairs fail, the DB will be deleted and rebuilt.