### PR TITLE
Support ancestor args in CEL policies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20251110.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "9d5f99f65255e355f7d2375a8cf7f6059338479c",
+    commit = "571bb5316dc5db14a25b3dbae43e0cd57216eee2",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santad/CELActivation.mm
+++ b/Source/santad/CELActivation.mm
@@ -59,6 +59,9 @@ std::vector<santa::cel::CELProtoTraits<true>::AncestorT> Ancestors<true>(
 
     AncestorT ancestor;
     ancestor.set_path(p->program_->executable);
+    for (const auto &arg : p->program_->arguments) {
+      ancestor.add_args(arg);
+    }
 
     if (p->program_->code_signing) {
       const auto &cs = *p->program_->code_signing;


### PR DESCRIPTION
Bump protos dep to adopt https://github.com/northpolesec/protos/pull/95

Expose new `args` field in the Ancestors message for CELv2 policies to use.

Part of SNT-335