### PR TITLE
Support detecting first launch after boot

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -967,4 +967,9 @@ extern NSString *_Nonnull const kEnableMenuItemUserOverride;
 - (void)saveStatsSubmissionAttemptTime:(nullable NSDate *)timestamp
                                version:(nullable NSString *)version;
 
+///
+/// Returns true if the system has rebooted since the last time santad was run.
+///
+@property(readonly, nonatomic) BOOL isFirstLaunchAfterBoot;
+
 @end

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -64,6 +64,9 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
 // Re-declare read/write for KVO
 @property BOOL inTemporaryMonitorMode;
 
+// Internal boot session tracking
+@property(nullable) NSString *lastBootUUID;
+
 @end
 
 @implementation SNTConfigurator
@@ -80,6 +83,7 @@ static NSString *const kStateStatsKey = @"Stats";
 static NSString *const kStateStatsLastSubmissionAttemptKey = @"LastAttempt";
 static NSString *const kStateStatsLastSubmissionVersionKey = @"LastVersion";
 static NSString *const kStateTempMonitorModeKey = @"TMM";
+static NSString *const kStateLastBootUUIDKey = @"LastBootUUID";
 
 /// User defaults key for user override of the menu item enabled setting.
 NSString *const kEnableMenuItemUserOverride = @"EnableMenuItemUserOverride";
@@ -392,6 +396,15 @@ static NSString *const kModeTransitionKey = @"ModeTransition";
     if (self.stateAccessAuthorizerBlock()) {
       [self migrateDeprecatedStatsStatePath:oldStateFilePath];
       _state = [self readStateFromDisk] ?: [NSDictionary dictionary];
+
+      // Check if this is first launch after boot before updating the UUID
+      NSString *currentBootUUID = [SNTSystemInfo bootSessionUUID];
+      if (![currentBootUUID isEqualToString:_lastBootUUID]) {
+        // If the lastBootUUID wasn't set, it is indeterminate whether or not this is truly the
+        // first launch after boot. Treat this as a "No".
+        _isFirstLaunchAfterBoot = (_lastBootUUID != nil);
+        [self updateLastBootUUID:currentBootUUID];
+      }
     }
 
     [self startWatchingDefaults];
@@ -836,6 +849,13 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (nullable NSDictionary *)savedTemporaryMonitorModeState {
   return self.state[kStateTempMonitorModeKey];
+}
+
+- (void)updateLastBootUUID:(NSString *)bootUUID {
+  @synchronized(self) {
+    [self updateStateSynchronizedKey:kStateLastBootUUIDKey value:bootUUID];
+    _lastBootUUID = bootUUID;
+  }
 }
 
 - (BOOL)failClosed {
@@ -1753,6 +1773,11 @@ static SNTConfigurator *sharedConfigurator = nil;
     newState[kStateTempMonitorModeKey] = state[kStateTempMonitorModeKey];
   }
 
+  if ([state[kStateLastBootUUIDKey] isKindOfClass:[NSString class]]) {
+    _lastBootUUID = state[kStateLastBootUUIDKey];
+    newState[kStateLastBootUUIDKey] = _lastBootUUID;
+  }
+
   return newState;
 }
 
@@ -1769,7 +1794,7 @@ static SNTConfigurator *sharedConfigurator = nil;
   _lastStatsSubmissionVersion = version;
 }
 
-- (void)updateStateSynchronizedKey:(NSString *)key value:(NSDictionary *)value {
+- (void)updateStateSynchronizedKey:(NSString *)key value:(id)value {
   NSMutableDictionary *newState = [self.state mutableCopy];
 
   newState[key] = value;


### PR DESCRIPTION
Adds boot session UUID to the state file, compared to the current value on startup to determine whether or not this is the first launch after a reboot.

Part of SNT-261