### PR TITLE
Emit audit events from TemporaryMonitorMode

### DIFF
--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
@@ -45,6 +45,9 @@ typedef NS_ENUM(NSInteger, SNTTemporaryMonitorModeLeaveReason) {
   // The machine's SyncBaseURL configuration changed which cancelled
   // an active session.
   SNTTemporaryMonitorModeLeaveReasonSyncServerChanged,
+
+  // The machine rebooted and the previous session is no longer applicable
+  SNTTemporaryMonitorModeLeaveReasonReboot,
 };
 
 // Represents a temporary Monitor Mode audit event stored in the events database.

--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.mm
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.mm
@@ -23,7 +23,6 @@
 // random UUID on each instatiation to prevent caching.
 @property(readonly) NSUUID *uniqueUuid;
 @end
-;
 
 @implementation SNTStoredTemporaryMonitorModeEnterAuditEvent
 

--- a/Source/common/Timer.h
+++ b/Source/common/Timer.h
@@ -132,6 +132,18 @@ class Timer : public std::enable_shared_from_this<Timer<T>> {
   }
 
  protected:
+  // Convenience method to provide shared_from_this to derived classes
+  template <typename U>
+  std::shared_ptr<U> shared_from_base() {
+    return std::static_pointer_cast<T>(this->shared_from_this());
+  }
+
+  // Convenience method to provide weak_from_this to derived classes
+  template <typename U>
+  std::weak_ptr<U> weak_from_base() {
+    return std::weak_ptr<U>(std::static_pointer_cast<U>(this->shared_from_this()));
+  }
+
   // Like SetTimerInterval, but doesn't clamp to min/max
   // This is a protected interface that is exposed for testing.
   void ForceSetIntervalForTestingUnsafe(uint32_t interval_seconds) {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -257,7 +257,9 @@ objc_library(
         "//Source/common:Pinning",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTError",
+        "//Source/common:SNTKVOManager",
         "//Source/common:SNTModeTransition",
+        "//Source/common:SNTStoredTemporaryMonitorModeAuditEvent",
         "//Source/common:SNTSystemInfo",
         "//Source/common:SystemResources",
         "//Source/common:Timer",
@@ -269,11 +271,10 @@ santa_unit_test(
     name = "TemporaryMonitorModeTest",
     srcs = ["TemporaryMonitorModeTest.mm"],
     deps = [
-        ":TemporaryMonitorMode",
         ":SNTNotificationQueue",
+        ":TemporaryMonitorMode",
         "//Source/common:SNTModeTransition",
         "//Source/common:SystemResources",
-        # "//Source/common:TestUtils",
         "@OCMock",
     ],
 )

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -35,11 +35,4 @@
                                  logger:(std::shared_ptr<santa::Logger>)logger
                              watchItems:(std::shared_ptr<santa::WatchItems>)watchItems;
 
-// Will immediately end any active temporary Monitor Mode session and
-// remove sync server mode transition settings.
-//
-// Returns YES if there was an active temporary Monitor Mode session that was
-// ended. Otherwise NO.
-- (BOOL)revokeTemporaryMonitorMode;
-
 @end

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -261,10 +261,6 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
                 LOGI(@"SyncBaseURL changed: %@ -> %@", oldValue, newValue);
 
-                if ([dc revokeTemporaryMonitorMode]) {
-                  LOGI(@"Temporary Monitor Mode session revoked due to SyncBaseURL changing.");
-                }
-
                 [syncd_queue reassessSyncServiceConnection];
               }],
     [[SNTKVOManager alloc] initWithObject:configurator


### PR DESCRIPTION
This handles emitting audit events for the various enter/leave operations with appropriate reasons. The next part will take care of hooking up the newly emitted stored events to the EventUploadRequests.