### PR TITLE
Strip trailing whitespace in santaconfig.ts

### DIFF
--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -143,7 +143,7 @@ export const SantaConfigKeyGroups: SantaConfigGroups = {
     {
       key: "AllowedSantaCommands",
       description:
-        `Array of allowed Santa Commands. If the key \`AllowedSantaCommands\` is unset (nil), all commands are allowed. 
+        `Array of allowed Santa Commands. If the key \`AllowedSantaCommands\` is unset (nil), all commands are allowed.
         If \`AllowedSantaCommands\` is an empty array, none of the commands are allowed.`,
       type: "string",
       syncConfigurable: false,


### PR DESCRIPTION
The \`markdown-check\` job runs \`git grep -EIn $'[ \t]+$' -- ':(exclude)*.patch'\` across the working tree and fails on any trailing whitespace. A single line in \`docs/src/lib/santaconfig.ts\` has one trailing space, which currently fails CI on every open PR (e.g. #942).

This commit removes that one trailing character so the gate returns green.