### PR TITLE
Add hash field to NetworkActivity proto message

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -1183,7 +1183,7 @@ message NetworkActivity {
     // Use `id + hash` as a unique identifier.
     optional string id = 1;
 
-    // A Santa-computed identiifer to help distinguish duplicate flow ids.
+    // A Santa-computed identifier to help distinguish duplicate flow ids.
     optional string hash = 2;
 
     // Remote endpoint address (IPv4 or IPv6 string representation)


### PR DESCRIPTION
Inserts the new `hash` field, and updates the field numbers for everything else.