### PR TITLE
Percent-encode template values in block message event detail URLs

### DIFF
--- a/Source/common/SNTBlockMessage.mm
+++ b/Source/common/SNTBlockMessage.mm
@@ -22,8 +22,30 @@
 #import "Source/common/SNTStoredFileAccessEvent.h"
 #import "Source/common/SNTSystemInfo.h"
 
-static id ValueOrNull(id value) {
-  return value ?: [NSNull null];
+// Percent-encode a string so it is safe in both URL path and query positions.
+// Only RFC 3986 unreserved characters (ALPHA / DIGIT / "-" / "." / "_" / "~")
+// are left unencoded, since admin-controlled templates may place values in either.
+static NSString* PercentEncodeTemplateValue(NSString* value) {
+  if (!value) return nil;
+  static NSCharacterSet* allowed;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSMutableCharacterSet* chars = [NSMutableCharacterSet new];
+    [chars addCharactersInRange:NSMakeRange('A', 26)];
+    [chars addCharactersInRange:NSMakeRange('a', 26)];
+    [chars addCharactersInRange:NSMakeRange('0', 10)];
+    [chars addCharactersInString:@"-._~"];
+    allowed = [chars copy];
+  });
+  return [value stringByAddingPercentEncodingWithAllowedCharacters:allowed];
+}
+
+static id EncodedValueOrNull(id value) {
+  if (!value) return [NSNull null];
+  if ([value isKindOfClass:[NSString class]]) {
+    return PercentEncodeTemplateValue(value) ?: [NSNull null];
+  }
+  return value;
 }
 
 @implementation SNTBlockMessage
@@ -231,19 +253,20 @@ static id ValueOrNull(id value) {
 + (NSDictionary*)eventDetailTemplateMappingForEvent:(SNTStoredExecutionEvent*)event {
   SNTConfigurator* config = [SNTConfigurator configurator];
   return @{
-    @"%file_sha%" : ValueOrNull(event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil),
-    @"%file_identifier%" : ValueOrNull(event.fileSHA256),
+    @"%file_sha%" :
+        EncodedValueOrNull(event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil),
+    @"%file_identifier%" : EncodedValueOrNull(event.fileSHA256),
     @"%bundle_or_file_identifier%" :
-        ValueOrNull(event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil),
-    @"%username%" : ValueOrNull(event.executingUser),
-    @"%file_bundle_id%" : ValueOrNull(event.fileBundleID),
-    @"%team_id%" : ValueOrNull(event.teamID),
-    @"%signing_id%" : ValueOrNull(event.signingID),
-    @"%cdhash%" : ValueOrNull(event.cdhash),
-    @"%machine_id%" : ValueOrNull(config.machineID),
-    @"%hostname%" : ValueOrNull([SNTSystemInfo longHostname]),
-    @"%uuid%" : ValueOrNull([SNTSystemInfo hardwareUUID]),
-    @"%serial%" : ValueOrNull([SNTSystemInfo serialNumber]),
+        EncodedValueOrNull(event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil),
+    @"%username%" : EncodedValueOrNull(event.executingUser),
+    @"%file_bundle_id%" : EncodedValueOrNull(event.fileBundleID),
+    @"%team_id%" : EncodedValueOrNull(event.teamID),
+    @"%signing_id%" : EncodedValueOrNull(event.signingID),
+    @"%cdhash%" : EncodedValueOrNull(event.cdhash),
+    @"%machine_id%" : EncodedValueOrNull(config.machineID),
+    @"%hostname%" : EncodedValueOrNull([SNTSystemInfo longHostname]),
+    @"%uuid%" : EncodedValueOrNull([SNTSystemInfo hardwareUUID]),
+    @"%serial%" : EncodedValueOrNull([SNTSystemInfo serialNumber]),
   };
 }
 
@@ -266,18 +289,18 @@ static id ValueOrNull(id value) {
 //
 + (NSDictionary*)fileAccessEventDetailTemplateMappingForEvent:(SNTStoredFileAccessEvent*)event {
   return @{
-    @"%rule_version%" : ValueOrNull(event.ruleVersion),
-    @"%rule_name%" : ValueOrNull(event.ruleName),
-    @"%accessed_path%" : ValueOrNull(event.accessedPath),
-    @"%file_identifier%" : ValueOrNull(event.process.fileSHA256),
-    @"%username%" : ValueOrNull(event.process.executingUser),
-    @"%team_id%" : ValueOrNull(event.process.teamID),
-    @"%signing_id%" : ValueOrNull(event.process.signingID),
-    @"%cdhash%" : ValueOrNull(event.process.cdhash),
-    @"%machine_id%" : ValueOrNull([[SNTConfigurator configurator] machineID]),
-    @"%hostname%" : ValueOrNull([SNTSystemInfo longHostname]),
-    @"%uuid%" : ValueOrNull([SNTSystemInfo hardwareUUID]),
-    @"%serial%" : ValueOrNull([SNTSystemInfo serialNumber]),
+    @"%rule_version%" : EncodedValueOrNull(event.ruleVersion),
+    @"%rule_name%" : EncodedValueOrNull(event.ruleName),
+    @"%accessed_path%" : EncodedValueOrNull(event.accessedPath),
+    @"%file_identifier%" : EncodedValueOrNull(event.process.fileSHA256),
+    @"%username%" : EncodedValueOrNull(event.process.executingUser),
+    @"%team_id%" : EncodedValueOrNull(event.process.teamID),
+    @"%signing_id%" : EncodedValueOrNull(event.process.signingID),
+    @"%cdhash%" : EncodedValueOrNull(event.process.cdhash),
+    @"%machine_id%" : EncodedValueOrNull([[SNTConfigurator configurator] machineID]),
+    @"%hostname%" : EncodedValueOrNull([SNTSystemInfo longHostname]),
+    @"%uuid%" : EncodedValueOrNull([SNTSystemInfo hardwareUUID]),
+    @"%serial%" : EncodedValueOrNull([SNTSystemInfo serialNumber]),
   };
 }
 

--- a/Source/common/SNTBlockMessageTest.mm
+++ b/Source/common/SNTBlockMessageTest.mm
@@ -62,7 +62,7 @@
                   @"un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
   NSString* wantUrl = @"http://"
                       @"localhost?fs=my_fi&fi=my_fi&bfi=my_fi&"
-                      @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+                      @"fbid=s.n.t&ti=SNT&si=SNT%3As.n.t&ch=abc&"
                       @"un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
   NSURL* gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
@@ -72,7 +72,7 @@
 
   wantUrl = @"http://"
             @"localhost?fs=my_fbh&fi=my_fi&bfi=my_fbh&"
-            @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+            @"fbid=s.n.t&ti=SNT&si=SNT%3As.n.t&ch=abc&"
             @"un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
   gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
@@ -102,7 +102,7 @@
       @"ap=%accessed_path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
   NSString* wantUrl = @"http://"
                       @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&"
-                      @"ti=SNT&si=SNT:s.n.t&ch=abc&"
+                      @"ti=SNT&si=SNT%3As.n.t&ch=abc&"
                       @"ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
   NSURL* gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
@@ -313,6 +313,67 @@
       @"/> Making a note here, huge success!";
   got = [SNTBlockMessage stringFromHTML:html];
   XCTAssertEqualObjects(got, @"This was a a triumph  Making a note here, huge success!");
+}
+
+- (void)testEventDetailURLEncodesUnsafeCharacters {
+  SNTStoredExecutionEvent* se = [[SNTStoredExecutionEvent alloc] init];
+
+  se.fileSHA256 = @"abc123";
+  se.executingUser = @"José García";
+  se.fileBundleID = @"com.example.my app";
+
+  NSString* url = @"http://localhost?un=%username%&fbid=%file_bundle_id%&fi=%file_identifier%";
+  NSURL* gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+
+  XCTAssertNotNil(gotUrl, @"URL with encoded values must not be nil");
+  XCTAssertEqualObjects(gotUrl.absoluteString, @"http://localhost?"
+                                               @"un=Jos%C3%A9%20Garc%C3%ADa&"
+                                               @"fbid=com.example.my%20app&"
+                                               @"fi=abc123");
+}
+
+- (void)testEventDetailURLEncodesQueryMetacharacters {
+  SNTStoredExecutionEvent* se = [[SNTStoredExecutionEvent alloc] init];
+
+  se.fileSHA256 = @"abc123";
+  se.executingUser = @"user&admin=true";
+
+  NSString* url = @"http://localhost?un=%username%&fi=%file_identifier%";
+  NSURL* gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+
+  XCTAssertNotNil(gotUrl);
+  XCTAssertEqualObjects(gotUrl.absoluteString,
+                        @"http://localhost?un=user%26admin%3Dtrue&fi=abc123");
+}
+
+- (void)testEventDetailURLEncodesEmptyValues {
+  SNTStoredExecutionEvent* se = [[SNTStoredExecutionEvent alloc] init];
+
+  se.fileSHA256 = @"abc123";
+  se.fileBundleID = @"";
+
+  NSString* url = @"http://localhost?fbid=%file_bundle_id%&fi=%file_identifier%";
+  NSURL* gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+
+  XCTAssertNotNil(gotUrl);
+  XCTAssertEqualObjects(gotUrl.absoluteString, @"http://localhost?fbid=&fi=abc123");
+}
+
+- (void)testFileAccessEventDetailURLEncodesUnsafeCharacters {
+  SNTStoredFileAccessEvent* fae = [[SNTStoredFileAccessEvent alloc] init];
+
+  fae.ruleName = @"block #secrets";
+  fae.accessedPath = @"/Users/me/My Documents/file.txt";
+  fae.ruleVersion = @"v1";
+
+  NSString* url = @"http://localhost?rn=%rule_name%&ap=%accessed_path%&rv=%rule_version%";
+  NSURL* gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
+
+  XCTAssertNotNil(gotUrl, @"URL with encoded values must not be nil");
+  XCTAssertEqualObjects(gotUrl.absoluteString, @"http://localhost?"
+                                               @"rn=block%20%23secrets&"
+                                               @"ap=%2FUsers%2Fme%2FMy%20Documents%2Ffile.txt&"
+                                               @"rv=v1");
 }
 
 @end


### PR DESCRIPTION
Template values substituted into event detail URLs were passed through raw, causing NSURL to return nil when values contained URL-unsafe characters (spaces, #, ?, non-ASCII). This most commonly affected accessed_path, username, and rule_name fields.

Encode each value using only RFC 3986 unreserved characters before substitution so URLs are valid regardless of value content.

Fixes: SNT-381