### PR TITLE
Add Cookbook rule for stopping osascript asking for passwords.

### DIFF
--- a/docs/docs/cookbook/cel.md
+++ b/docs/docs/cookbook/cel.md
@@ -46,7 +46,7 @@ Note this will not stop using the system calls directly or otherwise programmati
 
 A lot of malware on macOS will attempt to get users to enter their passwords
 into a dialog box via osascript. This is a basic rule to stop directly asking
-for a password dialog. 
+for a password dialog.
 
 Make a SigningID rule for `platform:com.apple.osascript` with the following CEL
 Program
@@ -58,7 +58,7 @@ Program
 Note: This will not stop obfuscated osascript that's evaluated at runtime or
 any other malicious behavior triggered through osascript. For better security
 block osascript all together if you can.  Be aware software like the Google
-Cloud SDK installer and AI tools like claude code use osascript. 
+Cloud SDK installer and AI tools like claude code use osascript.
 
 Also if you're using osascript to do this legitimately this will break your
 usage.


### PR DESCRIPTION
This adds a cookbook CEL rule for blocking osascript when it attempts to pop open a  dialog prompting the user for passwords.