### PR TITLE
Eliminate TSAN-only race report in processEnrichedMessage:handler:

### DIFF
--- a/Source/common/es/SNTEndpointSecurityClient.mm
+++ b/Source/common/es/SNTEndpointSecurityClient.mm
@@ -283,9 +283,15 @@ using santa::Processor;
 
 - (void)processEnrichedMessage:(std::unique_ptr<EnrichedMessage>)msg
                        handler:(void (^)(std::unique_ptr<EnrichedMessage>))messageHandler {
-  __block std::unique_ptr<EnrichedMessage> msgTmp = std::move(msg);
+  // Ownership is handed off to the dispatched block via a raw pointer and
+  // re-wrapped on the worker thread. The obvious `__block std::unique_ptr<>`
+  // pattern is avoided because it shares the captured object across threads
+  // and TSAN flags the byref destructor racing with the move-out on the
+  // worker. The release() and the dispatch_async must remain paired: any
+  // path that releases but does not reach the dispatch_async leaks.
+  EnrichedMessage* rawMsg = msg.release();
   dispatch_async(_notifyQueue, ^{
-    messageHandler(std::move(msgTmp));
+    messageHandler(std::unique_ptr<EnrichedMessage>(rawMsg));
   });
 }
 

--- a/Source/common/es/SNTEndpointSecurityClientTest.mm
+++ b/Source/common/es/SNTEndpointSecurityClientTest.mm
@@ -437,12 +437,13 @@ using santa::WatchItemPathType;
 
     [client processEnrichedMessage:std::move(enrichedMsg)
                            handler:^(std::unique_ptr<EnrichedMessage> msg) {
-                             // reset the shared_ptr to drop the held message.
-                             // This is a workaround for a TSAN only false positive
-                             // which happens if we switch back to the sem wait
-                             // after signaling, but _before_ the implicit release
-                             // of msg. In that case, the mock verify and the
-                             // call of the mock's Release method can data race.
+                             // Force ~EnrichedMessage (which calls
+                             // mockESApi->ReleaseMessage) to run before the
+                             // signal so the mock call happens-before the
+                             // verify read on the main thread. Otherwise the
+                             // gmock counter is written here while being read
+                             // by VerifyAndClearExpectations -- a real (though
+                             // benign) data race.
                              msg.reset();
                              dispatch_semaphore_signal(sema);
                            }];


### PR DESCRIPTION
This is not a real production race: the Apple BlocksRuntime byref refcount provides happens-before between the move-out on the GCD worker and the byref destructor on the caller, so the unique_ptr destructor always observes a moved-from (null) pointer. TSAN does not appear to recognize that synchronization for the captured C++ payload, so the nightly TSAN run intermittently reports a data race between unique_ptr::release() on the worker and ~unique_ptr inside the byref disposer on the caller. Only the TSAN sanitizer build is affected; release and asan/ubsan builds are unaffected.

Hand off ownership via a raw pointer captured by value into the dispatched block, and reconstruct the unique_ptr on the worker thread. This eliminates the cross-thread sharing of the C++ object entirely, so there is no byref destructor to race with the move regardless of how TSAN models the BlocksRuntime atomics.

Also fix the stale/misleading comment on the test workaround for a separate gmock-counter race -- that one is a real (benign) race, not a TSAN-only false positive, and the held object is unique_ptr not shared_ptr.