### PR TITLE
Add support for firing a webhook when an FAA rule triggers.

### DIFF
--- a/Source/common/faa/WatchItemPolicy.h
+++ b/Source/common/faa/WatchItemPolicy.h
@@ -200,6 +200,7 @@ struct WatchItemPolicyBase {
                       bool esm = kWatchItemPolicyDefaultEnableSilentMode,
                       bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
                       std::string_view cm = "", NSString *edu = nil, NSString *edt = nil,
+                      NSString *wu = nil, NSDictionary *wh = nil,
                       SetWatchItemProcess procs = {})
       : name(n),
         version(v),
@@ -213,6 +214,8 @@ struct WatchItemPolicyBase {
         // overriding global setting in order to hide the button.
         event_detail_url(edu == nil ? std::nullopt : std::make_optional<NSString *>(edu)),
         event_detail_text(edt.length == 0 ? std::nullopt : std::make_optional<NSString *>(edt)),
+        webhook_url(wu == nil ? std::nullopt : std::make_optional<NSString *>(wu)),
+        webhook_headers(wh == nil ? std::nullopt : std::make_optional<NSDictionary *>(wh)),
         processes(std::move(procs)) {}
 
   virtual ~WatchItemPolicyBase() = default;
@@ -243,6 +246,8 @@ struct WatchItemPolicyBase {
   std::optional<std::string> custom_message;
   std::optional<NSString *> event_detail_url;
   std::optional<NSString *> event_detail_text;
+  std::optional<NSString *> webhook_url;
+  std::optional<NSDictionary *> webhook_headers;
   SetWatchItemProcess processes;
 };
 
@@ -255,8 +260,9 @@ struct DataWatchItemPolicy : public WatchItemPolicyBase {
                       bool esm = kWatchItemPolicyDefaultEnableSilentMode,
                       bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
                       std::string_view cm = "", NSString *edu = nil, NSString *edt = nil,
+                      NSString *wu = nil, NSDictionary *wh = nil,
                       SetWatchItemProcess procs = {})
-      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt, std::move(procs)),
+      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt, wu, wh, std::move(procs)),
         path(p),
         path_type(pt) {}
 
@@ -285,8 +291,9 @@ struct ProcessWatchItemPolicy : public WatchItemPolicyBase {
                          bool esm = kWatchItemPolicyDefaultEnableSilentMode,
                          bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
                          std::string_view cm = "", NSString *edu = nil, NSString *edt = nil,
+                         NSString *wu = nil, NSDictionary *wh = nil,
                          SetWatchItemProcess procs = {})
-      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt, std::move(procs)),
+      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt, wu, wh, std::move(procs)),
         path_type_pairs(std::move(pt)),
         tree(std::make_unique<santa::PrefixTree<santa::Unit>>()) {
     // Build tree

--- a/Source/common/faa/WatchItems.h
+++ b/Source/common/faa/WatchItems.h
@@ -50,6 +50,8 @@ extern NSString *const kWatchItemConfigKeyOptionsCustomMessage;
 extern NSString *const kWatchItemConfigKeyOptionsEventDetailText;
 extern NSString *const kWatchItemConfigKeyOptionsEventDetailURL;
 extern NSString *const kWatchItemConfigKeyOptionsVersion;
+extern NSString *const kWatchItemConfigKeyOptionsWebhookURL;
+extern NSString *const kWatchItemConfigKeyOptionsWebhookHeaders;
 extern NSString *const kWatchItemConfigKeyProcesses;
 extern NSString *const kWatchItemConfigKeyProcessesBinaryPath;
 extern NSString *const kWatchItemConfigKeyProcessesCertificateSha256;

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -466,6 +466,24 @@ objc_library(
 )
 
 objc_library(
+    name = "FAAWebhookClient",
+    srcs = ["EventProviders/FAAWebhookClient.mm"],
+    hdrs = ["EventProviders/FAAWebhookClient.h"],
+    deps = [
+        ":EndpointSecurityMessage",
+        ":SNTDecisionCache",
+        "//Source/common:AuditUtilities",
+        "//Source/common:SNTBlockMessage",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTStoredFileAccessEvent",
+        "//Source/common:SNTSystemInfo",
+        "//Source/common:String",
+        "//Source/common/faa:WatchItemPolicy",
+    ],
+)
+
+objc_library(
     name = "FAAPolicyProcessor",
     srcs = ["EventProviders/FAAPolicyProcessor.mm"],
     hdrs = ["EventProviders/FAAPolicyProcessor.h"],
@@ -491,6 +509,7 @@ objc_library(
         "//Source/common:SantaVnode",
         "//Source/common:String",
         "//Source/common/faa:WatchItemPolicy",
+        ":FAAWebhookClient",
     ],
 )
 

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -34,6 +34,7 @@
 #include "Source/common/faa/WatchItemPolicy.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Enricher.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "Source/santad/EventProviders/FAAWebhookClient.h"
 #include "Source/santad/EventProviders/RateLimiter.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
@@ -130,6 +131,7 @@ class FAAPolicyProcessor {
   SNTConfigurator *configurator_;
   dispatch_queue_t queue_;
   RateLimiter rate_limiter_;
+  std::unique_ptr<FAAWebhookClient> webhook_client_;
 
   virtual NSString *__strong GetCertificateHash(const es_file_t *es_file);
 

--- a/Source/santad/EventProviders/FAAWebhookClient.h
+++ b/Source/santad/EventProviders/FAAWebhookClient.h
@@ -1,0 +1,48 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA__SANTAD__EVENTPROVIDERS_FAAWEBHOOKCLIENT_H
+#define SANTA__SANTAD__EVENTPROVIDERS_FAAWEBHOOKCLIENT_H
+
+#import <Foundation/Foundation.h>
+
+#include <memory>
+#include <string>
+
+#import "Source/common/SNTStoredFileAccessEvent.h"
+#include "Source/common/faa/WatchItemPolicy.h"
+#include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+
+namespace santa {
+
+class FAAWebhookClient {
+ public:
+  FAAWebhookClient();
+  ~FAAWebhookClient();
+
+  // Trigger a webhook request for a rule match
+  // This is non-blocking and will dispatch the request asynchronously
+  void TriggerWebhookForRuleMatch(const WatchItemPolicyBase &policy,
+                                  const std::string &target_path,
+                                  const Message &msg);
+
+ private:
+  dispatch_queue_t queue_;
+  NSURLSession *url_session_;
+};
+
+}  // namespace santa
+
+#endif  // SANTA__SANTAD__EVENTPROVIDERS_FAAWEBHOOKCLIENT_H
+

--- a/Source/santad/EventProviders/FAAWebhookClient.mm
+++ b/Source/santad/EventProviders/FAAWebhookClient.mm
@@ -1,0 +1,152 @@
+/// Copyright 2025 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/EventProviders/FAAWebhookClient.h"
+
+#import <Foundation/Foundation.h>
+#include <bsm/libbsm.h>
+#include <pwd.h>
+#include <string>
+
+#include "Source/common/AuditUtilities.h"
+#import "Source/common/SNTBlockMessage.h"
+#import "Source/common/SNTConfigurator.h"
+#import "Source/santad/SNTDecisionCache.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTStoredFileAccessEvent.h"
+#import "Source/common/SNTSystemInfo.h"
+#import "Source/common/String.h"
+
+namespace santa {
+
+FAAWebhookClient::FAAWebhookClient() {
+  queue_ = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+  NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+  config.timeoutIntervalForRequest = 10.0;  // 10 second timeout
+  config.timeoutIntervalForResource = 30.0;
+  url_session_ = [NSURLSession sessionWithConfiguration:config];
+}
+
+FAAWebhookClient::~FAAWebhookClient() {
+  // Invalidate and cancel the session to cancel any pending tasks
+  // This ensures the object outlives any async operations
+  if (url_session_) {
+    [url_session_ invalidateAndCancel];
+    url_session_ = nil;
+  }
+}
+
+void FAAWebhookClient::TriggerWebhookForRuleMatch(const WatchItemPolicyBase &policy,
+                                                  const std::string &target_path,
+                                                  const Message &msg) {
+  // Check if webhook is configured
+  if (!policy.webhook_url.has_value() || !policy.webhook_url.value()) {
+    return;
+  }
+
+  NSString *webhook_url_template = policy.webhook_url.value();
+  NSDictionary *webhook_headers = policy.webhook_headers.has_value()
+                                      ? policy.webhook_headers.value()
+                                      : nil;
+
+  // Create a copy of necessary data before going async
+  std::string policy_name_copy = policy.name;
+  std::string policy_version_copy = policy.version;
+  std::string target_path_copy = target_path;
+  Message msg_copy = msg;
+
+  // Capture url_session_ explicitly to avoid accessing 'this' in the async block
+  // This ensures the NSURLSession is retained even if FAAWebhookClient is destroyed
+  NSURLSession *session = url_session_;
+
+  dispatch_async(queue_, ^{
+    // Build the event for template mapping
+    // We need to create a minimal event with the information we have
+    SNTCachedDecision *cd = [[SNTDecisionCache sharedCache]
+        cachedDecisionForFile:msg_copy->process->executable->stat];
+    SNTStoredFileAccessEvent *event = [[SNTStoredFileAccessEvent alloc] init];
+
+    event.accessedPath = StringToNSString(target_path_copy);
+    event.ruleVersion = StringToNSString(policy_version_copy);
+    event.ruleName = StringToNSString(policy_name_copy);
+    event.process.fileSHA256 = cd.sha256 ?: @"<unknown sha>";
+    event.process.filePath = StringToNSString(msg_copy->process->executable->path.data);
+    event.process.teamID = cd.teamID ?: @"<unknown team id>";
+    event.process.signingID = cd.signingID ?: @"<unknown signing id>";
+    event.process.cdhash = cd.cdhash ?: @"<unknown CDHash>";
+    event.process.pid = @(audit_token_to_pid(msg_copy->process->audit_token));
+    event.process.signingChain = cd.certChain;
+    struct passwd *user = getpwuid(audit_token_to_ruid(msg_copy->process->audit_token));
+    if (user) event.process.executingUser = @(user->pw_name);
+    event.process.parent = [[SNTStoredFileAccessProcess alloc] init];
+    event.process.parent.pid = @(audit_token_to_pid(msg_copy->process->parent_audit_token));
+    event.process.parent.filePath = StringToNSString(msg_copy.ParentProcessPath());
+
+    // Build the URL with variable substitution (using static helper to avoid accessing 'this')
+    NSURL *url = [SNTBlockMessage eventDetailURLForFileAccessEvent:event
+                                                         customURL:webhook_url_template];
+    if (!url) {
+      NSString *rule_name = StringToNSString(policy_name_copy);
+      LOGW(@"Failed to build webhook URL for rule '%@'", rule_name);
+      return;
+    }
+
+    // Create the request (inline to avoid accessing 'this')
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    [request setHTTPMethod:@"POST"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+
+    // Add custom headers if provided
+    if (webhook_headers) {
+      for (NSString *key in webhook_headers) {
+        id value = webhook_headers[key];
+        if ([value isKindOfClass:[NSString class]]) {
+          [request setValue:(NSString *)value forHTTPHeaderField:key];
+        }
+      }
+    }
+
+    // Perform the request asynchronously using the captured session
+    // Convert rule name to NSString inside the completion handler to avoid use-after-free
+    // The policy_name_copy std::string is captured by the dispatch_async block and will
+    // remain valid until the block completes
+    NSURLSessionDataTask *task = [session
+        dataTaskWithRequest:request
+          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            // Convert string inside completion handler to ensure it's valid when used
+            NSString *rule_name = StringToNSString(policy_name_copy);
+            if (error) {
+              LOGW(@"Webhook request failed for rule '%@': %@", rule_name,
+                   error.localizedDescription);
+              return;
+            }
+
+            if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+              NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+              if (httpResponse.statusCode >= 200 && httpResponse.statusCode < 300) {
+                LOGD(@"Webhook request succeeded for rule '%@' (status: %ld)",
+                     rule_name, (long)httpResponse.statusCode);
+              } else {
+                LOGW(@"Webhook request returned error status for rule '%@': %ld",
+                     rule_name, (long)httpResponse.statusCode);
+              }
+            }
+          }];
+
+    [task resume];
+  });
+}
+
+}  // namespace santa
+

--- a/docs/docs/configuration/faa.md
+++ b/docs/docs/configuration/faa.md
@@ -184,6 +184,35 @@ The `Options` dictionary within each rule supports the following keys:
 
 - `EnableSilentTTYMode` (optional): Boolean. When `true`, violations are logged, but no notification is sent to the controlling TTY. Defaults to `false`.
 
+- `WebhookURL` (optional): URL template for webhook notifications. When configured, a POST request will be sent to this URL whenever the rule matches (including audit-only rules). Supports the same [variable substitution placeholders](#eventdetailurl-and-webhookurl-placeholders) as `EventDetailURL`. The webhook is sent asynchronously and will not block the file access decision.
+
+- `WebhookHeaders` (optional): Dictionary of custom HTTP headers to include in webhook requests. Keys are header names and values are header values (both must be strings). Useful for authentication tokens or other custom headers required by your webhook endpoint.
+
+### Webhook Example
+
+The following example shows how to configure a webhook for a rule:
+
+```xml
+<key>Options</key>
+<dict>
+	<key>RuleType</key>
+	<string>PathsWithAllowedProcesses</string>
+	<key>AuditOnly</key>
+	<true/>
+	<key>WebhookURL</key>
+	<string>https://my-server/webhooks/faa/%rule_name%/%file_identifier%</string>
+	<key>WebhookHeaders</key>
+	<dict>
+		<key>Authorization</key>
+		<string>Bearer my-token</string>
+		<key>X-Custom-Header</key>
+		<string>custom-value</string>
+	</dict>
+</dict>
+```
+
+When this rule matches, a POST request will be sent to the webhook URL with the specified headers. The URL will have placeholders replaced with actual values (e.g., `%rule_name%` will be replaced with the rule name, `%file_identifier%` with the SHA-256 of the accessing process).
+
 ## Rule Type Selection
 
 Choose your rule type based on what you're protecting:
@@ -197,12 +226,16 @@ Choose your rule type based on what you're protecting:
 
 **Process-centric example**: Prevent AirDrop processes from reading files in folders containing sensitive corporate data.
 
-## EventDetailURL placeholders
+## EventDetailURL and WebhookURL placeholders
 
 When an FAA rule blocks access to a file, the user will be presented with a block notification dialog. On this dialog a
 button can be displayed which will take the user to a page with more information about that event. For the button to
 appear you must populate the `EventDetailURL` field, either at the top-level of the configuration or in an individual
-rule. This URL can contain placeholders, which will be populated at runtime; the supported placeholders are:
+rule. This URL can contain placeholders, which will be populated at runtime.
+
+The `WebhookURL` option also supports the same placeholders and will be triggered whenever a rule matches (including audit-only rules).
+
+The supported placeholders are:
 
 | Placeholder         | Description                                                                                                               |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This PR adds an option to FAA that will cause a web request to be made any time an FAA rule match occurs. 

Note this is a non-interactive web request. This supports similar templating as the event details URL. It can be used to allow FAA to watch files and trigger an action in other systems when they're  matched.