### PR TITLE
santactl/fileinfo: Add Expected Decision field

### DIFF
--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -57,6 +57,9 @@ struct RuleCounts {
                                     NSString *fileAccessRulesHash))reply;
 - (void)databaseRuleForIdentifiers:(SNTRuleIdentifiers *)identifiers
                              reply:(void (^)(SNTRule *))reply;
+- (void)staticDecisionForFilePath:(NSString *)filePath
+                      identifiers:(SNTRuleIdentifiers *)identifiers
+                            reply:(void (^)(SNTRule *rule, NSString *decision))reply;
 
 ///
 ///  Config ops

--- a/Source/santactl/Commands/SNTCommandFileInfo.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfo.mm
@@ -48,6 +48,7 @@ static NSString *const kCodeSigned = @"Code-signed";
 static NSString *const kValidation = @"Validation";
 static NSString *const kAssessment = @"Security Assessment";
 static NSString *const kRule = @"Rule";
+static NSString *const kDecision = @"Expected Decision";
 static NSString *const kSigningChain = @"Signing Chain";
 static NSString *const kUniversalSigningChain = @"Universal Signing Chain";
 static NSString *const kTeamID = @"Team ID";
@@ -144,6 +145,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 @property(readonly, copy, nonatomic) SNTAttributeBlock validation;
 @property(readonly, copy, nonatomic) SNTAttributeBlock assessment;
 @property(readonly, copy, nonatomic) SNTAttributeBlock rule;
+@property(readonly, copy, nonatomic) SNTAttributeBlock decision;
 @property(readonly, copy, nonatomic) SNTAttributeBlock signingChain;
 @property(readonly, copy, nonatomic) SNTAttributeBlock universalSigningChain;
 @property(readonly, copy, nonatomic) SNTAttributeBlock entitlements;
@@ -253,6 +255,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     kSecureSigningTime,
     kSigningTime,
     kRule,
+    kDecision,
     kEntitlements,
     kSigningChain,
     kUniversalSigningChain,
@@ -287,6 +290,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       kValidation : self.validation,
       kAssessment : self.assessment,
       kRule : self.rule,
+      kDecision : self.decision,
       kSigningChain : self.signingChain,
       kUniversalSigningChain : self.universalSigningChain,
       kTeamID : self.teamID,
@@ -469,14 +473,18 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   };
 }
 
+static void ResumeDaemonConnection(SNTCommandFileInfo *cmd) {
+  static dispatch_once_t token;
+  dispatch_once(&token, ^{
+    [cmd.daemonConn resume];
+  });
+}
+
 - (SNTAttributeBlock)rule {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     // If we previously were unable to connect, don't try again.
     if (cmd.daemonUnavailable) return kCommunicationErrorMsg;
-    static dispatch_once_t token;
-    dispatch_once(&token, ^{
-      [cmd.daemonConn resume];
-    });
+    ResumeDaemonConnection(cmd);
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
     NSError *err;
@@ -516,6 +524,57 @@ REGISTER_COMMAND_NAME(@"fileinfo")
                                 }
                                 dispatch_semaphore_signal(sema);
                               }];
+
+    if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC))) {
+      cmd.daemonUnavailable = YES;
+      return kCommunicationErrorMsg;
+    }
+    return output;
+  };
+}
+
+- (SNTAttributeBlock)decision {
+  return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
+    if (cmd.daemonUnavailable) return kCommunicationErrorMsg;
+    ResumeDaemonConnection(cmd);
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    NSError *err;
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:&err];
+    SNTSigningStatus signingStatus = SigningStatus(csc, err);
+
+    struct RuleIdentifiers identifiers = {
+        .cdhash = csc.cdhash,
+        .binarySHA256 = fileInfo.SHA256,
+        .signingID = FormatSigningID(csc),
+        .certificateSHA256 = err ? nil : csc.leafCertificate.SHA256,
+        .teamID = csc.teamID,
+    };
+
+    SNTRuleIdentifiers *lookupIdentifiers =
+        signingStatus == SNTSigningStatusDevelopment
+            ? [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:identifiers]
+            : [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:identifiers
+                                                 andSigningStatus:signingStatus];
+
+    __block NSString *output;
+    id<SNTDaemonControlXPC> rop = [cmd.daemonConn remoteObjectProxy];
+    [rop
+        staticDecisionForFilePath:fileInfo.path
+                      identifiers:lookupIdentifiers
+                            reply:^(SNTRule *r, NSString *decisionStr) {
+                              if (signingStatus == SNTSigningStatusDevelopment && r &&
+                                  (r.type == SNTRuleTypeSigningID || r.type == SNTRuleTypeTeamID)) {
+                                output = [NSString
+                                    stringWithFormat:@"None (%@ rule ignored because code signed "
+                                                     @"with a development certificate.)",
+                                                     r.type == SNTRuleTypeTeamID ? @"TeamID"
+                                                                                 : @"SigningID"];
+                              } else {
+                                output = decisionStr;
+                              }
+                              dispatch_semaphore_signal(sema);
+                            }];
 
     if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC))) {
       cmd.daemonUnavailable = YES;

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -257,6 +257,71 @@ double watchdogRAMPeak = 0;
   reply([[SNTDatabaseController ruleTable] executionRuleForIdentifiers:[identifiers toStruct]]);
 }
 
+- (void)staticDecisionForFilePath:(NSString *)filePath
+                      identifiers:(SNTRuleIdentifiers *)identifiers
+                            reply:(void (^)(SNTRule *rule, NSString *decision))reply {
+  SNTRule *rule =
+      [[SNTDatabaseController ruleTable] executionRuleForIdentifiers:[identifiers toStruct]];
+
+  if (rule) {
+    NSString *action;
+    switch (rule.state) {
+      case SNTRuleStateBlock:
+      case SNTRuleStateSilentBlock: action = @"Denied by rule"; break;
+      default: action = @"Allowed by rule"; break;
+    }
+    reply(rule, action);
+    return;
+  }
+
+  SNTConfigurator *config = [SNTConfigurator configurator];
+
+  // CEL fallback rules cannot be evaluated statically (they require an
+  // ActivationCallbackBlock with process-level context like ancestors and
+  // args). Report their existence so the user knows the static prediction
+  // is incomplete.
+  if (config.celFallbackRules.count > 0) {
+    reply(nil, @"Unknown - cannot evaluate statically");
+    return;
+  }
+
+  // Check blocked path regex (mirrors SNTPolicyProcessor.fileIsScopeBlocked:)
+  NSRegularExpression *blockedRe = config.blockedPathRegex;
+  if (blockedRe && [blockedRe numberOfMatchesInString:filePath
+                                              options:0
+                                                range:NSMakeRange(0, filePath.length)]) {
+    reply(nil, @"Blocked (Regex)");
+    return;
+  }
+
+  // Note: Page zero protection (enablePageZeroProtection + isMissingPageZero)
+  // and bad signature protection (enableBadSignatureProtection) are omitted.
+  // Both require reading/validating the file at runtime. The fileinfo output
+  // already has dedicated "Page Zero" and "Validation" keys for these checks.
+
+  // Check allowed path regex (mirrors SNTPolicyProcessor.fileIsScopeAllowed:)
+  NSRegularExpression *allowedRe = config.allowedPathRegex;
+  if (allowedRe && [allowedRe numberOfMatchesInString:filePath
+                                              options:0
+                                                range:NSMakeRange(0, filePath.length)]) {
+    reply(nil, @"Allowed (Regex)");
+    return;
+  }
+
+  // Note: SNTPolicyProcessor.fileIsScopeAllowed: also returns "Not a Mach-O"
+  // for non-Mach-O files, effectively allowing them. This check requires an
+  // SNTFileInfo object (not just a path). The fileinfo "Type" key already
+  // shows whether the file is a Mach-O, so users can cross-reference.
+
+  // Default based on client mode
+  switch (config.clientMode) {
+    case SNTClientModeMonitor: reply(nil, @"Allowed (Unknown, Monitor mode)"); return;
+    case SNTClientModeStandalone: reply(nil, @"Blocked (Unknown, Standalone mode)"); return;
+    case SNTClientModeLockdown: reply(nil, @"Blocked (Unknown, Lockdown mode)"); return;
+    default: reply(nil, @"Blocked (Unknown)"); return;
+  }
+}
+
 - (void)dataFileAccessRuleForTarget:(NSString *)path reply:(void (^)(NSString *, NSString *))reply {
   __block NSString *ruleName;
   __block NSString *ruleVersion;


### PR DESCRIPTION
Given that many entries cannot be determined statically there are many cases where this will print "Unknown" but it's best-effort and useful in many cases.