### PR TITLE
Update FAA cookbook rule for macOS 26.3

### DIFF
--- a/docs/docs/cookbook/faa.md
+++ b/docs/docs/cookbook/faa.md
@@ -44,7 +44,7 @@ process.
 					<key>PlatformBinary</key>
 					<true/>
 				</dict>
-                                <!-- On macOS 26.3 the mds processs will also read cookies -->
+                                <!-- On macOS 26.3 the mds process will also read cookies -->
 				<dict>
 					<key>SigningID</key>
 					<string>com.apple.mds</string>


### PR DESCRIPTION
This updates the ChromeCookie rule to add a process exception for the `platform:com.apple.mds` process on macOS 26.3.