### PR TITLE
gui: Ensure window size is correct before displaying

### DIFF
--- a/Source/gui/SNTMessageWindowController.mm
+++ b/Source/gui/SNTMessageWindowController.mm
@@ -41,8 +41,14 @@
 - (IBAction)showWindow:(id)sender {
   [self.window setLevel:NSModalPanelWindowLevel];
   [self.window setMovableByWindowBackground:YES];
-  [self.window makeKeyAndOrderFront:sender];
+
+  // Force layout so NSHostingController sizes the window to fit the SwiftUI content
+  // before it becomes visible. Without this, the window briefly appears too small then
+  // snaps to the correct size once SwiftUI layout completes.
+  [self.window layoutIfNeeded];
   [self.window center];
+
+  [self.window makeKeyAndOrderFront:sender];
   [NSApp activateIgnoringOtherApps:YES];
 }
 


### PR DESCRIPTION
Force the window to layout before bringing to front, to try and ensure SwiftUI content has been properly sized.

I believe this will fix the issue where occasionally the window appears just slightly too small until it's clicked but because I can't reliably reproduce that issue I'm not 100% certain.