### PR TITLE
Move pinning code to common where it belongs

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -46,6 +46,12 @@ objc_library(
 )
 
 objc_library(
+    name = "Pinning",
+    srcs = ["Pinning.mm"],
+    hdrs = ["Pinning.h"],
+)
+
+objc_library(
     name = "NSData+Zlib",
     srcs = ["NSData+Zlib.mm"],
     hdrs = ["NSData+Zlib.h"],
@@ -437,6 +443,7 @@ objc_library(
         "Foundation",
     ],
     deps = [
+        ":Pinning",
         ":SNTCommonEnums",
         ":SNTExportConfiguration",
         ":SNTLogging",
@@ -445,7 +452,6 @@ objc_library(
         ":SNTStrengthify",
         ":SNTSystemInfo",
         ":SystemResources",
-        "//Source/santasyncservice:Pinning",
     ],
 )
 

--- a/Source/common/Pinning.h
+++ b/Source/common/Pinning.h
@@ -12,8 +12,8 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#ifndef SANTA__SANTASYNCSERVICE__PINNING_H
-#define SANTA__SANTASYNCSERVICE__PINNING_H
+#ifndef SANTA__COMMON__PINNING_H
+#define SANTA__COMMON__PINNING_H
 
 #include <Foundation/Foundation.h>
 
@@ -27,4 +27,4 @@ NSString *PinnedCertPEMs();
 
 }  // namespace santa
 
-#endif  // SANTA__SANTASYNCSERVICE__PINNING_H
+#endif  // SANTA__COMMON__PINNING_H

--- a/Source/common/Pinning.mm
+++ b/Source/common/Pinning.mm
@@ -25,6 +25,10 @@ static NSArray<NSString *> *const kPinnedDomains = @[
 ];
 
 bool IsDomainPinned(NSURL *url) {
+  if (!url.host.length) {
+    return false;
+  }
+
   NSString *host = url.host;
 
   // Check if the given host or host suffix matches a pinned domain

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -18,7 +18,7 @@
 #include <mach/mach_time.h>
 #include <sys/stat.h>
 
-#include "Source/santasyncservice/Pinning.h"
+#include "Source/common/Pinning.h"
 
 #import "Source/common/SNTExportConfiguration.h"
 #import "Source/common/SNTLogging.h"
@@ -1421,8 +1421,7 @@ static SNTConfigurator *sharedConfigurator = nil;
   }
   // Default to true when neither key is set, and the SyncBaseURL is a pinned
   // Workshop URL.
-  NSURL *syncBaseURL = [self syncBaseURL];
-  if (syncBaseURL && santa::IsDomainPinned(syncBaseURL)) {
+  if (santa::IsDomainPinned([self syncBaseURL])) {
     return YES;
   }
   return NO;

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -58,13 +58,6 @@ objc_library(
 )
 
 objc_library(
-    name = "Pinning",
-    srcs = ["Pinning.mm"],
-    hdrs = ["Pinning.h"],
-    visibility = ["//Source/common:__pkg__"],
-)
-
-objc_library(
     name = "SNTSyncConfigBundle",
     srcs = ["SNTSyncConfigBundle.mm"],
     hdrs = ["SNTSyncConfigBundle.h"],
@@ -208,7 +201,6 @@ objc_library(
     deps = [
         ":FCM_lib",
         ":NATS_lib",
-        ":Pinning",
         ":ProtoTraits",
         ":SNTPushNotificationsTracker",
         ":SNTSyncConfigBundle",
@@ -223,6 +215,7 @@ objc_library(
         "//Source/common:MOLCertificate",
         "//Source/common:MOLXPCConnection",
         "//Source/common:NSData+Zlib",
+        "//Source/common:Pinning",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTError",
@@ -274,7 +267,6 @@ santa_unit_test(
     deps = [
         ":FCM_lib",
         ":NATS_lib",
-        ":Pinning",
         ":SNTPushNotificationsTracker",
         ":SNTSyncConfigBundle",
         ":SNTSyncLogging",
@@ -287,6 +279,7 @@ santa_unit_test(
         "//Source/common:MOLCertificate",
         "//Source/common:MOLXPCConnection",
         "//Source/common:NSData+Zlib",
+        "//Source/common:Pinning",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTDropRootPrivs",
@@ -325,8 +318,6 @@ santa_unit_test(
 santa_unit_test(
     name = "SNTSyncManagerTest",
     srcs = [
-        "Pinning.h",
-        "Pinning.mm",
         "ProtoTraits.h",
         "SNTPushClientAPNS.h",
         "SNTPushClientAPNS.mm",
@@ -360,6 +351,7 @@ santa_unit_test(
         "//Source/common:MOLCertificate",
         "//Source/common:MOLXPCConnection",
         "//Source/common:NSData+Zlib",
+        "//Source/common:Pinning",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTDropRootPrivs",

--- a/Source/santasyncservice/SNTSyncManager.mm
+++ b/Source/santasyncservice/SNTSyncManager.mm
@@ -19,6 +19,7 @@
 
 #import "Source/common/MOLAuthenticatingURLSession.h"
 #import "Source/common/MOLXPCConnection.h"
+#include "Source/common/Pinning.h"
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
@@ -26,7 +27,6 @@
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
-#include "Source/santasyncservice/Pinning.h"
 #import "Source/santasyncservice/SNTPushClientAPNS.h"
 #import "Source/santasyncservice/SNTPushClientFCM.h"
 #import "Source/santasyncservice/SNTPushClientNATS.h"


### PR DESCRIPTION
This will keep our code boundaries cleaner so non-common code isn't pulled into common.