### PR TITLE
telemetry: Add TelemetryFilterExpressions, fix waiting for Sleigh

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -317,6 +317,13 @@
 @property(readonly) uint32_t telemetryExportMaxFilesPerBatch;
 
 ///
+///  CEL expressions used to filter telemetry events during export.
+///
+///  @note: This property is KVO compliant.
+///
+@property(nullable, readonly, nonatomic) NSArray<NSString *> *telemetryFilterExpressions;
+
+///
 ///  If set, contains the filesystem access policy configuration.
 ///
 ///  @note: The property fileAccessPolicyPlist will be ignored if

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -191,6 +191,7 @@ static NSString *const kEnableNATS =
 
 static NSString *const kEntitlementsPrefixFilterKey = @"EntitlementsPrefixFilter";
 static NSString *const kEntitlementsTeamIDFilterKey = @"EntitlementsTeamIDFilter";
+static NSString *const kTelemetryFilterExpressionsKey = @"TelemetryFilterExpressions";
 
 static NSString *const kOnStartUSBOptions = @"OnStartUSBOptions";
 
@@ -379,6 +380,7 @@ static NSString *const kNetworkExtensionSettingsKey = @"NetworkExtensionSettings
       kEntitlementsPrefixFilterKey : array,
       kEntitlementsTeamIDFilterKey : array,
       kEnabledProcessAnnotations : array,
+      kTelemetryFilterExpressionsKey : array,
       kTelemetryKey : array,
       kBrandingCompanyName : string,
       kBrandingCompanyLogo : string,
@@ -786,6 +788,10 @@ static SNTConfigurator *sharedConfigurator = nil;
 }
 
 + (NSSet *)keyPathsForValuesAffectingEntitlementsTeamIDFilter {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingTelemetryFilterExpressions {
   return [self configStateSet];
 }
 
@@ -1765,6 +1771,10 @@ static SNTConfigurator *sharedConfigurator = nil;
 
 - (NSArray *)entitlementsTeamIDFilter {
   return EnsureArrayOfStrings(self.configState[kEntitlementsTeamIDFilterKey]);
+}
+
+- (NSArray *)telemetryFilterExpressions {
+  return EnsureArrayOfStrings(self.configState[kTelemetryFilterExpressionsKey]);
 }
 
 - (void)migrateDeprecatedStatsStatePath:(NSString *)oldPath {

--- a/Source/santad/SleighLauncher.mm
+++ b/Source/santad/SleighLauncher.mm
@@ -195,7 +195,11 @@ absl::StatusOr<std::string> SleighLauncher::SerializeConfig(const std::vector<in
     config.add_input_fds(fd);
   }
 
-  // filter_expressions left empty (reserved for future use)
+  NSArray<NSString *> *filterExpressions =
+      [[SNTConfigurator configurator] telemetryFilterExpressions];
+  for (NSString *expr in filterExpressions) {
+    config.add_filter_expressions([expr UTF8String]);
+  }
 
   // Convert export config to parameters for sleigh
   SNTExportConfiguration *exportConfig = [[SNTConfigurator configurator] exportConfig];

--- a/Source/santad/main.mm
+++ b/Source/santad/main.mm
@@ -103,9 +103,6 @@ void InstallServices() {
 
 int main(int argc, char *argv[]) {
   @autoreleasepool {
-    // Do not wait on child processes
-    signal(SIGCHLD, SIG_IGN);
-
     NSString *product_version = [SNTSystemInfo santaProductVersion];
     NSString *build_version = [SNTSystemInfo santaBuildVersion];
 

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -442,6 +442,13 @@ changes in the release notes of any future release that changes them.`,
       type: "string",
       repeated: true,
     },
+    {
+      key: "TelemetryFilterExpressions",
+      description: `A list of CEL expressions for filtering/redacting rows before upload. Only useful for Workshop customers.`,
+      type: "string",
+      repeated: true,
+      versionAdded: "2026.2",
+    },
   ],
   faa: [
     {


### PR DESCRIPTION
This adds the ability to send CEL filter expressions to Sleigh, filtering/redacting events before upload. It also unsets SIG_IGN on SIGCHLD so that santad can correctly determine Sleigh's exit code

Part of WS-954