### PR TITLE
Process tree perf improvements

### DIFF
--- a/Source/common/processtree/BUILD
+++ b/Source/common/processtree/BUILD
@@ -39,6 +39,7 @@ objc_library(
         "//Source/common/processtree/annotations:annotator",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/container:inlined_vector",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/synchronization",

--- a/Source/common/processtree/process.h
+++ b/Source/common/processtree/process.h
@@ -18,6 +18,7 @@
 
 #include <sys/types.h>
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -84,6 +85,14 @@ struct Program {
   }
 };
 
+// Lightweight container for process data loaded during backfill, before
+// a Process is constructed and inserted into the tree.
+struct BackfilledProcess {
+  struct Pid pid;
+  struct Cred cred;
+  std::shared_ptr<const Program> program;
+};
+
 // Fwd decls
 class ProcessTree;
 
@@ -99,9 +108,9 @@ class Process {
         parent_(parent),
         refcnt_(0),
         tombstoned_(false) {}
-  Process(const Process &) = default;
+  Process(const Process &) = delete;
   Process &operator=(const Process &) = delete;
-  Process(Process &&) = default;
+  Process(Process &&) = delete;
   Process &operator=(Process &&) = delete;
 
   // Const "attributes" are public
@@ -118,8 +127,7 @@ class Process {
   absl::flat_hash_map<std::type_index, std::shared_ptr<const Annotator>>
       annotations_;
   std::shared_ptr<const Process> parent_;
-  // TODO(nickmg): atomic here breaks the build.
-  int refcnt_;
+  std::atomic<int> refcnt_;
   // If the process is tombstoned, the event removing it from the tree has been
   // processed, but refcnt>0 keeps it alive.
   bool tombstoned_;

--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -39,18 +39,18 @@
 namespace santa::santad::process_tree {
 
 void ProcessTree::BackfillInsertChildren(
-    absl::flat_hash_map<pid_t, std::vector<Process>> &parent_map,
-    std::shared_ptr<Process> parent, const Process &unlinked_proc) {
+    absl::flat_hash_map<pid_t, std::vector<BackfilledProcess>> &parent_map,
+    std::shared_ptr<Process> parent, const BackfilledProcess &backfilled_proc) {
   auto proc = std::make_shared<Process>(
-      unlinked_proc.pid_, unlinked_proc.effective_cred_,
+      backfilled_proc.pid, backfilled_proc.cred,
       // Re-use shared pointers from parent if value equivalent
-      (parent && *(unlinked_proc.program_) == *(parent->program_))
+      (parent && *(backfilled_proc.program) == *(parent->program_))
           ? parent->program_
-          : unlinked_proc.program_,
+          : backfilled_proc.program,
       parent);
   {
     absl::MutexLock lock(mtx_);
-    map_.emplace(unlinked_proc.pid_, proc);
+    map_.emplace(backfilled_proc.pid, proc);
   }
 
   // The only case where we should not have a parent is the root processes
@@ -64,7 +64,7 @@ void ProcessTree::BackfillInsertChildren(
     }
   }
 
-  for (const Process &child : parent_map[unlinked_proc.pid_.pid]) {
+  for (const BackfilledProcess &child : parent_map[backfilled_proc.pid.pid]) {
     BackfillInsertChildren(parent_map, proc, child);
   }
 }
@@ -145,7 +145,7 @@ bool ProcessTree::Step(uint64_t timestamp) {
   for (auto it = remove_at_.begin(); it != remove_at_.end();) {
     if (it->first < new_cutoff) {
       if (auto target = GetLocked(it->second);
-          target && (*target)->refcnt_ > 0) {
+          target && (*target)->refcnt_.load(std::memory_order_relaxed) > 0) {
         (*target)->tombstoned_ = true;
       } else {
         map_.erase(it->second);
@@ -159,22 +159,28 @@ bool ProcessTree::Step(uint64_t timestamp) {
   return true;
 }
 
-void ProcessTree::RetainProcess(std::vector<struct Pid> &pids) {
-  absl::MutexLock lock(mtx_);
+void ProcessTree::RetainProcess(const PidList &pids) {
+  // Reader lock suffices: we only need the map to be stable for lookup.
+  // relaxed is safe because the increment has no dependent memory operations —
+  // we are only bumping a counter.
+  absl::ReaderMutexLock lock(mtx_);
   for (const struct Pid &p : pids) {
     auto proc = GetLocked(p);
     if (proc) {
-      (*proc)->refcnt_++;
+      (*proc)->refcnt_.fetch_add(1, std::memory_order_relaxed);
     }
   }
 }
 
-void ProcessTree::ReleaseProcess(std::vector<struct Pid> &pids) {
+void ProcessTree::ReleaseProcess(const PidList &pids) {
   absl::MutexLock lock(mtx_);
   for (const struct Pid &p : pids) {
     auto proc = GetLocked(p);
     if (proc) {
-      if (--(*proc)->refcnt_ == 0 && (*proc)->tombstoned_) {
+      // relaxed is safe: the exclusive lock provides ordering for
+      // tombstoned_ and map_.erase().
+      if ((*proc)->refcnt_.fetch_sub(1, std::memory_order_relaxed) == 1 &&
+          (*proc)->tombstoned_) {
         map_.erase(p);
       }
     }
@@ -303,8 +309,7 @@ Tokens
 ----
 */
 
-ProcessToken::ProcessToken(std::shared_ptr<ProcessTree> tree,
-                           std::vector<struct Pid> pids)
+ProcessToken::ProcessToken(std::shared_ptr<ProcessTree> tree, PidList pids)
     : state_(std::make_shared<State>(std::move(tree), std::move(pids))) {
   if (state_->tree) {
     state_->tree->RetainProcess(state_->pids);

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -22,13 +22,18 @@
 
 #include "Source/common/processtree/process.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
 
 namespace santa::santad::process_tree {
 
-absl::StatusOr<Process> LoadPID(pid_t pid);
+absl::StatusOr<BackfilledProcess> LoadPID(pid_t pid);
+
+// Events reference 1-2 pids (the process + optional child/target for
+// fork/exec). InlinedVector avoids a heap allocation for these.
+using PidList = absl::InlinedVector<struct Pid, 2>;
 
 // Fwd decl for test peer.
 class ProcessTreeTestPeer;
@@ -69,11 +74,11 @@ class ProcessTree {
   // event which would remove the Process (e.g. exit), however in cases where
   // async processing occurs, the Process may need to be accessed after the
   // exit.
-  void RetainProcess(std::vector<struct Pid> &pids);
+  void RetainProcess(const PidList &pids);
 
   // Release previously retained processes, signaling that the client is done
   // processing the event that retained them.
-  void ReleaseProcess(std::vector<struct Pid> &pids);
+  void ReleaseProcess(const PidList &pids);
 
   // Annotate the given process with an Annotator (state).
   void AnnotateProcess(const Process &p, std::shared_ptr<const Annotator> a);
@@ -112,8 +117,9 @@ class ProcessTree {
  private:
   friend class ProcessTreeTestPeer;
   void BackfillInsertChildren(
-      absl::flat_hash_map<pid_t, std::vector<Process>> &parent_map,
-      std::shared_ptr<Process> parent, const Process &unlinked_proc);
+      absl::flat_hash_map<pid_t, std::vector<BackfilledProcess>> &parent_map,
+      std::shared_ptr<Process> parent,
+      const BackfilledProcess &backfilled_proc);
 
   // Mark that an event with the given timestamp is being processed.
   // Returns whether the given timestamp is "novel", and the tree should be
@@ -165,8 +171,7 @@ absl::StatusOr<std::shared_ptr<ProcessTree>> CreateTree(
 // fallen out otherwise due to a destruction event (e.g. exit).
 class ProcessToken {
  public:
-  explicit ProcessToken(std::shared_ptr<ProcessTree> tree,
-                        std::vector<struct Pid> pids);
+  explicit ProcessToken(std::shared_ptr<ProcessTree> tree, PidList pids);
 
   // Default copy/move/destructor — shared_ptr<State> handles lifetime.
   ProcessToken(const ProcessToken &) = default;
@@ -178,8 +183,8 @@ class ProcessToken {
  private:
   struct State {
     std::shared_ptr<ProcessTree> tree;
-    std::vector<struct Pid> pids;
-    State(std::shared_ptr<ProcessTree> tree, std::vector<struct Pid> pids)
+    PidList pids;
+    State(std::shared_ptr<ProcessTree> tree, PidList pids)
         : tree(std::move(tree)), pids(std::move(pids)) {}
     ~State();
   };

--- a/Source/common/processtree/process_tree_macos.mm
+++ b/Source/common/processtree/process_tree_macos.mm
@@ -142,7 +142,7 @@ struct Pid PidFromAuditToken(const audit_token_t &tok) {
                       .pidversion = (uint64_t)audit_token_to_pidversion(tok)};
 }
 
-absl::StatusOr<Process> LoadPID(pid_t pid) {
+absl::StatusOr<BackfilledProcess> LoadPID(pid_t pid) {
   task_name_t task;
   mach_msg_type_number_t size = TASK_AUDIT_TOKEN_COUNT;
   audit_token_t token;
@@ -165,18 +165,16 @@ absl::StatusOr<Process> LoadPID(pid_t pid) {
   std::vector<std::string> args =
       ProcessArgumentsForPID(audit_token_to_pid(token)).value_or(std::vector<std::string>());
 
-  return Process((struct Pid){.pid = audit_token_to_pid(token),
-                              .pidversion = (uint64_t)audit_token_to_pidversion(token)},
-                 (struct Cred){
-                     .uid = audit_token_to_euid(token),
-                     .gid = audit_token_to_egid(token),
-                 },
-                 std::make_shared<struct Program>((struct Program){
-                     .executable = path,
-                     .arguments = args,
-                     .code_signing = LoadCodeSigningInfoForPID(pid),
-                 }),
-                 nullptr);
+  return BackfilledProcess{
+      .pid = {.pid = audit_token_to_pid(token),
+              .pidversion = (uint64_t)audit_token_to_pidversion(token)},
+      .cred = {.uid = audit_token_to_euid(token), .gid = audit_token_to_egid(token)},
+      .program = std::make_shared<struct Program>((struct Program){
+          .executable = path,
+          .arguments = args,
+          .code_signing = LoadCodeSigningInfoForPID(pid),
+      }),
+  };
 }
 
 absl::Status ProcessTree::Backfill() {
@@ -185,11 +183,11 @@ absl::Status ProcessTree::Backfill() {
     return absl::InternalError("GetPidList() failed");
   }
 
-  absl::flat_hash_map<pid_t, std::vector<Process>> parent_map;
+  absl::flat_hash_map<pid_t, std::vector<BackfilledProcess>> parent_map;
   for (pid_t pid : pid_list.value()) {
     auto proc_status = LoadPID(pid);
     if (proc_status.ok()) {
-      auto unlinked_proc = proc_status.value();
+      auto backfilled_proc = std::move(proc_status).value();
 
       // Determine ppid
       // Alternatively, there's a sysctl interface:
@@ -200,12 +198,12 @@ absl::Status ProcessTree::Backfill() {
         continue;
       };
 
-      parent_map[bsdinfo.pbi_ppid].push_back(unlinked_proc);
+      parent_map[bsdinfo.pbi_ppid].push_back(std::move(backfilled_proc));
     }
   }
 
   auto &roots = parent_map[0];
-  for (const Process &p : roots) {
+  for (const BackfilledProcess &p : roots) {
     BackfillInsertChildren(parent_map, std::shared_ptr<Process>(), p);
   }
 

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -120,17 +120,18 @@ using namespace santa::santad::process_tree;
   XCTAssertEqual(task_info(mach_task_self(), TASK_AUDIT_TOKEN, (task_info_t)&self_tok, &count),
                  KERN_SUCCESS);
 
-  XCTAssertEqual(proc.pid_.pid, audit_token_to_pid(self_tok));
-  XCTAssertEqual(proc.pid_.pidversion, audit_token_to_pidversion(self_tok));
+  XCTAssertEqual(proc.pid.pid, audit_token_to_pid(self_tok));
+  XCTAssertEqual(proc.pid.pidversion, audit_token_to_pidversion(self_tok));
 
-  XCTAssertEqual(proc.effective_cred_.uid, geteuid());
-  XCTAssertEqual(proc.effective_cred_.gid, getegid());
+  XCTAssertEqual(proc.cred.uid, geteuid());
+  XCTAssertEqual(proc.cred.gid, getegid());
 
+  auto program = proc.program;
   [[[NSProcessInfo processInfo] arguments]
       enumerateObjectsUsingBlock:^(NSString *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-        XCTAssertEqualObjects(@(proc.program_->arguments[idx].c_str()), obj);
+        XCTAssertEqualObjects(@(program->arguments[idx].c_str()), obj);
         if (idx == 0) {
-          XCTAssertEqualObjects(@(proc.program_->executable.c_str()), obj);
+          XCTAssertEqualObjects(@(program->executable.c_str()), obj);
         }
       }];
 }
@@ -217,7 +218,7 @@ using namespace santa::santad::process_tree;
   {
     auto child = self.tree->Get(child_pid);
     XCTAssertTrue(child.has_value());
-    std::vector<struct Pid> pids = {(*child)->pid_};
+    PidList pids = {(*child)->pid_};
     self.tree->RetainProcess(pids);
   }
 
@@ -234,7 +235,7 @@ using namespace santa::santad::process_tree;
   {
     auto child = self.tree->Get(child_pid);
     XCTAssertTrue(child.has_value());
-    std::vector<struct Pid> pids = {(*child)->pid_};
+    PidList pids = {(*child)->pid_};
     self.tree->ReleaseProcess(pids);
   }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
@@ -95,7 +95,7 @@ using santa::Processor;
   }
 
   // Now enumerate the processes that processing this event might require access to...
-  std::vector<struct santa::santad::process_tree::Pid> pids;
+  santa::santad::process_tree::PidList pids;
   pids.emplace_back(santa::santad::process_tree::PidFromAuditToken(esMsg->process->audit_token));
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_AUTH_EXEC:


### PR DESCRIPTION
Remove vector heap allocs, remove copies on backfill, move refcnt to be atomic.

The refcnt change is not a very big win until there are more tree-aware clients, but it doesn't hurt anything. Now that `Process` is not copyable/movable it's an easy enough change.

We can in the future consider making `ReleaseProcess` also take a reader lock opportunistically, but we'll need more analysis on how handy this will be since it would require dropping the reader lock and grabbing the exclusive lock if we need to touch the `map_`.

