### PR TITLE
build: Disable signing timestamps in bazel

### DIFF
--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -171,6 +171,7 @@ macos_application(
     bundle_id = "com.northpolesec.santa",
     bundle_name = "Santa",
     codesignopts = [
+        "--timestamp=none",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -28,6 +28,7 @@ macos_command_line_application(
     name = "santabundleservice",
     bundle_id = "com.northpolesec.santa.bundleservice",
     codesignopts = [
+        "--timestamp=none",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -147,6 +147,7 @@ macos_command_line_application(
     name = "santactl",
     bundle_id = "com.northpolesec.santa.ctl",
     codesignopts = [
+        "--timestamp=none",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1091,6 +1091,7 @@ macos_bundle(
     bundle_extension = "systemextension",
     bundle_id = "com.northpolesec.santa.daemon",
     codesignopts = [
+        "--timestamp=none",
         "--force",
         "--options library,kill,runtime",
     ],

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -420,6 +420,7 @@ macos_command_line_application(
     name = "santasyncservice",
     bundle_id = "com.northpolesec.santa.syncservice",
     codesignopts = [
+        "--timestamp=none",
         "--force",
         "--options library,kill,runtime",
     ],


### PR DESCRIPTION
I already did this back in #392 but codesign's behavior when timestamp is not set is "a system-specific default behavior is invoked" which appears to add the timestamp if the certificate that's being used is a "prod" certificate. Force bazel to send `--timestamp=none` so that the produced binaries are never timestamped. For release builds we re-sign everything with timestamps anyway.