### PR TITLE
Add NetworkActivity to protobuf schema

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -1173,7 +1173,7 @@ message NetworkActivity {
   // A single network socket flow observed during the monitoring window
   message Flow {
     // Unique identifier for this flow
-    optional bytes id = 1;
+    optional string id = 1;
 
     // Remote endpoint address (IPv4 or IPv6 string representation)
     optional string remote_address = 2;


### PR DESCRIPTION
Add messages to the santa.proto schema for tracking network flow activity. Telemetry is grouped per-process, per-window in order to help deduplicate process data when several flows are generated.