### PR TITLE
Stub module to allow build time injection of network capabilities

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,6 +22,15 @@ git_override(
     remote = "https://github.com/northpolesec/protos",
 )
 
+# Santa Network Extension
+# By default, points to a stub that provides an empty implementation.
+# Maintainers can inject the real implementation at build time.
+bazel_dep(name = "santanetd", version = "1.0.0")
+local_path_override(
+    module_name = "santanetd",
+    path = "stubs/santanetd",
+)
+
 # FMDB
 non_module_deps = use_extension("//deps:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "FMDB")

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -5,6 +5,19 @@ load("//:helper.bzl", "SANTA_MINIMUM_OS_VERSION", "santa_unit_test")
 
 licenses(["notice"])
 
+# Hook for build-time injection of Santa's network capabilities from external repo.
+label_flag(
+    name = "network_extension_bundle",
+    build_setting_default = ":no_network_extension",
+)
+
+# Empty filegroup used to keep Santa buildable without access to the external repo.
+filegroup(
+    name = "no_network_extension",
+    srcs = [],
+    visibility = ["//visibility:public"],
+)
+
 swift_library(
     name = "SNTMessageView",
     srcs = ["SNTMessageView.swift"],
@@ -165,6 +178,7 @@ macos_application(
         "//Source/santametricservice": "MacOS",
         "//Source/santasyncservice": "MacOS",
         "//Source/santad:com.northpolesec.santa.daemon": "Library/SystemExtensions",
+        ":network_extension_bundle": "Library/SystemExtensions",
         "Resources/Fonts/StarJedi.ttf": ".",
     },
     app_icons = glob(["Resources/Assets.xcassets/**"]),

--- a/stubs/santanetd/MODULE.bazel
+++ b/stubs/santanetd/MODULE.bazel
@@ -1,0 +1,3 @@
+# Stub module for santanetd
+
+module(name = "santanetd", version = "1.0.0")

--- a/stubs/santanetd/README.md
+++ b/stubs/santanetd/README.md
@@ -1,0 +1,5 @@
+# santanetd Stub Module
+
+This is a minimal stub implementation of the `santanetd` module that allows
+the `santa` repository to build without requiring access to the private
+`santanetd` repository.


### PR DESCRIPTION
This sets up an injectable hook to allow non-maintainers of Santa to continue to properly build, but also allows maintainers to inject the real dependency at build time.

Part of SNT-252