### PR TITLE
Improve perf related to event metrics

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1049,7 +1049,6 @@ objc_library(
     srcs = ["Metrics.mm"],
     hdrs = ["Metrics.h"],
     deps = [
-        ":EndpointSecurityMessage",
         ":SNTApplicationCoreMetrics",
         "//Source/common:MOLXPCConnection",
         "//Source/common:Platform",
@@ -1057,6 +1056,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTXPCMetricServiceInterface",
+        "@abseil-cpp//absl/container:flat_hash_map",
     ],
 )
 
@@ -1599,9 +1599,7 @@ santa_unit_test(
     name = "MetricsTest",
     srcs = ["MetricsTest.mm"],
     deps = [
-        ":EndpointSecurityMessage",
         ":Metrics",
-        ":MockEndpointSecurityAPI",
         "//Source/common:Platform",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTMetricSet",

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -142,26 +142,28 @@ using santa::Processor;
 
     // Update event stats BEFORE calling into the processor class to ensure
     // sequence numbers are processed in order.
-    self->_metrics->UpdateEventStats(self->_processor, esMsg.operator->());
+    self->_metrics->UpdateEventStats(self->_processor, esMsg->event_type, esMsg->seq_num,
+                                     esMsg->global_seq_num);
 
     if ([self handleContextMessage:esMsg]) {
       int64_t processingEnd = clock_gettime_nsec_np(CLOCK_MONOTONIC);
       self->_metrics->SetEventMetrics(self->_processor, EventDisposition::kProcessed,
-                                      processingEnd - processingStart, esMsg);
+                                      processingEnd - processingStart, esMsg->event_type);
       return;
     }
 
+    es_event_type_t event_type = esMsg->event_type;
     if ([self shouldHandleMessage:esMsg]) {
       [self handleMessage:std::move(esMsg)
           recordEventMetrics:^(EventDisposition disposition) {
             int64_t processingEnd = clock_gettime_nsec_np(CLOCK_MONOTONIC);
             self->_metrics->SetEventMetrics(self->_processor, disposition,
-                                            processingEnd - processingStart, esMsg);
+                                            processingEnd - processingStart, event_type);
           }];
     } else {
       int64_t processingEnd = clock_gettime_nsec_np(CLOCK_MONOTONIC);
       self->_metrics->SetEventMetrics(self->_processor, EventDisposition::kDropped,
-                                      processingEnd - processingStart, esMsg);
+                                      processingEnd - processingStart, event_type);
     }
   });
 

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -21,14 +21,13 @@
 #include <dispatch/dispatch.h>
 
 #include <atomic>
-#include <map>
 #include <memory>
 #include <string>
 
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTMetricSet.h"
-#include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "absl/container/flat_hash_map.h"
 
 namespace santa {
 
@@ -87,10 +86,11 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   void Export();
 
   // Used for tracking event sequence numbers to determine if drops occured
-  void UpdateEventStats(Processor processor, const es_message_t *msg);
+  void UpdateEventStats(Processor processor, es_event_type_t event_type, uint64_t seq_num,
+                        uint64_t global_seq_num);
 
   void SetEventMetrics(Processor processor, EventDisposition event_disposition, int64_t nanos,
-                       const santa::Message &msg);
+                       es_event_type_t event_type);
 
   void AddRateLimitingMetrics(int64_t events_rate_limited_count);
 
@@ -130,11 +130,11 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   dispatch_queue_t events_q_;
 
   // Small caches for storing event metrics between metrics export operations
-  std::map<EventCountTuple, int64_t> event_counts_cache_;
-  std::map<EventTimesTuple, int64_t> event_times_cache_;
+  absl::flat_hash_map<EventCountTuple, int64_t> event_counts_cache_;
+  absl::flat_hash_map<EventTimesTuple, int64_t> event_times_cache_;
   std::atomic<int64_t> rate_limit_counts_cache_;
-  std::map<FileAccessEventCountTuple, int64_t> faa_event_counts_cache_;
-  std::map<EventStatsTuple, SequenceStats> drop_cache_;
+  absl::flat_hash_map<FileAccessEventCountTuple, int64_t> faa_event_counts_cache_;
+  absl::flat_hash_map<EventStatsTuple, SequenceStats> drop_cache_;
 };
 
 }  // namespace santa

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -289,6 +289,10 @@ Metrics::Metrics(dispatch_queue_t q, dispatch_source_t timer_source, uint64_t in
 }
 
 Metrics::~Metrics() {
+  // Drain pending async metric updates before destroying member state
+  dispatch_sync(events_q_, ^{
+                });
+
   if (!running_) {
     // The timer_source_ must be resumed to ensure it has a proper retain count before being
     // destroyed. Additionally, it should first be cancelled to ensure the timer isn't ever fired
@@ -420,16 +424,17 @@ void Metrics::StopPoll() {
 }
 
 void Metrics::SetEventMetrics(Processor processor, EventDisposition event_disposition,
-                              int64_t nanos, const santa::Message &msg) {
-  dispatch_sync(events_q_, ^{
-    event_counts_cache_[EventCountTuple{processor, msg->event_type, event_disposition}]++;
-    event_times_cache_[EventTimesTuple{processor, msg->event_type}] = nanos;
+                              int64_t nanos, es_event_type_t event_type) {
+  dispatch_async(events_q_, ^{
+    event_counts_cache_[EventCountTuple{processor, event_type, event_disposition}]++;
+    event_times_cache_[EventTimesTuple{processor, event_type}] = nanos;
   });
 }
 
-void Metrics::UpdateEventStats(Processor processor, const es_message_t *msg) {
-  dispatch_sync(events_q_, ^{
-    EventStatsTuple event_stats_key{processor, msg->event_type};
+void Metrics::UpdateEventStats(Processor processor, es_event_type_t event_type, uint64_t seq_num,
+                               uint64_t global_seq_num) {
+  dispatch_async(events_q_, ^{
+    EventStatsTuple event_stats_key{processor, event_type};
     // NB: Using the invalid event type ES_EVENT_TYPE_LAST to store drop counts
     // based on the global sequence number.
     EventStatsTuple global_stats_key{processor, ES_EVENT_TYPE_LAST};
@@ -440,26 +445,25 @@ void Metrics::UpdateEventStats(Processor processor, const es_message_t *msg) {
     // Sequence number should always increment by 1.
     // Drops detected if there is a difference between the current sequence
     // number and the expected sequence number
-    int64_t new_event_drops = msg->seq_num - old_event_stats.next_seq_num;
-    int64_t new_global_drops = msg->global_seq_num - old_global_stats.next_seq_num;
+    int64_t new_event_drops = seq_num - old_event_stats.next_seq_num;
+    int64_t new_global_drops = global_seq_num - old_global_stats.next_seq_num;
 
     // Only log one or the other, prefer the event specific log.
     // For higher volume event types, we'll normally see the event-specific log eventually
     // For lower volume event types, we may only see the global drop message
     if (new_event_drops > 0) {
       LOGD(@"Drops detected for client: %@, event: %@, drops: %llu", ProcessorToString(processor),
-           EventTypeToString(msg->event_type), new_event_drops);
+           EventTypeToString(event_type), new_event_drops);
     } else if (new_global_drops > 0) {
       LOGD(@"Drops detected globally for client: %@, drops: %llu", ProcessorToString(processor),
            new_global_drops);
     }
 
-    drop_cache_[event_stats_key] = SequenceStats{.next_seq_num = msg->seq_num + 1,
+    drop_cache_[event_stats_key] = SequenceStats{.next_seq_num = seq_num + 1,
                                                  .drops = old_event_stats.drops + new_event_drops};
 
-    drop_cache_[global_stats_key] =
-        SequenceStats{.next_seq_num = msg->global_seq_num + 1,
-                      .drops = old_global_stats.drops + new_global_drops};
+    drop_cache_[global_stats_key] = SequenceStats{
+        .next_seq_num = global_seq_num + 1, .drops = old_global_stats.drops + new_global_drops};
   });
 }
 
@@ -470,7 +474,7 @@ void Metrics::AddRateLimitingMetrics(int64_t events_rate_limited_count) {
 void Metrics::SetFileAccessEventMetrics(std::string policy_version, std::string rule_name,
                                         FileAccessMetricStatus status, es_event_type_t event_type,
                                         FileAccessPolicyDecision decision) {
-  dispatch_sync(events_q_, ^{
+  dispatch_async(events_q_, ^{
     faa_event_counts_cache_[FileAccessEventCountTuple{
         std::move(policy_version), std::move(rule_name), status, event_type, decision}]++;
   });

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -29,8 +29,6 @@
 #import "Source/common/SNTCommonEnums.h"
 #include "Source/common/SNTMetricSet.h"
 #include "Source/common/TestUtils.h"
-#include "Source/santad/EventProviders/EndpointSecurity/Message.h"
-#include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 
 using santa::EventCountTuple;
 using santa::EventDisposition;
@@ -59,12 +57,19 @@ class MetricsPeer : public Metrics {
   using Metrics::drop_cache_;
   using Metrics::event_counts_cache_;
   using Metrics::event_times_cache_;
+  using Metrics::events_q_;
   using Metrics::faa_event_counts_cache_;
   using Metrics::interval_;
   using Metrics::rate_limit_counts_cache_;
   using Metrics::running_;
 
   using Metrics::SequenceStats;
+
+  // Drain the events queue to ensure all async blocks have completed
+  void DrainEventQueue() {
+    dispatch_sync(events_q_, ^{
+                  });
+  }
 };
 
 }  // namespace santa
@@ -74,7 +79,6 @@ using santa::EventTypeToString;
 using santa::FileAccessMetricStatus;
 using santa::FileAccessMetricStatusToString;
 using santa::FileAccessPolicyDecisionToString;
-using santa::Message;
 using santa::Metrics;
 using santa::MetricsPeer;
 using santa::ProcessorToString;
@@ -267,11 +271,6 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
 
 - (void)testSetEventMetrics {
   int64_t nanos = 1234;
-  es_message_t esExecMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, NULL);
-  es_message_t esOpenMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_OPEN, NULL);
-
-  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage();
 
   std::shared_ptr<MetricsPeer> metrics = CreateBasicMetricsPeer(self.q, ^(Metrics *){
                                                                 });
@@ -280,20 +279,21 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   XCTAssertEqual(metrics->event_counts_cache_.size(), 0);
   XCTAssertEqual(metrics->event_times_cache_.size(), 0);
 
-  {
-    Message execMsg(mockESApi, &esExecMsg);
-    Message openMsg(mockESApi, &esOpenMsg);
-    metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos, execMsg);
+  metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos,
+                           ES_EVENT_TYPE_AUTH_EXEC);
+  metrics->DrainEventQueue();
 
-    // Check sizes after setting metrics once
-    XCTAssertEqual(metrics->event_counts_cache_.size(), 1);
-    XCTAssertEqual(metrics->event_times_cache_.size(), 1);
+  // Check sizes after setting metrics once
+  XCTAssertEqual(metrics->event_counts_cache_.size(), 1);
+  XCTAssertEqual(metrics->event_times_cache_.size(), 1);
 
-    metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos, execMsg);
+  metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos,
+                           ES_EVENT_TYPE_AUTH_EXEC);
 
-    metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos * 2,
-                             openMsg);
-  }
+  metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos * 2,
+                           ES_EVENT_TYPE_AUTH_OPEN);
+
+  metrics->DrainEventQueue();
 
   // Re-check expected counts. One was an update, so should only be 2 items
   XCTAssertEqual(metrics->event_counts_cache_.size(), 2);
@@ -341,6 +341,7 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
 
   metrics->SetFileAccessEventMetrics("v1.0", "rule_abc", FileAccessMetricStatus::kOK,
                                      ES_EVENT_TYPE_AUTH_OPEN, FileAccessPolicyDecision::kDenied);
+  metrics->DrainEventQueue();
 
   // Check sizes after setting metrics once
   XCTAssertEqual(metrics->faa_event_counts_cache_.size(), 1);
@@ -352,6 +353,7 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   // Add a second metric
   metrics->SetFileAccessEventMetrics("v1.0", "rule_xyz", FileAccessMetricStatus::kOK,
                                      ES_EVENT_TYPE_AUTH_OPEN, FileAccessPolicyDecision::kDenied);
+  metrics->DrainEventQueue();
 
   // Re-check expected counts. One was an update, so should only be 2 items
   XCTAssertEqual(metrics->faa_event_counts_cache_.size(), 2);
@@ -366,10 +368,6 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
 }
 
 - (void)testUpdateEventStats {
-  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXEC, NULL);
-  esMsg.seq_num = 0;
-  esMsg.global_seq_num = 0;
-
   std::shared_ptr<MetricsPeer> metrics = CreateBasicMetricsPeer(self.q, ^(Metrics *){
                                                                 });
 
@@ -379,7 +377,8 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   // Map does not initially contain entries
   XCTAssertEqual(0, metrics->drop_cache_.size());
 
-  metrics->UpdateEventStats(Processor::kRecorder, &esMsg);
+  metrics->UpdateEventStats(Processor::kRecorder, ES_EVENT_TYPE_NOTIFY_EXEC, 0, 0);
+  metrics->DrainEventQueue();
 
   // After the first update, 2 entries exist, one for the event, and one for global
   XCTAssertEqual(2, metrics->drop_cache_.size());
@@ -389,10 +388,8 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   XCTAssertEqual(0, metrics->drop_cache_[globalStats].drops);
 
   // Increment sequence numbers by 1 and check that no drop was detected
-  esMsg.seq_num++;
-  esMsg.global_seq_num++;
-
-  metrics->UpdateEventStats(Processor::kRecorder, &esMsg);
+  metrics->UpdateEventStats(Processor::kRecorder, ES_EVENT_TYPE_NOTIFY_EXEC, 1, 1);
+  metrics->DrainEventQueue();
 
   XCTAssertEqual(2, metrics->drop_cache_.size());
   XCTAssertEqual(2, metrics->drop_cache_[eventStats].next_seq_num);
@@ -400,11 +397,9 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   XCTAssertEqual(2, metrics->drop_cache_[globalStats].next_seq_num);
   XCTAssertEqual(0, metrics->drop_cache_[globalStats].drops);
 
-  // Now incremenet sequence numbers by a large amount to trigger drop detection
-  esMsg.seq_num += 10;
-  esMsg.global_seq_num += 10;
-
-  metrics->UpdateEventStats(Processor::kRecorder, &esMsg);
+  // Now increment sequence numbers by a large amount to trigger drop detection
+  metrics->UpdateEventStats(Processor::kRecorder, ES_EVENT_TYPE_NOTIFY_EXEC, 11, 11);
+  metrics->DrainEventQueue();
 
   XCTAssertEqual(2, metrics->drop_cache_.size());
   XCTAssertEqual(12, metrics->drop_cache_[eventStats].next_seq_num);
@@ -417,16 +412,6 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   id mockEventProcessingTimes = OCMClassMock([SNTMetricInt64Gauge class]);
   id mockEventCounts = OCMClassMock([SNTMetricCounter class]);
   int64_t nanos = 1234;
-  es_message_t esExecMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, NULL);
-  es_message_t esOpenMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_OPEN, NULL);
-
-  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage();
-
-  // Initial update will have non-zero sequence numbers, triggering drop detection
-  es_message_t esMsgWithDrops = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXEC, NULL);
-  esMsgWithDrops.seq_num = 123;
-  esMsgWithDrops.global_seq_num = 123;
 
   OCMStub([mockEventCounts incrementBy:0 forFieldValues:[OCMArg any]])
       .ignoringNonObjectArgs()
@@ -448,17 +433,15 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
                                         // This block intentionally left blank
                                     });
 
-  {
-    Message execMsg(mockESApi, &esExecMsg);
-    Message openMsg(mockESApi, &esOpenMsg);
-    metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos, execMsg);
-    metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos * 2,
-                             openMsg);
-  }
-  metrics->UpdateEventStats(Processor::kRecorder, &esMsgWithDrops);
+  metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos,
+                           ES_EVENT_TYPE_AUTH_EXEC);
+  metrics->SetEventMetrics(Processor::kAuthorizer, EventDisposition::kProcessed, nanos * 2,
+                           ES_EVENT_TYPE_AUTH_OPEN);
+  metrics->UpdateEventStats(Processor::kRecorder, ES_EVENT_TYPE_NOTIFY_EXEC, 123, 123);
   metrics->AddRateLimitingMetrics(123);
   metrics->SetFileAccessEventMetrics("v1.0", "rule_abc", FileAccessMetricStatus::kOK,
                                      ES_EVENT_TYPE_AUTH_OPEN, FileAccessPolicyDecision::kDenied);
+  metrics->DrainEventQueue();
 
   // First ensure we have the expected map sizes
   XCTAssertEqual(metrics->event_counts_cache_.size(), 2);
@@ -467,7 +450,7 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   XCTAssertEqual(metrics->faa_event_counts_cache_.size(), 1);
   XCTAssertEqual(metrics->drop_cache_.size(), 2);
 
-  EventStatsTuple eventStats{Processor::kRecorder, esMsgWithDrops.event_type};
+  EventStatsTuple eventStats{Processor::kRecorder, ES_EVENT_TYPE_NOTIFY_EXEC};
   EventStatsTuple globalStats{Processor::kRecorder, ES_EVENT_TYPE_LAST};
   XCTAssertEqual(metrics->drop_cache_[eventStats].next_seq_num, 124);
   XCTAssertEqual(metrics->drop_cache_[eventStats].drops, 123);


### PR DESCRIPTION
Replace `std::map` with `absl::flat_hash_map`. Move stats counting to be async to unblock event processing to improve event throughput.

Part of SNT-332
