### PR TITLE
Add HTTP Proxy Support for the Push Notification Service

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -725,6 +725,26 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 @property(nullable, readonly, nonatomic) NSDictionary* syncProxyConfig;
 
 ///
+///  Proxy URL for the NATS push connection.
+///  Accepted formats: http://host:port, https://host:port, http://user:pass@host:port, https://user:pass@host:port.
+///  When set, NATS push connections are tunneled through this proxy via HTTP CONNECT.
+///
+@property(nullable, readonly, nonatomic) NSString* pushProxyURL;
+
+///
+///  File path to a PEM-encoded CA certificate to trust for NATS push TLS connections.
+///  Used in MITM proxy environments where the proxy re-signs TLS traffic with a corporate CA.
+///
+@property(nullable, readonly, nonatomic) NSString* pushProxyCAFile;
+
+///
+///  Inline PEM-encoded CA certificate data for NATS push TLS connections.
+///  Alternative to PushProxyCAFile for MDM distribution.
+///  Takes precedence over PushProxyCAFile if both are set.
+///
+@property(nullable, readonly, nonatomic) NSData* pushProxyCAData;
+
+///
 ///  Extra headers to include in all requests made during syncing.
 ///  Keys and values must all be strings, any other type will be silently ignored.
 ///  Some headers cannot be set through this key, including:

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -726,8 +726,9 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 
 ///
 ///  Proxy URL for the NATS push connection.
-///  Accepted formats: http://host:port, https://host:port, http://user:pass@host:port, https://user:pass@host:port.
-///  When set, NATS push connections are tunneled through this proxy via HTTP CONNECT.
+///  Accepted formats: http://host:port, https://host:port, http://user:pass@host:port,
+///  https://user:pass@host:port. When set, NATS push connections are tunneled through this proxy
+///  via HTTP CONNECT.
 ///
 @property(nullable, readonly, nonatomic) NSString* pushProxyURL;
 

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -128,6 +128,9 @@ static NSString* const kStaticRulesKey = @"StaticRules";
 static NSString* const kSyncBaseURLKey = @"SyncBaseURL";
 static NSString* const kSyncEnableProtoTransfer = @"SyncEnableProtoTransfer";
 static NSString* const kSyncProxyConfigKey = @"SyncProxyConfiguration";
+static NSString* const kPushProxyURLKey = @"PushProxyURL";
+static NSString* const kPushProxyCAFileKey = @"PushProxyCAFile";
+static NSString* const kPushProxyCADataKey = @"PushProxyCAData";
 static NSString* const kSyncExtraHeadersKey = @"SyncExtraHeaders";
 static NSString* const kSyncEnableCleanSyncEventUpload = @"SyncEnableCleanSyncEventUpload";
 static NSString* const kClientAuthCertificateFileKey = @"ClientAuthCertificateFile";
@@ -380,6 +383,9 @@ static NSString* const kPushTokenChainKey = @"PushTokenChain";
       kSyncEnableProtoTransfer : number,
       kSyncEnableCleanSyncEventUpload : number,
       kSyncProxyConfigKey : dictionary,
+      kPushProxyURLKey : string,
+      kPushProxyCAFileKey : string,
+      kPushProxyCADataKey : data,
       kSyncExtraHeadersKey : dictionary,
       kClientAuthCertificateFileKey : string,
       kClientAuthCertificatePasswordKey : string,
@@ -926,6 +932,18 @@ static SNTConfigurator* sharedConfigurator = nil;
   return [self configStateSet];
 }
 
++ (NSSet*)keyPathsForValuesAffectingPushProxyURL {
+  return [self configStateSet];
+}
+
++ (NSSet*)keyPathsForValuesAffectingPushProxyCAFile {
+  return [self configStateSet];
+}
+
++ (NSSet*)keyPathsForValuesAffectingPushProxyCAData {
+  return [self configStateSet];
+}
+
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {
@@ -1156,6 +1174,18 @@ static SNTConfigurator* sharedConfigurator = nil;
 
 - (NSDictionary*)syncProxyConfig {
   return self.configState[kSyncProxyConfigKey];
+}
+
+- (NSString*)pushProxyURL {
+  return self.configState[kPushProxyURLKey];
+}
+
+- (NSString*)pushProxyCAFile {
+  return self.configState[kPushProxyCAFileKey];
+}
+
+- (NSData*)pushProxyCAData {
+  return self.configState[kPushProxyCADataKey];
 }
 
 - (NSDictionary*)syncExtraHeaders {

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -518,8 +518,8 @@ santa_unit_test(
     },
     tags = ["manual"],  # Only run when explicitly requested
     deps = [
-        ":NATS_lib",
         ":NATSProxyConnect",
+        ":NATS_lib",
         "//Source/common:SNTConfigurator",
         "@OCMock",
         "@nats_c//:nats",

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -519,6 +519,7 @@ santa_unit_test(
     tags = ["manual"],  # Only run when explicitly requested
     deps = [
         ":NATS_lib",
+        ":NATSProxyConnect",
         "//Source/common:SNTConfigurator",
         "@OCMock",
         "@nats_c//:nats",

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -15,6 +15,18 @@ objc_library(
 )
 
 objc_library(
+    name = "NATSProxyConnect",
+    srcs = ["SNTNATSProxyConnect.mm"],
+    hdrs = ["SNTNATSProxyConnect.h"],
+    deps = [
+        "//Source/common:SNTLogging",
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+        "@nats_c//:nats",
+    ],
+)
+
+objc_library(
     name = "NATS_lib",
     srcs = [
         "SNTPushClientNATS.mm",
@@ -26,6 +38,7 @@ objc_library(
         "SNTPushNotifications.h",
     ],
     deps = [
+        ":NATSProxyConnect",
         ":SNTSyncState",
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTConfigurator",
@@ -513,6 +526,15 @@ santa_unit_test(
 )
 
 santa_unit_test(
+    name = "SNTNATSProxyConnectTest",
+    srcs = ["SNTNATSProxyConnectTest.mm"],
+    deps = [
+        ":NATSProxyConnect",
+        "@nats_c//:nats",
+    ],
+)
+
+santa_unit_test(
     name = "SNTSyncManagerNATSTest",
     srcs = ["SNTSyncManagerNATSTest.mm"],
     deps = [
@@ -526,6 +548,7 @@ santa_unit_test(
 test_suite(
     name = "unit_tests",
     tests = [
+        ":SNTNATSProxyConnectTest",
         ":SNTPushClientNATSCommandTest",
         ":SNTPushClientNATSConnectionTest",
         ":SNTPushClientNATSTest",

--- a/Source/santasyncservice/SNTNATSProxyConnect.h
+++ b/Source/santasyncservice/SNTNATSProxyConnect.h
@@ -1,0 +1,78 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "src/nats.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Parsed components of a proxy URL.
+@interface SNTProxyConfig : NSObject
+@property(nonatomic, copy) NSString *host;
+@property(nonatomic) int port;
+@property(nonatomic) BOOL useTLS;
+/// Base64-encoded "user:pass" for Proxy-Authorization header. Nil if no credentials.
+@property(nullable, nonatomic, copy) NSString *basicAuth;
+/// PEM-encoded custom CA certificate data. Nil if using system trust store.
+@property(nullable, nonatomic, copy) NSData *customCAData;
+@end
+
+NS_ASSUME_NONNULL_END
+
+/// Parse a proxy URL string into its components.
+/// Accepted formats: http://host:port, https://host:port,
+/// http://user:pass@host:port, https://user:pass@host:port.
+/// Returns nil if the URL is malformed or has an unsupported scheme.
+SNTProxyConfig *_Nullable SNTParseProxyURL(NSString *_Nonnull proxyURL);
+
+/// Parse an HTTP response status line (e.g. "HTTP/1.1 200 Connection established").
+/// Returns the status code, or -1 if the line is malformed.
+/// Accepts both HTTP/1.0 and HTTP/1.1.
+int SNTParseHTTPStatusLine(NSString *_Nonnull statusLine);
+
+/// Closure structure passed to the NATS proxy connection handler callback.
+/// Heap-allocated; caller is responsible for freeing with SNTProxyClosureDestroy().
+typedef struct {
+  char *_Nonnull proxyHost;
+  int proxyPort;
+  bool proxyUseTLS;
+  char *_Nullable basicAuth;      // Base64-encoded "user:pass", or NULL
+  char *_Nullable customCAPEM;    // PEM CA data as C string, or NULL
+} SNTProxyClosure;
+
+/// Create a closure struct from an SNTProxyConfig. Caller must free with SNTProxyClosureDestroy().
+SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *_Nonnull config);
+
+/// Free a closure struct and all its owned strings. Also shuts down any active
+/// SSL bridge threads.
+void SNTProxyClosureDestroy(SNTProxyClosure *_Nullable closure);
+
+/// NATS proxy connection handler callback. Register with natsOptions_SetProxyConnHandler().
+/// The closure parameter must be a SNTProxyClosure*.
+///
+/// For http:// proxies: returns the raw tunnel socket directly.
+/// For https:// proxies: performs TLS to the proxy, creates a socketpair, and
+/// spawns a detached bridge thread that shuttles bytes between the socketpair
+/// and the SSL connection. Returns one end of the socketpair to NATS.
+natsStatus SNTNATSProxyConnHandler(natsSock *_Nonnull fd, char *_Nonnull host, int port,
+                                    void *_Nullable closure);

--- a/Source/santasyncservice/SNTNATSProxyConnect.h
+++ b/Source/santasyncservice/SNTNATSProxyConnect.h
@@ -63,8 +63,7 @@ typedef struct {
 /// Create a closure struct from an SNTProxyConfig. Caller must free with SNTProxyClosureDestroy().
 SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *_Nonnull config);
 
-/// Free a closure struct and all its owned strings. Also shuts down any active
-/// SSL bridge threads.
+/// Free a closure struct and all its owned strings.
 void SNTProxyClosureDestroy(SNTProxyClosure *_Nullable closure);
 
 /// NATS proxy connection handler callback. Register with natsOptions_SetProxyConnHandler().

--- a/Source/santasyncservice/SNTNATSProxyConnect.h
+++ b/Source/santasyncservice/SNTNATSProxyConnect.h
@@ -28,13 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Parsed components of a proxy URL.
 @interface SNTProxyConfig : NSObject
-@property(nonatomic, copy) NSString *host;
+@property(nonatomic, copy) NSString* host;
 @property(nonatomic) int port;
 @property(nonatomic) BOOL useTLS;
 /// Base64-encoded "user:pass" for Proxy-Authorization header. Nil if no credentials.
-@property(nullable, nonatomic, copy) NSString *basicAuth;
+@property(nullable, nonatomic, copy) NSString* basicAuth;
 /// PEM-encoded custom CA certificate data. Nil if using system trust store.
-@property(nullable, nonatomic, copy) NSData *customCAData;
+@property(nullable, nonatomic, copy) NSData* customCAData;
 @end
 
 NS_ASSUME_NONNULL_END
@@ -43,28 +43,28 @@ NS_ASSUME_NONNULL_END
 /// Accepted formats: http://host:port, https://host:port,
 /// http://user:pass@host:port, https://user:pass@host:port.
 /// Returns nil if the URL is malformed or has an unsupported scheme.
-SNTProxyConfig *_Nullable SNTParseProxyURL(NSString *_Nonnull proxyURL);
+SNTProxyConfig* _Nullable SNTParseProxyURL(NSString* _Nonnull proxyURL);
 
 /// Parse an HTTP response status line (e.g. "HTTP/1.1 200 Connection established").
 /// Returns the status code, or -1 if the line is malformed.
 /// Accepts both HTTP/1.0 and HTTP/1.1.
-int SNTParseHTTPStatusLine(NSString *_Nonnull statusLine);
+int SNTParseHTTPStatusLine(NSString* _Nonnull statusLine);
 
 /// Closure structure passed to the NATS proxy connection handler callback.
 /// Heap-allocated; caller is responsible for freeing with SNTProxyClosureDestroy().
 typedef struct {
-  char *_Nonnull proxyHost;
+  char* _Nonnull proxyHost;
   int proxyPort;
   bool proxyUseTLS;
-  char *_Nullable basicAuth;      // Base64-encoded "user:pass", or NULL
-  char *_Nullable customCAPEM;    // PEM CA data as C string, or NULL
+  char* _Nullable basicAuth;    // Base64-encoded "user:pass", or NULL
+  char* _Nullable customCAPEM;  // PEM CA data as C string, or NULL
 } SNTProxyClosure;
 
 /// Create a closure struct from an SNTProxyConfig. Caller must free with SNTProxyClosureDestroy().
-SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *_Nonnull config);
+SNTProxyClosure* _Nullable SNTProxyClosureCreate(SNTProxyConfig* _Nonnull config);
 
 /// Free a closure struct and all its owned strings.
-void SNTProxyClosureDestroy(SNTProxyClosure *_Nullable closure);
+void SNTProxyClosureDestroy(SNTProxyClosure* _Nullable closure);
 
 /// NATS proxy connection handler callback. Register with natsOptions_SetProxyConnHandler().
 /// The closure parameter must be a SNTProxyClosure*.
@@ -73,5 +73,5 @@ void SNTProxyClosureDestroy(SNTProxyClosure *_Nullable closure);
 /// For https:// proxies: performs TLS to the proxy, creates a socketpair, and
 /// spawns a detached bridge thread that shuttles bytes between the socketpair
 /// and the SSL connection. Returns one end of the socketpair to NATS.
-natsStatus SNTNATSProxyConnHandler(natsSock *_Nonnull fd, char *_Nonnull host, int port,
-                                    void *_Nullable closure);
+natsStatus SNTNATSProxyConnHandler(natsSock* _Nonnull fd, char* _Nonnull host, int port,
+                                   void* _Nullable closure);

--- a/Source/santasyncservice/SNTNATSProxyConnect.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnect.mm
@@ -18,6 +18,7 @@
 
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <poll.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -77,6 +78,10 @@ SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *config) {
   if (!closure) return NULL;
 
   closure->proxyHost = strdup(config.host.UTF8String);
+  if (!closure->proxyHost) {
+    free(closure);
+    return NULL;
+  }
   closure->proxyPort = config.port;
   closure->proxyUseTLS = config.useTLS;
 
@@ -156,14 +161,8 @@ typedef struct {
 static void *SSLBridgeThread(void *arg) {
   SSLBridgeCtx *ctx = (SSLBridgeCtx *)arg;
   char buf[16384];
-  fd_set readfds;
 
   while (true) {
-    FD_ZERO(&readfds);
-    FD_SET(ctx->localFd, &readfds);
-    FD_SET(ctx->proxySock, &readfds);
-    int maxfd = (ctx->localFd > ctx->proxySock ? ctx->localFd : ctx->proxySock) + 1;
-
     if (SSL_pending(ctx->ssl) > 0) {
       int n = SSL_read(ctx->ssl, buf, sizeof(buf));
       if (n <= 0) break;
@@ -171,17 +170,22 @@ static void *SSLBridgeThread(void *arg) {
       continue;
     }
 
-    struct timeval tv = {.tv_sec = 300, .tv_usec = 0};
-    int ready = select(maxfd, &readfds, NULL, NULL, &tv);
+    struct pollfd pfds[2];
+    pfds[0].fd = ctx->localFd;
+    pfds[0].events = POLLIN;
+    pfds[1].fd = ctx->proxySock;
+    pfds[1].events = POLLIN;
+
+    int ready = poll(pfds, 2, 300 * 1000);
     if (ready <= 0) break;
 
-    if (FD_ISSET(ctx->localFd, &readfds)) {
+    if (pfds[0].revents & POLLIN) {
       ssize_t n = read(ctx->localFd, buf, sizeof(buf));
       if (n <= 0) break;
       if (SSL_write(ctx->ssl, buf, (int)n) <= 0) break;
     }
 
-    if (FD_ISSET(ctx->proxySock, &readfds)) {
+    if (pfds[1].revents & POLLIN) {
       int n = SSL_read(ctx->ssl, buf, sizeof(buf));
       if (n <= 0) break;
       if (write(ctx->localFd, buf, n) <= 0) break;
@@ -345,6 +349,9 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
        proxy->proxyPort, host, port);
 
   if (!ssl) {
+    // Reset receive timeout before handing socket to NATS
+    struct timeval tv_zero = {0, 0};
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv_zero, sizeof(tv_zero));
     *fd = (natsSock)sock;
     return NATS_OK;
   }

--- a/Source/santasyncservice/SNTNATSProxyConnect.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnect.mm
@@ -248,27 +248,30 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
     return NATS_ERR;
   }
 
-  int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-  if (sock < 0) {
-    LOGE(@"NATS proxy: Failed to create socket: %s", strerror(errno));
-    freeaddrinfo(res);
-    return NATS_ERR;
-  }
+  // Iterate all resolved addresses (e.g. IPv4 + IPv6) until one connects
+  int sock = -1;
+  for (struct addrinfo* rp = res; rp != NULL; rp = rp->ai_next) {
+    sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (sock < 0) continue;
 
-  int on = 1;
-  setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+    int on = 1;
+    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
 
-  struct timeval tv = {.tv_sec = 30, .tv_usec = 0};
-  setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    struct timeval tv = {.tv_sec = 30, .tv_usec = 0};
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-  if (connect(sock, res->ai_addr, res->ai_addrlen) != 0) {
-    LOGE(@"NATS proxy: Failed to connect to %s:%d: %s", proxy->proxyHost, proxy->proxyPort,
-         strerror(errno));
+    if (connect(sock, rp->ai_addr, rp->ai_addrlen) == 0) break;
+
     close(sock);
-    freeaddrinfo(res);
-    return NATS_ERR;
+    sock = -1;
   }
   freeaddrinfo(res);
+
+  if (sock < 0) {
+    LOGE(@"NATS proxy: Failed to connect to %s:%d: %s", proxy->proxyHost, proxy->proxyPort,
+         strerror(errno));
+    return NATS_ERR;
+  }
 
   SSL_CTX* sslCtx = NULL;
   SSL* ssl = NULL;
@@ -365,9 +368,10 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
        proxy->proxyPort, host, port);
 
   if (!ssl) {
-    // Reset receive timeout before handing socket to NATS
+    // Reset timeouts before handing socket to NATS
     struct timeval tv_zero = {0, 0};
     setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv_zero, sizeof(tv_zero));
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv_zero, sizeof(tv_zero));
     *fd = (natsSock)sock;
     return NATS_OK;
   }

--- a/Source/santasyncservice/SNTNATSProxyConnect.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnect.mm
@@ -1,0 +1,382 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTNATSProxyConnect.h"
+
+#import "Source/common/SNTLogging.h"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
+@implementation SNTProxyConfig
+@end
+
+SNTProxyConfig *_Nullable SNTParseProxyURL(NSString *proxyURL) {
+  if (!proxyURL.length) return nil;
+
+  NSURL *url = [NSURL URLWithString:proxyURL];
+  if (!url || !url.host || !url.port) return nil;
+
+  NSString *scheme = url.scheme.lowercaseString;
+  if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) return nil;
+
+  SNTProxyConfig *config = [[SNTProxyConfig alloc] init];
+  config.host = url.host;
+  config.port = url.port.intValue;
+  config.useTLS = [scheme isEqualToString:@"https"];
+
+  if (url.user && url.password) {
+    NSString *user = url.user.stringByRemovingPercentEncoding;
+    NSString *password = url.password.stringByRemovingPercentEncoding;
+    NSString *credentials = [NSString stringWithFormat:@"%@:%@", user, password];
+    NSData *credData = [credentials dataUsingEncoding:NSUTF8StringEncoding];
+    config.basicAuth = [credData base64EncodedStringWithOptions:0];
+  }
+
+  return config;
+}
+
+int SNTParseHTTPStatusLine(NSString *statusLine) {
+  if (!statusLine.length) return -1;
+
+  NSArray<NSString *> *parts = [statusLine componentsSeparatedByString:@" "];
+  if (parts.count < 2) return -1;
+
+  NSString *version = parts[0];
+  if (![version hasPrefix:@"HTTP/"]) return -1;
+
+  NSInteger code = parts[1].integerValue;
+  if (code < 100 || code > 599) return -1;
+
+  return (int)code;
+}
+
+SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *config) {
+  if (!config) return NULL;
+
+  SNTProxyClosure *closure = (SNTProxyClosure *)calloc(1, sizeof(SNTProxyClosure));
+  if (!closure) return NULL;
+
+  closure->proxyHost = strdup(config.host.UTF8String);
+  closure->proxyPort = config.port;
+  closure->proxyUseTLS = config.useTLS;
+
+  if (config.basicAuth) {
+    closure->basicAuth = strdup(config.basicAuth.UTF8String);
+  }
+
+  if (config.customCAData) {
+    NSString *pemStr = [[NSString alloc] initWithData:config.customCAData
+                                             encoding:NSUTF8StringEncoding];
+    if (pemStr) {
+      closure->customCAPEM = strdup(pemStr.UTF8String);
+    }
+  }
+
+  return closure;
+}
+
+void SNTProxyClosureDestroy(SNTProxyClosure *closure) {
+  if (!closure) return;
+  free(closure->proxyHost);
+  free(closure->basicAuth);
+  free(closure->customCAPEM);
+  free(closure);
+}
+
+#pragma mark - I/O Helpers
+
+static ssize_t ProxyRead(int fd, SSL *ssl, void *buf, size_t len) {
+  return ssl ? SSL_read(ssl, buf, (int)len) : read(fd, buf, len);
+}
+
+static ssize_t ProxyWrite(int fd, SSL *ssl, const void *buf, size_t len) {
+  return ssl ? SSL_write(ssl, buf, (int)len) : write(fd, buf, len);
+}
+
+static NSString *ReadLineFromProxy(int fd, SSL *ssl, int timeoutSecs) {
+  NSMutableData *lineData = [NSMutableData data];
+  char c;
+  struct timeval tv = {.tv_sec = timeoutSecs, .tv_usec = 0};
+  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  while (lineData.length < 8192) {
+    ssize_t n = ProxyRead(fd, ssl, &c, 1);
+    if (n <= 0) return nil;
+    if (c == '\n') {
+      NSString *line = [[NSString alloc] initWithData:lineData encoding:NSUTF8StringEncoding];
+      if ([line hasSuffix:@"\r"]) line = [line substringToIndex:line.length - 1];
+      return line;
+    }
+    [lineData appendBytes:&c length:1];
+  }
+  return nil;
+}
+
+static bool SendAllToProxy(int fd, SSL *ssl, const void *data, size_t len) {
+  const char *p = (const char *)data;
+  size_t remaining = len;
+  while (remaining > 0) {
+    ssize_t n = ProxyWrite(fd, ssl, p, remaining);
+    if (n <= 0) return false;
+    p += n;
+    remaining -= (size_t)n;
+  }
+  return true;
+}
+
+#pragma mark - SSL Bridge for HTTPS Proxies
+
+typedef struct {
+  int localFd;
+  int proxySock;
+  SSL *ssl;
+  SSL_CTX *sslCtx;
+} SSLBridgeCtx;
+
+static void *SSLBridgeThread(void *arg) {
+  SSLBridgeCtx *ctx = (SSLBridgeCtx *)arg;
+  char buf[16384];
+  fd_set readfds;
+
+  while (true) {
+    FD_ZERO(&readfds);
+    FD_SET(ctx->localFd, &readfds);
+    FD_SET(ctx->proxySock, &readfds);
+    int maxfd = (ctx->localFd > ctx->proxySock ? ctx->localFd : ctx->proxySock) + 1;
+
+    if (SSL_pending(ctx->ssl) > 0) {
+      int n = SSL_read(ctx->ssl, buf, sizeof(buf));
+      if (n <= 0) break;
+      if (write(ctx->localFd, buf, n) <= 0) break;
+      continue;
+    }
+
+    struct timeval tv = {.tv_sec = 300, .tv_usec = 0};
+    int ready = select(maxfd, &readfds, NULL, NULL, &tv);
+    if (ready <= 0) break;
+
+    if (FD_ISSET(ctx->localFd, &readfds)) {
+      ssize_t n = read(ctx->localFd, buf, sizeof(buf));
+      if (n <= 0) break;
+      if (SSL_write(ctx->ssl, buf, (int)n) <= 0) break;
+    }
+
+    if (FD_ISSET(ctx->proxySock, &readfds)) {
+      int n = SSL_read(ctx->ssl, buf, sizeof(buf));
+      if (n <= 0) break;
+      if (write(ctx->localFd, buf, n) <= 0) break;
+    }
+  }
+
+  SSL_shutdown(ctx->ssl);
+  SSL_free(ctx->ssl);
+  SSL_CTX_free(ctx->sslCtx);
+  close(ctx->localFd);
+  close(ctx->proxySock);
+  free(ctx);
+  return NULL;
+}
+
+#pragma mark - HTTP CONNECT Handler
+
+static SSL_CTX *CreateProxySSLContext(const char *customCAPEM) {
+  SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+  if (!ctx) return NULL;
+
+  if (customCAPEM) {
+    BIO *bio = BIO_new_mem_buf(customCAPEM, -1);
+    if (bio) {
+      X509_STORE *store = SSL_CTX_get_cert_store(ctx);
+      X509 *cert;
+      while ((cert = PEM_read_bio_X509(bio, NULL, NULL, NULL)) != NULL) {
+        X509_STORE_add_cert(store, cert);
+        X509_free(cert);
+      }
+      BIO_free(bio);
+    }
+  } else {
+    SSL_CTX_set_default_verify_paths(ctx);
+  }
+
+  SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+  return ctx;
+}
+
+natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *closure) {
+  SNTProxyClosure *proxy = (SNTProxyClosure *)closure;
+  if (!proxy) return NATS_ERR;
+
+  struct addrinfo hints = {};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+
+  char portStr[16];
+  snprintf(portStr, sizeof(portStr), "%d", proxy->proxyPort);
+
+  struct addrinfo *res = NULL;
+  int gaiErr = getaddrinfo(proxy->proxyHost, portStr, &hints, &res);
+  if (gaiErr != 0 || !res) {
+    LOGE(@"NATS proxy: Failed to resolve %s:%d: %s", proxy->proxyHost, proxy->proxyPort,
+         gai_strerror(gaiErr));
+    return NATS_ERR;
+  }
+
+  int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+  if (sock < 0) {
+    LOGE(@"NATS proxy: Failed to create socket: %s", strerror(errno));
+    freeaddrinfo(res);
+    return NATS_ERR;
+  }
+
+  struct timeval tv = {.tv_sec = 30, .tv_usec = 0};
+  setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+  if (connect(sock, res->ai_addr, res->ai_addrlen) != 0) {
+    LOGE(@"NATS proxy: Failed to connect to %s:%d: %s", proxy->proxyHost, proxy->proxyPort,
+         strerror(errno));
+    close(sock);
+    freeaddrinfo(res);
+    return NATS_ERR;
+  }
+  freeaddrinfo(res);
+
+  SSL_CTX *sslCtx = NULL;
+  SSL *ssl = NULL;
+
+  if (proxy->proxyUseTLS) {
+    sslCtx = CreateProxySSLContext(proxy->customCAPEM);
+    if (!sslCtx) {
+      LOGE(@"NATS proxy: Failed to create SSL context for proxy TLS");
+      close(sock);
+      return NATS_ERR;
+    }
+
+    ssl = SSL_new(sslCtx);
+    if (!ssl) {
+      LOGE(@"NATS proxy: Failed to create SSL object");
+      SSL_CTX_free(sslCtx);
+      close(sock);
+      return NATS_ERR;
+    }
+
+    SSL_set_fd(ssl, sock);
+    SSL_set_tlsext_host_name(ssl, proxy->proxyHost);
+
+    if (SSL_connect(ssl) != 1) {
+      uint32_t sslErr = (uint32_t)ERR_get_error();
+      char errBuf[256];
+      ERR_error_string_n(sslErr, errBuf, sizeof(errBuf));
+      LOGE(@"NATS proxy: TLS handshake with proxy %s:%d failed: %s", proxy->proxyHost,
+           proxy->proxyPort, errBuf);
+      SSL_free(ssl);
+      SSL_CTX_free(sslCtx);
+      close(sock);
+      return NATS_ERR;
+    }
+    LOGD(@"NATS proxy: TLS established with proxy %s:%d", proxy->proxyHost, proxy->proxyPort);
+  }
+
+  NSMutableString *request = [NSMutableString stringWithFormat:@"CONNECT %s:%d HTTP/1.1\r\n"
+                                                               @"Host: %s:%d\r\n",
+                                                               host, port, host, port];
+  if (proxy->basicAuth) {
+    [request appendFormat:@"Proxy-Authorization: Basic %s\r\n", proxy->basicAuth];
+  }
+  [request appendString:@"\r\n"];
+
+  const char *reqBytes = request.UTF8String;
+  if (!SendAllToProxy(sock, ssl, reqBytes, strlen(reqBytes))) {
+    LOGE(@"NATS proxy: Failed to send CONNECT request to %s:%d", proxy->proxyHost,
+         proxy->proxyPort);
+    if (ssl) { SSL_free(ssl); SSL_CTX_free(sslCtx); }
+    close(sock);
+    return NATS_ERR;
+  }
+
+  NSString *statusLine = ReadLineFromProxy(sock, ssl, 30);
+  if (!statusLine) {
+    LOGE(@"NATS proxy: No response from proxy %s:%d", proxy->proxyHost, proxy->proxyPort);
+    if (ssl) { SSL_free(ssl); SSL_CTX_free(sslCtx); }
+    close(sock);
+    return NATS_ERR;
+  }
+
+  int statusCode = SNTParseHTTPStatusLine(statusLine);
+
+  NSString *headerLine;
+  while ((headerLine = ReadLineFromProxy(sock, ssl, 30)) != nil) {
+    if (headerLine.length == 0) break;
+  }
+
+  if (statusCode < 200 || statusCode > 299) {
+    if (statusCode == 407) {
+      LOGE(@"NATS proxy: Authentication required by proxy %s:%d -- check PushProxyURL credentials",
+           proxy->proxyHost, proxy->proxyPort);
+    } else {
+      LOGE(@"NATS proxy: CONNECT failed with status %d from %s:%d: %@", statusCode,
+           proxy->proxyHost, proxy->proxyPort, statusLine);
+    }
+    if (ssl) { SSL_free(ssl); SSL_CTX_free(sslCtx); }
+    close(sock);
+    return NATS_ERR;
+  }
+
+  LOGI(@"NATS proxy: CONNECT tunnel established through %s:%d to %s:%d", proxy->proxyHost,
+       proxy->proxyPort, host, port);
+
+  if (!ssl) {
+    *fd = (natsSock)sock;
+    return NATS_OK;
+  }
+
+  int pair[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair) != 0) {
+    LOGE(@"NATS proxy: socketpair failed: %s", strerror(errno));
+    SSL_free(ssl);
+    SSL_CTX_free(sslCtx);
+    close(sock);
+    return NATS_ERR;
+  }
+
+  SSLBridgeCtx *bridgeCtx = (SSLBridgeCtx *)calloc(1, sizeof(SSLBridgeCtx));
+  bridgeCtx->localFd = pair[1];
+  bridgeCtx->proxySock = sock;
+  bridgeCtx->ssl = ssl;
+  bridgeCtx->sslCtx = sslCtx;
+
+  pthread_t thread;
+  if (pthread_create(&thread, NULL, SSLBridgeThread, bridgeCtx) != 0) {
+    LOGE(@"NATS proxy: Failed to create bridge thread: %s", strerror(errno));
+    free(bridgeCtx);
+    SSL_free(ssl);
+    SSL_CTX_free(sslCtx);
+    close(sock);
+    close(pair[0]);
+    close(pair[1]);
+    return NATS_ERR;
+  }
+  pthread_detach(thread);
+
+  *fd = (natsSock)pair[0];
+  return NATS_OK;
+}

--- a/Source/santasyncservice/SNTNATSProxyConnect.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnect.mm
@@ -31,38 +31,38 @@
 @implementation SNTProxyConfig
 @end
 
-SNTProxyConfig *_Nullable SNTParseProxyURL(NSString *proxyURL) {
+SNTProxyConfig* _Nullable SNTParseProxyURL(NSString* proxyURL) {
   if (!proxyURL.length) return nil;
 
-  NSURL *url = [NSURL URLWithString:proxyURL];
+  NSURL* url = [NSURL URLWithString:proxyURL];
   if (!url || !url.host || !url.port) return nil;
 
-  NSString *scheme = url.scheme.lowercaseString;
+  NSString* scheme = url.scheme.lowercaseString;
   if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) return nil;
 
-  SNTProxyConfig *config = [[SNTProxyConfig alloc] init];
+  SNTProxyConfig* config = [[SNTProxyConfig alloc] init];
   config.host = url.host;
   config.port = url.port.intValue;
   config.useTLS = [scheme isEqualToString:@"https"];
 
   if (url.user && url.password) {
-    NSString *user = url.user.stringByRemovingPercentEncoding;
-    NSString *password = url.password.stringByRemovingPercentEncoding;
-    NSString *credentials = [NSString stringWithFormat:@"%@:%@", user, password];
-    NSData *credData = [credentials dataUsingEncoding:NSUTF8StringEncoding];
+    NSString* user = url.user.stringByRemovingPercentEncoding;
+    NSString* password = url.password.stringByRemovingPercentEncoding;
+    NSString* credentials = [NSString stringWithFormat:@"%@:%@", user, password];
+    NSData* credData = [credentials dataUsingEncoding:NSUTF8StringEncoding];
     config.basicAuth = [credData base64EncodedStringWithOptions:0];
   }
 
   return config;
 }
 
-int SNTParseHTTPStatusLine(NSString *statusLine) {
+int SNTParseHTTPStatusLine(NSString* statusLine) {
   if (!statusLine.length) return -1;
 
-  NSArray<NSString *> *parts = [statusLine componentsSeparatedByString:@" "];
+  NSArray<NSString*>* parts = [statusLine componentsSeparatedByString:@" "];
   if (parts.count < 2) return -1;
 
-  NSString *version = parts[0];
+  NSString* version = parts[0];
   if (![version hasPrefix:@"HTTP/"]) return -1;
 
   NSInteger code = parts[1].integerValue;
@@ -71,10 +71,10 @@ int SNTParseHTTPStatusLine(NSString *statusLine) {
   return (int)code;
 }
 
-SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *config) {
+SNTProxyClosure* _Nullable SNTProxyClosureCreate(SNTProxyConfig* config) {
   if (!config) return NULL;
 
-  SNTProxyClosure *closure = (SNTProxyClosure *)calloc(1, sizeof(SNTProxyClosure));
+  SNTProxyClosure* closure = (SNTProxyClosure*)calloc(1, sizeof(SNTProxyClosure));
   if (!closure) return NULL;
 
   closure->proxyHost = strdup(config.host.UTF8String);
@@ -90,7 +90,7 @@ SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *config) {
   }
 
   if (config.customCAData) {
-    NSString *pemStr = [[NSString alloc] initWithData:config.customCAData
+    NSString* pemStr = [[NSString alloc] initWithData:config.customCAData
                                              encoding:NSUTF8StringEncoding];
     if (pemStr) {
       closure->customCAPEM = strdup(pemStr.UTF8String);
@@ -100,7 +100,7 @@ SNTProxyClosure *_Nullable SNTProxyClosureCreate(SNTProxyConfig *config) {
   return closure;
 }
 
-void SNTProxyClosureDestroy(SNTProxyClosure *closure) {
+void SNTProxyClosureDestroy(SNTProxyClosure* closure) {
   if (!closure) return;
   free(closure->proxyHost);
   free(closure->basicAuth);
@@ -110,16 +110,16 @@ void SNTProxyClosureDestroy(SNTProxyClosure *closure) {
 
 #pragma mark - I/O Helpers
 
-static ssize_t ProxyRead(int fd, SSL *ssl, void *buf, size_t len) {
+static ssize_t ProxyRead(int fd, SSL* ssl, void* buf, size_t len) {
   return ssl ? SSL_read(ssl, buf, (int)len) : read(fd, buf, len);
 }
 
-static ssize_t ProxyWrite(int fd, SSL *ssl, const void *buf, size_t len) {
+static ssize_t ProxyWrite(int fd, SSL* ssl, const void* buf, size_t len) {
   return ssl ? SSL_write(ssl, buf, (int)len) : write(fd, buf, len);
 }
 
-static NSString *ReadLineFromProxy(int fd, SSL *ssl, int timeoutSecs) {
-  NSMutableData *lineData = [NSMutableData data];
+static NSString* ReadLineFromProxy(int fd, SSL* ssl, int timeoutSecs) {
+  NSMutableData* lineData = [NSMutableData data];
   char c;
   struct timeval tv = {.tv_sec = timeoutSecs, .tv_usec = 0};
   setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
@@ -128,7 +128,7 @@ static NSString *ReadLineFromProxy(int fd, SSL *ssl, int timeoutSecs) {
     ssize_t n = ProxyRead(fd, ssl, &c, 1);
     if (n <= 0) return nil;
     if (c == '\n') {
-      NSString *line = [[NSString alloc] initWithData:lineData encoding:NSUTF8StringEncoding];
+      NSString* line = [[NSString alloc] initWithData:lineData encoding:NSUTF8StringEncoding];
       if ([line hasSuffix:@"\r"]) line = [line substringToIndex:line.length - 1];
       return line;
     }
@@ -137,8 +137,8 @@ static NSString *ReadLineFromProxy(int fd, SSL *ssl, int timeoutSecs) {
   return nil;
 }
 
-static bool SendAllToProxy(int fd, SSL *ssl, const void *data, size_t len) {
-  const char *p = (const char *)data;
+static bool SendAllToProxy(int fd, SSL* ssl, const void* data, size_t len) {
+  const char* p = (const char*)data;
   size_t remaining = len;
   while (remaining > 0) {
     ssize_t n = ProxyWrite(fd, ssl, p, remaining);
@@ -154,12 +154,12 @@ static bool SendAllToProxy(int fd, SSL *ssl, const void *data, size_t len) {
 typedef struct {
   int localFd;
   int proxySock;
-  SSL *ssl;
-  SSL_CTX *sslCtx;
+  SSL* ssl;
+  SSL_CTX* sslCtx;
 } SSLBridgeCtx;
 
-static void *SSLBridgeThread(void *arg) {
-  SSLBridgeCtx *ctx = (SSLBridgeCtx *)arg;
+static void* SSLBridgeThread(void* arg) {
+  SSLBridgeCtx* ctx = (SSLBridgeCtx*)arg;
   char buf[16384];
 
   while (true) {
@@ -203,15 +203,15 @@ static void *SSLBridgeThread(void *arg) {
 
 #pragma mark - HTTP CONNECT Handler
 
-static SSL_CTX *CreateProxySSLContext(const char *customCAPEM) {
-  SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+static SSL_CTX* CreateProxySSLContext(const char* customCAPEM) {
+  SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
   if (!ctx) return NULL;
 
   if (customCAPEM) {
-    BIO *bio = BIO_new_mem_buf(customCAPEM, -1);
+    BIO* bio = BIO_new_mem_buf(customCAPEM, -1);
     if (bio) {
-      X509_STORE *store = SSL_CTX_get_cert_store(ctx);
-      X509 *cert;
+      X509_STORE* store = SSL_CTX_get_cert_store(ctx);
+      X509* cert;
       while ((cert = PEM_read_bio_X509(bio, NULL, NULL, NULL)) != NULL) {
         X509_STORE_add_cert(store, cert);
         X509_free(cert);
@@ -226,8 +226,8 @@ static SSL_CTX *CreateProxySSLContext(const char *customCAPEM) {
   return ctx;
 }
 
-natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *closure) {
-  SNTProxyClosure *proxy = (SNTProxyClosure *)closure;
+natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* closure) {
+  SNTProxyClosure* proxy = (SNTProxyClosure*)closure;
   if (!proxy) return NATS_ERR;
 
   struct addrinfo hints = {};
@@ -237,7 +237,7 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
   char portStr[16];
   snprintf(portStr, sizeof(portStr), "%d", proxy->proxyPort);
 
-  struct addrinfo *res = NULL;
+  struct addrinfo* res = NULL;
   int gaiErr = getaddrinfo(proxy->proxyHost, portStr, &hints, &res);
   if (gaiErr != 0 || !res) {
     LOGE(@"NATS proxy: Failed to resolve %s:%d: %s", proxy->proxyHost, proxy->proxyPort,
@@ -264,8 +264,8 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
   }
   freeaddrinfo(res);
 
-  SSL_CTX *sslCtx = NULL;
-  SSL *ssl = NULL;
+  SSL_CTX* sslCtx = NULL;
+  SSL* ssl = NULL;
 
   if (proxy->proxyUseTLS) {
     sslCtx = CreateProxySSLContext(proxy->customCAPEM);
@@ -300,7 +300,7 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
     LOGD(@"NATS proxy: TLS established with proxy %s:%d", proxy->proxyHost, proxy->proxyPort);
   }
 
-  NSMutableString *request = [NSMutableString stringWithFormat:@"CONNECT %s:%d HTTP/1.1\r\n"
+  NSMutableString* request = [NSMutableString stringWithFormat:@"CONNECT %s:%d HTTP/1.1\r\n"
                                                                @"Host: %s:%d\r\n",
                                                                host, port, host, port];
   if (proxy->basicAuth) {
@@ -308,26 +308,32 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
   }
   [request appendString:@"\r\n"];
 
-  const char *reqBytes = request.UTF8String;
+  const char* reqBytes = request.UTF8String;
   if (!SendAllToProxy(sock, ssl, reqBytes, strlen(reqBytes))) {
     LOGE(@"NATS proxy: Failed to send CONNECT request to %s:%d", proxy->proxyHost,
          proxy->proxyPort);
-    if (ssl) { SSL_free(ssl); SSL_CTX_free(sslCtx); }
+    if (ssl) {
+      SSL_free(ssl);
+      SSL_CTX_free(sslCtx);
+    }
     close(sock);
     return NATS_ERR;
   }
 
-  NSString *statusLine = ReadLineFromProxy(sock, ssl, 30);
+  NSString* statusLine = ReadLineFromProxy(sock, ssl, 30);
   if (!statusLine) {
     LOGE(@"NATS proxy: No response from proxy %s:%d", proxy->proxyHost, proxy->proxyPort);
-    if (ssl) { SSL_free(ssl); SSL_CTX_free(sslCtx); }
+    if (ssl) {
+      SSL_free(ssl);
+      SSL_CTX_free(sslCtx);
+    }
     close(sock);
     return NATS_ERR;
   }
 
   int statusCode = SNTParseHTTPStatusLine(statusLine);
 
-  NSString *headerLine;
+  NSString* headerLine;
   while ((headerLine = ReadLineFromProxy(sock, ssl, 30)) != nil) {
     if (headerLine.length == 0) break;
   }
@@ -340,7 +346,10 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
       LOGE(@"NATS proxy: CONNECT failed with status %d from %s:%d: %@", statusCode,
            proxy->proxyHost, proxy->proxyPort, statusLine);
     }
-    if (ssl) { SSL_free(ssl); SSL_CTX_free(sslCtx); }
+    if (ssl) {
+      SSL_free(ssl);
+      SSL_CTX_free(sslCtx);
+    }
     close(sock);
     return NATS_ERR;
   }
@@ -365,7 +374,7 @@ natsStatus SNTNATSProxyConnHandler(natsSock *fd, char *host, int port, void *clo
     return NATS_ERR;
   }
 
-  SSLBridgeCtx *bridgeCtx = (SSLBridgeCtx *)calloc(1, sizeof(SSLBridgeCtx));
+  SSLBridgeCtx* bridgeCtx = (SSLBridgeCtx*)calloc(1, sizeof(SSLBridgeCtx));
   bridgeCtx->localFd = pair[1];
   bridgeCtx->proxySock = sock;
   bridgeCtx->ssl = ssl;

--- a/Source/santasyncservice/SNTNATSProxyConnect.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnect.mm
@@ -121,13 +121,19 @@ static ssize_t ProxyWrite(int fd, SSL* ssl, const void* buf, size_t len) {
   return ssl ? SSL_write(ssl, buf, (int)len) : write(fd, buf, len);
 }
 
-static NSString* ReadLineFromProxy(int fd, SSL* ssl, int timeoutSecs) {
+static NSString* ReadLineFromProxy(int fd, SSL* ssl, NSDate* deadline) {
   NSMutableData* lineData = [NSMutableData data];
   char c;
-  struct timeval tv = {.tv_sec = timeoutSecs, .tv_usec = 0};
-  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
   while (lineData.length < 8192) {
+    NSTimeInterval remaining = [deadline timeIntervalSinceNow];
+    if (remaining <= 0) return nil;
+
+    // Clamp per-read timeout to time remaining on the overall deadline
+    int secs = (int)(remaining < 1.0 ? 1 : remaining);
+    struct timeval tv = {.tv_sec = secs, .tv_usec = 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
     ssize_t n = ProxyRead(fd, ssl, &c, 1);
     if (n <= 0) return nil;
     if (c == '\n') {
@@ -310,6 +316,19 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
     LOGD(@"NATS proxy: TLS established with proxy %s:%d", proxy->proxyHost, proxy->proxyPort);
   }
 
+  // Validate host from NATS callback does not contain CRLF (HTTP header injection)
+  for (const char* p = host; *p; p++) {
+    if (*p == '\r' || *p == '\n') {
+      LOGE(@"NATS proxy: Rejecting host containing CR/LF characters");
+      if (ssl) {
+        SSL_free(ssl);
+        SSL_CTX_free(sslCtx);
+      }
+      close(sock);
+      return NATS_ERR;
+    }
+  }
+
   NSMutableString* request = [NSMutableString stringWithFormat:@"CONNECT %s:%d HTTP/1.1\r\n"
                                                                @"Host: %s:%d\r\n",
                                                                host, port, host, port];
@@ -330,7 +349,11 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
     return NATS_ERR;
   }
 
-  NSString* statusLine = ReadLineFromProxy(sock, ssl, 30);
+  // Overall deadline for the CONNECT handshake response (prevents slow-loris)
+  static const NSTimeInterval kConnectHandshakeTimeoutSecs = 30;
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:kConnectHandshakeTimeoutSecs];
+
+  NSString* statusLine = ReadLineFromProxy(sock, ssl, deadline);
   if (!statusLine) {
     LOGE(@"NATS proxy: No response from proxy %s:%d", proxy->proxyHost, proxy->proxyPort);
     if (ssl) {
@@ -343,9 +366,14 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
 
   int statusCode = SNTParseHTTPStatusLine(statusLine);
 
+  // Consume remaining response headers; cap at 64 to bound a misbehaving proxy
+  static const int kMaxProxyResponseHeaders = 64;
+  int headerCount = 0;
   NSString* headerLine;
-  while ((headerLine = ReadLineFromProxy(sock, ssl, 30)) != nil) {
+  while (headerCount < kMaxProxyResponseHeaders &&
+         (headerLine = ReadLineFromProxy(sock, ssl, deadline)) != nil) {
     if (headerLine.length == 0) break;
+    headerCount++;
   }
 
   if (statusCode < 200 || statusCode > 299) {

--- a/Source/santasyncservice/SNTNATSProxyConnect.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnect.mm
@@ -103,7 +103,10 @@ SNTProxyClosure* _Nullable SNTProxyClosureCreate(SNTProxyConfig* config) {
 void SNTProxyClosureDestroy(SNTProxyClosure* closure) {
   if (!closure) return;
   free(closure->proxyHost);
-  free(closure->basicAuth);
+  if (closure->basicAuth) {
+    memset(closure->basicAuth, 0, strlen(closure->basicAuth));
+    free(closure->basicAuth);
+  }
   free(closure->customCAPEM);
   free(closure);
 }
@@ -234,7 +237,7 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
 
-  char portStr[16];
+  char portStr[16] = {};
   snprintf(portStr, sizeof(portStr), "%d", proxy->proxyPort);
 
   struct addrinfo* res = NULL;
@@ -251,6 +254,9 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
     freeaddrinfo(res);
     return NATS_ERR;
   }
+
+  int on = 1;
+  setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
 
   struct timeval tv = {.tv_sec = 30, .tv_usec = 0};
   setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
@@ -285,10 +291,11 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
 
     SSL_set_fd(ssl, sock);
     SSL_set_tlsext_host_name(ssl, proxy->proxyHost);
+    SSL_set1_host(ssl, proxy->proxyHost);
 
     if (SSL_connect(ssl) != 1) {
       uint32_t sslErr = (uint32_t)ERR_get_error();
-      char errBuf[256];
+      char errBuf[256] = {};
       ERR_error_string_n(sslErr, errBuf, sizeof(errBuf));
       LOGE(@"NATS proxy: TLS handshake with proxy %s:%d failed: %s", proxy->proxyHost,
            proxy->proxyPort, errBuf);
@@ -365,7 +372,7 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
     return NATS_OK;
   }
 
-  int pair[2];
+  int pair[2] = {};
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair) != 0) {
     LOGE(@"NATS proxy: socketpair failed: %s", strerror(errno));
     SSL_free(ssl);
@@ -374,7 +381,20 @@ natsStatus SNTNATSProxyConnHandler(natsSock* fd, char* host, int port, void* clo
     return NATS_ERR;
   }
 
+  int nosig = 1;
+  setsockopt(pair[0], SOL_SOCKET, SO_NOSIGPIPE, &nosig, sizeof(nosig));
+  setsockopt(pair[1], SOL_SOCKET, SO_NOSIGPIPE, &nosig, sizeof(nosig));
+
   SSLBridgeCtx* bridgeCtx = (SSLBridgeCtx*)calloc(1, sizeof(SSLBridgeCtx));
+  if (!bridgeCtx) {
+    LOGE(@"NATS proxy: Failed to allocate bridge context");
+    SSL_free(ssl);
+    SSL_CTX_free(sslCtx);
+    close(sock);
+    close(pair[0]);
+    close(pair[1]);
+    return NATS_ERR;
+  }
   bridgeCtx->localFd = pair[1];
   bridgeCtx->proxySock = sock;
   bridgeCtx->ssl = ssl;

--- a/Source/santasyncservice/SNTNATSProxyConnectTest.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnectTest.mm
@@ -1,0 +1,145 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "Source/santasyncservice/SNTNATSProxyConnect.h"
+
+@interface SNTNATSProxyConnectTest : XCTestCase
+@end
+
+@implementation SNTNATSProxyConnectTest
+
+#pragma mark - URL Parsing Tests
+
+- (void)testParseHTTPProxyURL {
+  SNTProxyConfig *config = SNTParseProxyURL(@"http://proxy.corp:8080");
+  XCTAssertNotNil(config);
+  XCTAssertEqualObjects(config.host, @"proxy.corp");
+  XCTAssertEqual(config.port, 8080);
+  XCTAssertFalse(config.useTLS);
+  XCTAssertNil(config.basicAuth);
+}
+
+- (void)testParseHTTPSProxyURL {
+  SNTProxyConfig *config = SNTParseProxyURL(@"https://proxy.corp:8443");
+  XCTAssertNotNil(config);
+  XCTAssertEqualObjects(config.host, @"proxy.corp");
+  XCTAssertEqual(config.port, 8443);
+  XCTAssertTrue(config.useTLS);
+  XCTAssertNil(config.basicAuth);
+}
+
+- (void)testParseProxyURLWithBasicAuth {
+  SNTProxyConfig *config = SNTParseProxyURL(@"http://user:pass@proxy.corp:8080");
+  XCTAssertNotNil(config);
+  XCTAssertEqualObjects(config.host, @"proxy.corp");
+  XCTAssertEqual(config.port, 8080);
+  XCTAssertFalse(config.useTLS);
+  XCTAssertNotNil(config.basicAuth);
+  NSData *decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
+  NSString *decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+  XCTAssertEqualObjects(decodedStr, @"user:pass");
+}
+
+- (void)testParseHTTPSProxyURLWithBasicAuth {
+  SNTProxyConfig *config = SNTParseProxyURL(@"https://admin:s3cret@proxy.corp:8443");
+  XCTAssertNotNil(config);
+  XCTAssertTrue(config.useTLS);
+  XCTAssertNotNil(config.basicAuth);
+  NSData *decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
+  NSString *decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+  XCTAssertEqualObjects(decodedStr, @"admin:s3cret");
+}
+
+- (void)testParseProxyURLWithSpecialCharsInPassword {
+  SNTProxyConfig *config = SNTParseProxyURL(@"http://user:p%40ss%3Aword@proxy.corp:8080");
+  XCTAssertNotNil(config);
+  NSData *decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
+  NSString *decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+  XCTAssertEqualObjects(decodedStr, @"user:p@ss:word");
+}
+
+- (void)testParseProxyURLRejectsUnsupportedScheme {
+  XCTAssertNil(SNTParseProxyURL(@"socks5://proxy.corp:1080"));
+}
+
+- (void)testParseProxyURLRejectsMissingPort {
+  XCTAssertNil(SNTParseProxyURL(@"http://proxy.corp"));
+}
+
+- (void)testParseProxyURLRejectsMissingHost {
+  XCTAssertNil(SNTParseProxyURL(@":8080"));
+}
+
+- (void)testParseProxyURLRejectsEmptyString {
+  XCTAssertNil(SNTParseProxyURL(@""));
+}
+
+- (void)testParseProxyURLRejectsNonsense {
+  XCTAssertNil(SNTParseProxyURL(@"not-a-url"));
+}
+
+#pragma mark - HTTP Status Line Parsing Tests
+
+- (void)testParseHTTP11Status200 {
+  XCTAssertEqual(SNTParseHTTPStatusLine(@"HTTP/1.1 200 Connection established"), 200);
+}
+
+- (void)testParseHTTP10Status200 {
+  XCTAssertEqual(SNTParseHTTPStatusLine(@"HTTP/1.0 200 Connection established"), 200);
+}
+
+- (void)testParseHTTPStatus407 {
+  XCTAssertEqual(SNTParseHTTPStatusLine(@"HTTP/1.1 407 Proxy Authentication Required"), 407);
+}
+
+- (void)testParseHTTPStatus502 {
+  XCTAssertEqual(SNTParseHTTPStatusLine(@"HTTP/1.1 502 Bad Gateway"), 502);
+}
+
+- (void)testParseHTTPStatusMalformed {
+  XCTAssertEqual(SNTParseHTTPStatusLine(@"garbage"), -1);
+}
+
+- (void)testParseHTTPStatusEmpty {
+  XCTAssertEqual(SNTParseHTTPStatusLine(@""), -1);
+}
+
+#pragma mark - Closure Lifecycle Tests
+
+- (void)testClosureCreateAndDestroy {
+  SNTProxyConfig *config = SNTParseProxyURL(@"http://user:pass@proxy.corp:8080");
+  SNTProxyClosure *closure = SNTProxyClosureCreate(config);
+  XCTAssertTrue(closure != NULL);
+  XCTAssertEqual(strcmp(closure->proxyHost, "proxy.corp"), 0);
+  XCTAssertEqual(closure->proxyPort, 8080);
+  XCTAssertFalse(closure->proxyUseTLS);
+  XCTAssertTrue(closure->basicAuth != NULL);
+  XCTAssertTrue(closure->customCAPEM == NULL);
+  SNTProxyClosureDestroy(closure);
+}
+
+- (void)testClosureWithCustomCA {
+  SNTProxyConfig *config = SNTParseProxyURL(@"http://proxy.corp:8080");
+  config.customCAData = [@"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
+      dataUsingEncoding:NSUTF8StringEncoding];
+  SNTProxyClosure *closure = SNTProxyClosureCreate(config);
+  XCTAssertTrue(closure != NULL);
+  XCTAssertTrue(closure->customCAPEM != NULL);
+  XCTAssertTrue(strstr(closure->customCAPEM, "BEGIN CERTIFICATE") != NULL);
+  SNTProxyClosureDestroy(closure);
+}
+
+@end

--- a/Source/santasyncservice/SNTNATSProxyConnectTest.mm
+++ b/Source/santasyncservice/SNTNATSProxyConnectTest.mm
@@ -24,7 +24,7 @@
 #pragma mark - URL Parsing Tests
 
 - (void)testParseHTTPProxyURL {
-  SNTProxyConfig *config = SNTParseProxyURL(@"http://proxy.corp:8080");
+  SNTProxyConfig* config = SNTParseProxyURL(@"http://proxy.corp:8080");
   XCTAssertNotNil(config);
   XCTAssertEqualObjects(config.host, @"proxy.corp");
   XCTAssertEqual(config.port, 8080);
@@ -33,7 +33,7 @@
 }
 
 - (void)testParseHTTPSProxyURL {
-  SNTProxyConfig *config = SNTParseProxyURL(@"https://proxy.corp:8443");
+  SNTProxyConfig* config = SNTParseProxyURL(@"https://proxy.corp:8443");
   XCTAssertNotNil(config);
   XCTAssertEqualObjects(config.host, @"proxy.corp");
   XCTAssertEqual(config.port, 8443);
@@ -42,32 +42,32 @@
 }
 
 - (void)testParseProxyURLWithBasicAuth {
-  SNTProxyConfig *config = SNTParseProxyURL(@"http://user:pass@proxy.corp:8080");
+  SNTProxyConfig* config = SNTParseProxyURL(@"http://user:pass@proxy.corp:8080");
   XCTAssertNotNil(config);
   XCTAssertEqualObjects(config.host, @"proxy.corp");
   XCTAssertEqual(config.port, 8080);
   XCTAssertFalse(config.useTLS);
   XCTAssertNotNil(config.basicAuth);
-  NSData *decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
-  NSString *decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+  NSData* decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
+  NSString* decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
   XCTAssertEqualObjects(decodedStr, @"user:pass");
 }
 
 - (void)testParseHTTPSProxyURLWithBasicAuth {
-  SNTProxyConfig *config = SNTParseProxyURL(@"https://admin:s3cret@proxy.corp:8443");
+  SNTProxyConfig* config = SNTParseProxyURL(@"https://admin:s3cret@proxy.corp:8443");
   XCTAssertNotNil(config);
   XCTAssertTrue(config.useTLS);
   XCTAssertNotNil(config.basicAuth);
-  NSData *decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
-  NSString *decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+  NSData* decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
+  NSString* decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
   XCTAssertEqualObjects(decodedStr, @"admin:s3cret");
 }
 
 - (void)testParseProxyURLWithSpecialCharsInPassword {
-  SNTProxyConfig *config = SNTParseProxyURL(@"http://user:p%40ss%3Aword@proxy.corp:8080");
+  SNTProxyConfig* config = SNTParseProxyURL(@"http://user:p%40ss%3Aword@proxy.corp:8080");
   XCTAssertNotNil(config);
-  NSData *decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
-  NSString *decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+  NSData* decoded = [[NSData alloc] initWithBase64EncodedString:config.basicAuth options:0];
+  NSString* decodedStr = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
   XCTAssertEqualObjects(decodedStr, @"user:p@ss:word");
 }
 
@@ -120,8 +120,8 @@
 #pragma mark - Closure Lifecycle Tests
 
 - (void)testClosureCreateAndDestroy {
-  SNTProxyConfig *config = SNTParseProxyURL(@"http://user:pass@proxy.corp:8080");
-  SNTProxyClosure *closure = SNTProxyClosureCreate(config);
+  SNTProxyConfig* config = SNTParseProxyURL(@"http://user:pass@proxy.corp:8080");
+  SNTProxyClosure* closure = SNTProxyClosureCreate(config);
   XCTAssertTrue(closure != NULL);
   XCTAssertEqual(strcmp(closure->proxyHost, "proxy.corp"), 0);
   XCTAssertEqual(closure->proxyPort, 8080);
@@ -132,10 +132,10 @@
 }
 
 - (void)testClosureWithCustomCA {
-  SNTProxyConfig *config = SNTParseProxyURL(@"http://proxy.corp:8080");
+  SNTProxyConfig* config = SNTParseProxyURL(@"http://proxy.corp:8080");
   config.customCAData = [@"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
       dataUsingEncoding:NSUTF8StringEncoding];
-  SNTProxyClosure *closure = SNTProxyClosureCreate(config);
+  SNTProxyClosure* closure = SNTProxyClosureCreate(config);
   XCTAssertTrue(closure != NULL);
   XCTAssertTrue(closure->customCAPEM != NULL);
   XCTAssertTrue(strstr(closure->customCAPEM, "BEGIN CERTIFICATE") != NULL);

--- a/Source/santasyncservice/SNTPushClientNATS.mm
+++ b/Source/santasyncservice/SNTPushClientNATS.mm
@@ -27,8 +27,8 @@
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTSystemInfo.h"
-#import "Source/santasyncservice/SNTSyncState.h"
 #import "Source/santasyncservice/SNTNATSProxyConnect.h"
+#import "Source/santasyncservice/SNTSyncState.h"
 
 __BEGIN_DECLS
 
@@ -160,7 +160,7 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
 // Track the last error for better retry diagnostics
 @property(nonatomic, copy) NSString* lastConnectionError;
 // Proxy connection closure -- must remain valid for NATS reconnections
-@property(nonatomic) SNTProxyClosure *proxyClosure;
+@property(nonatomic) SNTProxyClosure* proxyClosure;
 @end
 
 @implementation SNTPushClientNATS
@@ -447,9 +447,9 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
     natsOptions_SetClosedCB(opts, &closedCallback, (__bridge void*)self);
 
     // Configure proxy if set
-    NSString *proxyURL = [[SNTConfigurator configurator] pushProxyURL];
+    NSString* proxyURL = [[SNTConfigurator configurator] pushProxyURL];
     if (proxyURL.length) {
-      SNTProxyConfig *proxyConfig = SNTParseProxyURL(proxyURL);
+      SNTProxyConfig* proxyConfig = SNTParseProxyURL(proxyURL);
       if (!proxyConfig) {
         LOGE(@"NATS: Invalid PushProxyURL: %@", proxyURL);
         natsOptions_Destroy(opts);
@@ -457,14 +457,15 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
       }
 
       // Load custom CA if configured (PushProxyCAData takes precedence over PushProxyCAFile)
-      NSData *caData = [[SNTConfigurator configurator] pushProxyCAData];
+      NSData* caData = [[SNTConfigurator configurator] pushProxyCAData];
       if (!caData) {
-        NSString *caFile = [[SNTConfigurator configurator] pushProxyCAFile];
+        NSString* caFile = [[SNTConfigurator configurator] pushProxyCAFile];
         if (caFile.length) {
-          NSError *error;
+          NSError* error;
           caData = [NSData dataWithContentsOfFile:caFile options:0 error:&error];
           if (!caData) {
-            LOGW(@"NATS: Failed to read PushProxyCAFile %@: %@", caFile, error.localizedDescription);
+            LOGW(@"NATS: Failed to read PushProxyCAFile %@: %@", caFile,
+                 error.localizedDescription);
             natsOptions_Destroy(opts);
             return;
           }
@@ -475,7 +476,7 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
       // Load custom CA into NATS TLS context for the inner connection too.
       // natsOptions_SetCATrustedCertificates takes PEM string data directly (not a file path).
       if (caData) {
-        NSString *pemStr = [[NSString alloc] initWithData:caData encoding:NSUTF8StringEncoding];
+        NSString* pemStr = [[NSString alloc] initWithData:caData encoding:NSUTF8StringEncoding];
         if (!pemStr) {
           LOGW(@"NATS: PushProxyCAData/PushProxyCAFile is not valid UTF-8 PEM data");
           natsOptions_Destroy(opts);

--- a/Source/santasyncservice/SNTPushClientNATS.mm
+++ b/Source/santasyncservice/SNTPushClientNATS.mm
@@ -28,6 +28,7 @@
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTSystemInfo.h"
 #import "Source/santasyncservice/SNTSyncState.h"
+#import "Source/santasyncservice/SNTNATSProxyConnect.h"
 
 __BEGIN_DECLS
 
@@ -158,6 +159,8 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
 @property(atomic) BOOL isRetrying;
 // Track the last error for better retry diagnostics
 @property(nonatomic, copy) NSString* lastConnectionError;
+// Proxy connection closure -- must remain valid for NATS reconnections
+@property(nonatomic) SNTProxyClosure *proxyClosure;
 @end
 
 @implementation SNTPushClientNATS
@@ -188,6 +191,10 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
   // Cleanup should be done explicitly before dealloc
   if (self.conn && self.isConnected) {
     LOGW(@"NATS: Client deallocated without proper disconnect");
+  }
+  if (self.proxyClosure) {
+    SNTProxyClosureDestroy(self.proxyClosure);
+    self.proxyClosure = NULL;
   }
 }
 
@@ -439,6 +446,76 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
     natsOptions_SetReconnectedCB(opts, &reconnectedCallback, (__bridge void*)self);
     natsOptions_SetClosedCB(opts, &closedCallback, (__bridge void*)self);
 
+    // Configure proxy if set
+    NSString *proxyURL = [[SNTConfigurator configurator] pushProxyURL];
+    if (proxyURL.length) {
+      SNTProxyConfig *proxyConfig = SNTParseProxyURL(proxyURL);
+      if (!proxyConfig) {
+        LOGE(@"NATS: Invalid PushProxyURL: %@", proxyURL);
+        natsOptions_Destroy(opts);
+        return;
+      }
+
+      // Load custom CA if configured (PushProxyCAData takes precedence over PushProxyCAFile)
+      NSData *caData = [[SNTConfigurator configurator] pushProxyCAData];
+      if (!caData) {
+        NSString *caFile = [[SNTConfigurator configurator] pushProxyCAFile];
+        if (caFile.length) {
+          NSError *error;
+          caData = [NSData dataWithContentsOfFile:caFile options:0 error:&error];
+          if (!caData) {
+            LOGW(@"NATS: Failed to read PushProxyCAFile %@: %@", caFile, error.localizedDescription);
+            natsOptions_Destroy(opts);
+            return;
+          }
+        }
+      }
+      proxyConfig.customCAData = caData;
+
+      // Load custom CA into NATS TLS context for the inner connection too.
+      // natsOptions_SetCATrustedCertificates takes PEM string data directly (not a file path).
+      if (caData) {
+        NSString *pemStr = [[NSString alloc] initWithData:caData encoding:NSUTF8StringEncoding];
+        if (!pemStr) {
+          LOGW(@"NATS: PushProxyCAData/PushProxyCAFile is not valid UTF-8 PEM data");
+          natsOptions_Destroy(opts);
+          return;
+        }
+        status = natsOptions_SetCATrustedCertificates(opts, pemStr.UTF8String);
+        if (status != NATS_OK) {
+          LOGW(@"NATS: Failed to set custom CA for NATS TLS: %s", natsStatus_GetText(status));
+          natsOptions_Destroy(opts);
+          return;
+        }
+      }
+
+      // Free any previous proxy closure from a prior connection attempt
+      if (self.proxyClosure) {
+        SNTProxyClosureDestroy(self.proxyClosure);
+        self.proxyClosure = NULL;
+      }
+
+      self.proxyClosure = SNTProxyClosureCreate(proxyConfig);
+      if (!self.proxyClosure) {
+        LOGE(@"NATS: Failed to create proxy closure");
+        natsOptions_Destroy(opts);
+        return;
+      }
+
+      status = natsOptions_SetProxyConnHandler(opts, &SNTNATSProxyConnHandler, self.proxyClosure);
+      if (status != NATS_OK) {
+        LOGE(@"NATS: Failed to set proxy handler: %s", natsStatus_GetText(status));
+        SNTProxyClosureDestroy(self.proxyClosure);
+        self.proxyClosure = NULL;
+        natsOptions_Destroy(opts);
+        return;
+      }
+
+      // Log proxy usage (redact credentials)
+      LOGI(@"NATS: Using proxy %@://%@:%d", proxyConfig.useTLS ? @"https" : @"http",
+           proxyConfig.host, proxyConfig.port);
+    }
+
     // Create connection
     natsConnection* conn = NULL;
     status = natsConnection_Connect(&conn, opts);
@@ -523,6 +600,11 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
       LOGD(@"NATS: Destroying connection");
       natsConnection_Destroy(self.conn);
       self.conn = NULL;
+    }
+
+    if (self.proxyClosure) {
+      SNTProxyClosureDestroy(self.proxyClosure);
+      self.proxyClosure = NULL;
     }
 
     self.isConnected = NO;

--- a/Source/santasyncservice/SNTPushClientNATSConnectionTest.mm
+++ b/Source/santasyncservice/SNTPushClientNATSConnectionTest.mm
@@ -17,6 +17,7 @@
 #include <sys/cdefs.h>
 
 #import "Source/common/SNTConfigurator.h"
+#import "Source/santasyncservice/SNTNATSProxyConnect.h"
 #import "Source/santasyncservice/SNTPushClientNATS.h"
 
 __BEGIN_DECLS
@@ -260,5 +261,54 @@ __END_DECLS
 //   // (This will fail with invalid credentials or if NATS server doesn't accept them)
 //   XCTAssertTrue(self.client.isConnected, @"Should connect with valid nkey/JWT");
 // }
+
+- (void)testConnectWithProxyConfigured {
+  // Given: Client with proxy configured
+  self.client = [[SNTPushClientNATS alloc] initWithSyncDelegate:self.mockSyncDelegate];
+
+  OCMStub([self.mockConfigurator pushProxyURL]).andReturn(@"http://proxy.example:8080");
+  OCMStub([self.mockConfigurator pushProxyCAData]).andReturn(nil);
+  OCMStub([self.mockConfigurator pushProxyCAFile]).andReturn(nil);
+
+  [self.client configureWithPushServer:@"nats-server"
+                             pushToken:@"test-key"
+                                   jwt:@"test-jwt"
+                          pushDeviceID:@"testmachine12345"
+                                  tags:@[ @"test-tag" ]];
+
+  [NSThread sleepForTimeInterval:0.1];
+
+  // When: Attempt to connect (will fail since proxy doesn't exist, but verifies
+  // the proxy code path is exercised without crashing)
+  [self.client connect];
+  [NSThread sleepForTimeInterval:0.5];
+
+  // Then: Should not be connected (proxy unreachable) but should not crash
+  XCTAssertFalse(self.client.isConnected);
+}
+
+- (void)testConnectWithInvalidProxyURL {
+  // Given: Client with invalid proxy URL
+  self.client = [[SNTPushClientNATS alloc] initWithSyncDelegate:self.mockSyncDelegate];
+
+  OCMStub([self.mockConfigurator pushProxyURL]).andReturn(@"not-a-valid-url");
+  OCMStub([self.mockConfigurator pushProxyCAData]).andReturn(nil);
+  OCMStub([self.mockConfigurator pushProxyCAFile]).andReturn(nil);
+
+  [self.client configureWithPushServer:@"nats-server"
+                             pushToken:@"test-key"
+                                   jwt:@"test-jwt"
+                          pushDeviceID:@"testmachine12345"
+                                  tags:@[ @"test-tag" ]];
+
+  [NSThread sleepForTimeInterval:0.1];
+
+  // When: Attempt to connect
+  [self.client connect];
+  [NSThread sleepForTimeInterval:0.2];
+
+  // Then: Should not connect due to invalid proxy URL
+  XCTAssertFalse(self.client.isConnected);
+}
 
 @end

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -1055,14 +1055,14 @@ thousand static rules working correctly, but we don't recommend using StaticRule
     },
     {
       key: "PushProxyURL",
-      description: `Proxy URL for the NATS push connection. When set, all NATS push connections are tunneled through this proxy via HTTP CONNECT.
+      description: `Proxy URL for the push notification connection. When set, all push connections are tunneled through this proxy via HTTP CONNECT.
         Accepted formats: http://proxy.corp:8080, https://proxy.corp:8443, http://user:pass@proxy.corp:8080, https://user:pass@proxy.corp:8443.
         For https:// proxies, the connection to the proxy itself is TLS-encrypted (TLS-in-TLS)`,
       type: "string",
     },
     {
       key: "PushProxyCAFile",
-      description: `File path to a PEM-encoded CA certificate to trust for NATS TLS connections through the proxy.
+      description: `File path to a PEM-encoded CA certificate to trust for push TLS connections through the proxy.
         Used in MITM proxy environments where the proxy re-signs TLS traffic with a corporate CA`,
       type: "string",
     },

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -1054,6 +1054,25 @@ thousand static rules working correctly, but we don't recommend using StaticRule
       type: "string",
     },
     {
+      key: "PushProxyURL",
+      description: `Proxy URL for the NATS push connection. When set, all NATS push connections are tunneled through this proxy via HTTP CONNECT.
+        Accepted formats: http://proxy.corp:8080, https://proxy.corp:8443, http://user:pass@proxy.corp:8080, https://user:pass@proxy.corp:8443.
+        For https:// proxies, the connection to the proxy itself is TLS-encrypted (TLS-in-TLS)`,
+      type: "string",
+    },
+    {
+      key: "PushProxyCAFile",
+      description: `File path to a PEM-encoded CA certificate to trust for NATS TLS connections through the proxy.
+        Used in MITM proxy environments where the proxy re-signs TLS traffic with a corporate CA`,
+      type: "string",
+    },
+    {
+      key: "PushProxyCAData",
+      description: `Inline PEM-encoded CA certificate data. Alternative to PushProxyCAFile for MDM-based distribution.
+        Takes precedence over PushProxyCAFile if both are set`,
+      type: "data",
+    },
+    {
       key: "MachineOwner",
       description: `The machine owner`,
       type: "string",


### PR DESCRIPTION
This PR adds HTTP Proxy support for the push notification service per SNT-354