### PR TITLE
Make fileinfo output helpful when rule was ignored due to dev signed code

### DIFF
--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -154,6 +154,7 @@ santa_unit_test(
         "//Source/common:MOLCodesignChecker",
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTCachedDecision",
+        "//Source/common:SNTCommonEnums",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
         "//Source/common:SNTRule",


### PR DESCRIPTION
For dev signed code, SigningID and TeamID rules are intentionally ignored. This PR changes the `santactl fileinfo` output to indicate if a rule in the database would have matched if the code was prod signed.

For example, the [Hidden Bar](https://github.com/dwarvesf/hidden) app is on the macOS App Store, but also publishes releases on GitHub that are signed with the development cert. If a TeamID/SigningID rule were added for this app, e.g.:

```
$ sudo santactl rule --allow --teamid --identifier W777S7V8TN
```

The updated output for `santactl fileinfo` is:
```
$ santactl fileinfo --key Rule ~/Downloads/Hidden\ Bar.app
None (TeamID rule ignored because code signed with a development certificate.)
```