### PR TITLE
Add network extension info to santactl status

### DIFF
--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -125,6 +125,8 @@ struct RuleCounts {
 /// Returns the desired enabled state for the network extension content filter.
 /// Returns NO if no settings have been synced yet.
 - (void)networkExtensionEnabled:(void (^)(BOOL enabled))reply;
+/// Returns whether the network extension is currently loaded and connected.
+- (void)networkExtensionLoaded:(void (^)(BOOL loaded))reply;
 
 @end
 

--- a/Source/santactl/Commands/SNTCommandStatus.mm
+++ b/Source/santactl/Commands/SNTCommandStatus.mm
@@ -261,9 +261,17 @@ REGISTER_COMMAND_NAME(@"status")
   }];
 
   __block NSNumber *networkMountExceptions;
+  __block BOOL networkExtensionEnabled = NO;
+  __block BOOL networkExtensionLoaded = NO;
   if (isSyncV2Enabled) {
     [rop blockNetworkMount:^(NSNumber *numExceptions) {
       networkMountExceptions = numExceptions;
+    }];
+    [rop networkExtensionEnabled:^(BOOL enabled) {
+      networkExtensionEnabled = enabled;
+    }];
+    [rop networkExtensionLoaded:^(BOOL loaded) {
+      networkExtensionLoaded = loaded;
     }];
   }
 
@@ -325,6 +333,11 @@ REGISTER_COMMAND_NAME(@"status")
       daemon[@"block_network_mounts"] = @(networkMountExceptions != nil);
       daemon[@"network_mount_host_exceptions"] = @([networkMountExceptions intValue]);
       stats[@"daemon"] = daemon;
+
+      stats[@"network_extension"] = @{
+        @"enabled" : @(networkExtensionEnabled),
+        @"loaded" : @(networkExtensionLoaded),
+      };
     }
 
     if (syncURLStr.length) {
@@ -427,6 +440,12 @@ REGISTER_COMMAND_NAME(@"status")
     printf("  %-35s | %s\n", "Enabled", (enableTransitiveRules ? "Yes" : "No"));
     printf("  %-35s | %lld\n", "Compiler Rules", ruleCounts.compiler);
     printf("  %-35s | %lld\n", "Transitive Rules", ruleCounts.transitive);
+
+    if (isSyncV2Enabled) {
+      printf(">>> Network Extension\n");
+      printf("  %-35s | %s\n", "Enabled", (networkExtensionEnabled ? "Yes" : "No"));
+      printf("  %-35s | %s\n", "Loaded", (networkExtensionLoaded ? "Yes" : "No"));
+    }
 
     printf(">>> Rule Types\n");
     printf("  %-35s | %lld\n", "Binary Rules", ruleCounts.binary);

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -810,4 +810,8 @@ double watchdogRAMPeak = 0;
   reply(settings ? settings.enable : NO);
 }
 
+- (void)networkExtensionLoaded:(void (^)(BOOL loaded))reply {
+  reply([self.netExtQueue isLoaded]);
+}
+
 @end

--- a/Source/santad/SNTNetworkExtensionQueue.h
+++ b/Source/santad/SNTNetworkExtensionQueue.h
@@ -46,4 +46,7 @@ extern NSString *const kSantaNetworkExtensionProtocolVersion;
 /// Checks that sync v2 is enabled and network extension settings have enable set to YES.
 - (BOOL)shouldInstallNetworkExtension;
 
+/// Returns YES if the network extension is currently connected.
+- (BOOL)isLoaded;
+
 @end

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -233,6 +233,10 @@ NSString *const kSantaNetworkExtensionProtocolVersion = @"1.0";
   return [configurator isSyncV2Enabled] && [configurator syncNetworkExtensionSettings].enable;
 }
 
+- (BOOL)isLoaded {
+  return self.netExtConnection != nil;
+}
+
 - (NSDictionary *)generateSettingsForProtocolVersion:(NSString *)protocolVersion {
   if (!protocolVersion) {
     return nil;


### PR DESCRIPTION
If using sync v2, show network extension status.

Part of SNT-261
