### PR TITLE
Set a more readable name for the FDA pane

### DIFF
--- a/Source/santad/Info.plist
+++ b/Source/santad/Info.plist
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+	"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
@@ -14,12 +15,14 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Santa Endpoint Security Extension</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>North Pole Security, Inc.</string>
 	<key>NSSystemExtensionUsageDescription</key>
 	<string>Santa knows who is naughty and nice.</string>
-    <key>NSEndpointSecurityEarlyBoot</key>
-    <true/>
+	<key>NSEndpointSecurityEarlyBoot</key>
+	<true />
 	<key>CFBundleExecutable</key>
 	<string>com.northpolesec.santa.daemon</string>
 </dict>


### PR DESCRIPTION
This updates the name displayed for in the Privacy & Security Full Disk Access settings pane.

<img width="474" height="45" alt="Screenshot 2025-11-22 at 11 29 54 PM" src="https://github.com/user-attachments/assets/027afa91-0f0f-45bf-b818-1b2eaf52e815" />

The old name was just `com.northpolesec.santa.daemon`.