### PR TITLE
Wrap proc token data in shared_ptr to reduce retains/releases

### DIFF
--- a/Source/santad/ProcessTree/process_tree.cc
+++ b/Source/santad/ProcessTree/process_tree.cc
@@ -303,15 +303,15 @@ Tokens
 
 ProcessToken::ProcessToken(std::shared_ptr<ProcessTree> tree,
                            std::vector<struct Pid> pids)
-    : tree_(std::move(tree)), pids_(std::move(pids)) {
-  if (tree_) {
-    tree_->RetainProcess(pids_);
+    : state_(std::make_shared<State>(std::move(tree), std::move(pids))) {
+  if (state_->tree) {
+    state_->tree->RetainProcess(state_->pids);
   }
 }
 
-ProcessToken::~ProcessToken() {
-  if (tree_) {
-    tree_->ReleaseProcess(pids_);
+ProcessToken::State::~State() {
+  if (tree) {
+    tree->ReleaseProcess(pids);
   }
 }
 

--- a/Source/santad/ProcessTree/process_tree.h
+++ b/Source/santad/ProcessTree/process_tree.h
@@ -165,23 +165,23 @@ class ProcessToken {
  public:
   explicit ProcessToken(std::shared_ptr<ProcessTree> tree,
                         std::vector<struct Pid> pids);
-  ~ProcessToken();
-  ProcessToken(const ProcessToken &other)
-      : ProcessToken(other.tree_, other.pids_) {}
-  ProcessToken(ProcessToken &&other) noexcept
-      : tree_(std::move(other.tree_)), pids_(std::move(other.pids_)) {}
-  ProcessToken &operator=(const ProcessToken &other) {
-    return *this = ProcessToken(other.tree_, other.pids_);
-  }
-  ProcessToken &operator=(ProcessToken &&other) noexcept {
-    tree_ = std::move(other.tree_);
-    pids_ = std::move(other.pids_);
-    return *this;
-  }
+
+  // Default copy/move/destructor — shared_ptr<State> handles lifetime.
+  ProcessToken(const ProcessToken &) = default;
+  ProcessToken(ProcessToken &&) noexcept = default;
+  ProcessToken &operator=(const ProcessToken &) = default;
+  ProcessToken &operator=(ProcessToken &&) noexcept = default;
+  ~ProcessToken() = default;
 
  private:
-  std::shared_ptr<ProcessTree> tree_;
-  std::vector<struct Pid> pids_;
+  struct State {
+    std::shared_ptr<ProcessTree> tree;
+    std::vector<struct Pid> pids;
+    State(std::shared_ptr<ProcessTree> tree, std::vector<struct Pid> pids)
+        : tree(std::move(tree)), pids(std::move(pids)) {}
+    ~State();
+  };
+  std::shared_ptr<State> state_;
 };
 
 }  // namespace santa::santad::process_tree


### PR DESCRIPTION
This puts the `ProcessToken` members into an inner `State` object that is wrapped in a `shared_ptr`. This allows us to reduce the number of retains/releases for AUTH code paths by 50%.

Part of SNT-332
