### PR TITLE
Fix latent FD leak in ScopedFile move assignment operator

### DIFF
--- a/Source/common/ScopedFile.h
+++ b/Source/common/ScopedFile.h
@@ -81,13 +81,11 @@ class ScopedFile {
   ScopedFile(const ScopedFile&) = delete;
   ScopedFile& operator=(const ScopedFile&) = delete;
 
-  ScopedFile(ScopedFile&& other) {
-    fd_ = other.fd_;
-    other.fd_ = -1;
-  }
+  ScopedFile(ScopedFile&& other) : fd_(other.fd_) { other.fd_ = -1; }
 
   ScopedFile& operator=(ScopedFile&& rhs) {
     if (this != &rhs) {
+      if (fd_ >= 0) close(fd_);
       fd_ = rhs.fd_;
       rhs.fd_ = -1;
     }

--- a/Source/common/ScopedFileTest.mm
+++ b/Source/common/ScopedFileTest.mm
@@ -69,4 +69,27 @@
   XCTAssertEqualObjects(readContents, writeContents);
 }
 
+- (void)testMoveAssignmentClosesExistingFD {
+  int originalFD;
+  int movedFD;
+
+  auto file1 = santa::ScopedFile::CreateTemporary();
+  XCTAssertStatusOk(file1);
+  originalFD = file1->UnsafeFD();
+
+  auto file2 = santa::ScopedFile::CreateTemporary();
+  XCTAssertStatusOk(file2);
+  movedFD = file2->UnsafeFD();
+
+  // Move-assign file2 into file1. file1's original FD should be closed.
+  *file1 = std::move(*file2);
+
+  XCTAssertEqual(file1->UnsafeFD(), movedFD);
+  XCTAssertEqual(file2->UnsafeFD(), -1);
+
+  // The original FD should have been closed by the move assignment.
+  XCTAssertLessThan(close(originalFD), 0);
+  XCTAssertEqual(errno, EBADF);
+}
+
 @end


### PR DESCRIPTION
If the move assignment operator were used, the exisitng FD would have been leaked. The move assignment operator is not currently used in the codebase so no release is affected.


Fixes SNT-376
