### PR TITLE
Cleanup minor issues on rule download path

### DIFF
--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -139,6 +139,7 @@ objc_library(
     srcs = ["SNTPushNotificationsTracker.mm"],
     hdrs = ["SNTPushNotificationsTracker.h"],
     deps = [
+        "//Source/common:SNTDeepCopy",
         "//Source/common:SNTLogging",
         "//Source/common:SNTSyncConstants",
     ],

--- a/Source/santasyncservice/SNTPushNotificationsTracker.mm
+++ b/Source/santasyncservice/SNTPushNotificationsTracker.mm
@@ -14,6 +14,7 @@
 
 #import "Source/santasyncservice/SNTPushNotificationsTracker.h"
 
+#import "Source/common/SNTDeepCopy.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTSyncConstants.h"
 
@@ -91,7 +92,7 @@
 - (NSDictionary *)all {
   __block NSDictionary *d;
   dispatch_sync(self.notificationsQueue, ^() {
-    d = self.notifications;
+    d = [self.notifications sntDeepCopy];
   });
   return d;
 }

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -267,7 +267,7 @@ SNTFileAccessRule *FAARuleFromProtoFAARuleAdd(const ::pbv2::FileAccessRule::Add 
   details[kWatchItemConfigKeyOptions] = optionsDict;
 
   NSArray *processes = ProcessesFromProtoFAARuleProcesses(pbAddRule.processes());
-  if (!paths) {
+  if (!processes) {
     return nil;
   }
   details[kWatchItemConfigKeyProcesses] = processes;
@@ -389,7 +389,7 @@ void ProcessDeprecatedBundleNotificationsForRule(
         decrementPendingRulesForHash:primaryHash
                       totalRuleCount:@(protoRule->file_bundle_binary_count())];
   }
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
 }
 
 @implementation SNTSyncRuleDownload


### PR DESCRIPTION
Fixes 3 issues:

1. Checking wrong variable for nil. The improper code appears to be safe, even when looking at downstream effects. But the fix should short circuit work when invalid rules are provided.
2. lang diagnostic push/pop copy paste issue
3. There is a small race that could potentially exist if unblocked announcements dictionary is mutated after being returned. If this happens, the original caller would operate on a dictionary that was being mutated.