### PR TITLE
ci: disable bazel-internal metrics in continuous, shrink ArenaGrowthTest

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -17,6 +17,15 @@ jobs:
 
       # Note: Using Bazel flags documented here to reduce memory footprint:
       # https://bazel.build/advanced/performance/memory
+      #
+      # The --noexperimental_collect_* flags disable bazel-internal metrics
+      # collectors that have no value here (we don't capture profiles or
+      # consume BEP from runner output). One of them (system network usage)
+      # was observed crashing the bazel server with `sysctl: Cannot allocate
+      # memory` on the 7GB macos runners. If a future Bazel bump fails with
+      # "Unrecognized option" on any of these, the `experimental_` prefix
+      # has likely been dropped or the flag renamed; run `bazel help build`
+      # against the new version to reconcile.
       - name: Check for flaky tests
         run: |
           bazel test \
@@ -26,6 +35,13 @@ jobs:
             --discard_analysis_cache \
             --notrack_incremental_state \
             --nokeep_state_after_build \
+            --noexperimental_collect_system_network_usage \
+            --noexperimental_collect_load_average_in_profiler \
+            --noexperimental_collect_resource_estimation \
+            --noexperimental_collect_local_sandbox_action_metrics \
+            --show_progress_rate_limit=5 \
+            --curses=no \
+            --color=no \
             --define=SANTA_BUILD_TYPE=adhoc \
             -t- \
             :unit_tests

--- a/Source/common/cel/ArenaGrowthTest.mm
+++ b/Source/common/cel/ArenaGrowthTest.mm
@@ -116,8 +116,10 @@ static size_t GetResidentMemoryBytes() {
 
   // Run many iterations of CompileAndEvaluate. Each iteration materializes
   // ~200 * 256 = ~50KB of arg strings onto the arena, plus compilation
-  // temporaries. Before the fix this grew by ~600MB+ over 5000 iterations.
-  const int iterations = 5000;
+  // temporaries. Before the fix this grew by ~600MB+ over 5000 iterations,
+  // so 1500 iterations still produces ~180MB pre-fix while keeping post-fix
+  // RSS comfortably under the 50MB threshold.
+  const int iterations = 1500;
   for (int i = 0; i < iterations; i++) {
     @autoreleasepool {
       auto f = std::make_unique<ExecutableFileT>();


### PR DESCRIPTION
The `continuous` workflow has been failing intermittently with bazel crashing in its profiler thread:

```
FATAL: bazel ran out of memory and crashed. Printing stack trace:
java.lang.OutOfMemoryError: sysctl (Cannot allocate memory)
  at SystemNetworkStats.getNetIoCountersNative
  at NetworkMetricsCollector.collectSystemNetworkUsages
```

Across four recent OOM jobs, the test running at crash time was different each time (`SNTTimerTest`, `SNTCommandMetricsTest`, `SantadTest`, `TelemetryEventMapTest`) — confirming the OOM is not test-specific but rather system-level RAM exhaustion on the 7GB `macos-latest` runners, with bazel's bundled metrics collectors as the unlucky thread that trips over it.

This PR:

- Disables four bazel-internal metrics collectors that have no value in CI (we don't capture profiles or consume BEP from runner output).
- Adds explicit `--curses=no`, `--color=no`, and `--show_progress_rate_limit=5` to cut log noise on a non-TTY runner.
- Drops `ArenaGrowthTest` iteration count from 5000 → 1500. The pre-fix leak was ~600MB over 5000 iterations; 1500 still produces ~180MB pre-fix (well above the 50MB threshold), while cutting ~7 minutes off each continuous run.

A maintainer comment is included noting that the `experimental_` prefix on these flag names occasionally drops or renames across Bazel releases — if a future Bazel bump errors with `Unrecognized option`, run `bazel help build` against the new version to reconcile. All flags verified against the pinned Bazel 8.6.0.