### PR TITLE
Fix: Remove the unintentional inclusion of tty control codes in santactl fileinfo --json output

### DIFF
--- a/Source/santactl/Commands/SNTCommandFileInfo.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfo.mm
@@ -423,8 +423,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
                                                        r.type == SNTRuleTypeTeamID ? @"TeamID"
                                                                                    : @"SigningID"];
                                 } else {
-                                  if (r)
-                                    output = [r stringifyWithColor:(isatty(STDOUT_FILENO) == 1)];
+                                  if (r) output = [r stringifyWithColor:cmd.prettyOutput];
                                 }
                                 dispatch_semaphore_signal(sema);
                               }];


### PR DESCRIPTION
This removes the unintentional inclusion of tty control codes in santactl fileinfo --json output.

Fix #703 