### PR TITLE
BETA FAA rule download

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "zstd", version = "1.5.7")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "69a9af15863a0963f5d2669fa35ddf3d6e096c05",
+    commit = "31b32378292adc13b08e3036d8a24d6f63223bbd",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -155,12 +155,9 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
   // 3. Rules obtained by reading the plist at the configured path
   std::shared_ptr<::WatchItems> watch_items = ^{
     uint32_t interval = [configurator fileAccessPolicyUpdateIntervalSec];
-#ifdef DEBUG
     if ([rule_table fileAccessRuleCount] > 0) {
       return WatchItems::CreateFromRules([rule_table retrieveAllFileAccessRules], interval);
-    }
-#endif
-    if ([configurator fileAccessPolicy]) {
+    } else if ([configurator fileAccessPolicy]) {
       return WatchItems::CreateFromEmbeddedConfig([configurator fileAccessPolicy], interval);
     } else {
       return WatchItems::CreateFromPath([configurator fileAccessPolicyPlist], interval);
@@ -172,7 +169,6 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
     exit(EXIT_FAILURE);
   }
 
-#ifdef DEBUG
   WEAKIFY(rule_table);
   rule_table.fileAccessRulesChangedCallback = ^(int64_t faaRuleCount) {
     if (faaRuleCount > 0) {
@@ -184,7 +180,6 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
       watch_items->SetConfigPath([configurator fileAccessPolicyPlist]);
     }
   };
-#endif
 
   std::shared_ptr<::Metrics> metrics =
       Metrics::Create(metric_set, [configurator metricExportInterval]);

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -169,8 +169,8 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
         [newRules addObject:r];
       }
 
-#ifdef DEBUG
-      for (const ::pbv1::FileAccessRule &faaRule : response.file_access_rules()) {
+      for (const ::pbv1::FileAccessRule &faaRule :
+           response.beta_do_not_use_yet_file_access_rules()) {
         SNTFileAccessRule *rule = [self fileAccessRuleFromProtoFileAccessRule:faaRule];
         if (!rule) {
           SLOGD(@"Ignoring bad file access rule: %s", faaRule.Utf8DebugString().c_str());
@@ -178,12 +178,12 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
         }
         [newFileAccessRules addObject:rule];
       }
-#endif
 
       cursor = response.cursor();
       SLOGI(@"Received %lu rules", (unsigned long)response.rules_size());
       self.syncState.rulesReceived += response.rules_size();
-      self.syncState.fileAccessRulesReceived += response.file_access_rules_size();
+      self.syncState.fileAccessRulesReceived +=
+          response.beta_do_not_use_yet_file_access_rules_size();
     }
   } while (!cursor.empty());
 


### PR DESCRIPTION
This PR adopts the beta FAA rule download fields and removes the `#ifdef DEBUG` checks that had previously gated FAA rule download.

FAA rules in the sync protocol is still considered beta and the protocol is likely to change.