### PR TITLE
Add identity verification step to exec policy evaluation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "82ff2bad461c860ee9c48c342e51d1a59bd40065",
+    commit = "54add5f78242fc2093290503b8eec4dd473b5251",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -11,6 +11,14 @@ package(
 
 licenses(["notice"])
 
+# Expose individual test fixtures for use by tests in other packages.
+exports_files(["testdata/cal-yikes-universal_signed"])
+
+filegroup(
+    name = "testdata_cal_yikes_universal_signed",
+    srcs = ["testdata/cal-yikes-universal_signed"],
+)
+
 proto_library(
     name = "santa_proto",
     srcs = ["santa.proto"],
@@ -1045,7 +1053,10 @@ santa_unit_test(
         "testdata/BundleExample.app/**",
         "testdata/DirectoryBundle/**",
     ]),
-    deps = [":SNTFileInfo"],
+    deps = [
+        ":SNTFileInfo",
+        ":TestUtils",
+    ],
 )
 
 santa_unit_test(

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1054,6 +1054,7 @@ santa_unit_test(
         "testdata/DirectoryBundle/**",
     ]),
     deps = [
+        ":MOLCodesignChecker",
         ":SNTFileInfo",
         ":TestUtils",
     ],

--- a/Source/common/MOLCodesignChecker.h
+++ b/Source/common/MOLCodesignChecker.h
@@ -155,11 +155,16 @@
 - (instancetype)initWithBinaryPath:(NSString*)binaryPath;
 
 /**
-  Wrapper around initWithBinaryPath:error: that takes a file descriptor for reading.
-  The file descriptor will be used to read binary header infomation. This provides a minor
-  performace increase if the caller already has the file open.
+  Initialize with a binary on disk via a caller-supplied file descriptor.
 
-  @note The file offset will be set to the amount of bytes read while parsing the header.
+  The descriptor must refer to a regular-file Mach-O. SecStaticCode operates
+  on the descriptor's vnode (via /dev/fd/N) rather than re-resolving
+  `binaryPath`, so a rename of `binaryPath` between the caller's open() and
+  this call does not affect the result. The caller-supplied path is retained
+  for display via the `binaryPath` accessor only.
+
+  @note The file offset will be set to the amount of bytes read while parsing
+  the header.
 */
 - (instancetype)initWithBinaryPath:(NSString*)binaryPath
                     fileDescriptor:(int)fileDescriptor

--- a/Source/common/MOLCodesignChecker.h
+++ b/Source/common/MOLCodesignChecker.h
@@ -16,6 +16,7 @@
 @class MOLCertificate;
 
 #import <Foundation/Foundation.h>
+#import <mach/machine.h>
 
 /**
   `MOLCodesignChecker` validates a binary (either on-disk or in memory) has been signed
@@ -173,6 +174,30 @@
   Wrapper around initWithBinaryPath:fileDescriptor:error:.
 */
 - (instancetype)initWithBinaryPath:(NSString*)binaryPath fileDescriptor:(int)fileDescriptor;
+
+/**
+  Initialize with a binary on disk via a caller-supplied file descriptor, with an
+  active-slice hint for universal binaries.
+
+  When `cpuType` is non-sentinel and the binary is fat, the per-slice signing dict
+  for the matching arch is used to populate `_signingInformation` and `_certificates`,
+  regardless of cross-slice signing consistency. The per-arch consistency check still
+  runs and still surfaces `errSecCSSignatureInvalid` on the error param informationally.
+
+  When `cpuType == CPU_TYPE_ANY` (and/or for thin binaries) this method behaves
+  identically to `initWithBinaryPath:fileDescriptor:error:`.
+
+  @param binaryPath     Path to a binary file on disk (display only when fd is provided).
+  @param fileDescriptor Open fd to the binary, or `-1` to re-resolve `binaryPath`.
+  @param cpuType        Active-slice CPU type, or `CPU_TYPE_ANY` for no hint.
+  @param cpuSubtype     Active-slice CPU subtype, or `CPU_SUBTYPE_ANY` for no hint.
+  @param error          NSError to be filled in if validation fails.
+*/
+- (instancetype)initWithBinaryPath:(NSString*)binaryPath
+                    fileDescriptor:(int)fileDescriptor
+                           cpuType:(cpu_type_t)cpuType
+                        cpuSubtype:(cpu_subtype_t)cpuSubtype
+                             error:(NSError**)error;
 
 /**
   Initialize with a running binary using its process ID.

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -538,9 +538,12 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 
 - (NSDictionary*)architectureAndOffsetsForFileDescriptor:(int)fd {
   size_t len = sizeof(struct fat_header);
+  // Use pread() so the caller's file offset is preserved. SecStaticCode
+  // operates on this descriptor via /dev/fd/N, which shares the underlying
+  // file table entry (and offset) with the original fd; using pread() here
+  // avoids contributing further to that shared offset's drift.
   const uint8* headerBytes = (const uint8*)alloca(len);
-  lseek(fd, 0, SEEK_SET);
-  if (read(fd, (void*)headerBytes, len) != len) return nil;
+  if (pread(fd, (void*)headerBytes, len, 0) != (ssize_t)len) return nil;
   struct fat_header* fh = (struct fat_header*)headerBytes;
   uint32_t m = fh->magic;
   if (!(m == FAT_MAGIC || m == FAT_CIGAM || m == FAT_MAGIC_64 || m == FAT_CIGAM_64)) return nil;
@@ -549,11 +552,11 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
   BOOL use64 = (m == FAT_MAGIC_64 || m == FAT_CIGAM_64);
 
   int archCount = bigEndian ? OSSwapBigToHostInt32(fh->nfat_arch) : fh->nfat_arch;
-  if (archCount < 1 || archCount > 128) return nil;  // Upper bound of 4k
+  if (archCount < 1 || archCount > 128) return nil;
 
   len = use64 ? sizeof(struct fat_arch_64) * archCount : sizeof(struct fat_arch) * archCount;
   const uint8* archBytes = (const uint8*)alloca(len);
-  if (read(fd, (void*)archBytes, len) != len) return nil;
+  if (pread(fd, (void*)archBytes, len, sizeof(struct fat_header)) != (ssize_t)len) return nil;
 
   NSMutableDictionary* offsets = [NSMutableDictionary dictionaryWithCapacity:archCount];
   if (use64) {

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -440,12 +440,16 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
   }
 
   if (!offsets) return nil;
+  // When a fd is provided, validate each slice against the same vnode the
+  // primary code ref is bound to (see initWithBinaryPath:fileDescriptor:error:).
+  // The fd-derived offsets are only meaningful relative to that vnode's bytes.
+  NSString* secCodePath = (fd != -1) ? [NSString stringWithFormat:@"/dev/fd/%d", fd] : path;
   NSMutableArray* infos = [NSMutableArray arrayWithCapacity:offsets.count];
   for (NSString* arch in offsets) {
     NSDictionary* attributes =
         @{(__bridge NSString*)kSecCodeAttributeUniversalFileOffset : offsets[arch]};
     SecStaticCodeRef codeRef = NULL;
-    SecStaticCodeCreateWithPathAndAttributes((__bridge CFURLRef)[NSURL fileURLWithPath:path],
+    SecStaticCodeCreateWithPathAndAttributes((__bridge CFURLRef)[NSURL fileURLWithPath:secCodePath],
                                              kSecCSDefaultFlags,
                                              (__bridge CFDictionaryRef)attributes, &codeRef);
     CFDictionaryRef signingDict = NULL;

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -157,8 +157,16 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
   OSStatus status = errSecSuccess;
   SecStaticCodeRef codeRef = NULL;
 
-  // Get SecStaticCodeRef for binary
-  status = SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:binaryPath],
+  // When a fd is provided, point SecStaticCode at the caller's vnode via
+  // /dev/fd/N rather than re-resolving binaryPath. The descriptor must refer
+  // to a regular file; SecStaticCode rejects directory descriptors with
+  // errSecCSBadDiskRep, so callers passing a bundle directory fd will get an
+  // error here. The caller-supplied path is retained for display only.
+  NSString* secCodePath = (fileDescriptor != -1)
+                              ? [NSString stringWithFormat:@"/dev/fd/%d", fileDescriptor]
+                              : binaryPath;
+
+  status = SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:secCodePath],
                                        kSecCSDefaultFlags, &codeRef);
   if (status != errSecSuccess) {
     if (error) {

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -30,6 +30,24 @@ using ScopedCFError = santa::ScopedCFTypeRef<CFErrorRef>;
 using ScopedCFString = santa::ScopedCFTypeRef<CFStringRef>;
 using ScopedSecStaticCode = santa::ScopedCFTypeRef<SecStaticCodeRef>;
 
+// Reads exactly `len` bytes from `fd` at `offset`, retrying on EINTR and
+// short reads. Returns YES on full read, NO on any other failure (including
+// premature EOF).
+static BOOL PreadFull(int fd, void* buf, size_t len, off_t offset) {
+  size_t total = 0;
+  while (total < len) {
+    ssize_t n = pread(fd, (uint8_t*)buf + total, len - total, offset + (off_t)total);
+    if (n > 0) {
+      total += (size_t)n;
+    } else if (n == -1 && errno == EINTR) {
+      continue;
+    } else {
+      return NO;
+    }
+  }
+  return YES;
+}
+
 /**
   kStaticSigningFlags are the flags used when validating signatures on disk.
 
@@ -543,7 +561,7 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
   // file table entry (and offset) with the original fd; using pread() here
   // avoids contributing further to that shared offset's drift.
   const uint8* headerBytes = (const uint8*)alloca(len);
-  if (pread(fd, (void*)headerBytes, len, 0) != (ssize_t)len) return nil;
+  if (!PreadFull(fd, (void*)headerBytes, len, 0)) return nil;
   struct fat_header* fh = (struct fat_header*)headerBytes;
   uint32_t m = fh->magic;
   if (!(m == FAT_MAGIC || m == FAT_CIGAM || m == FAT_MAGIC_64 || m == FAT_CIGAM_64)) return nil;
@@ -556,7 +574,7 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 
   len = use64 ? sizeof(struct fat_arch_64) * archCount : sizeof(struct fat_arch) * archCount;
   const uint8* archBytes = (const uint8*)alloca(len);
-  if (pread(fd, (void*)archBytes, len, sizeof(struct fat_header)) != (ssize_t)len) return nil;
+  if (!PreadFull(fd, (void*)archBytes, len, sizeof(struct fat_header))) return nil;
 
   NSMutableDictionary* offsets = [NSMutableDictionary dictionaryWithCapacity:archCount];
   if (use64) {

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -75,6 +75,11 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 
 // Cached on-disk binary file descriptor
 @property int binaryFileDescriptor;
+
+// Active-slice hint; values <= 0 mean no hint (CPU_TYPE_ANY is -1; ivar zero-default
+// from non-fd init paths also fails the > 0 gate in -initWithSecStaticCodeRef:error:).
+@property cpu_type_t cpuTypeHint;
+@property cpu_subtype_t cpuSubtypeHint;
 @end
 
 @implementation MOLCodesignChecker
@@ -98,6 +103,12 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
       }
     });
 
+    // hintActiveForFat is YES when the caller passed a real arch hint and we're
+    // looking at a fat binary. In that mode the per-slice dict is the authority
+    // for _signingInformation/_certificates; the whole-binary fallback below is
+    // suppressed regardless of whether a matching slice was found.
+    BOOL hintActiveForFat = NO;
+
     // For static code checks perform additional checks across all slices
     if (CFGetTypeID(codeRef) == SecStaticCodeGetTypeID()) {
       // Ensure signing is consistent for all architectures.
@@ -106,6 +117,26 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
       NSArray* infos = [self universalSigningInformationForBinaryPath:_binaryPath
                                                        fileDescriptor:_binaryFileDescriptor];
       if (infos) _universalSigningInformation = infos;
+
+      // When the caller provided an active-slice hint and this is a fat binary,
+      // populate _signingInformation/_certificates from the matching slice.
+      // The cross-slice consistency check below still runs and still surfaces
+      // its error informationally; the per-arch identity is already locked in
+      // via the active-slice extraction. If no slice matches the hint (e.g. a
+      // PowerPC hint against an i386/x86_64 binary), _signingInformation stays
+      // nil and hintActiveForFat suppresses the whole-binary fallback below so
+      // callers see an empty identity for the mismatched arch request.
+      hintActiveForFat = (_cpuTypeHint > 0 && _universalSigningInformation.count > 0);
+      if (hintActiveForFat) {
+        NSDictionary* sliceDict = [self perSliceDictForCpuType:_cpuTypeHint
+                                                    cpuSubtype:_cpuSubtypeHint];
+        if (sliceDict.count > 0) {
+          _signingInformation = sliceDict;
+          NSArray* certs = sliceDict[(__bridge id)kSecCodeInfoCertificates];
+          _certificates = [MOLCertificate certificatesFromArray:certs];
+        }
+      }
+
       if (infos && ![self allSigningInformationMatches:infos]) {
         status = errSecCSSignatureInvalid;
         scopedError = ScopedCFError::BridgeRetain([self
@@ -114,9 +145,14 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
       }
     }
 
-    // Do not set _signingInformation or _certificates for universal binaries with signing issues.
+    // Do not set _signingInformation or _certificates for universal binaries with
+    // signing issues EXCEPT when the cputype hint already populated them from the
+    // active slice (above). Also suppress when hint mode is active but no slice
+    // matched — callers asked for a specific arch and should not receive the
+    // whole-binary aggregate identity.
     NSError* err = scopedError.BridgeRelease<NSError*>();
-    if (!([err.domain isEqualToString:kMOLCodesignCheckerErrorDomain] &&
+    if (!_signingInformation && !hintActiveForFat &&
+        !([err.domain isEqualToString:kMOLCodesignCheckerErrorDomain] &&
           status == errSecCSSignatureInvalid)) {
       // Get CFDictionary of signing information for binary
       CFDictionaryRef signingDict = NULL;
@@ -154,6 +190,18 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 - (instancetype)initWithBinaryPath:(NSString*)binaryPath
                     fileDescriptor:(int)fileDescriptor
                              error:(NSError**)error {
+  return [self initWithBinaryPath:binaryPath
+                   fileDescriptor:fileDescriptor
+                          cpuType:CPU_TYPE_ANY
+                       cpuSubtype:CPU_SUBTYPE_ANY
+                            error:error];
+}
+
+- (instancetype)initWithBinaryPath:(NSString*)binaryPath
+                    fileDescriptor:(int)fileDescriptor
+                           cpuType:(cpu_type_t)cpuType
+                        cpuSubtype:(cpu_subtype_t)cpuSubtype
+                             error:(NSError**)error {
   OSStatus status = errSecSuccess;
   SecStaticCodeRef codeRef = NULL;
 
@@ -177,6 +225,8 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 
   _binaryPath = binaryPath;
   _binaryFileDescriptor = (fileDescriptor != -1) ? fileDescriptor : -1;
+  _cpuTypeHint = cpuType;
+  _cpuSubtypeHint = cpuSubtype;
 
   self = [self initWithSecStaticCodeRef:codeRef error:error];
   if (codeRef) CFRelease(codeRef);  // it was retained above
@@ -415,6 +465,11 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
   return [self errorWithCode:code description:nil];
 }
 
+// Reports whether every slice of a universal binary shares the same signing
+// identity (cert chain, or "-" for ad-hoc). Callers that care about per-arch
+// identity should use the cputype-aware initializer instead; this check is
+// retained as an informational signal that surfaces `errSecCSSignatureInvalid`
+// in MOL's error domain for cross-slice inconsistencies.
 - (BOOL)allSigningInformationMatches:(NSArray*)signingInformation {
   NSMutableSet* chains = [NSMutableSet set];
   for (NSDictionary* arch in signingInformation) {
@@ -458,6 +513,17 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
     if (codeRef) CFRelease(codeRef);
   }
   return infos.count ? infos : nil;
+}
+
+- (NSDictionary*)perSliceDictForCpuType:(cpu_type_t)cpuType cpuSubtype:(cpu_subtype_t)cpuSubtype {
+  const char* nameRaw = macho_arch_name_for_cpu_type(cpuType, cpuSubtype);
+  NSString* archName =
+      nameRaw ? @(nameRaw) : [NSString stringWithFormat:@"%i:%i", cpuType, cpuSubtype];
+  for (NSDictionary* arch in _universalSigningInformation) {
+    NSDictionary* dict = arch[archName];
+    if (dict) return dict;
+  }
+  return nil;
 }
 
 - (NSString*)architectureString:(struct fat_arch*)fatArch bigEndian:(BOOL)bigEndian {

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -138,19 +138,24 @@
 // cdhash.
 - (void)testInitWithFileDescriptor_SurvivesAtomicRenameSwap {
   NSString* tmp = NSTemporaryDirectory();
-  NSString* a = [tmp stringByAppendingPathComponent:[NSString
-      stringWithFormat:@"mol_a_%d_%@", getpid(), [[NSUUID UUID] UUIDString]]];
-  NSString* b = [tmp stringByAppendingPathComponent:[NSString
-      stringWithFormat:@"mol_b_%d_%@", getpid(), [[NSUUID UUID] UUIDString]]];
+  NSString* a =
+      [tmp stringByAppendingPathComponent:[NSString stringWithFormat:@"mol_a_%d_%@", getpid(),
+                                                                     [[NSUUID UUID] UUIDString]]];
+  NSString* b =
+      [tmp stringByAppendingPathComponent:[NSString stringWithFormat:@"mol_b_%d_%@", getpid(),
+                                                                     [[NSUUID UUID] UUIDString]]];
   NSError* err;
-  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/yes" toPath:a error:&err]);
-  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/true" toPath:b error:&err]);
+  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/yes"
+                                                        toPath:a
+                                                         error:&err]);
+  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/true"
+                                                        toPath:b
+                                                         error:&err]);
 
   int fd = open(a.UTF8String, O_RDONLY | O_CLOEXEC);
   XCTAssertGreaterThanOrEqual(fd, 0, "open: %s", strerror(errno));
 
-  MOLCodesignChecker* aRef =
-      [[MOLCodesignChecker alloc] initWithBinaryPath:a fileDescriptor:fd];
+  MOLCodesignChecker* aRef = [[MOLCodesignChecker alloc] initWithBinaryPath:a fileDescriptor:fd];
   MOLCodesignChecker* bRef = [[MOLCodesignChecker alloc] initWithBinaryPath:b];
   XCTAssertNotNil(aRef.cdhash);
   XCTAssertNotNil(bRef.cdhash);
@@ -163,8 +168,7 @@
   XCTAssertEqual(rename(b.UTF8String, a.UTF8String), 0, "rename: %s", strerror(errno));
 
   // fd-based: must still see A's identity.
-  MOLCodesignChecker* afterFD =
-      [[MOLCodesignChecker alloc] initWithBinaryPath:a fileDescriptor:fd];
+  MOLCodesignChecker* afterFD = [[MOLCodesignChecker alloc] initWithBinaryPath:a fileDescriptor:fd];
   XCTAssertEqualObjects(afterFD.cdhash, originalACdhash);
 
   // Path-based control: now sees B's identity (proving the rename happened
@@ -180,8 +184,9 @@
 // after the caller's open(): the fd holds the vnode regardless.
 - (void)testInitWithFileDescriptor_SurvivesUnlink {
   NSString* tmp = NSTemporaryDirectory();
-  NSString* path = [tmp stringByAppendingPathComponent:[NSString
-      stringWithFormat:@"mol_unlink_%d_%@", getpid(), [[NSUUID UUID] UUIDString]]];
+  NSString* path =
+      [tmp stringByAppendingPathComponent:[NSString stringWithFormat:@"mol_unlink_%d_%@", getpid(),
+                                                                     [[NSUUID UUID] UUIDString]]];
   NSError* err;
   XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/yes"
                                                         toPath:path
@@ -192,15 +197,13 @@
 
   XCTAssertEqual(unlink(path.UTF8String), 0);
 
-  MOLCodesignChecker* sut =
-      [[MOLCodesignChecker alloc] initWithBinaryPath:path fileDescriptor:fd];
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path fileDescriptor:fd];
   XCTAssertNotNil(sut.cdhash);
 
   // Path-based at the now-missing path must fail, confirming the fd was the
   // load-bearing source.
   NSError* pathErr;
-  MOLCodesignChecker* viaPath = [[MOLCodesignChecker alloc] initWithBinaryPath:path
-                                                                         error:&pathErr];
+  MOLCodesignChecker* viaPath = [[MOLCodesignChecker alloc] initWithBinaryPath:path error:&pathErr];
   XCTAssertNil(viaPath);
   XCTAssertNotNil(pathErr);
 

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -17,6 +17,7 @@
 
 #include <fcntl.h>
 #include <mach-o/fat.h>
+#include <mach/machine.h>
 #include <unistd.h>
 
 #import "Source/common/MOLCodesignChecker.h"
@@ -384,6 +385,133 @@
   [wantedEntitlements enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL* stop) {
     XCTAssertEqualObjects(sut.entitlements[key], value);
   }];
+}
+
+// yikes-universal_signed has i386 + x86_64, both signed with the same cert chain.
+- (void)testCpuTypeHint_ConsistentFat_PicksActiveSlice {
+  NSError* error;
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"yikes-universal_signed" ofType:@""];
+
+  MOLCodesignChecker* sutA = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                             fileDescriptor:-1
+                                                                    cpuType:CPU_TYPE_I386
+                                                                 cpuSubtype:CPU_SUBTYPE_I386_ALL
+                                                                      error:&error];
+  XCTAssertNotNil(sutA);
+  XCTAssertNil(error);
+  XCTAssertGreaterThan(sutA.cdhash.length, 0u);
+
+  error = nil;
+  MOLCodesignChecker* sutB = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                             fileDescriptor:-1
+                                                                    cpuType:CPU_TYPE_X86_64
+                                                                 cpuSubtype:CPU_SUBTYPE_X86_64_ALL
+                                                                      error:&error];
+  XCTAssertNotNil(sutB);
+  XCTAssertNil(error);
+  XCTAssertGreaterThan(sutB.cdhash.length, 0u);
+
+  // Per-slice cdhashes always differ across slices of the same fat file.
+  XCTAssertNotEqualObjects(sutA.cdhash, sutB.cdhash);
+}
+
+// cal-yikes-universal_signed: two different cert chains, one per slice.
+- (void)testCpuTypeHint_InconsistentFat_PopulatesActiveSlice_AndSurfacesError {
+  NSError* error;
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"cal-yikes-universal_signed" ofType:@""];
+
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                            fileDescriptor:-1
+                                                                   cpuType:CPU_TYPE_I386
+                                                                cpuSubtype:CPU_SUBTYPE_I386_ALL
+                                                                     error:&error];
+  XCTAssertNotNil(sut);
+  // Active-slice signing info is now present despite the per-arch inconsistency.
+  XCTAssertGreaterThan(sut.cdhash.length, 0u);
+  XCTAssertNotNil(sut.leafCertificate);
+  // The consistency-check error still surfaces informationally.
+  XCTAssertEqual(error.code, errSecCSSignatureInvalid);
+  XCTAssertEqualObjects(error.domain, kMOLCodesignCheckerErrorDomain);
+}
+
+// cal-yikes-universal: unknown-arch slice is cert-signed; i386 slice is unsigned.
+// Requesting i386 should yield empty identity with a consistency-check error.
+- (void)testCpuTypeHint_InconsistentFat_UnsignedActiveSlice_LeavesEmpty {
+  NSError* error;
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"cal-yikes-universal" ofType:@""];
+
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                            fileDescriptor:-1
+                                                                   cpuType:CPU_TYPE_I386
+                                                                cpuSubtype:CPU_SUBTYPE_I386_ALL
+                                                                     error:&error];
+  XCTAssertNotNil(sut);
+  XCTAssertEqual(sut.cdhash.length, 0u);
+  XCTAssertNil(sut.leafCertificate);
+  XCTAssertEqual(error.code, errSecCSSignatureInvalid);
+  XCTAssertEqualObjects(error.domain, kMOLCodesignCheckerErrorDomain);
+}
+
+// PowerPC won't be in any modern universal fixture; requesting it should leave empty identity.
+- (void)testCpuTypeHint_NoMatchingSlice_LeavesEmpty {
+  NSError* error;
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"yikes-universal_signed" ofType:@""];
+
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                            fileDescriptor:-1
+                                                                   cpuType:CPU_TYPE_POWERPC
+                                                                cpuSubtype:CPU_SUBTYPE_POWERPC_ALL
+                                                                     error:&error];
+  XCTAssertNotNil(sut);
+  XCTAssertEqual(sut.cdhash.length, 0u);
+  XCTAssertNil(sut.leafCertificate);
+}
+
+// signed-with-teamid is a thin x86_64 fixture. The cputype hint must be inert
+// for thin binaries: behavior must match the no-hint path exactly.
+- (void)testCpuTypeHint_ThinBinary_Ignored {
+  NSError* error;
+  NSError* errorWithoutHint;
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"signed-with-teamid" ofType:@""];
+
+  MOLCodesignChecker* sutNoHint = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                                           error:&errorWithoutHint];
+
+  MOLCodesignChecker* sutWithHint =
+      [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                      fileDescriptor:-1
+                                             cpuType:CPU_TYPE_X86_64
+                                          cpuSubtype:CPU_SUBTYPE_X86_64_ALL
+                                               error:&error];
+  XCTAssertNotNil(sutNoHint);
+  XCTAssertNotNil(sutWithHint);
+  XCTAssertEqualObjects(sutNoHint.cdhash, sutWithHint.cdhash);
+  XCTAssertEqualObjects(sutNoHint.teamID, sutWithHint.teamID);
+  XCTAssertEqualObjects(sutNoHint.signingID, sutWithHint.signingID);
+}
+
+// CPU_TYPE_ANY must fall back to today's (no-hint) behavior.
+- (void)testCpuTypeAny_FallsBackToTodayBehavior {
+  NSError* errorBaseline;
+  NSError* errorSentinel;
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"yikes-universal_signed" ofType:@""];
+
+  MOLCodesignChecker* sutBaseline = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                                             error:&errorBaseline];
+  MOLCodesignChecker* sutSentinel = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                                    fileDescriptor:-1
+                                                                           cpuType:CPU_TYPE_ANY
+                                                                        cpuSubtype:CPU_SUBTYPE_ANY
+                                                                             error:&errorSentinel];
+  XCTAssertEqualObjects(sutBaseline.cdhash, sutSentinel.cdhash);
+  XCTAssertEqualObjects(sutBaseline.teamID, sutSentinel.teamID);
+  XCTAssertEqualObjects(sutBaseline.signingID, sutSentinel.signingID);
 }
 
 @end

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -15,7 +15,9 @@
 
 #import <XCTest/XCTest.h>
 
+#include <fcntl.h>
 #include <mach-o/fat.h>
+#include <unistd.h>
 
 #import "Source/common/MOLCodesignChecker.h"
 
@@ -126,6 +128,82 @@
   int fd = open(path.UTF8String, O_RDONLY | O_CLOEXEC);
   MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path fileDescriptor:fd];
   XCTAssertNotNil(sut.signingInformation);
+  close(fd);
+}
+
+// fd-based init must reflect the caller's vnode, not the path. Stage two
+// distinct signed binaries; open the fd of one; atomic-rename the other into
+// the staged path; verify the fd-based checker still reports the original
+// vnode's cdhash, and a path-based checker reports the swapped binary's
+// cdhash.
+- (void)testInitWithFileDescriptor_SurvivesAtomicRenameSwap {
+  NSString* tmp = NSTemporaryDirectory();
+  NSString* a = [tmp stringByAppendingPathComponent:[NSString
+      stringWithFormat:@"mol_a_%d_%@", getpid(), [[NSUUID UUID] UUIDString]]];
+  NSString* b = [tmp stringByAppendingPathComponent:[NSString
+      stringWithFormat:@"mol_b_%d_%@", getpid(), [[NSUUID UUID] UUIDString]]];
+  NSError* err;
+  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/yes" toPath:a error:&err]);
+  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/true" toPath:b error:&err]);
+
+  int fd = open(a.UTF8String, O_RDONLY | O_CLOEXEC);
+  XCTAssertGreaterThanOrEqual(fd, 0, "open: %s", strerror(errno));
+
+  MOLCodesignChecker* aRef =
+      [[MOLCodesignChecker alloc] initWithBinaryPath:a fileDescriptor:fd];
+  MOLCodesignChecker* bRef = [[MOLCodesignChecker alloc] initWithBinaryPath:b];
+  XCTAssertNotNil(aRef.cdhash);
+  XCTAssertNotNil(bRef.cdhash);
+  XCTAssertNotEqualObjects(aRef.cdhash, bRef.cdhash);
+  NSString* originalACdhash = aRef.cdhash;
+  NSString* originalBCdhash = bRef.cdhash;
+
+  // Atomic swap: rename(b, a) makes path `a` point at b's vnode. Original
+  // a-vnode survives only via the open fd.
+  XCTAssertEqual(rename(b.UTF8String, a.UTF8String), 0, "rename: %s", strerror(errno));
+
+  // fd-based: must still see A's identity.
+  MOLCodesignChecker* afterFD =
+      [[MOLCodesignChecker alloc] initWithBinaryPath:a fileDescriptor:fd];
+  XCTAssertEqualObjects(afterFD.cdhash, originalACdhash);
+
+  // Path-based control: now sees B's identity (proving the rename happened
+  // and was visible to a path-based reader).
+  MOLCodesignChecker* afterPath = [[MOLCodesignChecker alloc] initWithBinaryPath:a];
+  XCTAssertEqualObjects(afterPath.cdhash, originalBCdhash);
+
+  close(fd);
+  [[NSFileManager defaultManager] removeItemAtPath:a error:nil];
+}
+
+// fd-based init must succeed even when the original path has been removed
+// after the caller's open(): the fd holds the vnode regardless.
+- (void)testInitWithFileDescriptor_SurvivesUnlink {
+  NSString* tmp = NSTemporaryDirectory();
+  NSString* path = [tmp stringByAppendingPathComponent:[NSString
+      stringWithFormat:@"mol_unlink_%d_%@", getpid(), [[NSUUID UUID] UUIDString]]];
+  NSError* err;
+  XCTAssertTrue([[NSFileManager defaultManager] copyItemAtPath:@"/usr/bin/yes"
+                                                        toPath:path
+                                                         error:&err]);
+
+  int fd = open(path.UTF8String, O_RDONLY | O_CLOEXEC);
+  XCTAssertGreaterThanOrEqual(fd, 0);
+
+  XCTAssertEqual(unlink(path.UTF8String), 0);
+
+  MOLCodesignChecker* sut =
+      [[MOLCodesignChecker alloc] initWithBinaryPath:path fileDescriptor:fd];
+  XCTAssertNotNil(sut.cdhash);
+
+  // Path-based at the now-missing path must fail, confirming the fd was the
+  // load-bearing source.
+  NSError* pathErr;
+  MOLCodesignChecker* viaPath = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                                         error:&pathErr];
+  XCTAssertNil(viaPath);
+  XCTAssertNotNil(pathErr);
+
   close(fd);
 }
 

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -305,6 +305,67 @@
   XCTAssertTrue(sut.platformBinary);
 }
 
+// MOLCodesignChecker must continue to populate `_signingInformation` even
+// when SecStaticCodeCheckValidityWithErrors returns a non-fatal error. Bundle
+// binaries opened by fd produce errSecCSInfoPlistFailed (the bundle's
+// Info.plist hash slot in the Mach-O signature can't be matched against an
+// on-disk Info.plist when SecStaticCode is fed /dev/fd/N), and downstream
+// callers — notably SNTPolicyProcessor's identity verifier — depend on the
+// signing dictionary remaining accessible so the cdhash / TeamID / SigningID
+// can still be read off the binary. This test pins that contract: a future
+// refactor that returns nil or skips dictionary population on any error
+// would silently regress identity verification for every signed bundle
+// binary on the system (~all GUI apps and many framework-housed tools).
+- (void)testInitWithFileDescriptor_BundleBinary_PreservesSigningInfoOnPartialError {
+  NSArray<NSString*>* candidates = @[
+    @"/System/Applications/Calculator.app/Contents/MacOS/Calculator",
+    @"/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+    @"/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation",
+  ];
+  NSString* path = nil;
+  for (NSString* c in candidates) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:c]) {
+      path = c;
+      break;
+    }
+  }
+  if (!path) {
+    XCTSkip(@"No signed bundle binary available on this host");
+  }
+
+  // Sanity baseline: path-based init succeeds cleanly and gives us reference
+  // identity values to compare against.
+  NSError* viaPathErr;
+  MOLCodesignChecker* viaPath = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                                         error:&viaPathErr];
+  XCTAssertNotNil(viaPath);
+  XCTAssertNil(viaPathErr);
+  XCTAssertNotNil(viaPath.cdhash);
+
+  int fd = open(path.UTF8String, O_RDONLY | O_CLOEXEC);
+  XCTAssertGreaterThanOrEqual(fd, 0, "open(%@): %s", path, strerror(errno));
+
+  // fd-based init must surface the validity error AND populate the signing
+  // dictionary anyway. The two behaviors are independent — together they let
+  // the SNT-377 verifier compare identity even when bundle context is
+  // unavailable through /dev/fd/N.
+  NSError* err;
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path
+                                                            fileDescriptor:fd
+                                                                     error:&err];
+  XCTAssertNotNil(sut, @"init must return an instance, not nil, on partial validity failure");
+  XCTAssertNotNil(err, @"validity check failure must surface to the caller");
+
+  XCTAssertNotNil(sut.signingInformation, @"signing dictionary must be populated");
+  XCTAssertEqualObjects(sut.cdhash, viaPath.cdhash,
+                        @"fd-based cdhash must agree with path-based cdhash");
+  XCTAssertEqualObjects(sut.signingID, viaPath.signingID);
+  XCTAssertEqualObjects(sut.teamID, viaPath.teamID);
+  XCTAssertNotNil(sut.leafCertificate, @"leaf certificate must be readable");
+
+  close(fd);
+}
+
 - (void)testEntitlements {
   NSError* error;
   NSBundle* bundle = [NSBundle bundleForClass:[self class]];

--- a/Source/common/SNTBlockMessage.mm
+++ b/Source/common/SNTBlockMessage.mm
@@ -167,6 +167,9 @@ static id EncodedValueOrNull(id value) {
       return NSLocalizedString(@"Blocked path regex", @"Block reason for blocked path regex match");
     case SNTEventStateBlockCELFallback:
       return NSLocalizedString(@"CEL fallback rule", @"Block reason for CEL fallback rule match");
+    case SNTEventStateBlockBinaryMismatch:
+      return NSLocalizedString(@"Binary identity verification failed",
+                               @"Block reason when ES event and on-disk binary identity disagree");
     case SNTEventStateBlockLongPath:
       return NSLocalizedString(@"Path too long",
                                @"Block reason when file path exceeds maximum length");

--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -103,6 +103,7 @@ typedef NS_ENUM(uint64_t, SNTEventState) {
   SNTEventStateBlockSigningID = 1ULL << 22,
   SNTEventStateBlockCDHash = 1ULL << 23,
   SNTEventStateBlockCELFallback = 1ULL << 24,
+  SNTEventStateBlockBinaryMismatch = 1ULL << 25,
 
   // Bits 40-63 store allow decision types
   SNTEventStateAllowUnknown = 1ULL << 40,

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -243,6 +243,13 @@
 ///
 ///  @return The underlying file handle.
 ///
+///  @note The file offset is unspecified after `codesignCheckerWithError:`
+///  has been called: SecStaticCode operates on the descriptor via
+///  `/dev/fd/N`, which shares its file offset with this fd, and consumes
+///  bytes during validation. Callers reading directly from
+///  `fileHandle.fileDescriptor` should use `pread(2)` (or seek explicitly
+///  before each read) rather than relying on a particular offset.
+///
 @property(readonly) NSFileHandle* fileHandle;
 
 ///

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -15,6 +15,7 @@
 
 #import <EndpointSecurity/EndpointSecurity.h>
 #import <Foundation/Foundation.h>
+#import <mach/machine.h>
 
 #import "Source/common/SantaVnode.h"
 
@@ -43,6 +44,17 @@
 ///      Assumes that the path is a resolved path.
 ///
 - (instancetype)initWithEndpointSecurityFile:(const es_file_t*)esFile error:(NSError**)error;
+
+///
+///  Initialize with an Endpoint Security `es_event_exec_t`. Captures the active-slice
+///  CPU type/subtype from `image_cputype` / `image_cpusubtype` so subsequent
+///  `codesignCheckerWithError:` calls return active-slice-correct identity for
+///  fat binaries.
+///
+///  Equivalent to `initWithEndpointSecurityFile:` for thin binaries.
+///
+- (instancetype)initWithEndpointSecurityExecEvent:(const es_event_exec_t*)esExec
+                                            error:(NSError**)error;
 
 ///
 ///  Convenience initializer.
@@ -232,6 +244,18 @@
 ///  @return The underlying file handle.
 ///
 @property(readonly) NSFileHandle* fileHandle;
+
+///
+///  Active-slice CPU type captured at init time (from `es_event_exec_t.image_cputype`).
+///  Defaults to `CPU_TYPE_ANY` for inits without exec-event context.
+///
+@property(readonly) cpu_type_t cpuType;
+
+///
+///  Active-slice CPU subtype captured at init time (from `es_event_exec_t.image_cpusubtype`).
+///  Defaults to `CPU_SUBTYPE_ANY` for inits without exec-event context.
+///
+@property(readonly) cpu_subtype_t cpuSubtype;
 
 ///
 ///  @return Returns an instance of MOLCodeSignChecker initialized with the file's binary path.

--- a/Source/common/SNTFileInfo.mm
+++ b/Source/common/SNTFileInfo.mm
@@ -796,7 +796,12 @@
 - (MOLCodesignChecker*)codesignCheckerWithError:(NSError**)error {
   if (!self.cachedCodesignChecker && !self.codesignCheckerError) {
     NSError* e;
-    self.cachedCodesignChecker = [[MOLCodesignChecker alloc] initWithBinaryPath:self.path error:&e];
+    // Pass the descriptor SNTFileInfo already has open so SecStaticCode
+    // operates on the same vnode (via /dev/fd/N), not a fresh path resolution.
+    self.cachedCodesignChecker =
+        [[MOLCodesignChecker alloc] initWithBinaryPath:self.path
+                                        fileDescriptor:self.fileHandle.fileDescriptor
+                                                 error:&e];
     self.codesignCheckerError = e;
   }
   if (error) *error = self.codesignCheckerError;

--- a/Source/common/SNTFileInfo.mm
+++ b/Source/common/SNTFileInfo.mm
@@ -56,6 +56,8 @@
 @property SantaVnode vnode;
 @property NSString* fileOwnerHomeDir;
 @property NSString* sha256Storage;
+@property(readwrite) cpu_type_t cpuType;
+@property(readwrite) cpu_subtype_t cpuSubtype;
 
 // Cached properties
 @property NSBundle* bundleRef;
@@ -80,6 +82,18 @@
   return [self initWithResolvedPath:@(esFile->path.data) stat:&esFile->stat error:error];
 }
 
+- (instancetype)initWithEndpointSecurityExecEvent:(const es_event_exec_t*)esExec
+                                            error:(NSError**)error {
+  self = [self initWithResolvedPath:@(esExec->target->executable->path.data)
+                               stat:&esExec->target->executable->stat
+                              error:error];
+  if (self) {
+    _cpuType = esExec->image_cputype;
+    _cpuSubtype = esExec->image_cpusubtype;
+  }
+  return self;
+}
+
 - (instancetype)initWithResolvedPath:(NSString*)path
                                 stat:(const struct stat*)fileStat
                                error:(NSError**)error {
@@ -91,6 +105,9 @@
 
   self = [super init];
   if (self) {
+    _cpuType = CPU_TYPE_ANY;
+    _cpuSubtype = CPU_SUBTYPE_ANY;
+
     _path = path;
     if (!_path.length) {
       [SNTError populateError:error
@@ -796,11 +813,16 @@
 - (MOLCodesignChecker*)codesignCheckerWithError:(NSError**)error {
   if (!self.cachedCodesignChecker && !self.codesignCheckerError) {
     NSError* e;
-    // Pass the descriptor SNTFileInfo already has open so SecStaticCode
-    // operates on the same vnode (via /dev/fd/N), not a fresh path resolution.
+    // Pass the descriptor SNTFileInfo already has open so SecStaticCode operates
+    // on the same vnode (via /dev/fd/N), not a fresh path resolution. Pass the
+    // cputype/cpusubtype hint (CPU_TYPE_ANY / CPU_SUBTYPE_ANY when not initialized
+    // via -initWithEndpointSecurityExecEvent:) so universal binaries produce
+    // active-slice-correct identity.
     self.cachedCodesignChecker =
         [[MOLCodesignChecker alloc] initWithBinaryPath:self.path
                                         fileDescriptor:self.fileHandle.fileDescriptor
+                                               cpuType:self.cpuType
+                                            cpuSubtype:self.cpuSubtype
                                                  error:&e];
     self.codesignCheckerError = e;
   }

--- a/Source/common/SNTFileInfo.mm
+++ b/Source/common/SNTFileInfo.mm
@@ -813,17 +813,24 @@
 - (MOLCodesignChecker*)codesignCheckerWithError:(NSError**)error {
   if (!self.cachedCodesignChecker && !self.codesignCheckerError) {
     NSError* e;
-    // Pass the descriptor SNTFileInfo already has open so SecStaticCode operates
-    // on the same vnode (via /dev/fd/N), not a fresh path resolution. Pass the
-    // cputype/cpusubtype hint (CPU_TYPE_ANY / CPU_SUBTYPE_ANY when not initialized
-    // via -initWithEndpointSecurityExecEvent:) so universal binaries produce
-    // active-slice-correct identity.
-    self.cachedCodesignChecker =
-        [[MOLCodesignChecker alloc] initWithBinaryPath:self.path
-                                        fileDescriptor:self.fileHandle.fileDescriptor
-                                               cpuType:self.cpuType
-                                            cpuSubtype:self.cpuSubtype
-                                                 error:&e];
+    if (self.cpuType > 0) {
+      // Exec-event path: bind SecStaticCode to the descriptor SNTFileInfo
+      // already has open (via /dev/fd/N) so policy-time identity comparisons
+      // see the same vnode the kernel saw, and forward the active-slice
+      // cputype hint so universal binaries report the slice that was loaded.
+      self.cachedCodesignChecker =
+          [[MOLCodesignChecker alloc] initWithBinaryPath:self.path
+                                          fileDescriptor:self.fileHandle.fileDescriptor
+                                                 cpuType:self.cpuType
+                                              cpuSubtype:self.cpuSubtype
+                                                   error:&e];
+    } else {
+      // Diagnostic path (santactl, compiler controller, GUI, etc.): re-resolve
+      // the on-disk path so SecStaticCode has full bundle context, producing
+      // richer signing-status output (e.g. proper Info.plist validation).
+      self.cachedCodesignChecker = [[MOLCodesignChecker alloc] initWithBinaryPath:self.path
+                                                                            error:&e];
+    }
     self.codesignCheckerError = e;
   }
   if (error) *error = self.codesignCheckerError;

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -16,6 +16,7 @@
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTFileInfo.h"
+#import "Source/common/TestUtils.h"
 
 @interface SNTFileInfoTest : XCTestCase
 @end
@@ -262,6 +263,51 @@
     XCTAssertNotNil(sut);
     XCTAssertEqualObjects([sut codesignStatus], @"Yes, platform binary");
   }
+}
+
+- (void)testInitWithEndpointSecurityExecEvent_StoresCpuType {
+  // Use a real path so the underlying initWithResolvedPath:stat:error: succeeds.
+  const char* path = "/usr/bin/yes";
+  struct stat sb;
+  XCTAssertEqual(stat(path, &sb), 0);
+
+  es_file_t file = MakeESFile(path, sb);
+  es_process_t proc = MakeESProcess(&file);
+  es_event_exec_t exec = {
+      .target = &proc,
+      .image_cputype = CPU_TYPE_ARM64,
+      .image_cpusubtype = CPU_SUBTYPE_ARM64_ALL,
+  };
+
+  NSError* error;
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithEndpointSecurityExecEvent:&exec error:&error];
+  XCTAssertNotNil(sut);
+  XCTAssertNil(error);
+  XCTAssertEqual(sut.cpuType, CPU_TYPE_ARM64);
+  XCTAssertEqual(sut.cpuSubtype, CPU_SUBTYPE_ARM64_ALL);
+}
+
+- (void)testInitWithEndpointSecurityFile_DefaultsCpuTypeToAny {
+  const char* path = "/usr/bin/yes";
+  struct stat sb;
+  XCTAssertEqual(stat(path, &sb), 0);
+
+  es_file_t file = MakeESFile(path, sb);
+
+  NSError* error;
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithEndpointSecurityFile:&file error:&error];
+  XCTAssertNotNil(sut);
+  XCTAssertEqual(sut.cpuType, CPU_TYPE_ANY);
+  XCTAssertEqual(sut.cpuSubtype, CPU_SUBTYPE_ANY);
+}
+
+- (void)testInitWithPath_DefaultsCpuTypeToAny {
+  // Path-based init: cputype/cpusubtype default to ANY since there's no
+  // exec-event context to infer them from.
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:@"/usr/bin/yes"];
+  XCTAssertNotNil(sut);
+  XCTAssertEqual(sut.cpuType, CPU_TYPE_ANY);
+  XCTAssertEqual(sut.cpuSubtype, CPU_SUBTYPE_ANY);
 }
 
 @end

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -15,6 +15,12 @@
 
 #import <XCTest/XCTest.h>
 
+#include <fcntl.h>
+#include <mach/machine.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#import "Source/common/MOLCodesignChecker.h"
 #import "Source/common/SNTFileInfo.h"
 #import "Source/common/TestUtils.h"
 
@@ -308,6 +314,62 @@
   XCTAssertNotNil(sut);
   XCTAssertEqual(sut.cpuType, CPU_TYPE_ANY);
   XCTAssertEqual(sut.cpuSubtype, CPU_SUBTYPE_ANY);
+}
+
+// On the exec-event path, codesignCheckerWithError: routes through MOL's
+// fd-bound init, which calls SecStaticCode APIs that read from the
+// underlying file via /dev/fd/N. That descriptor shares its file offset
+// with the SNTFileInfo fd, so the absolute file offset is unspecified once
+// validation has run. Pin the contract that downstream callers using
+// pread() are unaffected: the bytes at a given offset must match before
+// and after codesignCheckerWithError:.
+- (void)testFileHandle_PreadStableAcrossCodesignCheckerWithError {
+  const char* path = "/bin/ls";  // signed binary present on every macOS host
+  struct stat sb;
+  XCTAssertEqual(stat(path, &sb), 0);
+
+  es_file_t file = MakeESFile(path, sb);
+  es_process_t proc = MakeESProcess(&file);
+  // image_cputype must be > 0 to engage the fd-binding path in
+  // codesignCheckerWithError: (CPU_TYPE_ANY = -1 falls through to the
+  // diagnostic / path-based MOL init).
+  // System binaries on Apple Silicon are arm64e (PAC); Intel hosts are x86_64.
+  // Match the host architecture so the cputype hint actually resolves to a
+  // real slice in /bin/ls's fat header (otherwise MOL leaves _signingInformation
+  // empty per its no-matching-slice path and cdhash is empty).
+  es_event_exec_t exec = {
+      .target = &proc,
+#if defined(__arm64__)
+      .image_cputype = CPU_TYPE_ARM64,
+      .image_cpusubtype = CPU_SUBTYPE_ARM64E,
+#else
+      .image_cputype = CPU_TYPE_X86_64,
+      .image_cpusubtype = CPU_SUBTYPE_X86_64_ALL,
+#endif
+  };
+
+  NSError* fiErr;
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithEndpointSecurityExecEvent:&exec error:&fiErr];
+  XCTAssertNotNil(fi);
+  XCTAssertGreaterThan(fi.cpuType, 0);
+
+  int fd = fi.fileHandle.fileDescriptor;
+
+  uint8_t before[16] = {0};
+  XCTAssertEqual(pread(fd, before, sizeof(before), 0), (ssize_t)sizeof(before));
+
+  NSError* csErr;
+  MOLCodesignChecker* csc = [fi codesignCheckerWithError:&csErr];
+  XCTAssertNotNil(csc);
+  XCTAssertGreaterThan(csc.cdhash.length, 0u);
+
+  uint8_t after[16] = {0};
+  XCTAssertEqual(pread(fd, after, sizeof(after), 0), (ssize_t)sizeof(after));
+
+  XCTAssertEqual(memcmp(before, after, sizeof(before)), 0,
+                 @"pread must return identical bytes before and after "
+                 @"codesignCheckerWithError: despite Sec framework's "
+                 @"manipulation of the shared file offset");
 }
 
 @end

--- a/Source/common/ScopedFile.h
+++ b/Source/common/ScopedFile.h
@@ -29,7 +29,8 @@ namespace santa {
 class ScopedFile {
  public:
   static absl::StatusOr<ScopedFile> CreateTemporary(
-      NSString* path_prefix = nil, NSString* filename_template = @"santa_test_XXXXXX") {
+      NSString* path_prefix = nil, size_t size = 0,
+      NSString* filename_template = @"santa_test_XXXXXX", bool keep_path = false) {
     if (filename_template.length == 0) {
       return absl::FailedPreconditionError("No temp file template provided");
     }
@@ -62,17 +63,29 @@ class ScopedFile {
     path = [NSString stringWithCString:mutable_path encoding:NSUTF8StringEncoding];
     free(mutable_path);
 
-    if (unlink(path.UTF8String) != 0) {
-      // Log warning, but otherwise continue.
-      LOGW(@"Unable to unlink backing temp file: %@. Error: %d: %s", path, errno, strerror(errno));
+    if (!keep_path) {
+      if (unlink(path.UTF8String) != 0) {
+        // Log warning, but otherwise continue.
+        LOGW(@"Unable to unlink backing temp file: %@. Error: %d: %s", path, errno,
+             strerror(errno));
+      }
+      path = nil;
     }
 
-    return ScopedFile(fd);
+    if (size > 0 && ftruncate(fd, static_cast<off_t>(size)) != 0) {
+      int saved_errno = errno;
+      if (path) unlink(path.UTF8String);
+      close(fd);
+      return absl::ErrnoToStatus(saved_errno, "Failed to size temp file");
+    }
+
+    return ScopedFile(fd, path);
   }
 
-  explicit ScopedFile(int fd) : fd_(fd) {}
+  explicit ScopedFile(int fd, NSString* path = nil) : fd_(fd), path_(path) {}
 
   ~ScopedFile() {
+    if (path_) unlink(path_.UTF8String);
     if (fd_ >= 0) {
       close(fd_);
     }
@@ -81,13 +94,19 @@ class ScopedFile {
   ScopedFile(const ScopedFile&) = delete;
   ScopedFile& operator=(const ScopedFile&) = delete;
 
-  ScopedFile(ScopedFile&& other) : fd_(other.fd_) { other.fd_ = -1; }
+  ScopedFile(ScopedFile&& other) : fd_(other.fd_), path_(other.path_) {
+    other.fd_ = -1;
+    other.path_ = nil;
+  }
 
   ScopedFile& operator=(ScopedFile&& rhs) {
     if (this != &rhs) {
+      if (path_) unlink(path_.UTF8String);
       if (fd_ >= 0) close(fd_);
       fd_ = rhs.fd_;
+      path_ = rhs.path_;
       rhs.fd_ = -1;
+      rhs.path_ = nil;
     }
     return *this;
   }
@@ -105,8 +124,13 @@ class ScopedFile {
   // doesn't outlast the lifetime of this object.
   int UnsafeFD() const { return fd_; }
 
+  // The on-disk path, or nil if the file was unlinked at creation time
+  // (the default `keep_path = false` behavior).
+  NSString* Path() const { return path_; }
+
  private:
   int fd_ = -1;
+  NSString* path_ = nil;
 };
 
 }  // namespace santa

--- a/Source/common/ScopedFileTest.mm
+++ b/Source/common/ScopedFileTest.mm
@@ -51,7 +51,7 @@
   // The shouldn't exist before creating the temporary file
   XCTAssertFalse([fileMgr fileExistsAtPath:fullPath]);
 
-  auto file = santa::ScopedFile::CreateTemporary(prefix, uuid);
+  auto file = santa::ScopedFile::CreateTemporary(prefix, /*size=*/0, uuid);
   XCTAssertStatusOk(file);
 
   // The path still shouldn't exist after getting a handle
@@ -67,6 +67,31 @@
   NSData* readContents = [reader readDataToEndOfFileAndReturnError:nil];
 
   XCTAssertEqualObjects(readContents, writeContents);
+}
+
+- (void)testCreateTemporaryWithSize {
+  auto file = santa::ScopedFile::CreateTemporary(/*path_prefix=*/nil, /*size=*/1024);
+  XCTAssertStatusOk(file);
+
+  struct stat sb;
+  XCTAssertEqual(fstat(file->UnsafeFD(), &sb), 0);
+  XCTAssertEqual(sb.st_size, 1024);
+}
+
+- (void)testCreateTemporaryKeepsPathWhenRequested {
+  NSFileManager* fileMgr = [NSFileManager defaultManager];
+  NSString* savedPath;
+  {
+    auto file = santa::ScopedFile::CreateTemporary(/*path_prefix=*/nil, /*size=*/16,
+                                                   /*filename_template=*/@"santa_test_XXXXXX",
+                                                   /*keep_path=*/true);
+    XCTAssertStatusOk(file);
+    XCTAssertNotNil(file->Path());
+    XCTAssertTrue([fileMgr fileExistsAtPath:file->Path()]);
+    savedPath = file->Path();
+  }
+  // Destructor should have unlinked the path.
+  XCTAssertFalse([fileMgr fileExistsAtPath:savedPath]);
 }
 
 - (void)testMoveAssignmentClosesExistingFD {

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -317,6 +317,7 @@ message Execution {
     REASON_SIGNING_ID = 11;
     REASON_CDHASH = 12;
     REASON_CEL_FALLBACK = 13;
+    REASON_BINARY_MISMATCH = 14;
   }
   optional Reason reason = 10;
 

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize execution of an application with name */
 "authorize execution of the application %@" = "Die Ausführung der Anwendung autorisieren %@";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Identitätsprüfung der Binärdatei fehlgeschlagen";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Binärer Pfad";
 

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "authorize temporary Monitor Mode";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Binary identity verification failed";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Binary Path";
 

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "autorizar el modo Monitor temporal";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Falló la verificación de identidad del binario";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Ruta del binario";
 

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -34,6 +34,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "autoriser le mode Moniteur temporaire";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Échec de la vérification de l'identité du binaire";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Chemin du binaire";
 

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "autoriser le mode Moniteur temporaire";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Échec de la vérification de l'identité du binaire";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Chemin du binaire";
 

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "一時的なモニターモードを許可する";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "バイナリの同一性検証に失敗しました";
+
 /* No comment provided by engineer. */
 "Binary Path" = "バイナリーパス";
 

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "разрешить временный режим мониторинга";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Не удалось проверить идентичность исполняемого файла";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Путь к исполняемому файлу";
 

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* Authorize temporary Monitor Mode exception */
 "authorize temporary Monitor Mode" = "дозволити тимчасовий режим монітора";
 
+/* Block reason when ES event and on-disk binary identity disagree */
+"Binary identity verification failed" = "Не вдалося перевірити ідентичність бінарного файлу";
+
 /* No comment provided by engineer. */
 "Binary Path" = "Двійковий шлях";
 

--- a/Source/santactl/Commands/SNTCommandFileInfoTest.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfoTest.mm
@@ -127,8 +127,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 
 - (void)testCodeSignedNo {
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSUnsigned userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), @"No");
 }
@@ -136,8 +135,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedSignatureFailed {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSSignatureFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -145,8 +143,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedStaticCodeChanged {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSStaticCodeChanged userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -154,8 +151,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedSignatureNotVerifiable {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSSignatureNotVerifiable userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -163,8 +159,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedSignatureUnsupported {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSSignatureUnsupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -172,8 +167,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourceDirectoryFailed {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourceDirectoryFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -181,8 +175,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourceNotSupported {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourceNotSupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -190,8 +183,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourceRulesInvalid {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourceRulesInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -199,8 +191,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourcesInvalid {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourcesInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -208,8 +199,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourcesNotFound {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotFound userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -217,8 +207,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourcesNotSealed {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotSealed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -226,8 +215,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedReqFailed {
   NSString* expected = @"Yes, but failed requirement validation";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSReqFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -235,8 +223,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedReqInvalid {
   NSString* expected = @"Yes, but failed requirement validation";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSReqInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -244,8 +231,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedReqUnsupported {
   NSString* expected = @"Yes, but failed requirement validation";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSReqUnsupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -253,8 +239,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedInfoPlistFailed {
   NSString* expected = @"Yes, but can't validate as the Info.plist has been modified";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSInfoPlistFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -262,8 +247,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedDefault {
   NSString* expected = @"Yes, but failed to validate (999)";
   NSError* err = [NSError errorWithDomain:@"" code:999 userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
-      .ignoringNonObjectArgs()
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }

--- a/Source/santactl/Commands/SNTCommandFileInfoTest.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfoTest.mm
@@ -127,7 +127,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 
 - (void)testCodeSignedNo {
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSUnsigned userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), @"No");
 }
@@ -135,7 +136,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedSignatureFailed {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSSignatureFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -143,7 +145,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedStaticCodeChanged {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSStaticCodeChanged userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -151,7 +154,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedSignatureNotVerifiable {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSSignatureNotVerifiable userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -159,7 +163,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedSignatureUnsupported {
   NSString* expected = @"Yes, but code/signature changed/unverifiable";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSSignatureUnsupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -167,7 +172,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourceDirectoryFailed {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourceDirectoryFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -175,7 +181,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourceNotSupported {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourceNotSupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -183,7 +190,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourceRulesInvalid {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourceRulesInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -191,7 +199,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourcesInvalid {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourcesInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -199,7 +208,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourcesNotFound {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotFound userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -207,7 +217,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedResourcesNotSealed {
   NSString* expected = @"Yes, but resources invalid";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotSealed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -215,7 +226,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedReqFailed {
   NSString* expected = @"Yes, but failed requirement validation";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSReqFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -223,7 +235,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedReqInvalid {
   NSString* expected = @"Yes, but failed requirement validation";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSReqInvalid userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -231,7 +244,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedReqUnsupported {
   NSString* expected = @"Yes, but failed requirement validation";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSReqUnsupported userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -239,7 +253,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedInfoPlistFailed {
   NSString* expected = @"Yes, but can't validate as the Info.plist has been modified";
   NSError* err = [NSError errorWithDomain:@"" code:errSecCSInfoPlistFailed userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
@@ -247,7 +262,8 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo*, SNTFileInfo*);
 - (void)testCodeSignedDefault {
   NSString* expected = @"Yes, but failed to validate (999)";
   NSError* err = [NSError errorWithDomain:@"" code:999 userInfo:nil];
-  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:err]])
+  OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY fileDescriptor:0 error:[OCMArg setTo:err]])
+      .ignoringNonObjectArgs()
       .andReturn(self.cscMock);
   XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -263,6 +263,9 @@ objc_library(
 santa_unit_test(
     name = "SNTPolicyProcessorTest",
     srcs = ["SNTPolicyProcessorTest.mm"],
+    resources = [
+        "//Source/common:testdata_cal_yikes_universal_signed",
+    ],
     sdk_dylibs = [
         "EndpointSecurity",
     ],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -229,6 +229,9 @@ objc_library(
     name = "SNTPolicyProcessor",
     srcs = ["SNTPolicyProcessor.mm"],
     hdrs = ["SNTPolicyProcessor.h"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
     deps = [
         ":EntitlementsFilter",
         ":SNTRuleTable",
@@ -260,13 +263,21 @@ objc_library(
 santa_unit_test(
     name = "SNTPolicyProcessorTest",
     srcs = ["SNTPolicyProcessorTest.mm"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
     deps = [
         ":SNTPolicyProcessor",
+        "//Source/common:MOLCodesignChecker",
         "//Source/common:SNTCELFallbackRule",
         "//Source/common:SNTCachedDecision",
+        "//Source/common:SNTConfigState",
         "//Source/common:SNTConfigurator",
+        "//Source/common:SNTFileInfo",
         "//Source/common:SNTRule",
+        "//Source/common:ScopedFile",
         "//Source/common:TestUtils",
+        "@OCMock",
     ],
 )
 
@@ -1489,6 +1500,7 @@ santa_unit_test(
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",
         "//Source/common:SNTRuleIdentifiers",
+        "//Source/common:String",
         "//Source/common:TestUtils",
         "//Source/common/es:EndpointSecurityMessage",
         "//Source/common/es:MockEndpointSecurityAPI",

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -104,6 +104,7 @@ std::string GetReasonString(SNTEventState event_state) {
     case SNTEventStateBlockCDHash: return "CDHASH";
     case SNTEventStateBlockCELFallback: return "CEL_FALLBACK";
     case SNTEventStateBlockLongPath: return "LONG_PATH";
+    case SNTEventStateBlockBinaryMismatch: return "BINARY_MISMATCH";
     case SNTEventStateBlockUnknown: return "UNKNOWN";
     case SNTEventStateUnknown: return "UNKNOWN";
     case SNTEventStateAllow: return "UNKNOWN";

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -1466,6 +1466,7 @@ std::string BasicStringSerializeMessage(es_message_t* esMsg) {
       case SNTEventStateUnknown: want = "UNKNOWN"; break;
       case SNTEventStateBundleBinary: want = "UNKNOWN"; break;
       case SNTEventStateBlockUnknown: want = "UNKNOWN"; break;
+      case SNTEventStateBlockBinaryMismatch: want = "BINARY_MISMATCH"; break;
       case SNTEventStateBlockBinary: want = "BINARY"; break;
       case SNTEventStateBlockCertificate: want = "CERT"; break;
       case SNTEventStateBlockScope: want = "SCOPE"; break;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -356,6 +356,7 @@ static inline void EncodeCertificateInfo(::pbv1::CertificateInfo* pb_cert_info, 
     case SNTEventStateBlockCDHash: return ::pbv1::Execution::REASON_CDHASH;
     case SNTEventStateBlockCELFallback: return ::pbv1::Execution::REASON_CEL_FALLBACK;
     case SNTEventStateBlockLongPath: return ::pbv1::Execution::REASON_LONG_PATH;
+    case SNTEventStateBlockBinaryMismatch: return ::pbv1::Execution::REASON_BINARY_MISMATCH;
     case SNTEventStateBlockUnknown: return ::pbv1::Execution::REASON_UNKNOWN;
     case SNTEventStateUnknown: return ::pbv1::Execution::REASON_UNKNOWN;
     case SNTEventStateAllow: return ::pbv1::Execution::REASON_UNKNOWN;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -548,6 +548,7 @@ void SerializeAndCheckNonESEvents(
       case SNTEventStateUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
       case SNTEventStateBundleBinary: want = ::pbv1::Execution::REASON_UNKNOWN; break;
       case SNTEventStateBlockUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
+      case SNTEventStateBlockBinaryMismatch: want = ::pbv1::Execution::REASON_BINARY_MISMATCH; break;
       case SNTEventStateBlockBinary: want = ::pbv1::Execution::REASON_BINARY; break;
       case SNTEventStateBlockCertificate: want = ::pbv1::Execution::REASON_CERT; break;
       case SNTEventStateBlockScope: want = ::pbv1::Execution::REASON_SCOPE; break;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -548,7 +548,9 @@ void SerializeAndCheckNonESEvents(
       case SNTEventStateUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
       case SNTEventStateBundleBinary: want = ::pbv1::Execution::REASON_UNKNOWN; break;
       case SNTEventStateBlockUnknown: want = ::pbv1::Execution::REASON_UNKNOWN; break;
-      case SNTEventStateBlockBinaryMismatch: want = ::pbv1::Execution::REASON_BINARY_MISMATCH; break;
+      case SNTEventStateBlockBinaryMismatch:
+        want = ::pbv1::Execution::REASON_BINARY_MISMATCH;
+        break;
       case SNTEventStateBlockBinary: want = ::pbv1::Execution::REASON_BINARY; break;
       case SNTEventStateBlockCertificate: want = ::pbv1::Execution::REASON_CERT; break;
       case SNTEventStateBlockScope: want = ::pbv1::Execution::REASON_SCOPE; break;

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -48,6 +48,7 @@ const static NSString* kDenyNoFileInfo = @"DenyNoFileInfo";
 const static NSString* kBlockLongPath = @"BlockLongPath";
 const static NSString* kBlockCELFallback = @"BlockCELFallback";
 const static NSString* kAllowCELFallback = @"AllowCELFallback";
+const static NSString* kBlockBinaryMismatch = @"BlockBinaryMismatch";
 
 @class SNTCachedDecision;
 @class SNTEventTable;

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -171,6 +171,7 @@ static SNTEventState BlockToAllowDecision(SNTEventState blockDecision) {
     case SNTEventStateBlockLongPath: eventTypeStr = kBlockLongPath; break;
     case SNTEventStateBlockCELFallback: eventTypeStr = kBlockCELFallback; break;
     case SNTEventStateAllowCELFallback: eventTypeStr = kAllowCELFallback; break;
+    case SNTEventStateBlockBinaryMismatch: eventTypeStr = kBlockBinaryMismatch; break;
     default: eventTypeStr = kUnknownEventState; break;
   }
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -87,6 +87,8 @@ static SNTEventState BlockToAllowDecision(SNTEventState blockDecision) {
     case SNTEventStateBlockCDHash: return SNTEventStateAllowCDHash;
     case SNTEventStateBlockCELFallback: return SNTEventStateAllowCELFallback;
     case SNTEventStateBlockLongPath: return SNTEventStateAllowUnknown;  // No direct equivalent
+    case SNTEventStateBlockBinaryMismatch:
+      return SNTEventStateAllowUnknown;  // No direct equivalent
     default: return SNTEventStateAllowUnknown;
   }
 }

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -233,8 +233,8 @@ static SNTEventState BlockToAllowDecision(SNTEventState blockDecision) {
 
   // Get info about the file. If we can't get this info, respond appropriately and log an error.
   NSError* fileInfoError;
-  SNTFileInfo* binInfo = [[SNTFileInfo alloc] initWithEndpointSecurityFile:targetProc->executable
-                                                                     error:&fileInfoError];
+  SNTFileInfo* binInfo = [[SNTFileInfo alloc] initWithEndpointSecurityExecEvent:&esMsg->event.exec
+                                                                          error:&fileInfoError];
   if (unlikely(!binInfo)) {
     if (config.failClosed) {
       LOGE(@"Failed to read file %@: %@ and denying action", @(targetProc->executable->path.data),

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -28,6 +28,7 @@
 #import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
+#include "Source/common/String.h"
 #include "Source/common/TestUtils.h"
 #include "Source/common/es/Message.h"
 #include "Source/common/es/MockEndpointSecurityAPI.h"
@@ -60,6 +61,10 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 @property(readwrite) SNTRuleState state;
 @property(readwrite) SNTRuleType type;
 @property(readwrite) NSString* customMsg;
+@end
+
+@interface SNTExecutionController (Testing)
+- (void)incrementEventCounters:(SNTEventState)eventType;
 @end
 
 @interface SNTExecutionControllerTest : XCTestCase
@@ -229,6 +234,24 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 
   if (messageSetupBlock) {
     messageSetupBlock(&esMsg);
+  }
+
+  // Configure mockCodesignChecker to match procExec's identity so that
+  // VerifyIdentity returns kMatch and does not short-circuit policy evaluation.
+  // Tests in this file are not exercising identity verification; that is covered
+  // by the +verifyIdentityForTargetProc:fd:csInfo: tests at the bottom of
+  // SNTPolicyProcessorTest.mm.
+  {
+    const es_process_t* target = esMsg.event.exec.target;
+    NSString* cdhexStr = santa::StringToNSString(santa::BufToHexString(target->cdhash, 20));
+    // Stubs below must mirror target identity; otherwise verifyIdentity short-circuits.
+    OCMStub([self.mockCodesignChecker cdhash]).andReturn(cdhexStr);
+    if (target->team_id.length > 0) {
+      OCMStub([self.mockCodesignChecker teamID]).andReturn(@(target->team_id.data));
+    }
+    if (target->signing_id.length > 0) {
+      OCMStub([self.mockCodesignChecker signingID]).andReturn(@(target->signing_id.data));
+    }
   }
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
@@ -430,6 +453,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 }
 
 - (void)testTeamIDAllowRule {
+  // Must match target->team_id set in messageSetup; otherwise verifyIdentity short-circuits.
   OCMStub([self.mockCodesignChecker teamID]).andReturn(@(kExampleTeamID));
 
   SNTRule* rule = [[SNTRule alloc] init];
@@ -446,6 +470,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 }
 
 - (void)testTeamIDBlockRule {
+  // Must match target->team_id set in messageSetup; otherwise verifyIdentity short-circuits.
   OCMStub([self.mockCodesignChecker teamID]).andReturn(@(kExampleTeamID));
 
   SNTRule* rule = [[SNTRule alloc] init];
@@ -1038,6 +1063,11 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 
   // Just verify that flush doesn't crash - the cache internals are private
   XCTAssertNoThrow([controller flushTouchIDApprovalCache]);
+}
+
+- (void)testIncrementEventCountersHandlesBinaryMismatch {
+  [self.sut incrementEventCounters:SNTEventStateBlockBinaryMismatch];
+  [self checkMetricCounters:kBlockBinaryMismatch expected:@1];
 }
 
 @end

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -101,7 +101,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 
   self.mockFileInfo = OCMClassMock([SNTFileInfo class]);
   OCMStub([self.mockFileInfo alloc]).andReturn(self.mockFileInfo);
-  OCMStub([self.mockFileInfo initWithEndpointSecurityFile:NULL error:[OCMArg setTo:nil]])
+  OCMStub([self.mockFileInfo initWithEndpointSecurityExecEvent:NULL error:[OCMArg setTo:nil]])
       .ignoringNonObjectArgs()
       .andReturn(self.mockFileInfo);
   OCMStub([self.mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]])

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -236,15 +236,21 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
     messageSetupBlock(&esMsg);
   }
 
-  // Configure mockCodesignChecker to match procExec's identity so that
-  // VerifyIdentity returns kMatch and does not short-circuit policy evaluation.
-  // Tests in this file are not exercising identity verification; that is covered
-  // by the +verifyIdentityForTargetProc:fd:csInfo: tests at the bottom of
+  // Auto-mirror target identity onto the mock codesign checker so that
+  // VerifyIdentity returns kMatch and doesn't short-circuit policy evaluation.
+  // Tests in this file aren't exercising identity verification — that's covered
+  // by the +verifyIdentityForTargetProc:fd:csInfo: tests in
   // SNTPolicyProcessorTest.mm.
+  //
+  // Tests should set target identity via messageSetupBlock and let this fixture
+  // mirror it onto the mock. Do NOT add per-test OCMStubs for cdhash, teamID,
+  // or signingID — OCMock resolves stubs FIFO, so a per-test stub added before
+  // validateExecEvent runs would shadow the mirror below and silently trip
+  // kMismatch if its value differs from what messageSetupBlock writes onto
+  // target.
   {
     const es_process_t* target = esMsg.event.exec.target;
     NSString* cdhexStr = santa::StringToNSString(santa::BufToHexString(target->cdhash, 20));
-    // Stubs below must mirror target identity; otherwise verifyIdentity short-circuits.
     OCMStub([self.mockCodesignChecker cdhash]).andReturn(cdhexStr);
     if (target->team_id.length > 0) {
       OCMStub([self.mockCodesignChecker teamID]).andReturn(@(target->team_id.data));
@@ -453,9 +459,6 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 }
 
 - (void)testTeamIDAllowRule {
-  // Must match target->team_id set in messageSetup; otherwise verifyIdentity short-circuits.
-  OCMStub([self.mockCodesignChecker teamID]).andReturn(@(kExampleTeamID));
-
   SNTRule* rule = [[SNTRule alloc] init];
   rule.state = SNTRuleStateAllow;
   rule.type = SNTRuleTypeTeamID;
@@ -470,9 +473,6 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 }
 
 - (void)testTeamIDBlockRule {
-  // Must match target->team_id set in messageSetup; otherwise verifyIdentity short-circuits.
-  OCMStub([self.mockCodesignChecker teamID]).andReturn(@(kExampleTeamID));
-
   SNTRule* rule = [[SNTRule alloc] init];
   rule.state = SNTRuleStateBlock;
   rule.type = SNTRuleTypeTeamID;

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -36,6 +36,14 @@
 using ActivationCallbackBlock =
     std::unique_ptr<::google::api::expr::runtime::BaseActivation> (^)(bool useV2);
 
+/// Outcome of comparing the kernel's view of an about-to-execute binary against
+/// Santa's on-disk view at policy-evaluation time.
+enum class IdentityVerifyResult {
+  kMatch,
+  kDriftAllowed,
+  kMismatch,
+};
+
 ///
 ///  Creates SNTCachedDecision objects from a SNTFileInfo object or a file path. Decisions are based
 ///  on any existing rules for that specific binary, its signing certificate and the operating mode
@@ -74,5 +82,16 @@ using ActivationCallbackBlock =
                      forRule:(nonnull SNTRule*)rule
          withTransitiveRules:(BOOL)transitive
     andCELActivationCallback:(nullable ActivationCallbackBlock)activationCallback;
+
+/// Compares the kernel's view of the about-to-execute binary (`targetProc`) against Santa's
+/// on-disk view (`csInfo` for signed, or `fstat(fd)` for unsigned / codesign-error fallback).
+///
+/// - `targetProc`: ES event's process; must be non-NULL.
+/// - `fd`: a valid file descriptor opened on the binary path (used only on the unsigned path).
+/// - `csInfo`: nil if codesign check errored or the binary is unsigned; otherwise the checker
+///   produced by `-[SNTFileInfo codesignCheckerWithError:]`.
++ (IdentityVerifyResult)verifyIdentityForTargetProc:(nonnull const es_process_t*)targetProc
+                                                 fd:(int)fd
+                                             csInfo:(nullable MOLCodesignChecker*)csInfo;
 
 @end

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -533,45 +533,101 @@ static void UpdateCachedDecisionSigningInfo(
 + (IdentityVerifyResult)verifyIdentityForTargetProc:(const es_process_t*)targetProc
                                                  fd:(int)fd
                                              csInfo:(MOLCodesignChecker*)csInfo {
+  // Each non-match return emits a log. Lazily hex-encode the cdhash so no penalty on the happy path
+  NSString* (^esCdhashHex)(void) = ^NSString*(void) {
+    return santa::StringToNSString(santa::BufToHexString(targetProc->cdhash, CS_CDHASH_LEN));
+  };
+  NSString* path =
+      targetProc->executable->path.data ? @(targetProc->executable->path.data) : @"(null)";
+
   BOOL esSigned = (targetProc->codesigning_flags & CS_SIGNED) != 0;
   BOOL diskSigned = (csInfo != nil && csInfo.cdhash.length > 0);
 
   // Case 1: signedness disagrees.
-  if (esSigned != diskSigned) return IdentityVerifyResult::kMismatch;
+  if (esSigned != diskSigned) {
+    LOGW(@"Identity verification: signedness mismatch path=%@ es_signed=%d disk_signed=%d "
+         @"es_cdhash=%@ disk_cdhash=%@",
+         path, esSigned, diskSigned, esCdhashHex(), csInfo.cdhash ?: @"(nil)");
+    return IdentityVerifyResult::kMismatch;
+  }
 
   if (esSigned) {
-    BOOL esHasIDs = targetProc->team_id.length > 0 && targetProc->signing_id.length > 0;
-    BOOL diskHasIDs = csInfo.teamID.length > 0 && csInfo.signingID.length > 0;
+    // ES suppresses team_id on platform binaries even when the on-disk
+    // signature carries an Apple TeamID (observed for Apple-signed XPC
+    // services inside framework bundles, e.g. Xcode's helpers). Skip the
+    // team_id presence and equality checks for that class; signing_id and
+    // cdhash still bind identity end-to-end.
+    BOOL esTeamSuppressed = targetProc->is_platform_binary;
+    BOOL esHasTeam = targetProc->team_id.length > 0;
+    BOOL diskHasTeam = csInfo.teamID.length > 0;
+    BOOL esHasSID = targetProc->signing_id.length > 0;
+    BOOL diskHasSID = csInfo.signingID.length > 0;
 
-    // Case 2: TID/SID presence disagrees.
-    if (esHasIDs != diskHasIDs) return IdentityVerifyResult::kMismatch;
-
-    if (esHasIDs) {
-      // Case 3: both signed, both have TID/SID — compare IDs then cdhash.
-      NSString* esTeam = @(targetProc->team_id.data);
-      NSString* esSID = @(targetProc->signing_id.data);
-      if (![esTeam isEqualToString:csInfo.teamID] || ![esSID isEqualToString:csInfo.signingID]) {
-        return IdentityVerifyResult::kMismatch;
-      }
-      return CdhashEqual(targetProc->cdhash, csInfo.cdhash) ? IdentityVerifyResult::kMatch
-                                                            : IdentityVerifyResult::kDriftAllowed;
+    // Case 2: presence disagrees on a non-suppressed dimension.
+    if (esHasSID != diskHasSID || (!esTeamSuppressed && esHasTeam != diskHasTeam)) {
+      LOGW(@"Identity verification: signing identifier presence mismatch path=%@ "
+           @"es_platform=%d es_has_team=%d disk_has_team=%d "
+           @"es_has_sid=%d disk_has_sid=%d es_team=%s es_sid=%s disk_team=%@ disk_sid=%@",
+           path, esTeamSuppressed, esHasTeam, diskHasTeam, esHasSID, diskHasSID,
+           esHasTeam ? targetProc->team_id.data : "", esHasSID ? targetProc->signing_id.data : "",
+           csInfo.teamID ?: @"", csInfo.signingID ?: @"");
+      return IdentityVerifyResult::kMismatch;
     }
 
-    // Case 4: both signed, neither has TID/SID (ad-hoc / platform-only) -> cdhash must match.
-    return CdhashEqual(targetProc->cdhash, csInfo.cdhash) ? IdentityVerifyResult::kMatch
-                                                          : IdentityVerifyResult::kMismatch;
+    if (esHasSID) {
+      // Case 3: signing_id must match. team_id is only enforced when ES
+      // surfaced one — platform binaries skip team_id equality entirely
+      // since the ES side is suppressed.
+      NSString* esSID = @(targetProc->signing_id.data);
+      if (![esSID isEqualToString:csInfo.signingID]) {
+        LOGW(@"Identity verification: signing ID mismatch path=%@ es_sid=%@ disk_sid=%@", path,
+             esSID, csInfo.signingID);
+        return IdentityVerifyResult::kMismatch;
+      }
+      if (esHasTeam) {
+        NSString* esTeam = @(targetProc->team_id.data);
+        if (![esTeam isEqualToString:csInfo.teamID]) {
+          LOGW(@"Identity verification: team ID mismatch path=%@ es_team=%@ disk_team=%@ sid=%@",
+               path, esTeam, csInfo.teamID, esSID);
+          return IdentityVerifyResult::kMismatch;
+        }
+      }
+      if (CdhashEqual(targetProc->cdhash, csInfo.cdhash)) {
+        return IdentityVerifyResult::kMatch;
+      }
+      LOGW(@"Identity verification: cdhash drift (allowed) path=%@ "
+           @"es_platform=%d sid=%@ disk_team=%@ es_cdhash=%@ disk_cdhash=%@",
+           path, esTeamSuppressed, esSID, csInfo.teamID ?: @"", esCdhashHex(),
+           csInfo.cdhash ?: @"(nil)");
+      return IdentityVerifyResult::kDriftAllowed;
+    }
+
+    // Case 4: no signing_id either side (ad-hoc) -> cdhash must match.
+    if (CdhashEqual(targetProc->cdhash, csInfo.cdhash)) {
+      return IdentityVerifyResult::kMatch;
+    }
+    LOGW(@"Identity verification: ad hoc cdhash mismatch path=%@ es_cdhash=%@ disk_cdhash=%@", path,
+         esCdhashHex(), csInfo.cdhash ?: @"(nil)");
+    return IdentityVerifyResult::kMismatch;
   }
 
   // Case 5: both unsigned -> stat compare on (dev, ino, size, mtime).
   struct stat st;
-  if (fstat(fd, &st) != 0) return IdentityVerifyResult::kMismatch;  // fail-closed
-  const struct stat* esStat = &targetProc->executable->stat;
-  if (st.st_dev != esStat->st_dev || st.st_ino != esStat->st_ino) {
-    return IdentityVerifyResult::kMismatch;
+  if (fstat(fd, &st) != 0) {
+    LOGW(@"Identity verification: disk fstat failed path=%@ errno=%d", path, errno);
+    return IdentityVerifyResult::kMismatch;  // fail-closed
   }
-  if (st.st_size != esStat->st_size) return IdentityVerifyResult::kMismatch;
-  if (st.st_mtimespec.tv_sec != esStat->st_mtimespec.tv_sec ||
+  const struct stat* esStat = &targetProc->executable->stat;
+  if (st.st_dev != esStat->st_dev || st.st_ino != esStat->st_ino || st.st_size != esStat->st_size ||
+      st.st_mtimespec.tv_sec != esStat->st_mtimespec.tv_sec ||
       st.st_mtimespec.tv_nsec != esStat->st_mtimespec.tv_nsec) {
+    LOGW(@"Identity verification: unsigned binary metadata mismatch path=%@ "
+         @"es_dev=%d disk_dev=%d es_ino=%llu disk_ino=%llu "
+         @"es_size=%lld disk_size=%lld es_mtime=%ld.%09ld disk_mtime=%ld.%09ld",
+         path, esStat->st_dev, st.st_dev, (unsigned long long)esStat->st_ino,
+         (unsigned long long)st.st_ino, (long long)esStat->st_size, (long long)st.st_size,
+         (long)esStat->st_mtimespec.tv_sec, (long)esStat->st_mtimespec.tv_nsec,
+         (long)st.st_mtimespec.tv_sec, (long)st.st_mtimespec.tv_nsec);
     return IdentityVerifyResult::kMismatch;
   }
   return IdentityVerifyResult::kMatch;
@@ -609,16 +665,19 @@ static void UpdateCachedDecisionSigningInfo(
 
   NSError* csInfoError;
   if (!cd.certSHA256.length) {
-    // Grab the code signature, if there's an error don't try to capture
-    // any of the signature details.
-    // TODO(mlw): MOLCodesignChecker should be updated to still grab signing information
-    // even if validity check fails. Once that is done, this code can be updated to grab
-    // cert information so that it can still be reported to the sync server.
     MOLCodesignChecker* csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
-    MOLCodesignChecker* checkerForVerify = csInfoError ? nil : csInfo;
 
+    // The verifier compares ES-side identity against whatever identity MOL
+    // was able to extract. MOLCodesignChecker populates `_signingInformation`
+    // for partial-validity errors that still let SecCodeCopySigningInformation
+    // succeed (e.g. errSecCSInfoPlistFailed for binaries inside bundles, where
+    // SecStaticCode via /dev/fd/N can't reach the bundle's Info.plist). When
+    // identity could not be extracted (createWithPath failed, or MOL's per-arch
+    // consistency check tripped errSecCSSignatureInvalid in MOL's domain), the
+    // cdhash is empty and the verifier's case-1 signedness check returns a
+    // mismatch on its own — no special-casing needed at the call site.
     if (verifyIdentity) {
-      switch (verifyIdentity(checkerForVerify)) {
+      switch (verifyIdentity(csInfo)) {
         case IdentityVerifyResult::kMismatch:
           cd.decision = SNTEventStateBlockBinaryMismatch;
           cd.decisionExtra = @"Binary identity mismatch between ES event and on-disk file";
@@ -630,14 +689,15 @@ static void UpdateCachedDecisionSigningInfo(
       }
     }
 
-    if (csInfoError) {
-      csInfo = nil;
+    if (csInfo && csInfo.cdhash.length > 0) {
+      // Identity was extracted — populate signing details and keep whatever
+      // signingStatus the kernel reported, even if csInfoError is set.
+      UpdateCachedDecisionSigningInfo(cd, csInfo, platformBinaryState, entitlementsFilterCallback);
+    } else if (csInfoError) {
       cd.decisionExtra = [NSString
           stringWithFormat:@"Signature ignored due to error: %ld", (long)csInfoError.code];
       cd.signingStatus = (cd.signingStatus == SNTSigningStatusUnsigned ? SNTSigningStatusUnsigned
                                                                        : SNTSigningStatusInvalid);
-    } else {
-      UpdateCachedDecisionSigningInfo(cd, csInfo, platformBinaryState, entitlementsFilterCallback);
     }
   }
 

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -589,7 +589,10 @@ static void UpdateCachedDecisionSigningInfo(
         (NSDictionary* _Nullable (^_Nullable)(NSDictionary* _Nullable entitlements))
             entitlementsFilterCallback {
   // If the binary is a critical system binary, don't check its signature.
-  // The binary was validated at startup when the rule table was initialized.
+  // Critical binaries are SIP or tamper protected and were validated at
+  // startup when the rule table was initialized; the kernel's CS_KILL/CS_HARD
+  // enforcement guarantees the SigningID matched here can only be issued for
+  // legitimately-signed binaries with that identity.
   SNTCachedDecision* systemCd = [self.ruleTable.criticalSystemBinaries[cd.signingID] copy];
   if (systemCd) {
     systemCd.decisionClientMode = configState.clientMode;

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -626,8 +626,7 @@ static void UpdateCachedDecisionSigningInfo(
         case IdentityVerifyResult::kDriftAllowed:
           cd.decisionExtra = @"CDHash drift allowed by matching TeamID/SigningID";
           break;
-        case IdentityVerifyResult::kMatch:
-          break;
+        case IdentityVerifyResult::kMatch: break;
       }
     }
 

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -20,6 +20,8 @@
 #include <Kernel/kern/cs_blobs.h>
 #import <Security/SecCode.h>
 #import <Security/Security.h>
+#include <string.h>
+#include <sys/stat.h>
 
 #import "Source/common/CertificateHelpers.h"
 #import "Source/common/MOLCodesignChecker.h"
@@ -44,6 +46,15 @@ enum class PlatformBinaryState {
   kRuntimeFalse,
   kStaticCheck,
 };
+
+using VerifyIdentityBlock = IdentityVerifyResult (^)(MOLCodesignChecker* _Nullable csInfo);
+
+static BOOL CdhashEqual(const uint8_t* targetCdhash, NSString* _Nullable diskCdhashHex) {
+  if (!diskCdhashHex || diskCdhashHex.length != CS_CDHASH_LEN * 2) return NO;
+  std::vector<uint8_t> diskBytes = santa::HexStringToBuf(diskCdhashHex);
+  if (diskBytes.size() != CS_CDHASH_LEN) return NO;
+  return memcmp(targetCdhash, diskBytes.data(), CS_CDHASH_LEN) == 0;
+}
 
 struct CELEvaluationResult {
   bool succeeded;            // Whether CEL evaluation succeeded
@@ -519,6 +530,53 @@ static void UpdateCachedDecisionSigningInfo(
   cd.signingTime = csInfo.signingTime;
 }
 
++ (IdentityVerifyResult)verifyIdentityForTargetProc:(const es_process_t*)targetProc
+                                                 fd:(int)fd
+                                             csInfo:(MOLCodesignChecker*)csInfo {
+  BOOL esSigned = (targetProc->codesigning_flags & CS_SIGNED) != 0;
+  BOOL diskSigned = (csInfo != nil && csInfo.cdhash.length > 0);
+
+  // Case 1: signedness disagrees.
+  if (esSigned != diskSigned) return IdentityVerifyResult::kMismatch;
+
+  if (esSigned) {
+    BOOL esHasIDs = targetProc->team_id.length > 0 && targetProc->signing_id.length > 0;
+    BOOL diskHasIDs = csInfo.teamID.length > 0 && csInfo.signingID.length > 0;
+
+    // Case 2: TID/SID presence disagrees.
+    if (esHasIDs != diskHasIDs) return IdentityVerifyResult::kMismatch;
+
+    if (esHasIDs) {
+      // Case 3: both signed, both have TID/SID — compare IDs then cdhash.
+      NSString* esTeam = @(targetProc->team_id.data);
+      NSString* esSID = @(targetProc->signing_id.data);
+      if (![esTeam isEqualToString:csInfo.teamID] || ![esSID isEqualToString:csInfo.signingID]) {
+        return IdentityVerifyResult::kMismatch;
+      }
+      return CdhashEqual(targetProc->cdhash, csInfo.cdhash) ? IdentityVerifyResult::kMatch
+                                                            : IdentityVerifyResult::kDriftAllowed;
+    }
+
+    // Case 4: both signed, neither has TID/SID (ad-hoc / platform-only) -> cdhash must match.
+    return CdhashEqual(targetProc->cdhash, csInfo.cdhash) ? IdentityVerifyResult::kMatch
+                                                          : IdentityVerifyResult::kMismatch;
+  }
+
+  // Case 5: both unsigned -> stat compare on (dev, ino, size, mtime).
+  struct stat st;
+  if (fstat(fd, &st) != 0) return IdentityVerifyResult::kMismatch;  // fail-closed
+  const struct stat* esStat = &targetProc->executable->stat;
+  if (st.st_dev != esStat->st_dev || st.st_ino != esStat->st_ino) {
+    return IdentityVerifyResult::kMismatch;
+  }
+  if (st.st_size != esStat->st_size) return IdentityVerifyResult::kMismatch;
+  if (st.st_mtimespec.tv_sec != esStat->st_mtimespec.tv_sec ||
+      st.st_mtimespec.tv_nsec != esStat->st_mtimespec.tv_nsec) {
+    return IdentityVerifyResult::kMismatch;
+  }
+  return IdentityVerifyResult::kMatch;
+}
+
 - (nonnull SNTCachedDecision*)
            decisionForFileInfo:(nonnull SNTFileInfo*)fileInfo
                    configState:(nonnull SNTConfigState*)configState
@@ -526,6 +584,7 @@ static void UpdateCachedDecisionSigningInfo(
            platformBinaryState:(PlatformBinaryState)platformBinaryState
          signingStatusCallback:(SNTSigningStatus (^_Nonnull)())signingStatusCallback
             activationCallback:(nullable ActivationCallbackBlock)activationCallback
+                verifyIdentity:(nullable VerifyIdentityBlock)verifyIdentity
     entitlementsFilterCallback:
         (NSDictionary* _Nullable (^_Nullable)(NSDictionary* _Nullable entitlements))
             entitlementsFilterCallback {
@@ -553,6 +612,22 @@ static void UpdateCachedDecisionSigningInfo(
     // even if validity check fails. Once that is done, this code can be updated to grab
     // cert information so that it can still be reported to the sync server.
     MOLCodesignChecker* csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
+    MOLCodesignChecker* checkerForVerify = csInfoError ? nil : csInfo;
+
+    if (verifyIdentity) {
+      switch (verifyIdentity(checkerForVerify)) {
+        case IdentityVerifyResult::kMismatch:
+          cd.decision = SNTEventStateBlockBinaryMismatch;
+          cd.decisionExtra = @"Binary identity mismatch between ES event and on-disk file";
+          return cd;
+        case IdentityVerifyResult::kDriftAllowed:
+          cd.decisionExtra = @"CDHash drift allowed by matching TeamID/SigningID";
+          break;
+        case IdentityVerifyResult::kMatch:
+          break;
+      }
+    }
+
     if (csInfoError) {
       csInfo = nil;
       cd.decisionExtra = [NSString
@@ -667,6 +742,14 @@ static void UpdateCachedDecisionSigningInfo(
     }
   }
 
+  VerifyIdentityBlock verifyIdentity = nil;
+  if (!existingDecision) {
+    int fd = fileInfo.fileHandle.fileDescriptor;
+    verifyIdentity = ^IdentityVerifyResult(MOLCodesignChecker* _Nullable csInfo) {
+      return [SNTPolicyProcessor verifyIdentityForTargetProc:targetProc fd:fd csInfo:csInfo];
+    };
+  }
+
   return [self decisionForFileInfo:fileInfo
       configState:configState
       cachedDecision:cd
@@ -686,6 +769,7 @@ static void UpdateCachedDecisionSigningInfo(
         }
       }
       activationCallback:activationCallback
+      verifyIdentity:verifyIdentity
       entitlementsFilterCallback:^NSDictionary*(NSDictionary* entitlements) {
         return entitlementsFilter_->Filter(entitlementsFilterTeamID, entitlements);
       }];

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -664,8 +664,9 @@ static void UpdateCachedDecisionSigningInfo(
   cd.quarantineURL = fileInfo.quarantineDataURL;
 
   NSError* csInfoError;
+  MOLCodesignChecker* csInfo;
   if (!cd.certSHA256.length) {
-    MOLCodesignChecker* csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
+    csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
 
     // The verifier compares ES-side identity against whatever identity MOL
     // was able to extract. MOLCodesignChecker populates `_signingInformation`
@@ -712,8 +713,14 @@ static void UpdateCachedDecisionSigningInfo(
     }
   }
 
+  // Skip bad-sig protection when MOL surfaced a partial-validity error but
+  // identity was still extractable (e.g. errSecCSInfoPlistFailed when reading
+  // a bundle binary via /dev/fd/N — the signature itself is intact, only the
+  // bundle's side-input Info.plist file was unreachable through the fd).
+  // Mirrors the same identity-extracted predicate used at the
+  // UpdateCachedDecisionSigningInfo callsite above.
   if ([[SNTConfigurator configurator] enableBadSignatureProtection] && csInfoError &&
-      csInfoError.code != errSecCSUnsigned) {
+      csInfoError.code != errSecCSUnsigned && !(csInfo && csInfo.cdhash.length > 0)) {
     cd.decisionExtra =
         [NSString stringWithFormat:@"Blocked due to signature error: %ld", (long)csInfoError.code];
     cd.decision = SNTEventStateBlockCertificate;

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -16,14 +16,24 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 
 #import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#include <Kernel/kern/cs_blobs.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#import "Source/common/MOLCodesignChecker.h"
 #import "Source/common/SNTCELFallbackRule.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTConfigState.h"
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
+#include "Source/common/ScopedFile.h"
+#import "Source/common/TestUtils.h"
 #import "Source/common/cel/Activation.h"
 
 #include "cel/v1.pb.h"
@@ -57,6 +67,40 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   XCTAssertTrue(res, "teamID mismatch: got: %@, want: %@", r1.teamID, r2.teamID);
 
   return res;
+}
+
+// Helpers for the verifyIdentity tests at the bottom of the file.
+static const uint8_t kHashA[20] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+                                   0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14};
+static const uint8_t kHashB[20] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33,
+                                   0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd};
+
+static NSString* HexOf(const uint8_t* b, size_t n) {
+  NSMutableString* s = [NSMutableString stringWithCapacity:n * 2];
+  for (size_t i = 0; i < n; i++) [s appendFormat:@"%02x", b[i]];
+  return s;
+}
+
+// Builds an es_file_t + es_process_t pair. The es_file_t is stored in an out-param
+// since es_process_t holds a pointer into it. Caller keeps both alive for the test.
+static void MakeTargetProc(es_file_t* outFile, es_process_t* outProc, const char* path,
+                           struct stat sb, uint32_t csFlags, const char* teamID,
+                           const char* signingID, const uint8_t cdhash[20]) {
+  *outFile = MakeESFile(path, sb);
+  *outProc = MakeESProcess(outFile);
+  outProc->codesigning_flags = csFlags;
+  outProc->team_id = MakeESStringToken(teamID);
+  outProc->signing_id = MakeESStringToken(signingID);
+  memcpy(outProc->cdhash, cdhash, 20);
+}
+
+static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
+                                           NSString* signingID) {
+  MOLCodesignChecker* m = OCMClassMock([MOLCodesignChecker class]);
+  OCMStub([m cdhash]).andReturn(cdhash);
+  OCMStub([m teamID]).andReturn(teamID);
+  OCMStub([m signingID]).andReturn(signingID);
+  return m;
 }
 
 @interface SNTPolicyProcessorTest : XCTestCase
@@ -1283,6 +1327,324 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   [self.processor decision:cd forRule:rule withTransitiveRules:YES andCELActivationCallback:nil];
   XCTAssertEqual(cd.decision, SNTEventStateAllowBinary);
   XCTAssertEqual(cd.ruleId, 0LL);
+}
+
+#pragma mark - End-to-end integration tests (outer decisionForFileInfo:targetProcess:…)
+
+// Unsigned file + ES stat that disagrees with disk → should return BlockBinaryMismatch.
+- (void)testOuter_Unsigned_StatMismatch_ReturnsBlockBinaryMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(
+      /*path_prefix=*/nil, /*size=*/16,
+      /*filename_template=*/@"santa_test_XXXXXX", /*keep_path=*/true);
+  XCTAssertStatusOk(scopedFile);
+
+  NSError *err;
+  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
+  XCTAssertNotNil(fi);
+
+  struct stat fakeStat = MakeStat(/*offset=*/42);  // differs from the real file's stat
+  es_file_t esFile = MakeESFile(scopedFile->Path().UTF8String, fakeStat);
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = 0;  // unsigned
+  esProc.team_id = MakeESStringToken("");
+  esProc.signing_id = MakeESStringToken("");
+
+  SNTConfigState *cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  SNTCachedDecision *cd = [self.processor decisionForFileInfo:fi
+                                                 targetProcess:&esProc
+                                                   configState:cs
+                                            activationCallback:nil
+                                                cachedDecision:nil];
+
+  XCTAssertEqual(cd.decision, SNTEventStateBlockBinaryMismatch);
+  XCTAssertNotNil(cd.decisionExtra);
+  XCTAssertFalse(cd.holdAndAsk, @"mismatch must never be TouchID-overridable");
+  XCTAssertNotEqual(cd.decision & SNTEventStateBlock, (SNTEventState)0);
+  XCTAssertEqual(cd.decision & SNTEventStateAllow, (SNTEventState)0);
+}
+
+// Re-eval path (existingDecision non-nil) with ES/disk disagreement: verifyIdentity is skipped,
+// so BlockBinaryMismatch must NOT be returned.
+- (void)testOuter_ReEvalPath_VerificationSkipped {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 16, @"santa_test_XXXXXX",
+                                                       /*keep_path=*/true);
+  XCTAssertStatusOk(scopedFile);
+
+  NSError *err;
+  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
+  XCTAssertNotNil(fi);
+
+  // Deliberate stat mismatch — if verifyIdentity ran, this would short-circuit to
+  // SNTEventStateBlockBinaryMismatch.
+  struct stat fakeStat = MakeStat(/*offset=*/42);
+  es_file_t esFile = MakeESFile(scopedFile->Path().UTF8String, fakeStat);
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = 0;
+  esProc.team_id = MakeESStringToken("");
+  esProc.signing_id = MakeESStringToken("");
+
+  // Seed an existing decision with NO certSHA256 — so the inner method's codesign
+  // branch (`if (!cd.certSHA256.length)`) would fire and would invoke verifyIdentity
+  // if it were non-nil. The bypass invariant under test is that the outer method
+  // passes verifyIdentity:nil whenever existingDecision is non-nil (per spec §4),
+  // independent of the inner method's certSHA256-skip optimization.
+  SNTCachedDecision *existing = [[SNTCachedDecision alloc] init];
+  // Do NOT set certSHA256.
+
+  SNTConfigState *cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  SNTCachedDecision *cd = [self.processor decisionForFileInfo:fi
+                                                 targetProcess:&esProc
+                                                   configState:cs
+                                            activationCallback:nil
+                                                cachedDecision:existing];
+
+  XCTAssertNotEqual(cd.decision, SNTEventStateBlockBinaryMismatch,
+                    @"re-eval path must never surface BinaryMismatch (outer method "
+                    @"is required to pass verifyIdentity:nil when existingDecision "
+                    @"is non-nil per spec §4)");
+}
+
+// Unsigned file + ES stat that agrees with disk → should NOT return BlockBinaryMismatch.
+- (void)testOuter_Unsigned_StatMatches_NoMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 16, @"santa_test_XXXXXX",
+                                                       /*keep_path=*/true);
+  XCTAssertStatusOk(scopedFile);
+
+  NSError *err;
+  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
+  XCTAssertNotNil(fi);
+
+  struct stat realStat;
+  XCTAssertEqual(fstat(fi.fileHandle.fileDescriptor, &realStat), 0);
+
+  es_file_t esFile = MakeESFile(scopedFile->Path().UTF8String, realStat);
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = 0;
+  esProc.team_id = MakeESStringToken("");
+  esProc.signing_id = MakeESStringToken("");
+
+  SNTConfigState *cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  SNTCachedDecision *cd = [self.processor decisionForFileInfo:fi
+                                                 targetProcess:&esProc
+                                                   configState:cs
+                                            activationCallback:nil
+                                                cachedDecision:nil];
+
+  XCTAssertNotEqual(cd.decision, SNTEventStateBlockBinaryMismatch);
+}
+
+#pragma mark - +verifyIdentityForTargetProc:fd:csInfo: tests
+
+// Case 1: ES signed, disk unsigned (csInfo == nil) -> Mismatch.
+- (void)testVerifyIdentity_SignednessDisagrees_EsSignedDiskUnsigned_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T", "S", kHashA);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 1 (symmetric): ES unsigned, disk signed -> Mismatch.
+- (void)testVerifyIdentity_SignednessDisagrees_EsUnsignedDiskSigned_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), /*csFlags=*/0, "", "", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"T", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 2: only ES has TID/SID -> Mismatch.
+- (void)testVerifyIdentity_IDPresenceDisagrees_OnlyEsHasIDs_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T", "S", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"", @"");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 2: only disk has TID/SID -> Mismatch.
+- (void)testVerifyIdentity_IDPresenceDisagrees_OnlyDiskHasIDs_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "", "", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"T", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 3: both have IDs, team ID differs -> Mismatch.
+- (void)testVerifyIdentity_BothHaveIDs_TeamIDDiffers_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T1", "S", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"T2", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 3: both have IDs, signing ID differs -> Mismatch.
+- (void)testVerifyIdentity_BothHaveIDs_SigningIDDiffers_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T", "S1", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"T", @"S2");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 3: both have IDs, IDs agree, cdhash agrees -> Match.
+- (void)testVerifyIdentity_BothHaveIDs_IDsAgreeCdhashAgrees_ReturnsMatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T", "S", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"T", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMatch);
+}
+
+// Case 3: both have IDs, IDs agree, cdhash drifts -> DriftAllowed.
+- (void)testVerifyIdentity_BothHaveIDs_IDsAgreeCdhashDrifts_ReturnsDriftAllowed {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T", "S", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashB, 20), @"T", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kDriftAllowed);
+}
+
+// Case 4: both signed, neither has TID/SID (ad-hoc), cdhash agrees -> Match.
+- (void)testVerifyIdentity_BothSignedNeitherHasIDs_CdhashAgrees_ReturnsMatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "", "", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), nil, nil);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMatch);
+}
+
+// Case 4: both signed, neither has TID/SID (ad-hoc), cdhash differs -> Mismatch.
+- (void)testVerifyIdentity_BothSignedNeitherHasIDs_CdhashDiffers_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "", "", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashB, 20), nil, nil);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Edge case: signed ES target but disk cdhash is empty -> diskSigned=false ->
+// signedness disagrees (Case 1) -> Mismatch. (This path returns from Case 1, not
+// from the unsigned-path Case 5.)
+- (void)testVerifyIdentity_SignedTargetDiskCdhashEmpty_TreatedAsUnsigned_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, "T", "S", kHashA);
+  MOLCodesignChecker* csInfo = MakeMockChecker(@"", @"T", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Case 5: both unsigned, stat fields all agree -> Match.
+- (void)testVerifyIdentity_Unsigned_StatMatches_ReturnsMatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(/*path_prefix=*/nil, /*size=*/100);
+  XCTAssertStatusOk(scopedFile);
+  struct stat realStat;
+  XCTAssertEqual(fstat(scopedFile->UnsafeFD(), &realStat), 0);
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", realStat, /*csFlags=*/0, "", "", kHashA);
+  XCTAssertEqual(
+      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
+      IdentityVerifyResult::kMatch);
+}
+
+// Case 5: both unsigned, st_dev differs -> Mismatch.
+- (void)testVerifyIdentity_Unsigned_DevDiffers_ReturnsMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 100);
+  XCTAssertStatusOk(scopedFile);
+  struct stat realStat;
+  XCTAssertEqual(fstat(scopedFile->UnsafeFD(), &realStat), 0);
+  realStat.st_dev += 1;
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
+  XCTAssertEqual(
+      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
+      IdentityVerifyResult::kMismatch);
+}
+
+// Case 5: both unsigned, st_ino differs -> Mismatch.
+- (void)testVerifyIdentity_Unsigned_InoDiffers_ReturnsMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 100);
+  XCTAssertStatusOk(scopedFile);
+  struct stat realStat;
+  XCTAssertEqual(fstat(scopedFile->UnsafeFD(), &realStat), 0);
+  realStat.st_ino += 1;
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
+  XCTAssertEqual(
+      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
+      IdentityVerifyResult::kMismatch);
+}
+
+// Case 5: both unsigned, st_size differs -> Mismatch.
+- (void)testVerifyIdentity_Unsigned_SizeDiffers_ReturnsMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 100);
+  XCTAssertStatusOk(scopedFile);
+  struct stat realStat;
+  XCTAssertEqual(fstat(scopedFile->UnsafeFD(), &realStat), 0);
+  realStat.st_size += 1;
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
+  XCTAssertEqual(
+      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
+      IdentityVerifyResult::kMismatch);
+}
+
+// Case 5: both unsigned, st_mtimespec.tv_sec differs -> Mismatch.
+- (void)testVerifyIdentity_Unsigned_MtimeSecDiffers_ReturnsMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 100);
+  XCTAssertStatusOk(scopedFile);
+  struct stat realStat;
+  XCTAssertEqual(fstat(scopedFile->UnsafeFD(), &realStat), 0);
+  realStat.st_mtimespec.tv_sec += 1;
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
+  XCTAssertEqual(
+      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
+      IdentityVerifyResult::kMismatch);
+}
+
+// Case 5: both unsigned, st_mtimespec.tv_nsec differs -> Mismatch.
+- (void)testVerifyIdentity_Unsigned_MtimeNsecDiffers_ReturnsMismatch {
+  auto scopedFile = santa::ScopedFile::CreateTemporary(nil, 100);
+  XCTAssertStatusOk(scopedFile);
+  struct stat realStat;
+  XCTAssertEqual(fstat(scopedFile->UnsafeFD(), &realStat), 0);
+  realStat.st_mtimespec.tv_nsec += 1;
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
+  XCTAssertEqual(
+      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
+      IdentityVerifyResult::kMismatch);
+}
+
+// Case 5: both unsigned, fstat fails (invalid fd) -> Mismatch (fail-closed).
+- (void)testVerifyIdentity_Unsigned_FstatFails_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), /*csFlags=*/0, "", "", kHashA);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
 }
 
 @end

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -20,6 +20,7 @@
 #import <XCTest/XCTest.h>
 
 #include <Kernel/kern/cs_blobs.h>
+#include <mach/machine.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -1438,6 +1439,81 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   XCTAssertNotEqual(cd.decision, SNTEventStateBlockBinaryMismatch);
 }
 
+// Per-arch-inconsistent universal binary: the active slice's cert chain must populate
+// cd.certSHA256. This exercises the end-to-end path through decisionForFileInfo:targetProcess: with
+// a real fixture that carries two different cert chains across its slices.
+- (void)testOuter_PerArchInconsistent_ActiveSlicePopulatesCertSHA256 {
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* fixturePath = [bundle pathForResource:@"cal-yikes-universal_signed" ofType:@""];
+  XCTAssertNotNil(fixturePath, @"fixture missing — check BUILD resources");
+
+  struct stat realStat;
+  XCTAssertEqual(stat(fixturePath.UTF8String, &realStat), 0);
+
+  // Compute the expected leaf-cert SHA256 directly from MOL using the same arch hint,
+  // so the assertion is grounded in the fixture's actual cert chain rather than a
+  // hard-coded string.
+  NSError* csErr;
+  MOLCodesignChecker* expectedCS =
+      [[MOLCodesignChecker alloc] initWithBinaryPath:fixturePath
+                                      fileDescriptor:-1
+                                             cpuType:CPU_TYPE_I386
+                                          cpuSubtype:CPU_SUBTYPE_I386_ALL
+                                               error:&csErr];
+  NSString* expectedCertSHA256 = expectedCS.leafCertificate.SHA256;
+  XCTAssertNotNil(expectedCertSHA256, @"expected real cert chain on the i386 slice");
+
+  // Build a synthetic es_file_t + es_process_t for the fixture path.
+  // The i386 slice of cal-yikes-universal_signed has team "998Z9C32TC" and
+  // identifier "yikes-i386-signed".  kHashA is a placeholder cdhash that won't
+  // match the on-disk cdhash; the verifier returns kDriftAllowed (team+SID match,
+  // cdhash drifts), allowing the signing path to proceed and populate certSHA256.
+  // This is the realistic scenario: the ES event carries the kernel-assigned cdhash
+  // for the loaded slice while MOL re-evaluates from the file, with the same result
+  // for a legitimately-signed binary with a small page-hash refresh.
+  // CS_SIGNED|CS_VALID|CS_KILL: signingStatusCallback() returns Production.
+  es_file_t esFile;
+  es_process_t esProc;
+  MakeTargetProc(&esFile, &esProc, fixturePath.UTF8String, realStat, CS_SIGNED | CS_VALID | CS_KILL,
+                 /*team=*/"998Z9C32TC",
+                 /*sid=*/"yikes-i386-signed", kHashA);
+
+  // Attach the arch hint via a synthetic es_event_exec_t so that SNTFileInfo picks up
+  // the i386 slice when it opens the Mach-O.
+  es_event_exec_t esExec = {};
+  esExec.target = &esProc;
+  esExec.image_cputype = CPU_TYPE_I386;
+  esExec.image_cpusubtype = CPU_SUBTYPE_I386_ALL;
+
+  NSError* fiErr;
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithEndpointSecurityExecEvent:&esExec error:&fiErr];
+  XCTAssertNotNil(fi);
+  XCTAssertEqual(fi.cpuType, CPU_TYPE_I386);
+
+  // Verify codesignChecker is non-nil and has a cdhash (pre-flight the assumption
+  // this integration test is built on).
+  NSError* csCheckErr;
+  MOLCodesignChecker* csCheck = [fi codesignCheckerWithError:&csCheckErr];
+  XCTAssertNotNil(csCheck, @"codesignChecker must be non-nil for a signed fixture");
+  XCTAssertGreaterThan(csCheck.cdhash.length, 0u, @"cdhash must be non-empty for the active slice");
+  XCTAssertNotNil(csCheck.leafCertificate, @"leaf cert must be present for the active slice");
+  XCTAssertEqualObjects(csCheck.leafCertificate.SHA256, expectedCertSHA256,
+                        @"SNTFileInfo codesignChecker must return the i386-slice cert chain");
+
+  SNTConfigState* cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  SNTCachedDecision* cd = [self.processor decisionForFileInfo:fi
+                                                targetProcess:&esProc
+                                                  configState:cs
+                                           activationCallback:nil
+                                               cachedDecision:nil];
+
+  XCTAssertEqualObjects(cd.certSHA256, expectedCertSHA256,
+                        @"cert chain should populate from the active i386 slice");
+  XCTAssertNotEqual(cd.signingStatus, SNTSigningStatusInvalid,
+                    @"signingStatus must reflect the active slice's real state, not Invalid");
+}
+
 #pragma mark - +verifyIdentityForTargetProc:fd:csInfo: tests
 
 // Case 1: ES signed, disk unsigned (csInfo == nil) -> Mismatch.
@@ -1674,8 +1750,7 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"",
                  /*sid=*/"com.apple.dt.X", kHashA);
   XCTAssertTrue(proc.is_platform_binary);  // default from MakeESProcess
-  MOLCodesignChecker* csInfo =
-      MakeMockChecker(HexOf(kHashA, 20), @"59GAB85EFG", @"com.apple.dt.X");
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"59GAB85EFG", @"com.apple.dt.X");
   XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
                  IdentityVerifyResult::kMatch);
 }
@@ -1688,8 +1763,7 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"",
                  /*sid=*/"com.apple.dt.X", kHashA);
-  MOLCodesignChecker* csInfo =
-      MakeMockChecker(HexOf(kHashB, 20), @"59GAB85EFG", @"com.apple.dt.X");
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashB, 20), @"59GAB85EFG", @"com.apple.dt.X");
   XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
                  IdentityVerifyResult::kDriftAllowed);
 }
@@ -1701,8 +1775,7 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"",
                  /*sid=*/"com.apple.dt.X", kHashA);
-  MOLCodesignChecker* csInfo =
-      MakeMockChecker(HexOf(kHashA, 20), @"59GAB85EFG", @"com.apple.dt.Y");
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"59GAB85EFG", @"com.apple.dt.Y");
   XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
                  IdentityVerifyResult::kMismatch);
 }

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -77,7 +77,8 @@ static const uint8_t kHashB[20] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x1
 
 static NSString* HexOf(const uint8_t* b, size_t n) {
   NSMutableString* s = [NSMutableString stringWithCapacity:n * 2];
-  for (size_t i = 0; i < n; i++) [s appendFormat:@"%02x", b[i]];
+  for (size_t i = 0; i < n; i++)
+    [s appendFormat:@"%02x", b[i]];
   return s;
 }
 
@@ -1338,8 +1339,8 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
       /*filename_template=*/@"santa_test_XXXXXX", /*keep_path=*/true);
   XCTAssertStatusOk(scopedFile);
 
-  NSError *err;
-  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
+  NSError* err;
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
   XCTAssertNotNil(fi);
 
   struct stat fakeStat = MakeStat(/*offset=*/42);  // differs from the real file's stat
@@ -1349,13 +1350,13 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   esProc.team_id = MakeESStringToken("");
   esProc.signing_id = MakeESStringToken("");
 
-  SNTConfigState *cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+  SNTConfigState* cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
 
-  SNTCachedDecision *cd = [self.processor decisionForFileInfo:fi
-                                                 targetProcess:&esProc
-                                                   configState:cs
-                                            activationCallback:nil
-                                                cachedDecision:nil];
+  SNTCachedDecision* cd = [self.processor decisionForFileInfo:fi
+                                                targetProcess:&esProc
+                                                  configState:cs
+                                           activationCallback:nil
+                                               cachedDecision:nil];
 
   XCTAssertEqual(cd.decision, SNTEventStateBlockBinaryMismatch);
   XCTAssertEqualObjects(cd.decisionExtra,
@@ -1372,8 +1373,8 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
                                                        /*keep_path=*/true);
   XCTAssertStatusOk(scopedFile);
 
-  NSError *err;
-  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
+  NSError* err;
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
   XCTAssertNotNil(fi);
 
   // Deliberate stat mismatch — if verifyIdentity ran, this would short-circuit to
@@ -1390,16 +1391,16 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   // if it were non-nil. The bypass invariant under test is that the outer method
   // passes verifyIdentity:nil whenever existingDecision is non-nil (per spec §4),
   // independent of the inner method's certSHA256-skip optimization.
-  SNTCachedDecision *existing = [[SNTCachedDecision alloc] init];
+  SNTCachedDecision* existing = [[SNTCachedDecision alloc] init];
   // Do NOT set certSHA256.
 
-  SNTConfigState *cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+  SNTConfigState* cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
 
-  SNTCachedDecision *cd = [self.processor decisionForFileInfo:fi
-                                                 targetProcess:&esProc
-                                                   configState:cs
-                                            activationCallback:nil
-                                                cachedDecision:existing];
+  SNTCachedDecision* cd = [self.processor decisionForFileInfo:fi
+                                                targetProcess:&esProc
+                                                  configState:cs
+                                           activationCallback:nil
+                                               cachedDecision:existing];
 
   XCTAssertNotEqual(cd.decision, SNTEventStateBlockBinaryMismatch,
                     @"re-eval path must never surface BinaryMismatch (outer method "
@@ -1413,8 +1414,8 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
                                                        /*keep_path=*/true);
   XCTAssertStatusOk(scopedFile);
 
-  NSError *err;
-  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
+  NSError* err;
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:scopedFile->Path() error:&err];
   XCTAssertNotNil(fi);
 
   struct stat realStat;
@@ -1426,13 +1427,13 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   esProc.team_id = MakeESStringToken("");
   esProc.signing_id = MakeESStringToken("");
 
-  SNTConfigState *cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+  SNTConfigState* cs = [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
 
-  SNTCachedDecision *cd = [self.processor decisionForFileInfo:fi
-                                                 targetProcess:&esProc
-                                                   configState:cs
-                                            activationCallback:nil
-                                                cachedDecision:nil];
+  SNTCachedDecision* cd = [self.processor decisionForFileInfo:fi
+                                                targetProcess:&esProc
+                                                  configState:cs
+                                           activationCallback:nil
+                                               cachedDecision:nil];
 
   XCTAssertNotEqual(cd.decision, SNTEventStateBlockBinaryMismatch);
 }
@@ -1559,9 +1560,10 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_file_t file;
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", realStat, /*csFlags=*/0, "", "", kHashA);
-  XCTAssertEqual(
-      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
-      IdentityVerifyResult::kMatch);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc
+                                                              fd:scopedFile->UnsafeFD()
+                                                          csInfo:nil],
+                 IdentityVerifyResult::kMatch);
 }
 
 // Case 5: both unsigned, st_dev differs -> Mismatch.
@@ -1574,9 +1576,10 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_file_t file;
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
-  XCTAssertEqual(
-      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
-      IdentityVerifyResult::kMismatch);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc
+                                                              fd:scopedFile->UnsafeFD()
+                                                          csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
 }
 
 // Case 5: both unsigned, st_ino differs -> Mismatch.
@@ -1589,9 +1592,10 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_file_t file;
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
-  XCTAssertEqual(
-      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
-      IdentityVerifyResult::kMismatch);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc
+                                                              fd:scopedFile->UnsafeFD()
+                                                          csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
 }
 
 // Case 5: both unsigned, st_size differs -> Mismatch.
@@ -1604,9 +1608,10 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_file_t file;
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
-  XCTAssertEqual(
-      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
-      IdentityVerifyResult::kMismatch);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc
+                                                              fd:scopedFile->UnsafeFD()
+                                                          csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
 }
 
 // Case 5: both unsigned, st_mtimespec.tv_sec differs -> Mismatch.
@@ -1619,9 +1624,10 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_file_t file;
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
-  XCTAssertEqual(
-      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
-      IdentityVerifyResult::kMismatch);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc
+                                                              fd:scopedFile->UnsafeFD()
+                                                          csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
 }
 
 // Case 5: both unsigned, st_mtimespec.tv_nsec differs -> Mismatch.
@@ -1634,9 +1640,10 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
   es_file_t file;
   es_process_t proc;
   MakeTargetProc(&file, &proc, "/tmp/test", realStat, 0, "", "", kHashA);
-  XCTAssertEqual(
-      [SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:scopedFile->UnsafeFD() csInfo:nil],
-      IdentityVerifyResult::kMismatch);
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc
+                                                              fd:scopedFile->UnsafeFD()
+                                                          csInfo:nil],
+                 IdentityVerifyResult::kMismatch);
 }
 
 // Case 5: both unsigned, fstat fails (invalid fd) -> Mismatch (fail-closed).

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1655,4 +1655,71 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
                  IdentityVerifyResult::kMismatch);
 }
 
+#pragma mark - Platform-binary team_id suppression (ES quirk)
+
+// ES does not populate team_id on the target field for binaries with
+// is_platform_binary=true, even when the on-disk signature carries a TeamID.
+// Observed in production for Apple-signed XPC services inside framework
+// bundles (Xcode helpers, Apple developer tooling). The verifier accommodates
+// this by suspending the team_id presence and equality checks on that path —
+// signing_id and cdhash continue to bind identity end-to-end. The four tests
+// below pin: the production case matches, drift still reaches kDriftAllowed,
+// signing_id mismatch still bites, and the non-platform path is unaffected.
+
+// Platform binary, ES team_id suppressed, disk has team_id, signing_id and
+// cdhash agree -> Match. The shape every Apple-signed XPC service produces.
+- (void)testVerifyIdentity_PlatformBinary_ESTeamSuppressed_DiskHasTeam_ReturnsMatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"",
+                 /*sid=*/"com.apple.dt.X", kHashA);
+  XCTAssertTrue(proc.is_platform_binary);  // default from MakeESProcess
+  MOLCodesignChecker* csInfo =
+      MakeMockChecker(HexOf(kHashA, 20), @"59GAB85EFG", @"com.apple.dt.X");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMatch);
+}
+
+// Platform binary, ES team_id suppressed, signing_id agrees, cdhash drifts ->
+// DriftAllowed. Same publisher (signing_id namespace), so the existing
+// drift-within-publisher reasoning carries over.
+- (void)testVerifyIdentity_PlatformBinary_ESTeamSuppressed_CdhashDrifts_ReturnsDriftAllowed {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"",
+                 /*sid=*/"com.apple.dt.X", kHashA);
+  MOLCodesignChecker* csInfo =
+      MakeMockChecker(HexOf(kHashB, 20), @"59GAB85EFG", @"com.apple.dt.X");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kDriftAllowed);
+}
+
+// Platform binary, ES team_id suppressed, signing_ids differ -> Mismatch.
+// Confirms signing_id equality still gates even when team is suppressed.
+- (void)testVerifyIdentity_PlatformBinary_ESTeamSuppressed_SigningIDDiffers_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"",
+                 /*sid=*/"com.apple.dt.X", kHashA);
+  MOLCodesignChecker* csInfo =
+      MakeMockChecker(HexOf(kHashA, 20), @"59GAB85EFG", @"com.apple.dt.Y");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
+// Non-platform binary, ES omits team_id but disk has one -> Mismatch.
+// Confirms the platform-binary relaxation does not bleed into the third-party
+// path: ES omitting team_id outside is_platform_binary=true is a real
+// presence disagreement and case-2 still bites.
+- (void)testVerifyIdentity_NonPlatform_ESNoTeam_DiskHasTeam_ReturnsMismatch {
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/test", MakeStat(), CS_SIGNED, /*team=*/"", /*sid=*/"S",
+                 kHashA);
+  proc.is_platform_binary = false;
+  MOLCodesignChecker* csInfo = MakeMockChecker(HexOf(kHashA, 20), @"T", @"S");
+  XCTAssertEqual([SNTPolicyProcessor verifyIdentityForTargetProc:&proc fd:-1 csInfo:csInfo],
+                 IdentityVerifyResult::kMismatch);
+}
+
 @end

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1358,7 +1358,8 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
                                                 cachedDecision:nil];
 
   XCTAssertEqual(cd.decision, SNTEventStateBlockBinaryMismatch);
-  XCTAssertNotNil(cd.decisionExtra);
+  XCTAssertEqualObjects(cd.decisionExtra,
+                        @"Binary identity mismatch between ES event and on-disk file");
   XCTAssertFalse(cd.holdAndAsk, @"mismatch must never be TouchID-overridable");
   XCTAssertNotEqual(cd.decision & SNTEventStateBlock, (SNTEventState)0);
   XCTAssertEqual(cd.decision & SNTEventStateAllow, (SNTEventState)0);

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1514,6 +1514,65 @@ static MOLCodesignChecker* MakeMockChecker(NSString* cdhash, NSString* teamID,
                     @"signingStatus must reflect the active slice's real state, not Invalid");
 }
 
+// enableBadSignatureProtection must NOT fire when MOL surfaces a partial-validity
+// error but identity was still extractable (the bundle-binary fd-binding case
+// where SecStaticCode via /dev/fd/N reports errSecCSInfoPlistFailed even though
+// cdhash / teamID / signingID / cert chain are all intact). Without the
+// identity-extracted gate at the bad-sig protection callsite, every bundle binary
+// on a host with enableBadSignatureProtection=YES would short-circuit to
+// BlockCertificate.
+- (void)testOuter_BadSigProtection_DoesNotFire_WhenIdentityExtracted {
+  id mockConfig = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfig configurator]).andReturn(mockConfig);
+  OCMStub([mockConfig enableBadSignatureProtection]).andReturn(YES);
+  OCMStub([mockConfig clientMode]).andReturn(SNTClientModeMonitor);
+
+  es_file_t file;
+  es_process_t proc;
+  MakeTargetProc(&file, &proc, "/tmp/fake_bundle_bin", MakeStat(), CS_SIGNED | CS_VALID | CS_KILL,
+                 /*team=*/"T", /*sid=*/"S", kHashA);
+  proc.is_platform_binary = false;
+
+  // The bundle-binary partial-validity shape: csInfo is non-nil with a populated
+  // cdhash, AND codesignCheckerWithError: surfaces errSecCSInfoPlistFailed.
+  NSError* infoPlistErr = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                              code:errSecCSInfoPlistFailed
+                                          userInfo:nil];
+  MOLCodesignChecker* mockChecker = MakeMockChecker(HexOf(kHashA, 20), @"T", @"S");
+
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMStub([mockFileInfo SHA256])
+      .andReturn(@"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+  OCMStub([mockFileInfo quarantineDataURL]).andReturn(nil);
+  OCMStub([mockFileInfo path]).andReturn(@"/tmp/fake_bundle_bin");
+  // fileHandle.fileDescriptor is consulted by the verifier block; -1 makes
+  // case-5 fstat fail-closed, but case-3 (signed, ID match, cdhash match) wins
+  // before that ever runs.
+  id mockHandle = OCMClassMock([NSFileHandle class]);
+  OCMStub([(NSFileHandle*)mockHandle fileDescriptor]).andReturn(-1);
+  OCMStub([mockFileInfo fileHandle]).andReturn(mockHandle);
+  OCMStub([mockFileInfo codesignCheckerWithError:[OCMArg setTo:infoPlistErr]])
+      .andReturn(mockChecker);
+
+  SNTConfigState* cs = [[SNTConfigState alloc] initWithConfig:mockConfig];
+
+  SNTCachedDecision* cd = [self.processor decisionForFileInfo:mockFileInfo
+                                                targetProcess:&proc
+                                                  configState:cs
+                                           activationCallback:nil
+                                               cachedDecision:nil];
+
+  XCTAssertNotEqual(cd.decision, SNTEventStateBlockCertificate,
+                    @"bad-sig protection must not fire when identity is intact");
+  XCTAssertFalse([cd.decisionExtra hasPrefix:@"Blocked due to signature error"],
+                 @"decisionExtra must not carry the bad-sig blocked message; got %@",
+                 cd.decisionExtra);
+
+  [mockConfig stopMocking];
+  [mockFileInfo stopMocking];
+  [mockHandle stopMocking];
+}
+
 #pragma mark - +verifyIdentityForTargetProc:fd:csInfo: tests
 
 // Case 1: ES signed, disk unsigned (csInfo == nil) -> Mismatch.

--- a/Source/santad/SantadTest.mm
+++ b/Source/santad/SantadTest.mm
@@ -197,7 +197,14 @@ static const char* kBlockedCDHash = "7218eddfee4d3eba4873dedf22d1391d79aea25f";
   NSError* csError = nil;
   MOLCodesignChecker* csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:binaryPath
                                                                         error:&csError];
-  if (csInfo == nil || csInfo.cdhash.length == 0) {
+  // A nil checker means MOL itself failed to construct (bad fixture path,
+  // unreadable file, etc.) — that's a setup bug, not a normal unsigned
+  // binary. Treat empty cdhash on a non-nil checker as the unsigned case.
+  if (csInfo == nil) {
+    XCTFail(@"MOLCodesignChecker init failed for fixture %@: %@", binaryPath, csError);
+    return NO;
+  }
+  if (csInfo.cdhash.length == 0) {
     // On-disk binary is unsigned. Clear ES-side CS_SIGNED so the verifier's
     // signedness-disagrees check (case 1) doesn't fire and we fall through
     // to the unsigned stat-compare path.

--- a/Source/santad/SantadTest.mm
+++ b/Source/santad/SantadTest.mm
@@ -76,9 +76,7 @@ static void SetBinaryDataFromHexString(const char* hexStr, uint8_t* buf, size_t 
 
 static const char* kAllowedSigningID = "com.google.allowed_signing_id";
 static const char* kBlockedSigningID = "com.google.blocked_signing_id";
-static const char* kNoRuleMatchSigningID = "com.google.no_rule_match_signing_id";
 static const char* kBlockedTeamID = "EQHXZ8M8AV";
-static const char* kAllowedTeamID = "TJNVEKW352";
 static const char* kAllowedCDHash = "dedebf2eac732d873008b17b3e44a56599dd614b";
 static const char* kBlockedCDHash = "7218eddfee4d3eba4873dedf22d1391d79aea25f";
 
@@ -188,6 +186,35 @@ static const char* kBlockedCDHash = "7218eddfee4d3eba4873dedf22d1391d79aea25f";
   es_process_t proc = MakeESProcess(&file);
   proc.is_platform_binary = false;
   proc.codesigning_flags = CS_SIGNED | CS_VALID | CS_HARD | CS_KILL;
+
+  // Mirror the disk-side binary's identity into the ES-side proc fields so
+  // SNTPolicyProcessor's identity verifier sees matching ES vs on-disk
+  // identity (the production reality for an unmolested exec). Buffers are
+  // stack-rooted in this method's frame, which lives until the dispatch
+  // semaphore signals at the bottom of this method.
+  char teamIDBuf[64] = {0};
+  char signingIDBuf[256] = {0};
+  NSError* csError = nil;
+  MOLCodesignChecker* csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:binaryPath
+                                                                        error:&csError];
+  if (csInfo == nil || csInfo.cdhash.length == 0) {
+    // On-disk binary is unsigned. Clear ES-side CS_SIGNED so the verifier's
+    // signedness-disagrees check (case 1) doesn't fire and we fall through
+    // to the unsigned stat-compare path.
+    proc.codesigning_flags = 0;
+  } else {
+    if (csInfo.cdhash.length == sizeof(proc.cdhash) * 2) {
+      SetBinaryDataFromHexString(csInfo.cdhash.UTF8String, proc.cdhash, sizeof(proc.cdhash));
+    }
+    if (csInfo.teamID.length > 0) {
+      strlcpy(teamIDBuf, csInfo.teamID.UTF8String, sizeof(teamIDBuf));
+      proc.team_id = MakeESStringToken(teamIDBuf);
+    }
+    if (csInfo.signingID.length > 0) {
+      strlcpy(signingIDBuf, csInfo.signingID.UTF8String, sizeof(signingIDBuf));
+      proc.signing_id = MakeESStringToken(signingIDBuf);
+    }
+  }
 
   // Set a 6.5 second deadline for the message and clamp deadline headroom to 5
   // seconds. This means there is a 1.5 second leeway given for the processing block
@@ -349,82 +376,62 @@ static const char* kBlockedCDHash = "7218eddfee4d3eba4873dedf22d1391d79aea25f";
                  }];
 }
 
+// "NoSigningIDMatch" tests rely on the on-disk binary's actual signing_id
+// (com.google.custom_signing_id for allowed_teamid, banned_teamid for
+// banned_teamid) not appearing in the rules.db, so the team_id rule is the
+// one that fires. Identity is auto-mirrored from disk in checkBinaryExecution.
 - (void)testBinaryWithTeamIDAllowRuleAndNoSigningIDMatchIsAllowedInLockdownMode {
   [self checkBinaryExecution:@"allowed_teamid"
-      wantResult:ES_AUTH_RESULT_ALLOW
-      clientMode:SNTClientModeLockdown
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateAllowTeamID;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kAllowedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_ALLOW
+                  clientMode:SNTClientModeLockdown
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateAllowTeamID;
+                 }];
 }
 
 - (void)testBinaryWithTeamIDAllowRuleAndNoSigningIDMatchIsAllowedInStandaloneMode {
   [self checkBinaryExecution:@"allowed_teamid"
-      wantResult:ES_AUTH_RESULT_ALLOW
-      clientMode:SNTClientModeStandalone
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateAllowTeamID;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kAllowedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_ALLOW
+                  clientMode:SNTClientModeStandalone
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateAllowTeamID;
+                 }];
 }
 
 - (void)testBinaryWithTeamIDAllowRuleAndNoSigningIDMatchIsAllowedInMonitorMode {
   [self checkBinaryExecution:@"allowed_teamid"
-      wantResult:ES_AUTH_RESULT_ALLOW
-      clientMode:SNTClientModeMonitor
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateAllowTeamID;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kAllowedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_ALLOW
+                  clientMode:SNTClientModeMonitor
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateAllowTeamID;
+                 }];
 }
 
 - (void)testBinaryWithTeamIDBlockRuleAndNoSigningIDMatchIsBlockedInLockdownMode {
   [self checkBinaryExecution:@"banned_teamid"
-      wantResult:ES_AUTH_RESULT_DENY
-      clientMode:SNTClientModeLockdown
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateBlockTeamID;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kBlockedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_DENY
+                  clientMode:SNTClientModeLockdown
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateBlockTeamID;
+                 }];
 }
 
 - (void)testBinaryWithTeamIDBlockRuleAndNoSigningIDMatchIsBlockedInStandaloneMode {
   [self checkBinaryExecution:@"banned_teamid"
-      wantResult:ES_AUTH_RESULT_DENY
-      clientMode:SNTClientModeStandalone
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateBlockTeamID;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kBlockedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_DENY
+                  clientMode:SNTClientModeStandalone
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateBlockTeamID;
+                 }];
 }
 
 - (void)testBinaryWithTeamIDBlockRuleAndNoSigningIDMatchIsBlockedInMonitorMode {
   [self checkBinaryExecution:@"banned_teamid"
-      wantResult:ES_AUTH_RESULT_DENY
-      clientMode:SNTClientModeMonitor
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateBlockTeamID;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kBlockedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_DENY
+                  clientMode:SNTClientModeMonitor
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateBlockTeamID;
+                 }];
 }
 
 - (void)testBinaryWithSigningIDBlockRuleIsBlockedInLockdownMode {
@@ -583,43 +590,34 @@ static const char* kBlockedCDHash = "7218eddfee4d3eba4873dedf22d1391d79aea25f";
       }];
 }
 
+// banned_teamid_allowed_binary is signed by EQHXZ8M8AV (a blocked team_id) but
+// has a SHA-256 allow rule that wins. Identity is auto-mirrored from disk; no
+// override needed.
 - (void)testBinaryWithSHA256AllowRuleAndBlockedTeamIDRuleIsAllowedInLockdownMode {
   [self checkBinaryExecution:@"banned_teamid_allowed_binary"
-      wantResult:ES_AUTH_RESULT_ALLOW
-      clientMode:SNTClientModeLockdown
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateAllowBinary;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kBlockedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_ALLOW
+                  clientMode:SNTClientModeLockdown
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateAllowBinary;
+                 }];
 }
 
 - (void)testBinaryWithSHA256AllowRuleAndBlockedTeamIDRuleIsAllowedInStandaloneMode {
   [self checkBinaryExecution:@"banned_teamid_allowed_binary"
-      wantResult:ES_AUTH_RESULT_ALLOW
-      clientMode:SNTClientModeStandalone
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateAllowBinary;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kBlockedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_ALLOW
+                  clientMode:SNTClientModeStandalone
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateAllowBinary;
+                 }];
 }
 
 - (void)testBinaryWithSHA256AllowRuleAndBlockedTeamIDRuleIsAllowedInMonitorMode {
   [self checkBinaryExecution:@"banned_teamid_allowed_binary"
-      wantResult:ES_AUTH_RESULT_ALLOW
-      clientMode:SNTClientModeMonitor
-      cdValidator:^BOOL(SNTCachedDecision* cd) {
-        return cd.decision == SNTEventStateAllowBinary;
-      }
-      messageSetup:^(es_message_t* msg) {
-        msg->event.exec.target->team_id = MakeESStringToken(kBlockedTeamID);
-        msg->event.exec.target->signing_id = MakeESStringToken(kNoRuleMatchSigningID);
-      }];
+                  wantResult:ES_AUTH_RESULT_ALLOW
+                  clientMode:SNTClientModeMonitor
+                 cdValidator:^BOOL(SNTCachedDecision* cd) {
+                   return cd.decision == SNTEventStateAllowBinary;
+                 }];
 }
 
 - (void)testBinaryWithoutBlockOrAllowRuleIsBlockedInLockdownMode {

--- a/Source/santasyncservice/ProtoTraits.h
+++ b/Source/santasyncservice/ProtoTraits.h
@@ -77,6 +77,7 @@ struct ProtoTraits<false> {
   // v1 doesn't have CEL fallback decisions; fall back to UNKNOWN.
   static constexpr Decision ALLOW_CEL_FALLBACK = ::santa::sync::v1::ALLOW_UNKNOWN;
   static constexpr Decision BLOCK_CEL_FALLBACK = ::santa::sync::v1::BLOCK_UNKNOWN;
+  static constexpr Decision BLOCK_BINARY_MISMATCH = ::santa::sync::v1::BLOCK_BINARY_MISMATCH;
 
   using FileAccessAction = ::santa::sync::v1::FileAccessAction;
   static constexpr FileAccessAction FILE_ACCESS_ACTION_UNSPECIFIED = ::santa::sync::v1::FILE_ACCESS_ACTION_UNSPECIFIED;
@@ -175,6 +176,7 @@ struct ProtoTraits<true> {
   static constexpr Decision BUNDLE_BINARY = ::santa::sync::v2::BUNDLE_BINARY;
   static constexpr Decision ALLOW_CEL_FALLBACK = ::santa::sync::v2::ALLOW_CEL_FALLBACK;
   static constexpr Decision BLOCK_CEL_FALLBACK = ::santa::sync::v2::BLOCK_CEL_FALLBACK;
+  static constexpr Decision BLOCK_BINARY_MISMATCH = ::santa::sync::v2::BLOCK_BINARY_MISMATCH;
 
   using FileAccessAction = ::santa::sync::v2::FileAccessAction;
   static constexpr FileAccessAction FILE_ACCESS_ACTION_UNSPECIFIED = ::santa::sync::v2::FILE_ACCESS_ACTION_UNSPECIFIED;

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -229,6 +229,7 @@ typename santa::ProtoTraits<IsV2>::EventT* MessageForExecutionEvent(
     case SNTEventStateBlockCDHash: e->set_decision(Traits::BLOCK_CDHASH); break;
     case SNTEventStateBlockCELFallback: e->set_decision(Traits::BLOCK_CEL_FALLBACK); break;
     case SNTEventStateAllowCELFallback: e->set_decision(Traits::ALLOW_CEL_FALLBACK); break;
+    case SNTEventStateBlockBinaryMismatch: e->set_decision(Traits::BLOCK_BINARY_MISMATCH); break;
     case SNTEventStateAllowTransitive: return nullptr;
     case SNTEventStateAllowLocalBinary: return nullptr;
     case SNTEventStateAllowLocalSigningID: return nullptr;


### PR DESCRIPTION
Also includes a `MOLCodesignChecker` change: when a file descriptor is supplied to `initWithBinaryPath:fileDescriptor:`, route `SecStaticCodeCreateWithPath` through `/dev/fd/N` so the static code ref operates on the caller's vnode. This avoids a redundant path resolution and aligns disk-side identity with the bytes the caller already has open.