### PR TITLE
protos: update hash, sync: set `encrypted` for USBMountEvent 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "fa0ad3f19cd1e32ec4946331e94fb1e13e9df4ea",
+    commit = "c961c48754eed5197a3b9cae42e7b941fd48236a",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -431,6 +431,8 @@ typename santa::ProtoTraits<IsV2>::FileAccessEventT *MessageForFileAccessEvent(
     default: pbUSBMountEvent->set_decision(::pbv2::USBMountEvent::USB_MOUNT_DECISION_UNSPECIFIED);
   }
 
+  pbUSBMountEvent->set_encrypted(event.isEncrypted);
+
   return pbUSBMountEvent;
 }
 


### PR DESCRIPTION
Part of WS-1092