### PR TITLE
Track compiler PIDs with pidversion for improved correctness

### DIFF
--- a/Source/santad/SNTCompilerController.mm
+++ b/Source/santad/SNTCompilerController.mm
@@ -38,8 +38,25 @@ using santa::Message;
 static const pid_t PID_MAX = 99999;
 static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
 
+// Tracks compiler PIDs using pidversion to prevent PID reuse attacks.
+//
+// Each slot stores the pidversion of the active compiler at that PID index, or 0
+// to indicate no compiler. This ensures that if a compiler exits and its EXIT
+// event is dropped by ES, a new process that reuses the same PID will not be
+// falsely treated as a compiler (since its pidversion will differ).
+//
+// Edge case: pidversion is a signed 32-bit kernel counter (incremented globally
+// via OSIncrementAtomic on each fork) that can wrap through all 2^32 values. If
+// a compiler happens to fork at the exact moment pidversion wraps to 0, the
+// stored value will be indistinguishable from "no compiler" — a false negative.
+// This requires ~2^32 forks (~62 days at a sustained ~800 fork/sec) and only
+// affects the single compiler instance at that moment. The failure mode is that
+// transitive rules are not created for that compiler's output, potentially
+// causing legitimate binaries to be blocked until the next compiler invocation
+// (which will have a non-zero pidversion). This is a correctness blip, not a
+// security issue, and is self-healing.
 @interface SNTCompilerController () {
-  std::atomic<bool> _compilerPIDs[PID_MAX];
+  std::atomic<int32_t> _compilerPIDs[PID_MAX];
 }
 @end
 
@@ -47,7 +64,15 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
 
 - (BOOL)isCompiler:(const audit_token_t&)tok {
   pid_t pid = audit_token_to_pid(tok);
-  return pid >= 0 && pid < PID_MAX && self->_compilerPIDs[pid].load();
+  if (pid < 0 || pid >= PID_MAX) return NO;
+  int32_t stored = self->_compilerPIDs[pid].load(std::memory_order_relaxed);
+  if (stored == 0) return NO;
+  int32_t pidversion = audit_token_to_pidversion(tok);
+  if (stored == pidversion) return YES;
+  // Stale entry: the original compiler exited and the PID was recycled.
+  // Clear it eagerly so subsequent checks short-circuit on 0.
+  self->_compilerPIDs[pid].store(0, std::memory_order_relaxed);
+  return NO;
 }
 
 - (void)setProcess:(const audit_token_t&)tok isCompiler:(bool)isCompiler {
@@ -57,9 +82,10 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
   } else if (pid >= PID_MAX) {
     LOGE(@"Unable to watch compiler pid=%d >= PID_MAX(%d)", pid, PID_MAX);
   } else {
-    self->_compilerPIDs[pid].store(isCompiler);
+    int32_t val = isCompiler ? audit_token_to_pidversion(tok) : 0;
+    self->_compilerPIDs[pid].store(val, std::memory_order_relaxed);
     if (isCompiler) {
-      LOGD(@"Watching compiler pid=%d", pid);
+      LOGD(@"Watching compiler pid=%d pidver=%d", pid, val);
     }
   }
 }

--- a/Source/santad/SNTCompilerControllerTest.mm
+++ b/Source/santad/SNTCompilerControllerTest.mm
@@ -89,6 +89,44 @@ static const pid_t PID_MAX = 99999;
   XCTAssertFalse([cc isCompiler:self.tok1]);
 }
 
+- (void)testIsCompilerChecksPidversion {
+  SNTCompilerController* cc = [[SNTCompilerController alloc] init];
+
+  // Register PID 12 with pidversion 11
+  audit_token_t compilerTok = MakeAuditToken(12, 11);
+  [cc setProcess:compilerTok isCompiler:true];
+  XCTAssertTrue([cc isCompiler:compilerTok]);
+
+  // Same PID, different pidversion (simulates PID reuse after missed EXIT)
+  audit_token_t reusedTok = MakeAuditToken(12, 99);
+  XCTAssertFalse([cc isCompiler:reusedTok]);
+
+  // Stale entry should have been eagerly cleared — even the original token returns NO now
+  XCTAssertFalse([cc isCompiler:compilerTok]);
+
+  // Negative pidversion should work normally
+  audit_token_t negPidverTok = MakeAuditToken(50, -1);
+  [cc setProcess:negPidverTok isCompiler:true];
+  XCTAssertTrue([cc isCompiler:negPidverTok]);
+
+  // Same PID, different negative pidversion
+  audit_token_t differentNegPidverTok = MakeAuditToken(50, -2);
+  XCTAssertFalse([cc isCompiler:differentNegPidverTok]);
+
+  // Stale entry should have been eagerly cleared
+  XCTAssertFalse([cc isCompiler:negPidverTok]);
+}
+
+- (void)testIsCompilerPidversionZeroEdgeCase {
+  SNTCompilerController* cc = [[SNTCompilerController alloc] init];
+
+  // Pidversion 0 is indistinguishable from "no compiler" — this is a known
+  // false negative that requires ~2^32 forks to trigger. Verify the behavior.
+  audit_token_t zeroPidverTok = MakeAuditToken(42, 0);
+  [cc setProcess:zeroPidverTok isCompiler:true];
+  XCTAssertFalse([cc isCompiler:zeroPidverTok]);
+}
+
 - (void)testSetProcessIsCompiler {
   SNTCompilerController* cc = [[SNTCompilerController alloc] init];
 


### PR DESCRIPTION
Store the kernel's pidversion (int32_t) instead of a bool when tracking compiler processes. isCompiler: now verifies the caller's pidversion matches the stored value. Stale entries are eagerly cleared on mismatch to avoid depending on EXIT events for cleanup.

Fixes: SNT-390