### PR TITLE
Add CEL rule to stop users from taking and mounting time machine snapshots

### DIFF
--- a/docs/docs/cookbook/cel.mdx
+++ b/docs/docs/cookbook/cel.mdx
@@ -95,7 +95,7 @@ args.join(" ").contains("-setremotelogin on") ||
 args.join(" ").contains("-setremoteappleevents on") ? BLOCKLIST : ALLOWLIST
 ```
 
-## Prevent Users from Mounting Time Machine Snapshots
+## Prevent Users from Taking and Mounting Time Machine Snapshots
 
 As was presented at [Kawaiicon 2025](https://kawaiicon.org/) by [Calum Hall](https://www.youtube.com/watch?v=hIeNuqq12sk&t=1390s), Time Machine snapshots can be used to bypass [File Access Authorization rules](https://www.youtube.com/watch?v=hIeNuqq12sk&t=1390s).
 
@@ -103,14 +103,16 @@ You can stop the taking of local snapshots by creating a signing ID for
 `platform:com.apple.tmutil` and attaching the following CEL program:
 
 ```clike
-('localsnapshot' in args ? BLOCKLIST : ALLOWLIST
+'localsnapshot' in args ? BLOCKLIST : ALLOWLIST
 ```
 
-Alternativelly if you can stop the mount of local snapshots with a signing ID rule
-`platform:com.apple.mount_apfs` with the following CEL program
+This will break taking local snapshots via the command line. Alternatively if
+you need to still be able to take time machine snapshots but don't want users
+to mount them locally you can stop the mount of local snapshots with a signing
+ID rule `platform:com.apple.mount_apfs` with the following CEL program
 
 
 ```clike
-'-s' in args && 
+('-s' in args &&
   args.exists(arg, arg.contains("com.apple.TimeMachine.")) ? BLOCKLIST : ALLOWLIST
 ```


### PR DESCRIPTION
This adds CEL rules to mitigate users using time machine snapshots as a way to try to bypass FAA.