### PR TITLE
Support checking if path is covered by a Data FAA rule

### DIFF
--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -75,6 +75,11 @@ struct RuleCounts {
 - (void)remountUSBMode:(void (^)(NSArray<NSString *> *))reply;
 
 ///
+/// FAA Retrieval ops
+///
+- (void)dataFileAccessRuleForTarget:(NSString *)path reply:(void (^)(NSString *, NSString *))reply;
+
+///
 /// Metrics ops
 ///
 - (void)metrics:(void (^)(NSDictionary *))reply;


### PR DESCRIPTION
This provides basic FAA lookup support only. Neither Proc FAA rule lookup nor process impersonation are supported.

```
$ sudo santactl rule --check --file-access --path /Users/mlw/Library/Application\ Support/Google/Chrome/Default/Cookies
Data File Access Rule
     Name: ChromeCookies
  Version: 1
$ sudo santactl rule --check --file-access --path /private/tmp/nps_flag1
No File Access Authorization rules exist
$ sudo santactl rule --check --file-access --path /private/tmp/nps_flag3
Data File Access Rule
     Name: AuditFlag3
  Version: 1
```