### PR TITLE
Timer improvements, allow FileAccessPolicyUpdateIntervalSec to be updated dynamically

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -314,6 +314,7 @@ objc_library(
     name = "Timer",
     hdrs = ["Timer.h"],
     deps = [
+        ":SNTLogging",
     ],
 )
 

--- a/Source/common/Timer.h
+++ b/Source/common/Timer.h
@@ -20,20 +20,27 @@
 #include <sys/qos.h>
 
 #include <algorithm>
+#include <string>
+
+#import "Source/common/SNTLogging.h"
 
 namespace santa {
 
 template <typename T>
-class Timer {
+class Timer : public std::enable_shared_from_this<Timer<T>> {
  public:
   enum class Mode {
     kContinuous,  // Default: timer fires repeatedly at intervals
     kSingleShot,  // Timer is cancelled while OnTimer fires and restarted once complete
   };
 
-  explicit Timer(NSTimeInterval minimum_interval, Mode mode = Mode::kContinuous,
-                 dispatch_qos_class_t qos_class = QOS_CLASS_UTILITY)
-      : interval_seconds_(minimum_interval), minimum_interval_(minimum_interval), mode_(mode) {
+  Timer(uint32_t minimum_interval, uint32_t maximum_interval, std::string backing_config_var,
+        Mode mode = Mode::kContinuous, dispatch_qos_class_t qos_class = QOS_CLASS_UTILITY)
+      : interval_seconds_(minimum_interval),
+        minimum_interval_(minimum_interval),
+        maximum_interval_(maximum_interval),
+        backing_config_var_(std::move(backing_config_var)),
+        mode_(mode) {
     static_assert(
         requires(T t) { t.OnTimer(); }, "Classes using Timer<T> must implement 'void OnTimer()'");
 
@@ -55,8 +62,13 @@ class Timer {
   }
 
   /// Set new timer parameters. If the timer is running, it will fire immediately.
-  void SetTimerInterval(NSTimeInterval interval_seconds) {
-    interval_seconds_ = std::max(interval_seconds, minimum_interval_);
+  void SetTimerInterval(uint32_t interval_seconds) {
+    interval_seconds_ = std::clamp(interval_seconds, minimum_interval_, maximum_interval_);
+    if (interval_seconds_ != interval_seconds) {
+      LOGW(@"Invalid config value for \"%s\": %u. Must be between %u and %u. Clamped to: %u.",
+           backing_config_var_.c_str(), interval_seconds, minimum_interval_, maximum_interval_,
+           interval_seconds_);
+    }
     UpdateTimingParameters(false);
   }
 
@@ -80,8 +92,11 @@ class Timer {
 
     timer_source_ = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, timer_queue_);
 
+    std::weak_ptr<Timer<T>> weak_self = this->shared_from_this();
     dispatch_source_set_event_handler(timer_source_, ^{
-      TimerCallback();
+      if (auto strong_self = weak_self.lock()) {
+        strong_self->TimerCallback();
+      }
     });
 
     UpdateTimingParameters(is_restart);
@@ -130,8 +145,10 @@ class Timer {
 
   dispatch_queue_t timer_queue_{nullptr};
   dispatch_source_t timer_source_{nullptr};
-  NSTimeInterval interval_seconds_;
-  NSTimeInterval minimum_interval_;
+  uint32_t interval_seconds_;
+  uint32_t minimum_interval_;
+  uint32_t maximum_interval_;
+  std::string backing_config_var_;
   Mode mode_;
 };
 

--- a/Source/common/faa/BUILD
+++ b/Source/common/faa/BUILD
@@ -39,6 +39,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:String",
         "//Source/common:Unit",
+        "//Source/common:Timer",
         "@abseil-cpp//absl/container:flat_hash_set",
     ],
 )

--- a/Source/common/faa/BUILD
+++ b/Source/common/faa/BUILD
@@ -38,8 +38,8 @@ objc_library(
         "//Source/common:SNTError",
         "//Source/common:SNTLogging",
         "//Source/common:String",
-        "//Source/common:Unit",
         "//Source/common:Timer",
+        "//Source/common:Unit",
         "@abseil-cpp//absl/container:flat_hash_set",
     ],
 )

--- a/Source/common/faa/WatchItems.h
+++ b/Source/common/faa/WatchItems.h
@@ -148,8 +148,7 @@ class ProcessWatchItems {
   SetSharedProcessWatchItemPolicy policies_;
 };
 
-class WatchItems : public Timer<WatchItems>
-{
+class WatchItems : public Timer<WatchItems> {
  public:
   // Type aliases
   using DataWatchItemsUpdatedBlock = std::function<void(

--- a/Source/common/faa/WatchItems.h
+++ b/Source/common/faa/WatchItems.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "Source/common/PrefixTree.h"
+#include "Source/common/Timer.h"
 #include "Source/common/faa/WatchItemPolicy.h"
 #include "absl/container/flat_hash_set.h"
 
@@ -147,7 +148,8 @@ class ProcessWatchItems {
   SetSharedProcessWatchItemPolicy policies_;
 };
 
-class WatchItems : public std::enable_shared_from_this<WatchItems> {
+class WatchItems : public Timer<WatchItems>
+{
  public:
   // Type aliases
   using DataWatchItemsUpdatedBlock = std::function<void(
@@ -156,20 +158,20 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   // Factory methods
   static std::shared_ptr<WatchItems> CreateFromPath(NSString *config_path,
-                                                    uint64_t reapply_config_frequency_secs);
+                                                    uint32_t reapply_config_frequency_secs);
   static std::shared_ptr<WatchItems> CreateFromEmbeddedConfig(
-      NSDictionary *config, uint64_t reapply_config_frequency_secs);
+      NSDictionary *config, uint32_t reapply_config_frequency_secs);
   static std::shared_ptr<WatchItems> CreateFromRules(NSDictionary *config,
-                                                     uint64_t reapply_config_frequency_secs);
+                                                     uint32_t reapply_config_frequency_secs);
 
-  WatchItems(NSString *config_path, dispatch_queue_t q, dispatch_source_t timer_source,
+  WatchItems(NSString *config_path, dispatch_queue_t q,
              void (^periodic_task_complete_f)(void) = nullptr);
-  WatchItems(NSDictionary *config, dispatch_queue_t q, dispatch_source_t timer_source,
+  WatchItems(NSDictionary *config, dispatch_queue_t q,
              void (^periodic_task_complete_f)(void) = nullptr);
 
-  ~WatchItems();
+  ~WatchItems() = default;
 
-  void BeginPeriodicTask();
+  void OnTimer();
 
   void RegisterDataWatchItemsUpdatedCallback(DataWatchItemsUpdatedBlock callback);
   void RegisterProcWatchItemsUpdatedCallback(ProcWatchItemsUpdatedBlock callback);
@@ -192,7 +194,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
  private:
   static std::shared_ptr<WatchItems> CreateInternal(NSString *config_path, NSDictionary *config,
-                                                    uint64_t reapply_config_frequency_secs);
+                                                    uint32_t reapply_config_frequency_secs);
 
   NSDictionary *ReadConfig();
   NSDictionary *ReadConfigLocked() ABSL_SHARED_LOCKS_REQUIRED(lock_);
@@ -203,7 +205,6 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   NSString *config_path_;
   NSDictionary *embedded_config_;
   dispatch_queue_t q_;
-  dispatch_source_t timer_source_;
   void (^periodic_task_complete_f_)(void);
 
   absl::Mutex lock_;

--- a/Source/common/faa/WatchItems.mm
+++ b/Source/common/faa/WatchItems.mm
@@ -77,10 +77,12 @@ static constexpr NSUInteger kMaxTeamIDLength = 10;
 // Semi-arbitrary upper bound.
 static constexpr NSUInteger kMaxSigningIDLength = 512;
 
-// Semi-arbitrary minimum allowed reapplication frequency.
+// Semi-arbitrary min/max allowed reapplication frequency.
 // Goal is to prevent a configuration setting that would cause too much
-// churn rebuilding glob paths based on the state of the filesystem.
+// churn rebuilding glob paths based on the state of the filesystem, while
+// also ensuring configuration isn't overly out of sync with the filesystem.
 static constexpr uint64_t kMinReapplyConfigFrequencySecs = 15;
+static constexpr uint64_t kMaxReapplyConfigFrequencySecs = 3600;
 
 // Semi-arbitrary max custom message length. The goal is to protect against
 // potential unbounded lengths, but no real reason this cannot be higher.
@@ -736,17 +738,17 @@ void ProcessWatchItems::IterateProcessPolicies(CheckPolicyBlock checkPolicyBlock
 #pragma mark WatchItems
 
 std::shared_ptr<WatchItems> WatchItems::CreateFromPath(NSString *config_path,
-                                                       uint64_t reapply_config_frequency_secs) {
+                                                       uint32_t reapply_config_frequency_secs) {
   return CreateInternal(config_path, nil, reapply_config_frequency_secs);
 }
 
 std::shared_ptr<WatchItems> WatchItems::CreateFromEmbeddedConfig(
-    NSDictionary *config, uint64_t reapply_config_frequency_secs) {
+    NSDictionary *config, uint32_t reapply_config_frequency_secs) {
   return CreateInternal(nil, config, reapply_config_frequency_secs);
 }
 
 std::shared_ptr<WatchItems> WatchItems::CreateFromRules(NSDictionary *rules,
-                                                        uint64_t reapply_config_frequency_secs) {
+                                                        uint32_t reapply_config_frequency_secs) {
   // The provided rules dictionary must be wrapped within another dictionary as a value
   // for the `kWatchItemConfigKeyWatchItems` key.
   NSDictionary *config = @{kWatchItemConfigKeyWatchItems : rules};
@@ -754,13 +756,7 @@ std::shared_ptr<WatchItems> WatchItems::CreateFromRules(NSDictionary *rules,
 }
 
 std::shared_ptr<WatchItems> WatchItems::CreateInternal(NSString *config_path, NSDictionary *config,
-                                                       uint64_t reapply_config_frequency_secs) {
-  if (reapply_config_frequency_secs < kMinReapplyConfigFrequencySecs) {
-    LOGW(@"Invalid watch item update interval provided: %llu. Min allowed: %llu",
-         reapply_config_frequency_secs, kMinReapplyConfigFrequencySecs);
-    return nullptr;
-  }
-
+                                                       uint32_t reapply_config_frequency_secs) {
   if (config_path && config) {
     LOGW(@"Invalid arguments creating WatchItems - both config and config_path cannot be set.");
     return nullptr;
@@ -768,42 +764,37 @@ std::shared_ptr<WatchItems> WatchItems::CreateInternal(NSString *config_path, NS
 
   dispatch_queue_t q = dispatch_queue_create("com.northpolesec.santa.daemon.watch_items.q",
                                              DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
-  dispatch_source_t timer_source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
-  dispatch_source_set_timer(timer_source, dispatch_time(DISPATCH_TIME_NOW, 0),
-                            NSEC_PER_SEC * reapply_config_frequency_secs, 0);
 
-  if (config_path) {
-    return std::make_shared<WatchItems>(config_path, q, timer_source);
-  } else {
-    return std::make_shared<WatchItems>(config, q, timer_source);
-  }
+  auto watch_items = ^{
+    if (config_path) {
+      return std::make_shared<WatchItems>(config_path, q);
+    } else {
+      return std::make_shared<WatchItems>(config, q);
+    }
+  }();
+
+  watch_items->SetTimerInterval(reapply_config_frequency_secs);
+
+  return watch_items;
 }
 
-WatchItems::WatchItems(NSString *config_path, dispatch_queue_t q, dispatch_source_t timer_source,
+WatchItems::WatchItems(NSString *config_path, dispatch_queue_t q,
                        void (^periodic_task_complete_f)(void))
-    : config_path_(config_path),
+    : Timer<WatchItems>(kMinReapplyConfigFrequencySecs, kMaxReapplyConfigFrequencySecs,
+                        "FileAccessPolicyUpdateIntervalSec"),
+      config_path_(config_path),
       embedded_config_(nil),
       q_(q),
-      timer_source_(timer_source),
       periodic_task_complete_f_(periodic_task_complete_f) {}
 
-WatchItems::WatchItems(NSDictionary *config, dispatch_queue_t q, dispatch_source_t timer_source,
+WatchItems::WatchItems(NSDictionary *config, dispatch_queue_t q,
                        void (^periodic_task_complete_f)(void))
-    : config_path_(nil),
+    : Timer<WatchItems>(kMinReapplyConfigFrequencySecs, kMaxReapplyConfigFrequencySecs,
+                        "FileAccessPolicyUpdateIntervalSec"),
+      config_path_(nil),
       embedded_config_(config),
       q_(q),
-      timer_source_(timer_source),
       periodic_task_complete_f_(periodic_task_complete_f) {}
-
-WatchItems::~WatchItems() {
-  if (!periodic_task_started_ && timer_source_ != NULL) {
-    // The timer_source_ must be resumed to ensure it has a proper retain count before being
-    // destroyed. Additionally, it should first be cancelled to ensure the timer isn't ever
-    // fired (see man page for `dispatch_source_cancel(3)`).
-    dispatch_source_cancel(timer_source_);
-    dispatch_resume(timer_source_);
-  }
-}
 
 bool WatchItems::IsValidRule(NSString *name, NSDictionary *rule, NSError **error) {
   return IsWatchItemNameValid(name, error) &&
@@ -925,27 +916,12 @@ NSDictionary *WatchItems::ReadConfigLocked() {
   }
 }
 
-void WatchItems::BeginPeriodicTask() {
-  if (periodic_task_started_) {
-    return;
+void WatchItems::OnTimer() {
+  ReloadConfig(embedded_config_ ?: ReadConfig());
+
+  if (periodic_task_complete_f_) {
+    periodic_task_complete_f_();
   }
-
-  std::weak_ptr<WatchItems> weak_watcher = weak_from_this();
-  dispatch_source_set_event_handler(timer_source_, ^{
-    std::shared_ptr<WatchItems> shared_watcher = weak_watcher.lock();
-    if (!shared_watcher) {
-      return;
-    }
-
-    shared_watcher->ReloadConfig(embedded_config_ ?: shared_watcher->ReadConfig());
-
-    if (shared_watcher->periodic_task_complete_f_) {
-      shared_watcher->periodic_task_complete_f_();
-    }
-  });
-
-  dispatch_resume(timer_source_);
-  periodic_task_started_ = true;
 }
 
 void WatchItems::FindPoliciesForTargets(IterateTargetsBlock iterateTargetsBlock) {

--- a/Source/common/faa/WatchItems.mm
+++ b/Source/common/faa/WatchItems.mm
@@ -81,8 +81,9 @@ static constexpr NSUInteger kMaxSigningIDLength = 512;
 // Goal is to prevent a configuration setting that would cause too much
 // churn rebuilding glob paths based on the state of the filesystem, while
 // also ensuring configuration isn't overly out of sync with the filesystem.
-static constexpr uint64_t kMinReapplyConfigFrequencySecs = 15;
-static constexpr uint64_t kMaxReapplyConfigFrequencySecs = 3600;
+static constexpr uint32_t kMinReapplyConfigFrequencySecs = 15;
+static constexpr uint32_t kMaxReapplyConfigFrequencySecs = 3600;
+static constexpr uint32_t kInitialTimerDelay = 0;
 
 // Semi-arbitrary max custom message length. The goal is to protect against
 // potential unbounded lengths, but no real reason this cannot be higher.
@@ -781,7 +782,7 @@ std::shared_ptr<WatchItems> WatchItems::CreateInternal(NSString *config_path, NS
 WatchItems::WatchItems(NSString *config_path, dispatch_queue_t q,
                        void (^periodic_task_complete_f)(void))
     : Timer<WatchItems>(kMinReapplyConfigFrequencySecs, kMaxReapplyConfigFrequencySecs,
-                        "FileAccessPolicyUpdateIntervalSec"),
+                        kInitialTimerDelay, "FileAccessPolicyUpdateIntervalSec"),
       config_path_(config_path),
       embedded_config_(nil),
       q_(q),
@@ -790,7 +791,7 @@ WatchItems::WatchItems(NSString *config_path, dispatch_queue_t q,
 WatchItems::WatchItems(NSDictionary *config, dispatch_queue_t q,
                        void (^periodic_task_complete_f)(void))
     : Timer<WatchItems>(kMinReapplyConfigFrequencySecs, kMaxReapplyConfigFrequencySecs,
-                        "FileAccessPolicyUpdateIntervalSec"),
+                        kInitialTimerDelay, "FileAccessPolicyUpdateIntervalSec"),
       config_path_(nil),
       embedded_config_(config),
       q_(q),

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -52,10 +52,12 @@ static constexpr uint64_t kFlushBufferTimeoutMS = 10000;
 static constexpr size_t kBufferBatchSizeBytes = (1024 * 128);
 // Reserve an extra 4kb of buffer space to account for event overflow
 static constexpr size_t kMaxExpectedWriteSizeBytes = 4096;
-// Minimum/maxium allowable telemetry export frequency.
+// Minimum/maximum allowable telemetry export frequency.
 // Semi-arbitrary. Goal is to protect against too much strain on the export path.
 static constexpr uint32_t kMinTelemetryExportIntervalSecs = 60;
 static constexpr uint32_t kMaxTelemetryExportIntervalSecs = 3600;
+// Set a small initial delay to let Santa come up and stablize a bit.
+static constexpr uint32_t kInitialTimerDelay = 10;
 
 // Translate configured log type to appropriate Serializer/Writer pairs
 std::unique_ptr<Logger> Logger::Create(
@@ -136,7 +138,8 @@ Logger::Logger(SNTSyncdQueue *syncd_queue, GetExportConfigBlock get_export_confi
                uint32_t telemetry_export_batch_threshold_size_mb,
                uint32_t telemetry_export_max_files_per_batch,
                std::shared_ptr<santa::Serializer> serializer, std::shared_ptr<santa::Writer> writer)
-    : Timer<Logger>(kMinTelemetryExportIntervalSecs, kMaxTelemetryExportIntervalSecs, "TelemetryExportIntervalSec", Logger::Mode::kSingleShot),
+    : Timer<Logger>(kMinTelemetryExportIntervalSecs, kMaxTelemetryExportIntervalSecs,
+                    kInitialTimerDelay, "TelemetryExportIntervalSec", Logger::Mode::kSingleShot),
       syncd_queue_(syncd_queue),
       get_export_config_block_(get_export_config_block),
       telemetry_mask_(telemetry_mask),

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -52,9 +52,10 @@ static constexpr uint64_t kFlushBufferTimeoutMS = 10000;
 static constexpr size_t kBufferBatchSizeBytes = (1024 * 128);
 // Reserve an extra 4kb of buffer space to account for event overflow
 static constexpr size_t kMaxExpectedWriteSizeBytes = 4096;
-// Minimum allowable telemetry export frequency.
+// Minimum/maxium allowable telemetry export frequency.
 // Semi-arbitrary. Goal is to protect against too much strain on the export path.
 static constexpr uint32_t kMinTelemetryExportIntervalSecs = 60;
+static constexpr uint32_t kMaxTelemetryExportIntervalSecs = 3600;
 
 // Translate configured log type to appropriate Serializer/Writer pairs
 std::unique_ptr<Logger> Logger::Create(
@@ -135,7 +136,7 @@ Logger::Logger(SNTSyncdQueue *syncd_queue, GetExportConfigBlock get_export_confi
                uint32_t telemetry_export_batch_threshold_size_mb,
                uint32_t telemetry_export_max_files_per_batch,
                std::shared_ptr<santa::Serializer> serializer, std::shared_ptr<santa::Writer> writer)
-    : Timer<Logger>(kMinTelemetryExportIntervalSecs, Logger::Mode::kSingleShot),
+    : Timer<Logger>(kMinTelemetryExportIntervalSecs, kMaxTelemetryExportIntervalSecs, "TelemetryExportIntervalSec", Logger::Mode::kSingleShot),
       syncd_queue_(syncd_queue),
       get_export_config_block_(get_export_config_block),
       telemetry_mask_(telemetry_mask),

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -629,12 +629,14 @@ class MockWriter : public santa::Writer {
       .WillOnce(Return(std::nullopt));
 
   // Ensure the batches happen in the expected order
-  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f4.UTF8String, true),
-                                                              Pair(f5.UTF8String, true))))
-      .After(
-          EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(Pair(f3.UTF8String, true)))))
+  EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre()))
       .After(EXPECT_CALL(*mockWriter, FilesExported(UnorderedElementsAre(
-                                          Pair(f1.UTF8String, true), Pair(f2.UTF8String, true)))));
+                                          Pair(f4.UTF8String, true), Pair(f5.UTF8String, true))))
+                 .After(EXPECT_CALL(*mockWriter,
+                                    FilesExported(UnorderedElementsAre(Pair(f3.UTF8String, true)))))
+                 .After(EXPECT_CALL(
+                     *mockWriter, FilesExported(UnorderedElementsAre(Pair(f1.UTF8String, true),
+                                                                     Pair(f2.UTF8String, true))))));
 
   l.ExportTelemetrySerialized();
 

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -686,6 +686,22 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                    }
                                  }],
     [[SNTKVOManager alloc] initWithObject:configurator
+                                 selector:@selector(fileAccessPolicyUpdateIntervalSec)
+                                     type:[NSNumber class]
+                                 callback:^(NSNumber *oldValue, NSNumber *newValue) {
+                                   uint32_t oldInterval = [oldValue unsignedIntValue];
+                                   uint32_t newInterval = [newValue unsignedIntValue];
+
+                                   if (oldInterval == newInterval) {
+                                     return;
+                                   }
+
+                                   LOGI(@"FileAccessPolicyUpdateIntervalSec changed: %u -> %u",
+                                        oldInterval, newInterval);
+
+                                   watch_items->SetTimerInterval(newInterval);
+                                 }],
+    [[SNTKVOManager alloc] initWithObject:configurator
                                  selector:@selector(fileAccessGlobalLogsPerSec)
                                      type:[NSNumber class]
                                  callback:^(NSNumber *oldValue, NSNumber *newValue) {
@@ -746,7 +762,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 #endif  // DEBUG
 
   // Start monitoring any watched items
-  watch_items->BeginPeriodicTask();
+  watch_items->StartTimer();
 
   [monitor_client enable];
   [device_client enable];


### PR DESCRIPTION
This PR makes several improvements to the Timer class:
* Now supports defining a max interval in addition to min that is enforced on config changes
* Inherits from `enable_shared_from_this` - this fixes a potential, but never seen issue related to object lifetimes that could occur on shutdown
* An initial startup delay is now configurable by classes that inherit the Timer

The `WatchItems` class now inherits from `Timer` instead of implementing its own. Additionally, `FileAccessPolicyUpdateIntervalSec` can now be dynamically updated.

Finally, a mock issue in the `LoggerTest` was fixed that was emitting warnings.