### PR TITLE
Remove the printer proxy workaround that is no longer necessary

### DIFF
--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -43,7 +43,6 @@ const static NSString* kAllowCompilerCDHash = @"AllowCompilerCDHash";
 const static NSString* kAllowCompilerSigningID = @"AllowCompilerSigningID";
 const static NSString* kAllowTransitive = @"AllowTransitive";
 const static NSString* kUnknownEventState = @"Unknown";
-const static NSString* kBlockPrinterWorkaround = @"BlockPrinterWorkaround";
 const static NSString* kAllowNoFileInfo = @"AllowNoFileInfo";
 const static NSString* kDenyNoFileInfo = @"DenyNoFileInfo";
 const static NSString* kBlockLongPath = @"BlockLongPath";

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -18,7 +18,6 @@
 #import <Foundation/Foundation.h>
 
 #include <bsm/libbsm.h>
-#include <copyfile.h>
 #include <libproc.h>
 #include <pwd.h>
 #include <sys/param.h>
@@ -104,10 +103,6 @@ static SNTEventState BlockToAllowDecision(SNTEventState blockDecision) {
 
   std::shared_ptr<santa::santad::process_tree::ProcessTree> _processTree;
 }
-
-static NSString* const kPrinterProxy =
-    (@"/System/Library/PrivateFrameworks/PrintingPrivate.framework/"
-     @"Versions/Current/Plugins/PrinterProxy.app/Contents/MacOS/PrinterProxy");
 
 #pragma mark Initializers
 
@@ -251,13 +246,6 @@ static NSString* const kPrinterProxy =
       postAction(SNTActionRespondAllow, nil);
       [self.events incrementForFieldValues:@[ (NSString*)kAllowNoFileInfo ]];
     }
-    return;
-  }
-
-  // PrinterProxy workaround, see description above the method for more details.
-  if ([self printerProxyWorkaround:binInfo]) {
-    postAction(SNTActionRespondDeny, nil);
-    [self.events incrementForFieldValues:@[ (NSString*)kBlockPrinterWorkaround ]];
     return;
   }
 
@@ -542,49 +530,6 @@ static NSString* const kPrinterProxy =
 }
 
 #pragma mark Helpers
-
-/**
-  Workaround for issue with PrinterProxy.app.
-
-  Every time a new printer is added to the machine, a copy of the PrinterProxy.app is copied from
-  the Print.framework to ~/Library/Printers with the name of the printer as the name of the app.
-  The binary inside is changed slightly (in a way that is unique to the printer name) and then
-  re-signed with an adhoc signature. I don't know why this is done but it seems that the binary
-  itself doesn't need to be changed as copying the old one back in-place seems to work,
-  so that's what we do.
-
-  If this workaround is applied the decision request is not responded to as the existing request
-  is invalidated when the file is closed which will trigger a brand new request coming from the
-  kernel.
-
-  @param fi SNTFileInfo object for the binary being executed.
-  @return YES if the workaround was applied, NO otherwise.
-*/
-- (BOOL)printerProxyWorkaround:(SNTFileInfo*)fi {
-  if ([fi.path hasSuffix:@"/Contents/MacOS/PrinterProxy"] &&
-      [fi.path containsString:@"Library/Printers"]) {
-    SNTFileInfo* proxyFi = [self printerProxyFileInfo];
-    if ([proxyFi.SHA256 isEqual:fi.SHA256]) return NO;
-
-    copyfile_flags_t copyflags = COPYFILE_ALL | COPYFILE_UNLINK;
-    if (copyfile(proxyFi.path.UTF8String, fi.path.UTF8String, NULL, copyflags) != 0) {
-      LOGE(@"Failed to apply PrinterProxy workaround for %@", fi.path);
-    } else {
-      LOGI(@"PrinterProxy workaround applied to: %@", fi.path);
-    }
-
-    return YES;
-  }
-  return NO;
-}
-
-/**
-  Returns an SNTFileInfo for the system PrinterProxy path on this system.
-*/
-- (SNTFileInfo*)printerProxyFileInfo {
-  SNTFileInfo* proxyInfo = [[SNTFileInfo alloc] initWithPath:kPrinterProxy];
-  return proxyInfo;
-}
 
 - (void)loggedInUsers:(NSArray**)users sessions:(NSArray**)sessions {
   NSMutableSet* loggedInUsers = [NSMutableSet set];


### PR DESCRIPTION
The printer proxy workaround app was removed in macOS Sonoma. The Santa support for the workaround can be removed now that we no longer support Ventura.