### PR TITLE
Support EventDetailURL and EventDetailText in the sync protocol

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20251002.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "e577bc8cb8fa335362460e7b04a492e97f8e3820",
+    commit = "18b32da8728a5d5a512d7e5d4e268faf9f9f1c76",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -53,8 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 ///  Return a URL generated from the EventDetailURL configuration key
 ///  after replacing templates in the URL with values from the event.
 ///
-+ (nullable NSURL *)eventDetailURLForEvent:(nullable SNTStoredExecutionEvent *)event
-                                 customURL:(nullable NSString *)url;
++ (nullable NSURL *)eventDetailURLForEvent:(SNTStoredExecutionEvent *)event
+                                 customURL:(nullable NSString *)url
+                               fallbackURL:(nullable NSString *)fallbackURL;
 + (nullable NSURL *)eventDetailURLForFileAccessEvent:(nullable SNTStoredFileAccessEvent *)event
                                            customURL:(nullable NSString *)url;
 

--- a/Source/common/SNTBlockMessage.mm
+++ b/Source/common/SNTBlockMessage.mm
@@ -241,12 +241,11 @@ static id ValueOrNull(id value) {
 // The "format strings" in `templateMapping` will be replaced in the URL, if they are present.
 + (NSURL *)eventDetailURLForEvent:(SNTStoredEvent *)event
                         customURL:(NSString *)url
+                      fallbackURL:(NSString *)fallbackURL
                   templateMapping:(NSDictionary *)templateMapping {
-  SNTConfigurator *config = [SNTConfigurator configurator];
-
   NSString *formatStr = url;
   if (!formatStr.length) {
-    formatStr = config.eventDetailURL;
+    formatStr = fallbackURL;
     if (!formatStr.length) {
       return nil;
     }
@@ -265,9 +264,12 @@ static id ValueOrNull(id value) {
   return u;
 }
 
-+ (NSURL *)eventDetailURLForEvent:(SNTStoredExecutionEvent *)event customURL:(NSString *)url {
++ (NSURL *)eventDetailURLForEvent:(SNTStoredExecutionEvent *)event
+                        customURL:(NSString *)url
+                      fallbackURL:(NSString *)fallbackURL {
   return [self eventDetailURLForEvent:event
                             customURL:url
+                          fallbackURL:fallbackURL
                       templateMapping:[self eventDetailTemplateMappingForEvent:event]];
 }
 
@@ -275,6 +277,7 @@ static id ValueOrNull(id value) {
                                   customURL:(NSString *)url {
   return [self eventDetailURLForEvent:event
                             customURL:url
+                          fallbackURL:[[SNTConfigurator configurator] eventDetailURL]
                       templateMapping:[self fileAccessEventDetailTemplateMappingForEvent:event]];
 }
 

--- a/Source/common/SNTBlockMessageTest.mm
+++ b/Source/common/SNTBlockMessageTest.mm
@@ -64,7 +64,7 @@
                       @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
                       @"un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
-  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url fallbackURL:nil];
 
   // Set fileBundleHash and test again for newly expected values
   se.fileBundleHash = @"my_fbh";
@@ -74,12 +74,12 @@
             @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
             @"un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
-  gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+  gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url fallbackURL:nil];
 
   XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
 
-  XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:nil]);
-  XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:@"null"]);
+  XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:nil fallbackURL:nil]);
+  XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:@"null" fallbackURL:nil]);
 }
 
 - (void)testEventDetailURLForFileAccessEvent {
@@ -120,7 +120,7 @@
   NSString *url = @"http://localhost?fi=%file_identifier%";
   NSString *wantUrl = @"http://localhost?fi=my_fi";
 
-  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url fallbackURL:nil];
 
   XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
 }

--- a/Source/common/SNTConfigBundle.h
+++ b/Source/common/SNTConfigBundle.h
@@ -37,5 +37,7 @@
 - (void)fullSyncLastSuccess:(void (^)(NSDate *))block;
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))block;
 - (void)modeTransition:(void (^)(SNTModeTransition *))block;
+- (void)eventDetailURL:(void (^)(NSString *))block;
+- (void)eventDetailText:(void (^)(NSString *))block;
 
 @end

--- a/Source/common/SNTConfigBundle.mm
+++ b/Source/common/SNTConfigBundle.mm
@@ -34,6 +34,8 @@
 @property NSDate *fullSyncLastSuccess;
 @property NSDate *ruleSyncLastSuccess;
 @property SNTModeTransition *modeTransition;
+@property NSString *eventDetailURL;
+@property NSString *eventDetailText;
 @end
 
 @implementation SNTConfigBundle
@@ -58,6 +60,8 @@
   ENCODE(coder, fullSyncLastSuccess);
   ENCODE(coder, ruleSyncLastSuccess);
   ENCODE(coder, modeTransition);
+  ENCODE(coder, eventDetailURL);
+  ENCODE(coder, eventDetailText);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
@@ -78,6 +82,8 @@
     DECODE(decoder, fullSyncLastSuccess, NSDate);
     DECODE(decoder, ruleSyncLastSuccess, NSDate);
     DECODE(decoder, modeTransition, SNTModeTransition);
+    DECODE(decoder, eventDetailURL, NSString);
+    DECODE(decoder, eventDetailText, NSString);
   }
   return self;
 }
@@ -168,6 +174,18 @@
 - (void)modeTransition:(void (^)(SNTModeTransition *))block {
   if (self.modeTransition) {
     block(self.modeTransition);
+  }
+}
+
+- (void)eventDetailURL:(void (^)(NSString *))block {
+  if (self.eventDetailURL) {
+    block(self.eventDetailURL);
+  }
+}
+
+- (void)eventDetailText:(void (^)(NSString *))block {
+  if (self.eventDetailText) {
+    block(self.eventDetailText);
   }
 }
 

--- a/Source/common/SNTConfigState.h
+++ b/Source/common/SNTConfigState.h
@@ -24,6 +24,7 @@
 //
 @property(readonly) SNTClientMode clientMode;
 @property(readonly) BOOL enableNotificationSilences;
+@property(readonly) NSString *eventDetailText;
 
 - (instancetype)initWithConfig:(SNTConfigurator *)config;
 

--- a/Source/common/SNTConfigState.mm
+++ b/Source/common/SNTConfigState.mm
@@ -24,6 +24,7 @@
   if (self) {
     _clientMode = config.clientMode;
     _enableNotificationSilences = config.enableNotificationSilences;
+    _eventDetailText = config.eventDetailText;
   }
   return self;
 }
@@ -35,6 +36,7 @@
 - (void)encodeWithCoder:(NSCoder *)coder {
   ENCODE_BOXABLE(coder, clientMode);
   ENCODE_BOXABLE(coder, enableNotificationSilences);
+  ENCODE(coder, eventDetailText);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
@@ -42,6 +44,7 @@
   if (self) {
     DECODE_SELECTOR(decoder, clientMode, NSNumber, integerValue);
     DECODE_SELECTOR(decoder, enableNotificationSilences, NSNumber, boolValue);
+    DECODE(decoder, eventDetailText, NSString);
   }
   return self;
 };

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -441,9 +441,19 @@
 @property(nullable, readonly, nonatomic) NSString *eventDetailURL;
 
 ///
+///  Set the EventDetailURL as received from a sync server.
+///
+- (void)setSyncServerEventDetailURL:(nullable NSString *)eventDetailURL;
+
+///
 ///  Related to the above property, this string represents the text to show on the button.
 ///
 @property(nullable, readonly, nonatomic) NSString *eventDetailText;
+
+///
+///  Set the EventDetailText as received from a sync server.
+///
+- (void)setSyncServerEventDetailText:(nullable NSString *)eventDetailText;
 
 ///
 ///  This string represents the text to show on the "Dismiss" button in the UI instead of "Dismiss".

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -119,8 +119,6 @@ static NSString *const kEnableSilentModeKey = @"EnableSilentMode";
 static NSString *const kEnableSilentTTYModeKey = @"EnableSilentTTYMode";
 static NSString *const kAboutTextKey = @"AboutText";
 static NSString *const kMoreInfoURLKey = @"MoreInfoURL";
-static NSString *const kEventDetailURLKey = @"EventDetailURL";
-static NSString *const kEventDetailTextKey = @"EventDetailText";
 static NSString *const kDismissTextKey = @"DismissText";
 static NSString *const kUnknownBlockMessage = @"UnknownBlockMessage";
 static NSString *const kBannedBlockMessage = @"BannedBlockMessage";
@@ -204,6 +202,8 @@ static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 static NSString *const kEnableAllEventUploadKey = @"EnableAllEventUpload";
 static NSString *const kOverrideFileAccessActionKey = @"OverrideFileAccessAction";
 static NSString *const kEnableBundlesKey = @"EnableBundles";
+static NSString *const kEventDetailURLKey = @"EventDetailURL";
+static NSString *const kEventDetailTextKey = @"EventDetailText";
 
 // The keys managed by a sync server.
 static NSString *const kFullSyncLastSuccess = @"FullSyncLastSuccess";
@@ -260,6 +260,8 @@ static NSString *const kModeTransitionKey = @"ModeTransition";
       kEnableBundlesKey : number,
       kExportConfigurationKey : data,
       kModeTransitionKey : data,
+      kEventDetailURLKey : string,
+      kEventDetailTextKey : string,
     };
     _forcedConfigKeyTypes = @{
       kClientModeKey : number,
@@ -504,11 +506,11 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 + (NSSet *)keyPathsForValuesAffectingEventDetailURL {
-  return [self configStateSet];
+  return [self syncAndConfigStateSet];
 }
 
 + (NSSet *)keyPathsForValuesAffectingEventDetailText {
-  return [self configStateSet];
+  return [self syncAndConfigStateSet];
 }
 
 + (NSSet *)keyPathsForValuesAffectingDismissText {
@@ -1028,11 +1030,19 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 - (NSString *)eventDetailURL {
-  return self.configState[kEventDetailURLKey];
+  return self.syncState[kEventDetailURLKey] ?: self.configState[kEventDetailURLKey];
+}
+
+- (void)setSyncServerEventDetailURL:(NSString *)eventDetailURL {
+  [self updateSyncStateForKey:kEventDetailURLKey value:eventDetailURL];
 }
 
 - (NSString *)eventDetailText {
-  return self.configState[kEventDetailTextKey];
+  return self.syncState[kEventDetailTextKey] ?: self.configState[kEventDetailTextKey];
+}
+
+- (void)setSyncServerEventDetailText:(NSString *)eventDetailText {
+  [self updateSyncStateForKey:kEventDetailTextKey value:eventDetailText];
 }
 
 - (NSString *)dismissText {

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -27,7 +27,7 @@
 @protocol SNTNotifierXPC
 - (void)postBlockNotification:(SNTStoredExecutionEvent *)event
             withCustomMessage:(NSString *)message
-                    customURL:(NSString *)url
+                    customURL:(NSURL *)url
                   configState:(SNTConfigState *)configState
                      andReply:(void (^)(BOOL authenticated))reply;
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event;

--- a/Source/gui/SNTBinaryMessageWindowController.h
+++ b/Source/gui/SNTBinaryMessageWindowController.h
@@ -28,7 +28,7 @@
 
 - (instancetype)initWithEvent:(SNTStoredExecutionEvent *)event
                     customMsg:(NSString *)message
-                    customURL:(NSString *)url
+                    customURL:(NSURL *)url
                   configState:(SNTConfigState *)configState
                         reply:(void (^)(BOOL authenticated))replyBlock;
 

--- a/Source/gui/SNTBinaryMessageWindowController.mm
+++ b/Source/gui/SNTBinaryMessageWindowController.mm
@@ -33,7 +33,7 @@
 @property(copy) NSString *customMessage;
 
 ///  The custom URL to use for this event
-@property(copy) NSString *customURL;
+@property(copy) NSURL *customURL;
 
 @end
 
@@ -41,7 +41,7 @@
 
 - (instancetype)initWithEvent:(SNTStoredExecutionEvent *)event
                     customMsg:(NSString *)message
-                    customURL:(NSString *)url
+                    customURL:(NSURL *)url
                   configState:(SNTConfigState *)configState
                         reply:(void (^)(BOOL))replyBlock {
   self = [super init];

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -405,7 +405,7 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 
 - (void)postBlockNotification:(SNTStoredExecutionEvent *)event
             withCustomMessage:(NSString *)message
-                    customURL:(NSString *)url
+                    customURL:(NSURL *)url
                   configState:(SNTConfigState *)configState
                      andReply:(void (^)(BOOL))replyBlock {
   if (!event) {

--- a/Source/gui/SNTNotificationManagerTest.mm
+++ b/Source/gui/SNTNotificationManagerTest.mm
@@ -61,7 +61,7 @@
 
   [sut postBlockNotification:ev
            withCustomMessage:@""
-                   customURL:@""
+                   customURL:nil
                  configState:nil
                     andReply:^(BOOL authenticated){
                     }];

--- a/Source/santactl/Commands/SNTCommandFileInfo.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfo.mm
@@ -15,7 +15,6 @@
 
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
-#import <objc/runtime.h>
 
 #import "Source/common/CertificateHelpers.h"
 #import "Source/common/MOLCertificate.h"

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -18,7 +18,6 @@
 #import <XCTest/XCTest.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <objc/NSObjCRuntime.h>
 #include <cstddef>
 
 #include <memory>

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -384,6 +384,14 @@ double watchdogRAMPeak = 0;
     [configurator setSyncServerModeTransition:val];
   }];
 
+  [result eventDetailURL:^(NSString *val) {
+    [configurator setSyncServerEventDetailURL:val];
+  }];
+
+  [result eventDetailText:^(NSString *val) {
+    [configurator setSyncServerEventDetailText:val];
+  }];
+
   reply();
 }
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -454,7 +454,9 @@ static NSString *const kPrinterProxyPostMonterey =
                             @"\033[1mIdentifier:\033[0m %@\n"
                             @"\033[1mParent:    \033[0m %@ (%@)\n\n",
                             se.filePath, se.fileSHA256, se.parentName, se.ppid];
-          NSURL *detailURL = [SNTBlockMessage eventDetailURLForEvent:se customURL:cd.customURL];
+          NSURL *detailURL = [SNTBlockMessage eventDetailURLForEvent:se
+                                                           customURL:cd.customURL
+                                                         fallbackURL:config.eventDetailURL];
           if (detailURL) {
             [msg appendFormat:@"More info:\n%@\n\n", detailURL.absoluteString];
           }
@@ -495,7 +497,9 @@ static NSString *const kPrinterProxyPostMonterey =
         // Let the user know what happened in the GUI.
         [self.notifierQueue addEvent:se
                    withCustomMessage:cd.customMsg
-                           customURL:cd.customURL
+                           customURL:[SNTBlockMessage eventDetailURLForEvent:se
+                                                                   customURL:cd.customURL
+                                                                 fallbackURL:config.eventDetailURL]
                          configState:configState
                             andReply:replyBlock];
       }

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -37,7 +37,7 @@ using NotificationReplyBlock = void (^)(BOOL);
 
 - (void)addEvent:(SNTStoredExecutionEvent *)event
     withCustomMessage:(NSString *)message
-            customURL:(NSString *)url
+            customURL:(NSURL *)url
           configState:(SNTConfigState *)configState
              andReply:(void (^)(BOOL authenticated))reply;
 

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -49,7 +49,7 @@
 
 - (void)addEvent:(SNTStoredExecutionEvent *)event
     withCustomMessage:(NSString *)message
-            customURL:(NSString *)url
+            customURL:(NSURL *)url
           configState:(SNTConfigState *)configState
              andReply:(NotificationReplyBlock)replyBlock {
   if (!event) {

--- a/Source/santad/SNTNotificationQueueTest.mm
+++ b/Source/santad/SNTNotificationQueueTest.mm
@@ -56,7 +56,7 @@
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
   SNTStoredExecutionEvent *se = [[SNTStoredExecutionEvent alloc] init];
   NSString *customMessage = @"custom msg";
-  NSString *customURL = @"https://northpolesec.com";
+  NSURL *customURL = [NSURL URLWithString:@"https://northpolesec.com"];
 
   OCMExpect([self.mockProxy postBlockNotification:se
                                 withCustomMessage:customMessage
@@ -88,7 +88,7 @@
 - (void)testAddEventNil {
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
   NSString *customMessage = @"custom msg";
-  NSString *customURL = @"https://northpolesec.com";
+  NSURL *customURL = [NSURL URLWithString:@"https://northpolesec.com"];
 
   [self.sut addEvent:nil
       withCustomMessage:customMessage
@@ -113,7 +113,7 @@
 // well as posting messages for everything in the queue.
 - (void)testAddEventMulti {
   NSString *customMessage = @"custom msg";
-  NSString *customURL = @"https://northpolesec.com";
+  NSURL *customURL = [NSURL URLWithString:@"https://northpolesec.com"];
 
   SNTStoredExecutionEvent *se1 = [[SNTStoredExecutionEvent alloc] init];
   SNTStoredExecutionEvent *se2 = [[SNTStoredExecutionEvent alloc] init];
@@ -149,19 +149,19 @@
   NSMutableDictionary *d1 = [NSMutableDictionary dictionary];
   [d1 setValue:se1 forKey:@"event"];
   [d1 setValue:@"Message 1" forKey:@"message"];
-  [d1 setValue:@"https://northpolesec.com/1" forKey:@"url"];
+  [d1 setValue:[NSURL URLWithString:@"https://northpolesec.com/1"] forKey:@"url"];
   [d1 setValue:replyBlock1 forKey:@"reply"];
 
   NSMutableDictionary *d2 = [NSMutableDictionary dictionary];
   [d2 setValue:se2 forKey:@"event"];
   [d2 setValue:@"Message 2" forKey:@"message"];
-  [d2 setValue:@"https://northpolesec.com/2" forKey:@"url"];
+  [d2 setValue:[NSURL URLWithString:@"https://northpolesec.com/2"] forKey:@"url"];
   [d2 setValue:replyBlock2 forKey:@"reply"];
 
   NSMutableDictionary *d3 = [NSMutableDictionary dictionary];
   [d3 setValue:se3 forKey:@"event"];
   [d3 setValue:@"Message 3" forKey:@"message"];
-  [d3 setValue:@"https://northpolesec.com/3" forKey:@"url"];
+  [d3 setValue:[NSURL URLWithString:@"https://northpolesec.com/3"] forKey:@"url"];
   [d3 setValue:replyBlock3 forKey:@"reply"];
 
   self.ringbuf->Enqueue(d1);
@@ -172,17 +172,19 @@
   XCTAssertFalse(self.ringbuf->Empty());
 
   // postBlockNotification should never be called for `se1` since it will fall out of the ring
-  OCMVerify(never(), [self.mockProxy postBlockNotification:se1
-                                         withCustomMessage:@"Message 1"
-                                                 customURL:@"https://northpolesec.com/1"
-                                               configState:OCMOCK_ANY
-                                                  andReply:OCMOCK_ANY]);
+  OCMVerify(never(), [self.mockProxy
+                         postBlockNotification:se1
+                             withCustomMessage:@"Message 1"
+                                     customURL:[NSURL URLWithString:@"https://northpolesec.com/1"]
+                                   configState:OCMOCK_ANY
+                                      andReply:OCMOCK_ANY]);
 
-  OCMExpect([self.mockProxy postBlockNotification:se2
-                                withCustomMessage:@"Message 2"
-                                        customURL:@"https://northpolesec.com/2"
-                                      configState:OCMOCK_ANY
-                                         andReply:OCMOCK_ANY])
+  OCMExpect([self.mockProxy
+                postBlockNotification:se2
+                    withCustomMessage:@"Message 2"
+                            customURL:[NSURL URLWithString:@"https://northpolesec.com/2"]
+                          configState:OCMOCK_ANY
+                             andReply:OCMOCK_ANY])
       .andDo(^(NSInvocation *invocation) {
         void (^__unsafe_unretained replyBlock)(BOOL);
         [invocation getArgument:&replyBlock atIndex:6];
@@ -192,11 +194,12 @@
         });
       });
 
-  OCMExpect([self.mockProxy postBlockNotification:se3
-                                withCustomMessage:@"Message 3"
-                                        customURL:@"https://northpolesec.com/3"
-                                      configState:OCMOCK_ANY
-                                         andReply:OCMOCK_ANY])
+  OCMExpect([self.mockProxy
+                postBlockNotification:se3
+                    withCustomMessage:@"Message 3"
+                            customURL:[NSURL URLWithString:@"https://northpolesec.com/3"]
+                          configState:OCMOCK_ANY
+                             andReply:OCMOCK_ANY])
       .andDo(^(NSInvocation *invocation) {
         void (^__unsafe_unretained replyBlock)(BOOL);
         [invocation getArgument:&replyBlock atIndex:6];
@@ -258,20 +261,20 @@
   NSMutableDictionary *d1 = [NSMutableDictionary dictionary];
   [d1 setValue:se1 forKey:@"event"];
   [d1 setValue:@"Message 1" forKey:@"message"];
-  [d1 setValue:@"https://northpolesec.com/1" forKey:@"url"];
+  [d1 setValue:[NSURL URLWithString:@"https://northpolesec.com/1"] forKey:@"url"];
   [d1 setValue:[replyBlock1 copy] forKey:@"reply"];
 
   NSMutableDictionary *d2 = [NSMutableDictionary dictionary];
   [d2 setValue:se2 forKey:@"event"];
   [d2 setValue:@"Message 2" forKey:@"message"];
-  [d2 setValue:@"https://northpolesec.com/2" forKey:@"url"];
+  [d2 setValue:[NSURL URLWithString:@"https://northpolesec.com/2"] forKey:@"url"];
   [d2 setValue:[replyBlock2 copy] forKey:@"reply"];
 
   // Create dictionary with no reply block
   NSMutableDictionary *d3 = [NSMutableDictionary dictionary];
   [d3 setValue:se3 forKey:@"event"];
   [d3 setValue:@"Message 3" forKey:@"message"];
-  [d3 setValue:@"https://northpolesec.com/3" forKey:@"url"];
+  [d3 setValue:[NSURL URLWithString:@"https://northpolesec.com/3"] forKey:@"url"];
   // Intentionally not setting a reply block for d3
 
   self.ringbuf->Enqueue(d1);

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -84,6 +84,7 @@ santa_unit_test(
         ":SNTSyncState",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigBundle",
+        "//Source/common:SNTModeTransition",
     ],
 )
 

--- a/Source/santasyncservice/SNTSyncConfigBundle.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundle.mm
@@ -35,6 +35,8 @@
 @property NSDate *fullSyncLastSuccess;
 @property NSDate *ruleSyncLastSuccess;
 @property SNTModeTransition *modeTransition;
+@property NSString *eventDetailURL;
+@property NSString *eventDetailText;
 @end
 
 SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
@@ -53,6 +55,8 @@ SNTConfigBundle *PostflightConfigBundle(SNTSyncState *syncState) {
   bundle.overrideFileAccessAction = syncState.overrideFileAccessAction;
   bundle.exportConfiguration = syncState.exportConfig;
   bundle.modeTransition = syncState.modeTransition;
+  bundle.eventDetailURL = syncState.eventDetailURL;
+  bundle.eventDetailText = syncState.eventDetailText;
 
   bundle.fullSyncLastSuccess = [NSDate now];
 

--- a/Source/santasyncservice/SNTSyncConfigBundleTest.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundleTest.mm
@@ -19,6 +19,7 @@
 
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigBundle.h"
+#import "Source/common/SNTModeTransition.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
 @interface SNTConfigBundle (ConfigBundleCreator)
@@ -35,6 +36,9 @@
 @property NSString *overrideFileAccessAction;
 @property NSDate *fullSyncLastSuccess;
 @property NSDate *ruleSyncLastSuccess;
+@property SNTModeTransition *modeTransition;
+@property NSString *eventDetailURL;
+@property NSString *eventDetailText;
 @end
 
 @interface SNTSyncConfigBundleTest : XCTestCase
@@ -65,6 +69,19 @@
   syncState.syncType = SNTSyncTypeCleanAll;
   bundle = PostflightConfigBundle(syncState);
   XCTAssertEqualObjects(bundle.syncType, @(SNTSyncTypeNormal));
+
+  syncState.modeTransition = [[SNTModeTransition alloc] initRevocation];
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertNotNil(bundle.modeTransition);
+  XCTAssertEqual(bundle.modeTransition.type, SNTModeTransitionTypeRevoke);
+
+  syncState.eventDetailURL = @"my://url";
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertEqualObjects(bundle.eventDetailURL, syncState.eventDetailURL);
+
+  syncState.eventDetailText = @"Click Button";
+  bundle = PostflightConfigBundle(syncState);
+  XCTAssertEqualObjects(bundle.eventDetailText, syncState.eventDetailText);
 }
 
 - (void)testRuleSyncConfigBundle {
@@ -85,6 +102,9 @@
   XCTAssertNil(bundle.disableUnknownEventUpload);
   XCTAssertNil(bundle.overrideFileAccessAction);
   XCTAssertNil(bundle.fullSyncLastSuccess);
+  XCTAssertNil(bundle.modeTransition);
+  XCTAssertNil(bundle.eventDetailURL);
+  XCTAssertNil(bundle.eventDetailText);
 }
 
 - (void)testSyncTypeConfigBundle {
@@ -111,6 +131,9 @@
   XCTAssertNil(bundle.overrideFileAccessAction);
   XCTAssertNil(bundle.fullSyncLastSuccess);
   XCTAssertNil(bundle.ruleSyncLastSuccess);
+  XCTAssertNil(bundle.modeTransition);
+  XCTAssertNil(bundle.eventDetailURL);
+  XCTAssertNil(bundle.eventDetailText);
 }
 
 @end

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -311,6 +311,14 @@ BOOL Preflight(SNTSyncPreflight *self, google::protobuf::Arena *arena,
     }
   }
 
+  if (resp.has_event_detail_url()) {
+    self.syncState.eventDetailURL = StringToNSString(resp.event_detail_url());
+  }
+
+  if (resp.has_event_detail_text()) {
+    self.syncState.eventDetailText = StringToNSString(resp.event_detail_text());
+  }
+
   // Default sync type is SNTSyncTypeNormal
   //
   // Logic overview:

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -82,6 +82,8 @@
 @property NSString *overrideFileAccessAction;
 @property SNTExportConfiguration *exportConfig;
 @property SNTModeTransition *modeTransition;
+@property NSString *eventDetailURL;
+@property NSString *eventDetailText;
 
 /// Clean sync flag, if True, all existing rules should be deleted before inserting any new rules.
 @property SNTSyncType syncType;


### PR DESCRIPTION
These two configuration keys can now be set by the sync server if desired.