### PR TITLE
Add support for time duration strings.

### DIFF
--- a/Source/santactl/Commands/SNTCommandMonitorMode.mm
+++ b/Source/santactl/Commands/SNTCommandMonitorMode.mm
@@ -61,36 +61,18 @@ REGISTER_COMMAND_NAME(@"monitormode")
   NSString *unit = nil;
 
   NSInteger intValue = 0;
-  NSUInteger locationBeforeScan = scanner.scanLocation;
   if ([scanner scanInteger:&intValue]) {
-    NSUInteger locationAfterInteger = scanner.scanLocation;
-
-    // Verify that we actually scanned something and didn't skip whitespace
-    if (locationAfterInteger == locationBeforeScan) {
-      return 0;  // Invalid: no integer found
-    }
-
     // Check if we're at the end (no unit specified)
     if ([scanner isAtEnd]) {
       return intValue;
     }
 
-    // Verify the next character is immediately adjacent (no whitespace)
-    unichar nextChar = [duration characterAtIndex:locationAfterInteger];
-    if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:nextChar]) {
-      return 0;  // Invalid: whitespace between integer and unit
-    }
-
     // Scan exactly one character from the unit set
     NSString *scannedUnit = nil;
-    NSUInteger locationBeforeUnit = scanner.scanLocation;
     if ([scanner scanCharactersFromSet:[NSCharacterSet characterSetWithCharactersInString:@"smhd"]
                             intoString:&scannedUnit]) {
-      NSUInteger locationAfterUnit = scanner.scanLocation;
-
       // Ensure unit is exactly one character and we're at the end
-      if (scannedUnit.length == 1 && locationAfterUnit == locationBeforeUnit + 1 &&
-          [scanner isAtEnd]) {
+      if (scannedUnit.length == 1 && [scanner isAtEnd]) {
         unit = scannedUnit;
       } else {
         return 0;  // Invalid: unit is not exactly one char or there's more content
@@ -129,15 +111,6 @@ REGISTER_COMMAND_NAME(@"monitormode")
       if (arg.length == 0) {
         [self printErrorUsageAndExit:
                   @"--duration requires a whole number argument or duration string"];
-      }
-
-      // Check if the next argument is a single-character unit (suggesting split input like "100 m")
-      if (i + 1 < arguments.count) {
-        NSString *nextArg = arguments[i + 1];
-        if (nextArg.length == 1 && [@"smhd" rangeOfString:nextArg].location != NSNotFound) {
-          [self printErrorUsageAndExit:
-                    @"--duration requires a whole number argument or duration string"];
-        }
       }
 
       requestedDuration = [self parseTimeInterval:arg];


### PR DESCRIPTION
This PR extends the `--duration` flag in `santactl monitormode` to support for parsing simple duration strings 

Specifically it adds support for  the following durations:

- `m` - minute e.g. `10m` this is basically ignored since the default is minutes
- `h` -  hours e.g. `2h` this gives you a short hand rather than typing 120
- `d`   - day - e.g. `1d` this is short hand for multiplying by 1440.

<img width="580" height="120" alt="Screenshot 2025-11-27 at 18 52 15" src="https://github.com/user-attachments/assets/a8c411c0-2701-4edf-86e4-a62e7a848742" />

