### PR TITLE
Clarify docs for entitlement filtering config keys

### DIFF
--- a/docs/docs/features/telemetry.mdx
+++ b/docs/docs/features/telemetry.mdx
@@ -388,10 +388,12 @@ Applies when using the `protobuf` or `json` log types.
 - `EnableMachineIDDecoration`: Adds machine ID to filelog entries
 - `EntitlementsPrefixFilter`: Entitlement prefixes to exclude from execution telemetry.
   Matching entitlements will be omitted from the logged event, but the execution event
-  itself is still logged.
+  itself is still logged. Entitlements are only logged when `EventLogType` is set to
+  `protobuf` or `json`.
 - `EntitlementsTeamIDFilter`: Team IDs whose process entitlements should be excluded from
   execution telemetry. Matching entitlements will be omitted from the logged event, but the
-  execution event itself is still logged.
+  execution event itself is still logged. Entitlements are only logged when `EventLogType`
+  is set to `protobuf` or `json`.
 
 ## Example Configuration
 

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -465,10 +465,11 @@ changes in the release notes of any future release that changes them.`,
     },
     {
       key: "EntitlementsPrefixFilter",
-      description: `Filters entitlements from execution telemetry based on prefix. Entitlements
-        matching a prefix in this list will be omitted from the logged event. This does not
-        prevent the execution event itself from being logged - it only controls which
-        entitlements are included in the event (for example: \`com.apple.private\`).`,
+      description: `Filters entitlements from execution telemetry based on prefix (for example:
+        \`com.apple.private\`). Entitlements matching a prefix in this list will be omitted
+        from the logged event. This does not prevent the execution event itself from being
+        logged - it only controls which entitlements are included in the event. Entitlements
+        are only logged when \`EventLogType\` is set to \`protobuf\` or \`json\`.`,
       type: "string",
       repeated: true,
     },
@@ -478,7 +479,8 @@ changes in the release notes of any future release that changes them.`,
         TeamID. When a process's code signature has a TeamID matching an entry in this list,
         its entitlements will be omitted from the logged event. This does not prevent the
         execution event itself from being logged - it only controls which entitlements are
-        included in the event. Use the value \`platform\` to filter entitlements from
+        included in the event. Entitlements are only logged when \`EventLogType\` is set to
+        \`protobuf\` or \`json\`. Use the value \`platform\` to filter entitlements from
         platform binaries.`,
       type: "string",
       repeated: true,


### PR DESCRIPTION
Hopefully addresses some of the ambiguity.

Part of #782 

Docs screenshots
<img width="951" height="323" alt="image" src="https://github.com/user-attachments/assets/0ec38542-0b11-4e78-98e5-9fa5ae1654a8" />

<img width="1002" height="183" alt="image" src="https://github.com/user-attachments/assets/c2106ce0-3dfe-43fb-bf0e-14ec0ee3d89b" />
