### PR TITLE
Remove unnecessary legacy wrapper to get the IO main port

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -160,7 +160,6 @@ santa_unit_test(
     ],
     deps = [
         ":ScopedIOObjectRef",
-        "//Source/santad:EndpointSecuritySerializerUtilities",
     ],
 )
 

--- a/Source/common/ScopedIOObjectRefTest.mm
+++ b/Source/common/ScopedIOObjectRefTest.mm
@@ -18,9 +18,7 @@
 #import <XCTest/XCTest.h>
 
 #include "Source/common/ScopedIOObjectRef.h"
-#include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
-using santa::GetDefaultIOKitCommsPort;
 using santa::ScopedIOObjectRef;
 
 @interface ScopedIOObjectRefTest : XCTestCase
@@ -47,7 +45,7 @@ using santa::ScopedIOObjectRef;
     CFMutableDictionaryRef matchingDict = IOServiceMatching(kIOUSBDeviceClassName);
     XCTAssertNotEqual((CFMutableDictionaryRef)NULL, matchingDict);
 
-    io_service_t service = IOServiceGetMatchingService(GetDefaultIOKitCommsPort(), matchingDict);
+    io_service_t service = IOServiceGetMatchingService(kIOMainPortDefault, matchingDict);
 
     ScopedIOObjectRef<io_service_t> scopedServiceRef =
         ScopedIOObjectRef<io_service_t>::Assume(service);
@@ -61,7 +59,7 @@ using santa::ScopedIOObjectRef;
   CFMutableDictionaryRef matchingDict = IOServiceMatching(kIOUSBDeviceClassName);
   XCTAssertNotEqual((CFMutableDictionaryRef)NULL, matchingDict);
 
-  io_service_t service = IOServiceGetMatchingService(GetDefaultIOKitCommsPort(), matchingDict);
+  io_service_t service = IOServiceGetMatchingService(kIOMainPortDefault, matchingDict);
 
   // Baseline state, initial retain count is 1 after object creation
   XCTAssertEqual(1, IOObjectGetUserRetainCount(service));
@@ -81,7 +79,7 @@ using santa::ScopedIOObjectRef;
   CFMutableDictionaryRef matchingDict = IOServiceMatching(kIOUSBDeviceClassName);
   XCTAssertNotEqual((CFMutableDictionaryRef)NULL, matchingDict);
 
-  io_service_t service = IOServiceGetMatchingService(GetDefaultIOKitCommsPort(), matchingDict);
+  io_service_t service = IOServiceGetMatchingService(kIOMainPortDefault, matchingDict);
 
   // Baseline state, initial retain count is 1 after object creation
   XCTAssertEqual(1, IOObjectGetUserRetainCount(service));

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -603,9 +603,6 @@ objc_library(
     sdk_dylibs = [
         "bsm",
     ],
-    visibility = [
-        "//Source/common:__pkg__",
-    ],
     deps = [
         ":EndpointSecurityMessage",
         ":SNTDecisionCache",

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h
@@ -18,7 +18,6 @@
 
 #include <EndpointSecurity/EndpointSecurity.h>
 #import <Foundation/Foundation.h>
-#include <IOKit/IOKitLib.h>
 #include <bsm/libbsm.h>
 
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
@@ -40,10 +39,6 @@ es_file_t *GetAllowListTargetFile(const santa::Message &msg);
 NSString *NormalizePath(es_string_token_t path);
 /// Concat `path` onto `prefix` if `path` is relative
 NSString *ConcatPrefixIfRelativePath(es_string_token_t path, es_string_token_t prefix);
-
-static inline const mach_port_t GetDefaultIOKitCommsPort() {
-  return kIOMainPortDefault;
-}
 
 }  // namespace santa
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
@@ -15,6 +15,7 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
+#include <IOKit/IOKitLib.h>
 #include <sys/mount.h>
 #include <sys/param.h>
 
@@ -63,8 +64,7 @@ NSString *SerialForDevice(NSString *devPath) {
     return nil;
   }
   NSString *serial;
-  io_registry_entry_t device =
-      IORegistryEntryFromPath(GetDefaultIOKitCommsPort(), devPath.UTF8String);
+  io_registry_entry_t device = IORegistryEntryFromPath(kIOMainPortDefault, devPath.UTF8String);
   while (!serial && device) {
     CFMutableDictionaryRef device_properties = NULL;
     IORegistryEntryCreateCFProperties(device, &device_properties, kCFAllocatorDefault, kNilOptions);
@@ -110,8 +110,7 @@ static NSDictionary *PropertiesForDevice(NSString *devPath) {
     return nil;
   }
 
-  io_registry_entry_t device =
-      IORegistryEntryFromPath(GetDefaultIOKitCommsPort(), devPath.UTF8String);
+  io_registry_entry_t device = IORegistryEntryFromPath(kIOMainPortDefault, devPath.UTF8String);
   CFMutableDictionaryRef device_properties = NULL;
   IORegistryEntryCreateCFProperties(device, &device_properties, kCFAllocatorDefault, kNilOptions);
   NSDictionary *properties = CFBridgingRelease(device_properties);


### PR DESCRIPTION
This removes a legacy function that was previously used when Santa needed to build on macOS 12. This is no longer necessary and removing it allows us to stop including some non-common code inside common.