### PR TITLE
Fix FAA rule counts

### DIFF
--- a/Source/common/faa/WatchItems.h
+++ b/Source/common/faa/WatchItems.h
@@ -203,7 +203,8 @@ class WatchItems : public Timer<WatchItems>, public PassKey<WatchItems> {
   NSDictionary *ReadConfigLocked() ABSL_SHARED_LOCKS_REQUIRED(lock_);
   void ReloadConfig(NSDictionary *new_config);
   void UpdateCurrentState(DataWatchItems new_data_watch_items,
-                          ProcessWatchItems new_proc_watch_items, NSDictionary *new_config);
+                          ProcessWatchItems new_proc_watch_items, NSDictionary *new_config,
+                          uint64_t rules_loaded);
 
   DataSource data_source_;
   NSString *config_path_;
@@ -223,6 +224,7 @@ class WatchItems : public Timer<WatchItems>, public PassKey<WatchItems> {
   bool periodic_task_started_ = false;
   NSString *policy_event_detail_url_ ABSL_GUARDED_BY(lock_);
   NSString *policy_event_detail_text_ ABSL_GUARDED_BY(lock_);
+  uint64_t rules_loaded_ ABSL_GUARDED_BY(lock_);
 };
 
 struct WatchItemsState {


### PR DESCRIPTION
After a recent change, the rule counts reflected the full count of watched paths, including non-yet-existing and those expanded from globs. This doesn't match user expectations which is the number of rules loaded from the current policy. This PR fixes the accounting so that `santactl status` only shows the number of valid rules loaded from the policy.