### PR TITLE
add missing notification keys

### DIFF
--- a/docs/docs/deployment/profile-notifications.md
+++ b/docs/docs/deployment/profile-notifications.md
@@ -30,9 +30,9 @@ You will need the following information to configure this profile:
 
 - Show In Notification Center: True
 
-- Show In Lock Screen: False
+- Show In Lock Screen: True
 
-- Alert Type: Banner
+- Alert Type: Temporary
 
 - Badges Enabled: True
 


### PR DESCRIPTION
Sounds Enabled and Alert Type were missing, and although there's probably no MDM using the 'spec' order, re-ordered for easier maintenance if you're diff'ing the mdm/profiles/com.apple.notificationsettings.yaml in github.com/apple/device-management
The 'Banner' designation for Alert Type matches what's in the GUI and maps to integer 1 (==Temporary) but Apple has a discrepancy with what you see in the DDM-applied MDM profile vs the Notifications GUI config interface in System Settings as of a bit ago

Please let me know if I should undo the ordering if that was unnecessary/to make the diff less noisy. For context, with Jamf (although they use arbitrary descriptions/naming), the order in the web configuration interface has been:

1. Bundle ID
2. Critical alerts
3. Notifications Enabled
4. Alert Type
5. Show In Lock Screen
6. Show In Notification Center
7. Badges Enabled
8. Sounds Enabled
![jamfRecentNotificationsGUI](https://github.com/user-attachments/assets/2dfe3e35-f4bf-495e-a878-0309effafd07)
