### PR TITLE
deps: Update NATS dep to use local_defines

### DIFF
--- a/deps/BUILD.nats
+++ b/deps/BUILD.nats
@@ -26,7 +26,7 @@ cc_library(
         "@boringssl//:ssl",
         "@boringssl//:crypto",
     ],
-    defines = [
+    local_defines = [
         "NATS_HAS_TLS",
         "_REENTRANT",
     ],


### PR DESCRIPTION
Without this, any target that has a dependency on NATS will have these same defines. They should be attached to the nats lib only