### PR TITLE
santactl command to temporarily enter Monitor Mode if eligible

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -618,6 +618,22 @@
 ///
 - (void)setSyncServerModeTransition:(nonnull SNTModeTransition *)modeTransition;
 
+///
+///  Return if Santa is temporarily in Monitor Mode and will revert back
+///  to Lockdown Mode after a configured time period.
+///
+@property(readonly) BOOL inTemporaryMonitorMode;
+
+///
+///  Set Santa to be in Monitor Mode temporarily
+///
+- (void)enterTemporaryMonitorMode;
+
+///
+///  Set Santa as having left temporary Monitor Mode
+///
+- (void)leaveTemporaryMonitorMode;
+
 #pragma mark - USB Settings
 
 ///

--- a/Source/common/SNTError.h
+++ b/Source/common/SNTError.h
@@ -72,4 +72,10 @@ typedef NS_ENUM(NSInteger, SNTErrorCode) {
 + (void)populateError:(NSError *_Nullable *_Nullable)error
            withFormat:(nonnull NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
+// Return a new SNTError with the provided format string message.
+// `msg` will populate the NSLocalizedErrorDescription key. The error code
+// will be SNTErrorCodeUnknown.
++ (nullable NSError *)createErrorWithFormat:(nonnull NSString *)format,
+                                            ... NS_FORMAT_FUNCTION(1, 2);
+
 @end

--- a/Source/common/SNTError.mm
+++ b/Source/common/SNTError.mm
@@ -62,4 +62,18 @@ const NSErrorDomain SantaErrorDomain = @"com.northpolesec.santa.error";
                            userInfo:@{NSLocalizedDescriptionKey : msg}];
 }
 
++ (nullable NSError *)createErrorWithFormat:(nonnull NSString *)format,
+                                            ... NS_FORMAT_FUNCTION(1, 2) {
+  NSError *error = nil;
+
+  va_list args;
+  va_start(args, format);
+  NSString *msg = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+
+  [self populateError:&error withFormat:@"%@", msg];
+
+  return error;
+}
+
 @end

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -38,6 +38,7 @@
                             configState:(SNTConfigState *)configState;
 - (void)postClientModeNotification:(SNTClientMode)clientmode;
 - (void)postRuleSyncNotificationForApplication:(NSString *)app;
+- (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply;
 - (void)requestAPNSToken:(void (^)(NSString *))reply;
 @end
 

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -100,6 +100,13 @@ struct RuleCounts {
 ///
 - (void)exportTelemetryWithReply:(void (^)(BOOL))reply;
 
+///
+/// Temporary Monitor Mode Ops
+///
+- (void)requestTemporaryMonitorModeWithDuration:(NSNumber *)requestedDuration
+                                          reply:(void (^)(uint32_t, NSError *))reply;
+- (void)cancelTemporaryMonitorMode:(void (^)(NSError *))reply;
+
 @end
 
 @interface SNTXPCUnprivilegedControlInterface : NSObject

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])
 swift_library(
     name = "SNTMessageView",
     srcs = ["SNTMessageView.swift"],
+    generates_header = 1,
     module_name = "santa_gui_SNTMessageView",
     deps = ["//Source/common:SNTConfigurator"],
 )

--- a/Source/gui/SNTMessageView.swift
+++ b/Source/gui/SNTMessageView.swift
@@ -209,6 +209,17 @@ public struct CopyDetailsButton: View {
   }
 }
 
+@objc public class SNTAuthorizationHelper: NSObject {
+  @objc public static func authorizeTemporaryMonitorMode(replyBlock: @escaping (Bool) -> Void) {
+    let format = NSLocalizedString(
+      "authorize temporary Monitor Mode",
+      comment: "Authorize temporary Monitor Mode exception"
+    )
+
+    AuthorizeViaTouchID(reason: format, replyBlock: replyBlock)
+  }
+}
+
 public func AuthorizeViaTouchID(reason: String, replyBlock: @escaping (Bool) -> Void) {
   let policy: LAPolicy =
     SNTConfigurator.configurator().enableStandalonePasswordFallback

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -37,6 +37,7 @@
 #import "Source/gui/SNTBinaryMessageWindowView-Swift.h"
 #import "Source/gui/SNTDeviceMessageWindowController.h"
 #import "Source/gui/SNTFileAccessMessageWindowController.h"
+#import "Source/gui/SNTMessageView-Swift.h"
 #import "Source/gui/SNTMessageWindowController.h"
 
 @interface SNTNotificationManager ()
@@ -451,6 +452,12 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
                                                       configState:configState];
 
   [self queueMessage:pendingMsg enableSilences:YES];
+}
+
+- (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply {
+  [SNTAuthorizationHelper authorizeTemporaryMonitorModeWithReplyBlock:^(BOOL success) {
+    reply(success);
+  }];
 }
 
 // XPC handler. The sync service requests the APNS token, by way of the daemon.

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -62,6 +62,17 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTCommandMonitorMode",
+    srcs = ["Commands/SNTCommandMonitorMode.mm"],
+    deps = [
+        ":santactl_cmd",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTXPCControlInterface",
+    ],
+)
+
+objc_library(
     name = "santactl_lib",
     srcs = [
         "Commands/SNTCommandCheckCache.mm",
@@ -87,6 +98,7 @@ objc_library(
     sdk_frameworks = ["IOKit"],
     deps = [
         ":SNTCommandInstall",
+        ":SNTCommandMonitorMode",
         ":SNTCommandPrintLog",
         ":SNTCommandTelemetry",
         ":santactl_cmd",

--- a/Source/santactl/Commands/SNTCommandMonitorMode.mm
+++ b/Source/santactl/Commands/SNTCommandMonitorMode.mm
@@ -1,0 +1,121 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTXPCControlInterface.h"
+#import "Source/santactl/SNTCommand.h"
+#import "Source/santactl/SNTCommandController.h"
+
+@interface SNTCommandMonitorMode : SNTCommand <SNTCommandProtocol>
+@end
+
+@implementation SNTCommandMonitorMode
+
+REGISTER_COMMAND_NAME(@"monitormode")
+
++ (BOOL)requiresRoot {
+  return NO;
+}
+
++ (BOOL)requiresDaemonConn {
+  return YES;
+}
+
++ (NSString *)shortHelpText {
+  return @"Temporarily switch to Monitor Mode if eligible.";
+}
+
++ (NSString *)longHelpText {
+  return (@"Usage: santactl monitormode [options]\n"
+          @"  Options:\n"
+          @"    --duration {minutes}: An optional number of minutes of temporary Monitor Mode\n"
+          @"                          to request. By default, will use configured time allotted\n"
+          @"                          by policy.\n"
+          @"    --cancel: End temporary Monitor Mode and revert to Lockdown Mode.\n"
+          @"\n");
+}
+
++ (NSSet<NSString *> *)aliases {
+  return [NSSet setWithArray:@[ @"mm" ]];
+}
+
+- (void)runWithArguments:(NSArray *)arguments {
+  NSNumber *requestedDuration;
+  bool shouldCancel = false;
+
+  // Parse arguments
+  for (NSUInteger i = 0; i < arguments.count; ++i) {
+    NSString *arg = arguments[i];
+
+    if ([arg caseInsensitiveCompare:@"--duration"] == NSOrderedSame) {
+      if (++i > arguments.count - 1) {
+        [self printErrorUsageAndExit:@"--duration requires an argument"];
+      }
+
+      arg = arguments[i];
+      if (arg.length == 0) {
+        [self printErrorUsageAndExit:@"--duration requires a whole number argument"];
+      }
+
+      NSCharacterSet *nonDigitCharacterSet =
+          [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+      if ([arg rangeOfCharacterFromSet:nonDigitCharacterSet].location != NSNotFound) {
+        [self printErrorUsageAndExit:@"--duration requires a whole number argument"];
+      }
+
+      NSInteger val = [arg integerValue];
+      if (val <= 0) {
+        [self printErrorUsageAndExit:@"--duration must be greater than 0"];
+      }
+
+      requestedDuration = @(val);
+    } else if ([arg caseInsensitiveCompare:@"--cancel"] == NSOrderedSame) {
+      shouldCancel = true;
+    }
+  }
+
+  __block BOOL success;
+
+  if (shouldCancel) {
+    [[self.daemonConn synchronousRemoteObjectProxy] cancelTemporaryMonitorMode:^(NSError *err) {
+      success = (err == nil);
+      if (err) {
+        TEE_LOGE(@"Unable cancel Monitor Mode: %@", err.localizedDescription);
+        return;
+      }
+    }];
+  } else {
+    [[self.daemonConn synchronousRemoteObjectProxy]
+        requestTemporaryMonitorModeWithDuration:requestedDuration
+                                          reply:^(uint32_t minutes, NSError *err) {
+                                            success = (err == nil);
+                                            if (err) {
+                                              TEE_LOGE(@"Unable to enter Monitor Mode: %@",
+                                                       err.localizedDescription);
+                                              return;
+                                            }
+
+                                            TEE_LOGI(
+                                                @"Temporarily switching to Monitor Mode for %u %@",
+                                                minutes, minutes > 1 ? @"minutes" : @"minute");
+                                          }];
+  }
+
+  exit(success ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+@end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -14,8 +14,6 @@
 /// limitations under the License.
 
 #import "Source/santad/SNTDaemonControlController.h"
-#import "Source/common/SNTModeTransition.h"
-#include "Source/common/faa/WatchItems.h"
 
 #import <Foundation/Foundation.h>
 
@@ -31,12 +29,15 @@
 #import "Source/common/SNTFileAccessRule.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTMetricSet.h"
+#import "Source/common/SNTModeTransition.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStrengthify.h"
+#import "Source/common/SNTTimer.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/common/SNTXPCSyncServiceInterface.h"
+#include "Source/common/faa/WatchItems.h"
 #import "Source/santad/DataLayer/SNTEventTable.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTDatabaseController.h"
@@ -57,10 +58,16 @@ uint64_t watchdogRAMEvents = 0;
 double watchdogCPUPeak = 0;
 double watchdogRAMPeak = 0;
 
+// Semi-arbitrary limits for temporary Monitor Mode.
+// Min: 1 minute. Max: 30 days.
+static constexpr uint32_t kMinTempMonitorModeMinutes = 1;
+static constexpr uint32_t kMaxTempMonitorModeMinutes = 1 * 60 * 24 * 30;
+
 @interface SNTDaemonControlController ()
 @property SNTPolicyProcessor *policyProcessor;
 @property SNTNotificationQueue *notQueue;
 @property SNTSyncdQueue *syncdQueue;
+@property SNTTimer *tempMonitorMode;
 @end
 
 @implementation SNTDaemonControlController {
@@ -83,6 +90,20 @@ double watchdogRAMPeak = 0;
     _watchItems = std::move(watchItems);
     _notQueue = notQueue;
     _syncdQueue = syncdQueue;
+
+    _tempMonitorMode =
+        [[SNTTimer alloc] initWithMinInterval:kMinTempMonitorModeMinutes * 60
+                                  maxInterval:kMaxTempMonitorModeMinutes * 60
+                                         name:@"Temporary Monitor Mode"
+                                  fireOnStart:NO
+                               rescheduleMode:SNTTimerRescheduleModeTrailingEdge
+                                     qosClass:QOS_CLASS_USER_INITIATED
+                                     callback:^bool {
+                                       [[SNTConfigurator configurator] leaveTemporaryMonitorMode];
+
+                                       // Don't restart the timer
+                                       return false;
+                                     }];
   }
   return self;
 }
@@ -556,6 +577,58 @@ double watchdogRAMPeak = 0;
 - (void)exportTelemetryWithReply:(void (^)(BOOL))reply {
   _logger->ExportTelemetry();
   reply(YES);
+}
+
+- (void)requestTemporaryMonitorModeWithDuration:(NSNumber *)requestedDuration
+                                          reply:(void (^)(uint32_t, NSError *))reply {
+  SNTConfigurator *configurator = [SNTConfigurator configurator];
+
+  SNTModeTransition *modeTransition = [configurator modeTransition];
+  if (modeTransition.type != SNTModeTransitionTypeOnDemand) {
+    reply(0,
+          [SNTError createErrorWithFormat:@"Machine is not eligible for temporary Monitor Mode"]);
+    return;
+  }
+
+  SNTClientMode clientMode = [configurator clientMode];
+  if (!(clientMode == SNTClientModeLockdown ||
+        (clientMode == SNTClientModeMonitor && [configurator inTemporaryMonitorMode]))) {
+    reply(0, [SNTError createErrorWithFormat:@"Machine must be in Lockdown Mode in order to "
+                                             @"transition to temporary Monitor Mode"]);
+    return;
+  }
+
+  __block BOOL authSuccess = NO;
+  [self.notQueue authorizeTemporaryMonitorMode:^(BOOL authenticated) {
+    authSuccess = authenticated;
+  }];
+
+  if (!authSuccess) {
+    reply(0, [SNTError createErrorWithFormat:@"User authorization failed"]);
+    return;
+  }
+
+  uint32_t durationMin = [modeTransition getDurationMinutes:requestedDuration];
+
+  [self.tempMonitorMode startWithInterval:(durationMin * 60)];
+
+  [configurator enterTemporaryMonitorMode];
+
+  reply(durationMin, nil);
+}
+
+- (void)cancelTemporaryMonitorMode:(void (^)(NSError *))reply {
+  SNTConfigurator *configurator = [SNTConfigurator configurator];
+  NSError *err;
+
+  if ([configurator inTemporaryMonitorMode]) {
+    [self.tempMonitorMode stop];
+    [configurator leaveTemporaryMonitorMode];
+  } else {
+    err = [SNTError createErrorWithFormat:@"Machine is not currently in temporary Monitor Mode"];
+  }
+
+  reply(err);
 }
 
 @end

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -41,4 +41,6 @@ using NotificationReplyBlock = void (^)(BOOL);
           configState:(SNTConfigState *)configState
              andReply:(void (^)(BOOL authenticated))reply;
 
+- (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply;
+
 @end

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -179,4 +179,8 @@
   });
 }
 
+- (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply {
+  [[self.notifierConnection synchronousRemoteObjectProxy] authorizeTemporaryMonitorMode:reply];
+}
+
 @end


### PR DESCRIPTION
Adds a new `santactl monitormode` command that will enable previously-authorized hosts to enter Monitor Mode, on-demand, for some configured duration.