### PR TITLE
Add support for null custom_url to remove open button

### DIFF
--- a/Source/gui/SNTBinaryMessageWindowView.swift
+++ b/Source/gui/SNTBinaryMessageWindowView.swift
@@ -345,7 +345,8 @@ struct SNTBinaryMessageWindowView: View {
   }
 
   func shouldAddOpenButton() -> Bool {
-    return customURL?.length ?? 0 > 0
+    guard let customURL = customURL else { return false }
+    return customURL.length > 0 && customURL as String != "null"
   }
 
   func openButton() {

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -233,7 +233,10 @@ struct SNTFileAccessMessageWindowView: View {
   @State public var preventFutureNotificationPeriod: TimeInterval = NotificationSilencePeriods[0]
 
   var effectiveURL: NSString? {
-    customURL ?? configState.fileAccessEventDetailURL as NSString?
+    if let customURL = customURL {
+      return (customURL as String) == "null" ? nil : customURL
+    }
+    return configState.fileAccessEventDetailURL as NSString?
   }
 
   var effectiveText: String? {


### PR DESCRIPTION
This makes it so that if you set a custom_url to the string `null` that Santa won't display the Open button.

<img width="604" height="457" alt="Screenshot 2026-02-24 at 22 03 10" src="https://github.com/user-attachments/assets/15c4941a-9e09-4f46-ad9b-f9a9db6965b8" />

Fix for SNT-312