### PR TITLE
Add network mount block config to santactl status

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -553,6 +553,11 @@ extern NSString *_Nonnull const kEnableMenuItemUserOverride;
 #pragma mark - Sync Settings
 
 ///
+/// Returns whether or not Santa is able to use private Sync V2 features
+///
+- (BOOL)isSyncV2Enabled;
+
+///
 ///  The base URL of the sync server.
 ///
 @property(nullable, readonly, nonatomic) NSURL *syncBaseURL;

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -1432,6 +1432,10 @@ static SNTConfigurator *sharedConfigurator = nil;
   return (self.fcmProject.length && self.fcmEntity.length && self.fcmAPIKey.length);
 }
 
+- (BOOL)isSyncV2Enabled {
+  return santa::IsDomainPinned([self syncBaseURL]);
+}
+
 - (BOOL)enablePushNotifications {
   // TODO: Consider supporting enablement from the sync server.
   // Check new key first, then fall back to deprecated key for backward compatibility
@@ -1443,9 +1447,8 @@ static SNTConfigurator *sharedConfigurator = nil;
   if (deprecatedValue != nil) {
     return [deprecatedValue boolValue];
   }
-  // Default to true when neither key is set, and the SyncBaseURL is a pinned
-  // Workshop URL.
-  if (santa::IsDomainPinned([self syncBaseURL])) {
+  // Default to true when neither key is set, and SyncV2 is enabled.
+  if ([self isSyncV2Enabled]) {
     return YES;
   }
   return NO;

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -61,6 +61,7 @@ struct RuleCounts {
 ///
 ///  Config ops
 ///
+- (void)isSyncV2Enabled:(void (^)(BOOL))reply;
 - (void)watchdogInfo:(void (^)(uint64_t, uint64_t, double, double))reply;
 - (void)watchItemsState:(void (^)(BOOL, uint64_t, NSString *,
                                   santa::WatchItems::DataSource dataSource, NSString *,
@@ -73,6 +74,7 @@ struct RuleCounts {
 - (void)enableTransitiveRules:(void (^)(BOOL))reply;
 - (void)blockUSBMount:(void (^)(BOOL))reply;
 - (void)remountUSBMode:(void (^)(NSArray<NSString *> *))reply;
+- (void)blockNetworkMount:(void (^)(NSNumber *))reply;
 
 ///
 /// FAA Retrieval ops

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -274,6 +274,10 @@ double watchdogRAMPeak = 0;
 
 #pragma mark Config Ops
 
+- (void)isSyncV2Enabled:(void (^)(BOOL))reply {
+  reply([[SNTConfigurator configurator] isSyncV2Enabled]);
+}
+
 - (void)watchdogInfo:(void (^)(uint64_t, uint64_t, double, double))reply {
   reply(watchdogCPUEvents, watchdogRAMEvents, watchdogCPUPeak, watchdogRAMPeak);
 }
@@ -315,6 +319,13 @@ double watchdogRAMPeak = 0;
 
 - (void)remountUSBMode:(void (^)(NSArray<NSString *> *))reply {
   reply([[SNTConfigurator configurator] remountUSBMode]);
+}
+
+- (void)blockNetworkMount:(void (^)(NSNumber *))reply {
+  // If blocking network mounts is enabled, respond with the number of
+  // host exceptions, otherwise nil.
+  SNTConfigurator *configurator = [SNTConfigurator configurator];
+  reply(configurator.blockNetworkMount ? @(configurator.allowedNetworkMountHosts.count) : nil);
 }
 
 - (void)enableBundles:(void (^)(BOOL))reply {


### PR DESCRIPTION
```
>>> Daemon Info
  Mode                      | Temporary Monitor Mode (About 5 hours, 35 minutes remaining)
  Log Type                  | syslog
  File Logging              | Yes
  USB Blocking              | Yes
  USB Remounting Mode       | rdonly, noexec, nosuid
  On Start USB Options      | None
  Network Mount Blocking    | Yes (1 host exception)
  Static Rules              | 4
  Watchdog CPU Events       | 0  (Peak: 0.49%)
  Watchdog RAM Events       | 0  (Peak: 25.02MB)
  ```
  ```
    "daemon" : {
    "watchdog_ram_events" : 0,
    "static_rules" : 4,
    "file_logging" : true,
    "log_type" : "syslog",
    "watchdog_cpu_events" : 0,
    "network_mount_host_exceptions" : 1,
    "block_network_mounts" : true,
    "mode" : "Temporary Monitor Mode (About 5 hours, 35 minutes remaining)",
    "watchdog_cpu_peak" : 0.48696582999999993,
    "watchdog_ram_peak" : 25.015625,
    "remount_usb_mode" : [
      "rdonly",
      "noexec",
      "nosuid"
    ],
    "block_usb" : true,
    "on_start_usb_options" : "None"
  },
  ```