### PR TITLE
Adopt mode transition sync protocol changes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20251002.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "6851a019998359e27b426d48685ff733a2539b28",
+    commit = "e577bc8cb8fa335362460e7b04a492e97f8e3820",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -422,6 +422,7 @@ objc_library(
         ":SNTCommonEnums",
         ":SNTExportConfiguration",
         ":SNTLogging",
+        ":SNTModeTransition",
         ":SNTRule",
         ":SNTStrengthify",
         ":SNTSystemInfo",
@@ -436,6 +437,7 @@ objc_library(
         ":CoderMacros",
         ":SNTCommonEnums",
         ":SNTExportConfiguration",
+        ":SNTModeTransition",
     ],
 )
 
@@ -446,6 +448,7 @@ santa_unit_test(
         ":SNTCommonEnums",
         ":SNTConfigBundle",
         ":SNTExportConfiguration",
+        ":SNTModeTransition",
     ],
 )
 

--- a/Source/common/SNTConfigBundle.h
+++ b/Source/common/SNTConfigBundle.h
@@ -17,6 +17,7 @@
 #import "Source/common/SNTCommonEnums.h"
 
 @class SNTExportConfiguration;
+@class SNTModeTransition;
 
 @interface SNTConfigBundle : NSObject <NSSecureCoding>
 
@@ -35,5 +36,6 @@
 - (void)exportConfiguration:(void (^)(SNTExportConfiguration *))block;
 - (void)fullSyncLastSuccess:(void (^)(NSDate *))block;
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))block;
+- (void)modeTransition:(void (^)(SNTModeTransition *))block;
 
 @end

--- a/Source/common/SNTConfigBundle.mm
+++ b/Source/common/SNTConfigBundle.mm
@@ -16,6 +16,7 @@
 
 #import "Source/common/CoderMacros.h"
 #import "Source/common/SNTExportConfiguration.h"
+#import "Source/common/SNTModeTransition.h"
 
 @interface SNTConfigBundle ()
 @property NSNumber *clientMode;
@@ -32,6 +33,7 @@
 @property SNTExportConfiguration *exportConfiguration;
 @property NSDate *fullSyncLastSuccess;
 @property NSDate *ruleSyncLastSuccess;
+@property SNTModeTransition *modeTransition;
 @end
 
 @implementation SNTConfigBundle
@@ -55,6 +57,7 @@
   ENCODE(coder, exportConfiguration);
   ENCODE(coder, fullSyncLastSuccess);
   ENCODE(coder, ruleSyncLastSuccess);
+  ENCODE(coder, modeTransition);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
@@ -74,6 +77,7 @@
     DECODE(decoder, exportConfiguration, SNTExportConfiguration);
     DECODE(decoder, fullSyncLastSuccess, NSDate);
     DECODE(decoder, ruleSyncLastSuccess, NSDate);
+    DECODE(decoder, modeTransition, SNTModeTransition);
   }
   return self;
 }
@@ -158,6 +162,12 @@
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))block {
   if (self.ruleSyncLastSuccess) {
     block(self.ruleSyncLastSuccess);
+  }
+}
+
+- (void)modeTransition:(void (^)(SNTModeTransition *))block {
+  if (self.modeTransition) {
+    block(self.modeTransition);
   }
 }
 

--- a/Source/common/SNTConfigBundleTest.mm
+++ b/Source/common/SNTConfigBundleTest.mm
@@ -19,6 +19,7 @@
 
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTExportConfiguration.h"
+#import "Source/common/SNTModeTransition.h"
 
 @interface SNTConfigBundle (Testing)
 @property NSNumber *clientMode;
@@ -35,6 +36,7 @@
 @property SNTExportConfiguration *exportConfiguration;
 @property NSDate *fullSyncLastSuccess;
 @property NSDate *ruleSyncLastSuccess;
+@property SNTModeTransition *modeTransition;
 @end
 
 @interface SNTConfigBundleTest : XCTestCase
@@ -44,7 +46,7 @@
 
 - (void)testGettersWithValues {
   __block XCTestExpectation *exp = [self expectationWithDescription:@"Result Blocks"];
-  exp.expectedFulfillmentCount = 14;
+  exp.expectedFulfillmentCount = 15;
   NSDate *nowDate = [NSDate now];
 
   SNTConfigBundle *bundle = [[SNTConfigBundle alloc] init];
@@ -64,6 +66,7 @@
   bundle.exportConfiguration = [[SNTExportConfiguration alloc]
       initWithURL:[NSURL URLWithString:@"https://example.com/upload"]
        formValues:@{@"key1" : @"value1", @"key2" : @"value2"}];
+  bundle.modeTransition = [[SNTModeTransition alloc] initOnDemandMinutes:4 defaultDuration:2];
 
   [bundle clientMode:^(SNTClientMode val) {
     XCTAssertEqual(val, SNTClientModeLockdown);
@@ -134,6 +137,13 @@
 
   [bundle ruleSyncLastSuccess:^(NSDate *val) {
     XCTAssertEqualObjects(val, nowDate);
+    [exp fulfill];
+  }];
+
+  [bundle modeTransition:^(SNTModeTransition *val) {
+    XCTAssertEqual(val.type, SNTModeTransitionTypeOnDemand);
+    XCTAssertEqualObjects(val.maxMinutes, @(4));
+    XCTAssertEqualObjects(val.defaultDurationMinutes, @(2));
     [exp fulfill];
   }];
 
@@ -216,6 +226,13 @@
 
   [bundle ruleSyncLastSuccess:^(NSDate *val) {
     XCTAssertEqualObjects(val, [NSDate now]);
+    [exp fulfill];
+  }];
+
+  [bundle modeTransition:^(SNTModeTransition *val) {
+    XCTAssertEqual(val.type, SNTModeTransitionTypeOnDemand);
+    XCTAssertEqualObjects(val.maxMinutes, @(2));
+    XCTAssertEqualObjects(val.defaultDurationMinutes, @(4));
     [exp fulfill];
   }];
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -18,6 +18,7 @@
 #import "Source/common/SNTCommonEnums.h"
 
 @class SNTExportConfiguration;
+@class SNTModeTransition;
 @class SNTRule;
 
 ///
@@ -606,6 +607,16 @@
 ///  Set the export configuration as received from a sync server.
 ///
 - (void)setSyncServerExportConfig:(nonnull SNTExportConfiguration *)exportConfig;
+
+///
+///  Currently defined mode transition configuration. Its value is set by a sync server.
+///
+@property(nullable, readonly) SNTModeTransition *modeTransition;
+
+///
+///  Set the mode transition configuration as received from a sync server.
+///
+- (void)setSyncServerModeTransition:(nonnull SNTModeTransition *)modeTransition;
 
 #pragma mark - USB Settings
 

--- a/Source/common/SNTModeTransition.mm
+++ b/Source/common/SNTModeTransition.mm
@@ -12,7 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#include "Source/common/SNTModeTransition.h"
+#import "Source/common/SNTModeTransition.h"
 
 #import "Source/common/CoderMacros.h"
 #import "Source/common/SNTLogging.h"

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -815,6 +815,7 @@ objc_library(
         ":SNTSyncdQueue",
         "//Source/common:MOLCodesignChecker",
         "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTModeTransition",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -14,6 +14,7 @@
 /// limitations under the License.
 
 #import "Source/santad/SNTDaemonControlController.h"
+#import "Source/common/SNTModeTransition.h"
 #include "Source/common/faa/WatchItems.h"
 
 #import <Foundation/Foundation.h>
@@ -353,6 +354,10 @@ double watchdogRAMPeak = 0;
 
   [result ruleSyncLastSuccess:^(NSDate *val) {
     [configurator setFullSyncLastSuccess:val];
+  }];
+
+  [result modeTransition:^(SNTModeTransition *val) {
+    [configurator setSyncServerModeTransition:val];
   }];
 
   reply();

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -53,6 +53,7 @@ objc_library(
     deps = [
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTExportConfiguration",
+        "//Source/common:SNTModeTransition",
     ],
 )
 
@@ -71,6 +72,7 @@ objc_library(
         ":SNTSyncState",
         "//Source/common:SNTConfigBundle",
         "//Source/common:SNTExportConfiguration",
+        "//Source/common:SNTModeTransition",
     ],
 )
 
@@ -226,6 +228,7 @@ objc_library(
         "//Source/common:SNTError",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTModeTransition",
         "//Source/common:SNTRule",
         "//Source/common:SNTSIPStatus",
         "//Source/common:SNTStoredEvent",
@@ -237,6 +240,7 @@ objc_library(
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCSyncServiceInterface",
         "//Source/common:String",
+        "@northpolesec_protos//syncv2:v2_cc_proto",
         "@protobuf//src/google/protobuf/json",
     ],
 )
@@ -288,6 +292,7 @@ santa_unit_test(
         "//Source/common:SNTDropRootPrivs",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTModeTransition",
         "//Source/common:SNTRule",
         "//Source/common:SNTSIPStatus",
         "//Source/common:SNTStoredEvent",
@@ -300,6 +305,7 @@ santa_unit_test(
         "//Source/common:String",
         "@OCMock",
         "@northpolesec_protos//sync:v1_cc_proto",
+        "@northpolesec_protos//syncv2:v2_cc_proto",
         "@protobuf//src/google/protobuf/json",
     ],
 )

--- a/Source/santasyncservice/SNTSyncConfigBundle.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundle.mm
@@ -15,6 +15,7 @@
 #import <Foundation/Foundation.h>
 
 #import "Source/common/SNTExportConfiguration.h"
+#import "Source/common/SNTModeTransition.h"
 #import "Source/santasyncservice/SNTSyncConfigBundle.h"
 
 // Expose necessary setters for SNTConfigBundle properties related to Postflight
@@ -33,6 +34,7 @@
 @property SNTExportConfiguration *exportConfiguration;
 @property NSDate *fullSyncLastSuccess;
 @property NSDate *ruleSyncLastSuccess;
+@property SNTModeTransition *modeTransition;
 @end
 
 SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
@@ -50,6 +52,7 @@ SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
   bundle.disableUnknownEventUpload = syncState.disableUnknownEventUpload;
   bundle.overrideFileAccessAction = syncState.overrideFileAccessAction;
   bundle.exportConfiguration = syncState.exportConfig;
+  bundle.modeTransition = syncState.modeTransition;
 
   bundle.fullSyncLastSuccess = [NSDate now];
 

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -17,6 +17,7 @@
 
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTExportConfiguration.h"
+#import "Source/common/SNTModeTransition.h"
 
 @class SNTSyncManager;
 @class MOLXPCConnection;
@@ -80,6 +81,7 @@
 @property NSArray *remountUSBMode;
 @property NSString *overrideFileAccessAction;
 @property SNTExportConfiguration *exportConfig;
+@property SNTModeTransition *modeTransition;
 
 /// Clean sync flag, if True, all existing rules should be deleted before inserting any new rules.
 @property SNTSyncType syncType;


### PR DESCRIPTION
This PR handles parsing out the mode transition message and getting the config over to the daemon to save in the sync state.