### PR TITLE
Simplify the cookbook rules for systemsetup

### DIFF
--- a/docs/docs/cookbook/cel.md
+++ b/docs/docs/cookbook/cel.md
@@ -89,6 +89,6 @@ To block this create a signing ID rule for `platform:com.apple.systemsetup` and
 attach the following CEL program:
 
 ```clike
-args.join(" ").contains("-setremotelogin on") || 
+args.join(" ").contains("-setremotelogin on") ||
 args.join(" ").contains("-setremoteappleevents on") ? BLOCKLIST : ALLOWLIST
 ```


### PR DESCRIPTION
This PR addresses the feedback from #653 and combines the CEL rules for systemsetup into a single rule. 