### PR TITLE
docs: Fix top-and-bottom CEL Playground editors

### DIFF
--- a/docs/src/components/CELPlayground/index.tsx
+++ b/docs/src/components/CELPlayground/index.tsx
@@ -102,7 +102,7 @@ export default function CELPlayground() {
 
   return (
     <div className="flex flex-col gap-4 mb-4">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid md:grid-cols-2 gap-4">
         <div className="flex flex-col gap-2">
           <div className="flex items-center min-h-8">
             <label className="text-sm font-medium text-foreground">


### PR DESCRIPTION
I've tested this locally by doing a full build and serve instead of using the dev server.