### PR TITLE
Add proper data length length to string conversion

### DIFF
--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -67,7 +67,9 @@ static inline NSString* StringTokenToNSString(es_string_token_t es_str) {
   if (es_str.length == 0) {
     return nil;
   }
-  return StringToNSString(es_str.data);
+  return [[NSString alloc] initWithBytes:es_str.data
+                                  length:es_str.length
+                                encoding:NSUTF8StringEncoding];
 }
 
 static inline std::string BufToHexString(const uint8_t* buf, size_t bufsize) {

--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -64,6 +64,9 @@ static inline std::string StringTokenToString(es_string_token_t es_str) {
 }
 
 static inline NSString* StringTokenToNSString(es_string_token_t es_str) {
+  if (es_str.length == 0) {
+    return nil;
+  }
   return StringToNSString(es_str.data);
 }
 


### PR DESCRIPTION
Makes `StringTokenToNSString` safe to use without first checking the length at each callsite.