### PR TITLE
Stop copying data unnecessarily when iterating DB results

### DIFF
--- a/Source/santad/DataLayer/SNTEventTable.mm
+++ b/Source/santad/DataLayer/SNTEventTable.mm
@@ -167,7 +167,7 @@ static const uint32_t kEventTableCurrentVersion = 5;
 }
 
 - (SNTStoredEvent *)eventFromResultSet:(FMResultSet *)rs {
-  NSData *eventData = [rs dataForColumn:@"eventdata"];
+  NSData *eventData = [rs dataNoCopyForColumn:@"eventdata"];
   if (!eventData) return nil;
 
   NSError *err;

--- a/Source/santad/DataLayer/SNTEventTableTest.mm
+++ b/Source/santad/DataLayer/SNTEventTableTest.mm
@@ -264,15 +264,16 @@ NSString *GenerateRandomHexStringWithSHA256Length() {
   id mockResultSet = OCMPartialMock(rs);
 
   NSData *oldStoredEventData = [self dataFromFixture:@"old_sntstoredevent_archive.plist"];
-  OCMExpect([mockResultSet dataForColumn:@"eventdata"]).andReturn(oldStoredEventData);
+  OCMExpect([mockResultSet dataNoCopyForColumn:@"eventdata"]).andReturn(oldStoredEventData);
 
   NSData *newStoredExecEventData =
       [self dataFromFixture:@"new_sntstoredexecutionevent_archive.plist"];
-  OCMExpect([mockResultSet dataForColumn:@"eventdata"]).andReturn(newStoredExecEventData);
+  OCMExpect([mockResultSet dataNoCopyForColumn:@"eventdata"]).andReturn(newStoredExecEventData);
 
   NSData *newStoredFileAccessEventData =
       [self dataFromFixture:@"sntstoredfileaccessevent_archive.plist"];
-  OCMExpect([mockResultSet dataForColumn:@"eventdata"]).andReturn(newStoredFileAccessEventData);
+  OCMExpect([mockResultSet dataNoCopyForColumn:@"eventdata"])
+      .andReturn(newStoredFileAccessEventData);
 
   XCTAssertNil([self.sut eventFromResultSet:mockResultSet]);
   XCTAssertNotNil([self.sut eventFromResultSet:mockResultSet]);

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -381,6 +381,10 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
   NSString *name = [rs stringForColumn:@"name"];
   NSData *details = [rs dataNoCopyForColumn:@"rule_data"];
 
+  if (!details) {
+    return nil;
+  }
+
   NSDictionary *ruleDict = [NSKeyedUnarchiver
       unarchivedObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class],
                                                       [NSString class], [NSNumber class],


### PR DESCRIPTION
Use `dataNoCopyForColumn` instead of `dataForColumn` when getting pending event table events. This data is immediately fed into `NSKeyedUnarchiver` and doesn't need to be copied.