### PR TITLE
santactl/status: Move sync interval field under current sync times

### DIFF
--- a/Source/santactl/Commands/SNTCommandStatus.mm
+++ b/Source/santactl/Commands/SNTCommandStatus.mm
@@ -438,16 +438,6 @@ REGISTER_COMMAND_NAME(@"status")
       printf("  %-25s | %s\n", "Clean Sync Required", (syncCleanReqd ? "Yes" : "No"));
       printf("  %-25s | %s\n", "Last Successful Full Sync", [fullSyncLastSuccessStr UTF8String]);
       printf("  %-25s | %s\n", "Last Successful Rule Sync", [ruleSyncLastSuccessStr UTF8String]);
-      // Format push notifications output
-      NSString *pushNotificationsOutput = pushNotifications;
-      if (pushServerAddress && [pushNotifications containsString:@"NPS Push Service"]) {
-        pushNotificationsOutput =
-            [NSString stringWithFormat:@"NPS Push Service (%@)", pushServerAddress];
-      }
-      printf("  %-25s | %s\n", "Push Notifications", [pushNotificationsOutput UTF8String]);
-      printf("  %-25s | %s\n", "Bundle Scanning", (enableBundles ? "Yes" : "No"));
-      printf("  %-25s | %lld\n", "Events Pending Upload", eventCount);
-      printf("  %-25s | %s\n", "Execution Rules Hash", [executionRulesHash UTF8String]);
 
       // If push notifications are enabled, show the push notifications full
       // sync interval since it's the active configuration.
@@ -460,6 +450,17 @@ REGISTER_COMMAND_NAME(@"status")
       }
       printf("  %-25s | %s\n", "Full Sync Interval", [fullSyncIntervalStr UTF8String]);
 
+      // Format push notifications output
+      NSString *pushNotificationsOutput = pushNotifications;
+      if (pushServerAddress && [pushNotifications containsString:@"NPS Push Service"]) {
+        pushNotificationsOutput =
+            [NSString stringWithFormat:@"NPS Push Service (%@)", pushServerAddress];
+      }
+      printf("  %-25s | %s\n", "Push Notifications", [pushNotificationsOutput UTF8String]);
+
+      printf("  %-25s | %s\n", "Bundle Scanning", (enableBundles ? "Yes" : "No"));
+      printf("  %-25s | %lld\n", "Events Pending Upload", eventCount);
+      printf("  %-25s | %s\n", "Execution Rules Hash", [executionRulesHash UTF8String]);
       if (watchItemsDataSource == santa::WatchItems::DataSource::kDatabase) {
         printf("  %-25s | %s\n", "File Access Rules Hash",
                [(fileAccessRulesHash ?: @"null") UTF8String]);


### PR DESCRIPTION
This avoids splitting the 2 database hashes and groups with the times above and the push notification status below.

```
>>> Sync
  Enabled                   | Yes
  Sync Server               | https://redacted/santa/
  Clean Sync Required       | No
  Last Successful Full Sync | 2025/11/24 12:16:16 -0500
  Last Successful Rule Sync | 2025/11/24 12:16:16 -0500
  Full Sync Interval        | 4 hours (with Push Notifications)
  Push Notifications        | NPS Push Service (us.push.northpole.security)
  Bundle Scanning           | Yes
  Events Pending Upload     | 19
  Execution Rules Hash      | 99aa06d3014798d86001c324468d497f
  File Access Rules Hash    | 580e785bcb917ee881ddcb1a089eb8d8
```