### PR TITLE
gui: deny execution of hold&ask events immediately if unavailable

### DIFF
--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -370,10 +370,8 @@ struct SNTBinaryMessageWindowView: View {
   // the "Open Event" button.
   func standAloneButton() {
     guard let e = self.event else {
-      if let cb = self.replyCallback {
-        DispatchQueue.main.async {
-          cb(false)
-        }
+      DispatchQueue.main.async {
+        callReplyCallback(false)
       }
       return
     }


### PR DESCRIPTION
Prior to this change, if a hold & ask execution triggered a Santa dialog but biometry is not available (and the `EnableStandalonePasswordFallback` key is not set to true) the execution would remain held until the dialog was dismissed. With this change, the execution will be denied immediately. 