### PR TITLE
verifyinghasher: add per-call skip_page_hash option

### DIFF
--- a/Source/common/verifyinghasher/HashTraits.h
+++ b/Source/common/verifyinghasher/HashTraits.h
@@ -120,6 +120,32 @@ struct Sha384Traits {
   static constexpr uint8_t kCsHashType = CS_HASHTYPE_SHA384;
 };
 
+// NoopHashTraits substitutes into PageVerifierT<> to make the per-page
+// hashing work disappear. Used when
+// VerifyingHasherCore::Options::skip_page_hash is set — e.g., when the caller
+// has independent assurance that the kernel will enforce page hashes (CS_HARD /
+// CS_KILL on AUTH EXEC), or via a future configuration escape hatch.
+// PageVerifierT<>::Update has an if-constexpr branch for this trait that
+// bulk-advances cur_slot_/cur_page_bytes_ in O(1) per chunk instead of running
+// the iterative per-page hashing loop; the iterative branch is the if-constexpr
+// discarded statement for this trait and is never instantiated, which is why
+// kDigestSize can be zero.
+//
+// Trait constants satisfy PageVerifierT's static_asserts trivially:
+//   kCompareSize (0) <= kSlotStride (0) <= kDigestSize (0).
+// Init/Update/Final are kept (rather than removed) only to model the trait
+// concept symmetrically with the real hash traits; the discarded-statement
+// rule means they're never called.
+struct NoopHashTraits {
+  struct Ctx {};
+  static constexpr size_t kDigestSize = 0;
+  static constexpr size_t kSlotStride = 0;
+  static constexpr size_t kCompareSize = 0;
+  static void Init(Ctx*) {}
+  static void Update(Ctx*, const void*, size_t) {}
+  static void Final(unsigned char*, Ctx*) {}
+};
+
 #undef VERIFYINGHASHER_CC_UPDATE_LOOP
 
 }  // namespace santa

--- a/Source/common/verifyinghasher/HashTraits.h
+++ b/Source/common/verifyinghasher/HashTraits.h
@@ -134,8 +134,11 @@ struct Sha384Traits {
 // Trait constants satisfy PageVerifierT's static_asserts trivially:
 //   kCompareSize (0) <= kSlotStride (0) <= kDigestSize (0).
 // Init/Update/Final are kept (rather than removed) only to model the trait
-// concept symmetrically with the real hash traits; the discarded-statement
-// rule means they're never called.
+// concept symmetrically with the real hash traits. Init is called once
+// unconditionally by PageVerifierT's constructor (no-op body). Update and
+// Final live in the iterative loop, which is the if-constexpr discarded
+// substatement under NoopHashTraits and is not instantiated, so those two
+// are never called.
 struct NoopHashTraits {
   struct Ctx {};
   static constexpr size_t kDigestSize = 0;

--- a/Source/common/verifyinghasher/HashTraitsTest.mm
+++ b/Source/common/verifyinghasher/HashTraitsTest.mm
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <vector>
 
+using santa::NoopHashTraits;
 using santa::Sha1Traits;
 using santa::Sha256Traits;
 using santa::Sha256TruncatedTraits;
@@ -146,6 +147,21 @@ bool RunChunkedEquivalence() {
 
 - (void)testChunkedEquivalenceSha384 {
   XCTAssertTrue(RunChunkedEquivalence<Sha384Traits>());
+}
+
+- (void)testNoopHashTraitsSizesValid {
+  // PageVerifierT static_asserts enforce:
+  //   kCompareSize <= kSlotStride <= kDigestSize
+  // All three are zero for NoopHashTraits — no per-page hashing, no slot
+  // comparison, no digest produced. The iterative branch of
+  // PageVerifierT::Update that would otherwise need kDigestSize > 0 (to
+  // declare `unsigned char digest[kDigestSize]`) is the if-constexpr
+  // discarded statement under this trait and is never instantiated.
+  XCTAssertEqual(NoopHashTraits::kCompareSize, 0u);
+  XCTAssertEqual(NoopHashTraits::kSlotStride, 0u);
+  XCTAssertEqual(NoopHashTraits::kDigestSize, 0u);
+  XCTAssertLessThanOrEqual(NoopHashTraits::kCompareSize, NoopHashTraits::kSlotStride);
+  XCTAssertLessThanOrEqual(NoopHashTraits::kSlotStride, NoopHashTraits::kDigestSize);
 }
 
 @end

--- a/Source/common/verifyinghasher/PageVerifier.h
+++ b/Source/common/verifyinghasher/PageVerifier.h
@@ -18,11 +18,13 @@
 #include <os/overflow.h>
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 #include "Source/common/verifyinghasher/HashTraits.h"
@@ -46,6 +48,18 @@ class PageVerifierT {
                   "slot stride must not exceed computed digest size");
     assert(signed_hi_ >= signed_lo_);
     assert(page_size_ > 0);
+    // Apple code-signing uses pow2 page sizes (4096 or 16384). Detect once
+    // so the NoopHashTraits bulk-advance path can use shift+mask instead
+    // of UDIV/UREM — those are ~16-cycle latencies on Apple Silicon, and
+    // putting them on the critical path of the streaming loop is wasteful
+    // when the CodeDirectory format guarantees a pow2 in practice.
+    // std::has_single_bit returns false for 0, so countr_zero is only
+    // called on a known-nonzero input (countr_zero(0) is well-defined but
+    // would yield bit_width, an invalid shift amount).
+    if (std::has_single_bit(page_size_)) {
+      page_size_shift_ = static_cast<int8_t>(std::countr_zero(page_size_));
+      page_size_mask_ = page_size_ - 1;
+    }
     HashTraits::Init(&ctx_);
   }
 
@@ -56,6 +70,12 @@ class PageVerifierT {
   // gap is detected we mark stream_corrupt_ and stop processing further
   // pages; the caller (VerifyingHasherCore) checks StreamCorrupt() and converts
   // to a malformed-signature error. Survives NDEBUG.
+  //
+  // When HashTraits is NoopHashTraits, the per-page hashing loop is
+  // replaced with O(1) bulk advance of cur_slot_/cur_page_bytes_. The
+  // gap-detect prologue is unchanged so StreamCorrupt() still fires on a
+  // contract violation, and the bulk advance reaches the same end state
+  // the iterative loop would have so Complete() still works correctly.
   void Update(const uint8_t* data, size_t len, uint64_t chunk_off) {
     if (stream_corrupt_) return;
     uint64_t a = std::max<uint64_t>(chunk_off, signed_lo_);
@@ -86,33 +106,70 @@ class PageVerifierT {
         return;
       }
     }
-    while (a < b) {
-      const uint64_t page_end_off =
-          signed_lo_ + static_cast<uint64_t>(cur_slot_) * page_size_ +
-          ExpectedPageLen(cur_slot_);
-      const uint64_t chunk_end = std::min(b, page_end_off);
-      const uint64_t take = chunk_end - a;
-      HashTraits::Update(&ctx_, data + (a - chunk_off), take);
-      cur_page_bytes_ += take;
-      a += take;
-
-      if (cur_page_bytes_ == ExpectedPageLen(cur_slot_)) {
-        unsigned char digest[HashTraits::kDigestSize];
-        HashTraits::Final(digest, &ctx_);
-        const uint8_t* slot =
-            slot_hashes_.data() +
-            static_cast<size_t>(cur_slot_) * HashTraits::kSlotStride;
-        if (std::memcmp(digest, slot, HashTraits::kCompareSize) != 0) {
-          ++mismatches_;
-          if (mismatched_slots_.size() < kMaxRecordedMismatches) {
-            mismatched_slots_.push_back(cur_slot_);
-          }
+    if constexpr (std::is_same_v<HashTraits, NoopHashTraits>) {
+      // Bulk-advance the page counter by the in-region byte count.
+      // Incremental form: cur_page_bytes_ + consumed = (pages_completed *
+      // page_size) + new_cur_page_bytes. Equivalent end state to the
+      // iterative loop in the else branch at O(1) per chunk; preserves
+      // Complete() and StreamCorrupt() invariants because the gap-detect
+      // prologue above still fires and the cur_slot_/cur_page_bytes_ end
+      // state matches what the iterative loop would have produced.
+      //
+      // Lives in the if-branch (not after an early return) so the else
+      // branch is the if-constexpr discarded statement and is not
+      // instantiated for NoopHashTraits — which lets NoopHashTraits keep
+      // kDigestSize=0 and avoids a zero-length-array compile concern.
+      if (b > a) {
+        const uint64_t consumed = b - a;
+        const uint64_t new_partial = cur_page_bytes_ + consumed;
+        uint32_t pages_completed;
+        if (page_size_shift_ >= 0) [[likely]] {
+          // Pow2 fast path (always taken in production — Apple's
+          // CodeDirectory page_size is 4096 or 16384). Shift+mask have
+          // 1-cycle latency each; UDIV/UREM on ARM are ~16-20 cycles and
+          // would serialize against the surrounding SHA-256 stream in
+          // cold-cache regimes where OoO slack is tighter.
+          pages_completed =
+              static_cast<uint32_t>(new_partial >> page_size_shift_);
+          cur_page_bytes_ = new_partial & page_size_mask_;
+        } else {
+          // Non-pow2 fallback. Operates on (cur_page_bytes_ + consumed)
+          // rather than reconstructing the absolute total, so the UDIV
+          // dividend stays small (< chunk_size + page_size).
+          pages_completed = static_cast<uint32_t>(new_partial / page_size_);
+          cur_page_bytes_ = new_partial % page_size_;
         }
-        ++cur_slot_;
-        cur_page_bytes_ = 0;
-        if (signed_lo_ + static_cast<uint64_t>(cur_slot_) * page_size_ <
-            signed_hi_) {
-          HashTraits::Init(&ctx_);
+        cur_slot_ += pages_completed;
+      }
+    } else {
+      while (a < b) {
+        const uint64_t page_end_off =
+            signed_lo_ + static_cast<uint64_t>(cur_slot_) * page_size_ +
+            ExpectedPageLen(cur_slot_);
+        const uint64_t chunk_end = std::min(b, page_end_off);
+        const uint64_t take = chunk_end - a;
+        HashTraits::Update(&ctx_, data + (a - chunk_off), take);
+        cur_page_bytes_ += take;
+        a += take;
+
+        if (cur_page_bytes_ == ExpectedPageLen(cur_slot_)) {
+          unsigned char digest[HashTraits::kDigestSize];
+          HashTraits::Final(digest, &ctx_);
+          const uint8_t* slot =
+              slot_hashes_.data() +
+              static_cast<size_t>(cur_slot_) * HashTraits::kSlotStride;
+          if (std::memcmp(digest, slot, HashTraits::kCompareSize) != 0) {
+            ++mismatches_;
+            if (mismatched_slots_.size() < kMaxRecordedMismatches) {
+              mismatched_slots_.push_back(cur_slot_);
+            }
+          }
+          ++cur_slot_;
+          cur_page_bytes_ = 0;
+          if (signed_lo_ + static_cast<uint64_t>(cur_slot_) * page_size_ <
+              signed_hi_) {
+            HashTraits::Init(&ctx_);
+          }
         }
       }
     }
@@ -145,6 +202,13 @@ class PageVerifierT {
   uint64_t signed_hi_;
   uint32_t page_size_;
   std::span<const uint8_t> slot_hashes_;
+
+  // Pow2 page-size hints set in the constructor. shift_ == -1 means
+  // page_size_ is not a power of two; the bulk-advance falls back to UDIV.
+  // In production, Apple's CodeDirectory always uses pow2 page sizes
+  // (kSecCodeMagicEmbeddedSignature.pageSize == 4096 or 16384).
+  int8_t page_size_shift_ = -1;
+  uint32_t page_size_mask_ = 0;
 
   uint32_t cur_slot_ = 0;
   uint64_t cur_page_bytes_ = 0;

--- a/Source/common/verifyinghasher/PageVerifier.h
+++ b/Source/common/verifyinghasher/PageVerifier.h
@@ -205,8 +205,9 @@ class PageVerifierT {
 
   // Pow2 page-size hints set in the constructor. shift_ == -1 means
   // page_size_ is not a power of two; the bulk-advance falls back to UDIV.
-  // In production, Apple's CodeDirectory always uses pow2 page sizes
-  // (kSecCodeMagicEmbeddedSignature.pageSize == 4096 or 16384).
+  // In production, Apple's CodeDirectory's pageSize field (which the
+  // parser resolves to 1 << pageSize before passing it here) is always
+  // either 4096 or 16384, so the fast path is always taken.
   int8_t page_size_shift_ = -1;
   uint32_t page_size_mask_ = 0;
 

--- a/Source/common/verifyinghasher/PageVerifierTest.mm
+++ b/Source/common/verifyinghasher/PageVerifierTest.mm
@@ -166,7 +166,8 @@ bool RunOneTraitsBody() {
 // returns true once the full signed region has been streamed, even when
 // the last page is partial (code_len not page-aligned).
 - (void)testNoopBulkAdvanceCompletePartialLastPage {
-  // 123 KiB, page size 4096 -> 30 full pages + one 3072-byte partial page.
+  // 123 KiB total - signed_lo=1024 = 124,928 bytes in signed region.
+  // 124,928 / 4096 = 30 full pages + one 2048-byte partial last page.
   std::vector<uint8_t> bytes(123 * 1024);
   PageVerifierT<NoopHashTraits> pv(/*lo=*/1024, /*hi=*/bytes.size(), /*page=*/4096, /*slots=*/{});
   // Mixed-size chunks straddle page boundaries and exercise the bulk path

--- a/Source/common/verifyinghasher/PageVerifierTest.mm
+++ b/Source/common/verifyinghasher/PageVerifierTest.mm
@@ -25,6 +25,7 @@
 
 #include "Source/common/verifyinghasher/HashTraits.h"
 
+using santa::NoopHashTraits;
 using santa::PageVerifierT;
 using santa::Sha1Traits;
 using santa::Sha256Traits;
@@ -157,6 +158,82 @@ bool RunOneTraitsBody() {
   XCTAssertFalse(pv.StreamCorrupt());
   pv.Update(bytes.data() + 8192, 4096, 8192);  // gap: missing [4096, 8192)
   XCTAssertTrue(pv.StreamCorrupt());
+}
+
+// Under NoopHashTraits, PageVerifier replaces the per-page hashing loop
+// with an O(1) bulk advance of cur_slot_/cur_page_bytes_. Verify the end
+// state is observationally equivalent to the iterative path: Complete()
+// returns true once the full signed region has been streamed, even when
+// the last page is partial (code_len not page-aligned).
+- (void)testNoopBulkAdvanceCompletePartialLastPage {
+  // 123 KiB, page size 4096 -> 30 full pages + one 3072-byte partial page.
+  std::vector<uint8_t> bytes(123 * 1024);
+  PageVerifierT<NoopHashTraits> pv(/*lo=*/1024, /*hi=*/bytes.size(), /*page=*/4096, /*slots=*/{});
+  // Mixed-size chunks straddle page boundaries and exercise the bulk path
+  // across multiple Update() calls.
+  for (uint64_t off = 0; off < bytes.size(); off += 13) {
+    size_t n = std::min<size_t>(13, bytes.size() - off);
+    pv.Update(bytes.data() + off, n, off);
+  }
+  XCTAssertFalse(pv.StreamCorrupt());
+  XCTAssertTrue(pv.Complete());
+  XCTAssertEqual(pv.Mismatches(), 0u);
+  XCTAssertTrue(pv.MismatchedSlots().empty());
+}
+
+// Same shape as above but with a page-aligned signed region (code_len
+// exactly divisible by page_size). Exercises the bulk-advance corner
+// where the iterative loop would have finalized the last page exactly.
+- (void)testNoopBulkAdvanceCompleteAlignedLastPage {
+  std::vector<uint8_t> bytes(8 * 4096);
+  PageVerifierT<NoopHashTraits> pv(0, bytes.size(), 4096, {});
+  pv.Update(bytes.data(), bytes.size(), 0);
+  XCTAssertFalse(pv.StreamCorrupt());
+  XCTAssertTrue(pv.Complete());
+  XCTAssertEqual(pv.Mismatches(), 0u);
+}
+
+// The bulk-advance path must preserve gap-detect — a contract violation
+// must trip StreamCorrupt() even when no hashing is happening.
+- (void)testNoopBulkAdvanceGapDetected {
+  std::vector<uint8_t> bytes(8 * 4096);
+  PageVerifierT<NoopHashTraits> pv(0, bytes.size(), 4096, {});
+  pv.Update(bytes.data(), 4096, 0);
+  XCTAssertFalse(pv.StreamCorrupt());
+  pv.Update(bytes.data() + 8192, 4096, 8192);  // gap: missing [4096, 8192)
+  XCTAssertTrue(pv.StreamCorrupt());
+}
+
+// A short stream under NoopHashTraits must NOT report Complete(): the
+// bulk advance only credits bytes actually fed, so an early-terminating
+// stream is still detectable. This is the symmetric counterpart to
+// VerifyingHasherCore's pv.Complete() defense-in-depth check.
+- (void)testNoopBulkAdvanceIncompleteStreamFlagged {
+  std::vector<uint8_t> bytes(8 * 4096);
+  PageVerifierT<NoopHashTraits> pv(0, bytes.size(), 4096, {});
+  // Feed only the first 5 pages.
+  pv.Update(bytes.data(), 5 * 4096, 0);
+  XCTAssertFalse(pv.StreamCorrupt());
+  XCTAssertFalse(pv.Complete());
+}
+
+// Non-power-of-two page size exercises the UDIV/UREM fallback in the
+// bulk-advance path. Apple CodeDirectory always uses pow2 sizes (4096,
+// 16384) in production, but the fallback must remain correct so a
+// future kernel/Apple change doesn't silently break.
+- (void)testNoopBulkAdvanceNonPow2PageSize {
+  // 3000-byte page, 7 full pages + one 1000-byte partial = 22000 bytes.
+  constexpr uint32_t kOddPage = 3000;
+  std::vector<uint8_t> bytes(7 * kOddPage + 1000);
+  PageVerifierT<NoopHashTraits> pv(0, bytes.size(), kOddPage, {});
+  // Feed in 17-byte chunks to exercise mid-page boundaries on the
+  // non-pow2 path.
+  for (uint64_t off = 0; off < bytes.size(); off += 17) {
+    size_t n = std::min<size_t>(17, bytes.size() - off);
+    pv.Update(bytes.data() + off, n, off);
+  }
+  XCTAssertFalse(pv.StreamCorrupt());
+  XCTAssertTrue(pv.Complete());
 }
 
 @end

--- a/Source/common/verifyinghasher/VerifyingHasher.h
+++ b/Source/common/verifyinghasher/VerifyingHasher.h
@@ -62,8 +62,25 @@ class VerifyingHasher {
     std::optional<std::array<uint8_t, CC_SHA256_DIGEST_LENGTH>> sha256;
   };
 
+  struct RunOptions {
+    // Skip per-page CodeDirectory verification while still computing the
+    // full-file SHA-256, cdhash, and signing-id/team-id extraction.
+    // Threaded through to VerifyingHasherCore::Options::skip_page_hash;
+    // see Core's documentation for the full contract.
+    bool skip_page_hash = false;
+  };
+
   static Result Run(int fd, cpu_type_t cputype, cpu_subtype_t cpusubtype,
-                    const Expected& expected);
+                    const Expected& expected, const RunOptions& opts);
+  // No-options overload. (We avoid `const RunOptions& opts = {}` directly
+  // on the primary declaration: brace-initializing the nested aggregate as
+  // a default argument inside the enclosing class definition trips the
+  // "default member initializer needed within definition of enclosing
+  // class outside of member functions" rule on clang.)
+  static Result Run(int fd, cpu_type_t cputype, cpu_subtype_t cpusubtype,
+                    const Expected& expected) {
+    return Run(fd, cputype, cpusubtype, expected, RunOptions{});
+  }
 };
 
 }  // namespace santa

--- a/Source/common/verifyinghasher/VerifyingHasher.mm
+++ b/Source/common/verifyinghasher/VerifyingHasher.mm
@@ -39,7 +39,7 @@ bool BytesEqual(std::span<const uint8_t> a, std::span<const uint8_t> b) {
 }  // namespace
 
 VerifyingHasher::Result VerifyingHasher::Run(int fd, cpu_type_t cputype, cpu_subtype_t cpusubtype,
-                                             const Expected& exp) {
+                                             const Expected& exp, const RunOptions& opts) {
   Result r{};
 
   struct stat st;
@@ -50,7 +50,9 @@ VerifyingHasher::Result VerifyingHasher::Run(int fd, cpu_type_t cputype, cpu_sub
 
   FdFileReader reader(fd, st.st_size);
   ArchSelector want{cputype, cpusubtype};
-  VerifyingHasherCore core(reader, want);
+  VerifyingHasherCore::Options core_opts;
+  core_opts.skip_page_hash = opts.skip_page_hash;
+  VerifyingHasherCore core(reader, want, core_opts);
 
   auto core_status = core.Run();
 

--- a/Source/common/verifyinghasher/VerifyingHasherCore.h
+++ b/Source/common/verifyinghasher/VerifyingHasherCore.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -46,6 +47,12 @@ class VerifyingHasherCore {
   struct Options {
     size_t buf_size = 1u << 20;  // pread chunk size; 1 MiB default.
                                  // Any positive value is valid.
+    // If true, skip per-page CodeDirectory verification while still
+    // computing the full-file SHA-256, cdhash, and signing-id/team-id
+    // extraction. Mismatches() returns std::nullopt under skip;
+    // Status::kPagesMismatched is structurally unreachable. See
+    // HashTraits.h::NoopHashTraits and PageHashSkipped() below.
+    bool skip_page_hash = false;
   };
 
   VerifyingHasherCore(FileReader& reader, ArchSelector want);
@@ -68,10 +75,15 @@ class VerifyingHasherCore {
   // Valid for kOk / kPagesMismatched:
   const ParsedCodeDirectory& ParsedCD() const { return parsed_cd_; }
   const SliceInfo& Slice() const { return slice_; }
-  bool PagesMatched() const { return mismatches_ == 0; }
-  // Total page-hash mismatch count (uncapped). Useful for telemetry.
-  uint32_t Mismatches() const { return mismatches_; }
+  // Total page-hash mismatch count (uncapped). std::nullopt iff
+  // Options.skip_page_hash was set on this run — reflects caller intent
+  // even on a Run() that errored in phase 1 before any page-hash work
+  // would have executed.
+  std::optional<uint32_t> Mismatches() const;
+  // Returns Options.skip_page_hash. Reflects caller intent, not outcome.
+  bool PageHashSkipped() const { return opts_.skip_page_hash; }
   // Up to kMaxRecordedMismatches slot indices, for diagnostic logging.
+  // Empty span under Options.skip_page_hash (no per-page work is performed).
   std::span<const uint32_t> MismatchedSlots() const;
 
   std::string_view LastError() const { return last_error_; }

--- a/Source/common/verifyinghasher/VerifyingHasherCore.mm
+++ b/Source/common/verifyinghasher/VerifyingHasherCore.mm
@@ -62,6 +62,11 @@ std::span<const uint32_t> VerifyingHasherCore::MismatchedSlots() const {
   return mismatched_slots_;
 }
 
+std::optional<uint32_t> VerifyingHasherCore::Mismatches() const {
+  if (opts_.skip_page_hash) return std::nullopt;
+  return mismatches_;
+}
+
 VerifyingHasherCore::Status VerifyingHasherCore::RunHeaderPhase() {
   const uint64_t total = static_cast<uint64_t>(reader_.Size());
   HeaderParser hp(want_, total);
@@ -359,6 +364,12 @@ VerifyingHasherCore::Status VerifyingHasherCore::Run() {
     return Status::kMalformedSignature;
   }
 
+  if (opts_.skip_page_hash) {
+    // Substitute NoopHashTraits so the existing PageVerifierT<>
+    // streaming machinery runs without crypto work. Status::kPagesMismatched
+    // is structurally unreachable under this dispatch.
+    return RunStreamingPhases<NoopHashTraits>();
+  }
   switch (parsed_cd_.hash_type) {
     case CS_HASHTYPE_SHA1: return RunStreamingPhases<Sha1Traits>();
     case CS_HASHTYPE_SHA256: return RunStreamingPhases<Sha256Traits>();

--- a/Source/common/verifyinghasher/VerifyingHasherCoreTest.mm
+++ b/Source/common/verifyinghasher/VerifyingHasherCoreTest.mm
@@ -270,7 +270,6 @@ class OverservingMemoryFileReader : public santa::FileReader {
   auto s = v.Run();
   XCTAssertEqual(s, VerifyingHasherCore::Status::kOk, @"Run: %s",
                  std::string(v.LastError()).c_str());
-  XCTAssertTrue(v.PagesMatched());
 
   std::string mine = HexLower(v.FullFileDigest());
   std::string sha = ShasumOf("/usr/bin/yes");
@@ -299,8 +298,8 @@ class OverservingMemoryFileReader : public santa::FileReader {
   VerifyingHasherCore v(r, kHostArch);
   auto s = v.Run();
   XCTAssertEqual(s, VerifyingHasherCore::Status::kPagesMismatched);
-  XCTAssertFalse(v.PagesMatched());
-  XCTAssertGreaterThanOrEqual(v.Mismatches(), 1u);
+  XCTAssertTrue(v.Mismatches().has_value());
+  XCTAssertGreaterThanOrEqual(*v.Mismatches(), 1u);
   XCTAssertGreaterThanOrEqual(v.MismatchedSlots().size(), 1u);
   std::remove(tampered.c_str());
 }
@@ -705,7 +704,6 @@ class OverservingMemoryFileReader : public santa::FileReader {
   VerifyingHasherCore v(r, ArchSelector{cputype, cpusubtype});
   XCTAssertEqual(v.Run(), VerifyingHasherCore::Status::kOk, @"Run: %s",
                  std::string(v.LastError()).c_str());
-  XCTAssertTrue(v.PagesMatched());
   // Picks the strongest CD: SHA-384 wins over SHA-256, SHA-256-TRUNCATED, SHA-1.
   XCTAssertEqual(v.ParsedCD().hash_type, CS_HASHTYPE_SHA384);
 
@@ -723,6 +721,129 @@ class OverservingMemoryFileReader : public santa::FileReader {
 
 - (void)testHwUniversalX86_64 {
   [self checkHwUniversalForArch:CPU_TYPE_X86_64 subtype:CPU_SUBTYPE_X86_64_ALL];
+}
+
+- (void)testPageHashSkippedReflectsOption {
+  auto bytes = Slurp("/usr/bin/yes");
+  XCTAssertFalse(bytes.empty());
+
+  {
+    MemoryFileReader r(bytes);
+    VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{});
+    XCTAssertFalse(v.PageHashSkipped(), @"default Options should leave skip off");
+  }
+  {
+    MemoryFileReader r(bytes);
+    VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{.skip_page_hash = true});
+    XCTAssertTrue(v.PageHashSkipped(), @"Options.skip_page_hash should be reflected");
+  }
+}
+
+- (void)testSkipPageHashBypassesTampered {
+  // Mirrors testDetectsTamperOnCopy but with skip_page_hash = true. The
+  // tamper that would normally drive kPagesMismatched is silently absorbed.
+  const char* tmp = std::getenv("TMPDIR");
+  if (!tmp) tmp = "/tmp";
+  std::string tampered = std::string(tmp) + "/yes_skip_bypass_cdverifier";
+  std::string cp = "cp /usr/bin/yes " + tampered;
+  XCTAssertEqual(std::system(cp.c_str()), 0);
+
+  auto bytes = Slurp(tampered.c_str());
+  if (bytes.empty()) {
+    XCTFail(@"Slurp returned empty bytes for %s", tampered.c_str());
+    std::remove(tampered.c_str());
+    return;
+  }
+  bytes[3 * bytes.size() / 4] ^= 0xFF;
+
+  MemoryFileReader r(bytes);
+  VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{.skip_page_hash = true});
+  auto s = v.Run();
+  XCTAssertEqual(s, VerifyingHasherCore::Status::kOk,
+                 @"skip should bypass page-hash tamper detection; got %s",
+                 std::string(v.LastError()).c_str());
+  XCTAssertTrue(v.PageHashSkipped());
+  XCTAssertFalse(v.Mismatches().has_value(), @"Mismatches() must be nullopt under skip");
+  XCTAssertEqual(v.MismatchedSlots().size(), 0u);
+  // Digest and cdhash still get populated — the bytes were fully read.
+  XCTAssertEqual(v.FullFileDigest().size(), 32u);
+  XCTAssertEqual(v.CDHash().size(), (size_t)CS_CDHASH_LEN);
+  std::remove(tampered.c_str());
+}
+
+- (void)testSkipPageHashCleanBinaryProducesIdenticalDigests {
+  // skip=true and skip=false must produce byte-equal FullFileDigest and
+  // byte-equal CDHash on a clean binary. Locks in that the skip path
+  // doesn't perturb the shared digest pipeline (full_ctx_ feeds +
+  // ParseCodeSignature).
+  auto bytes = Slurp("/usr/bin/yes");
+  XCTAssertFalse(bytes.empty());
+
+  std::vector<uint8_t> normal_sha;
+  std::vector<uint8_t> normal_cdhash;
+  {
+    MemoryFileReader r(bytes);
+    VerifyingHasherCore v(r, kHostArch);
+    XCTAssertEqual(v.Run(), VerifyingHasherCore::Status::kOk);
+    auto d = v.FullFileDigest();
+    normal_sha.assign(d.begin(), d.end());
+    auto c = v.CDHash();
+    normal_cdhash.assign(c.begin(), c.end());
+  }
+
+  MemoryFileReader r(bytes);
+  VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{.skip_page_hash = true});
+  XCTAssertEqual(v.Run(), VerifyingHasherCore::Status::kOk);
+  auto skip_sha = v.FullFileDigest();
+  auto skip_cdhash = v.CDHash();
+  XCTAssertEqual(skip_sha.size(), normal_sha.size());
+  XCTAssertEqual(skip_cdhash.size(), normal_cdhash.size());
+  XCTAssertEqual(0, std::memcmp(skip_sha.data(), normal_sha.data(), normal_sha.size()));
+  XCTAssertEqual(0, std::memcmp(skip_cdhash.data(), normal_cdhash.data(), normal_cdhash.size()));
+}
+
+- (void)testSkipPageHashPreservesIoError {
+  // TruncatedMemoryFileReader claims a larger size than data backs.
+  // Phase 1's "n == 0 with cursor_ < total" path classifies as kIoError.
+  // Skip must not paper over phase-1 I/O errors.
+  auto bytes = Slurp("/usr/bin/yes");
+  XCTAssertFalse(bytes.empty());
+  const off_t real_size = static_cast<off_t>(bytes.size());
+
+  TruncatedMemoryFileReader r(std::move(bytes), real_size + 1024 * 1024);
+  VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{.skip_page_hash = true});
+  auto s = v.Run();
+  XCTAssertEqual(s, VerifyingHasherCore::Status::kIoError);
+  XCTAssertTrue(v.PageHashSkipped());
+  XCTAssertFalse(v.Mismatches().has_value());
+  // Spec contract: digest is empty on kIoError (the only status without a
+  // populated digest).
+  XCTAssertTrue(v.FullFileDigest().empty());
+}
+
+- (void)testSkipPageHashPreservesPhaseOneError {
+  // /etc/hosts is not a Mach-O. Skip option must not bypass phase-1 errors.
+  auto bytes = Slurp("/etc/hosts");
+  MemoryFileReader r(bytes);
+  VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{.skip_page_hash = true});
+  auto s = v.Run();
+  XCTAssertEqual(s, VerifyingHasherCore::Status::kNotMachO);
+  XCTAssertTrue(v.PageHashSkipped());
+  // Digest is still finalized on non-IoError failure
+  // (FinalizeDigestDrainingToEof).
+  XCTAssertEqual(v.FullFileDigest().size(), 32u);
+}
+
+- (void)testPageHashSkippedReflectsIntentEvenOnPhaseOneError {
+  // PageHashSkipped() returns Options.skip_page_hash unconditionally —
+  // true even when Run() never reaches the streaming phases.
+  auto bytes = Slurp("/etc/hosts");
+  MemoryFileReader r(bytes);
+  VerifyingHasherCore v(r, kHostArch, VerifyingHasherCore::Options{.skip_page_hash = true});
+  XCTAssertTrue(v.PageHashSkipped(), @"PageHashSkipped() should reflect Options pre-Run()");
+  (void)v.Run();
+  XCTAssertTrue(v.PageHashSkipped(), @"PageHashSkipped() should still reflect Options post-Run()");
+  XCTAssertFalse(v.Mismatches().has_value());
 }
 
 @end

--- a/Source/common/verifyinghasher/VerifyingHasherTest.mm
+++ b/Source/common/verifyinghasher/VerifyingHasherTest.mm
@@ -411,4 +411,94 @@ std::vector<uint8_t> Slurp(const char* path) {
                  @"sha256 must be deterministic across two reads of the same file");
 }
 
+- (void)testFacadeSkipPageHashCleanBinary {
+  // skip_page_hash via RunOptions on a clean binary still drives
+  // kMatchCDHash, with an engaged sha256 that matches the non-skip run.
+  auto cdhash = [self hwUniversalArm64CdHash];
+
+  // Reference sha256 from the non-skip path.
+  std::array<uint8_t, 32> reference_sha;
+  {
+    santa::ScopedFile sf([self openHwUniversalFd]);
+    VerifyingHasher::Expected exp{
+        .cdhash = std::span<const uint8_t>(cdhash.data(), cdhash.size()),
+        .signing_id = kHwUniversalSigningID,
+        .team_id = kHwUniversalTeamID,
+    };
+    auto r = VerifyingHasher::Run(sf.UnsafeFD(), CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL, exp);
+    XCTAssertEqual(r.status, VerifyingHasher::Status::kMatchCDHash);
+    XCTAssertTrue(r.sha256.has_value());
+    reference_sha = *r.sha256;
+  }
+
+  santa::ScopedFile sf([self openHwUniversalFd]);
+  VerifyingHasher::Expected exp{
+      .cdhash = std::span<const uint8_t>(cdhash.data(), cdhash.size()),
+      .signing_id = kHwUniversalSigningID,
+      .team_id = kHwUniversalTeamID,
+  };
+  auto r = VerifyingHasher::Run(sf.UnsafeFD(), CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL, exp,
+                                VerifyingHasher::RunOptions{.skip_page_hash = true});
+  XCTAssertEqual(r.status, VerifyingHasher::Status::kMatchCDHash);
+  XCTAssertTrue(r.sha256.has_value());
+  XCTAssertEqual(0, std::memcmp(r.sha256->data(), reference_sha.data(), 32));
+}
+
+- (void)testFacadeSkipPageHashBypassesTampered {
+  // Write a tampered hw_universal into a temp file (mkstemp-backed,
+  // unlinked at creation), open it, and exercise the facade with skip
+  // on/off. Without skip the tamper drives kError (kPagesMismatched at
+  // the Core level); with skip it drives kMatchCDHash because the
+  // cdhash is computed from the unmodified CS blob and the tampered
+  // text bytes are no longer checked.
+  auto bytes = Slurp([[self fixturePath] UTF8String]);
+  XCTAssertFalse(bytes.empty(), @"Failed to slurp hw_universal fixture");
+
+  // Flip a byte 3/4 of the way through. hw_universal is a fat binary
+  // with x86_64 in the lower half and arm64 in the upper half; 3/4
+  // reliably lands inside the arm64 slice's signed region (before the
+  // CS blob at the slice's end). If hw_universal is regenerated with a
+  // different layout, this offset may need to be recomputed — symptom
+  // would be kMalformedSignature from either test branch.
+  bytes[3 * bytes.size() / 4] ^= 0xFF;
+
+  auto file = santa::ScopedFile::CreateTemporary();
+  XCTAssertTrue(file.ok(), @"CreateTemporary failed: %s", file.status().ToString().c_str());
+
+  NSData* data = [NSData dataWithBytes:bytes.data() length:bytes.size()];
+  NSFileHandle* writer = file->Writer();
+  NSError* writeErr = nil;
+  XCTAssertTrue([writer writeData:data error:&writeErr], @"Failed to write tampered fixture: %@",
+                writeErr);
+
+  auto cdhash = [self hwUniversalArm64CdHash];
+  VerifyingHasher::Expected exp{
+      .cdhash = std::span<const uint8_t>(cdhash.data(), cdhash.size()),
+      .signing_id = kHwUniversalSigningID,
+      .team_id = kHwUniversalTeamID,
+  };
+
+  // VerifyingHasher::Run uses pread internally (offset-explicit), so the
+  // same fd can be passed to both calls without rewind.
+
+  // Without skip: kError (Core returns kPagesMismatched).
+  {
+    auto r = VerifyingHasher::Run(file->UnsafeFD(), CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL, exp);
+    XCTAssertEqual(r.status, VerifyingHasher::Status::kError,
+                   @"tampered binary without skip must surface as kError");
+  }
+
+  // With skip: kMatchCDHash.
+  {
+    auto r = VerifyingHasher::Run(file->UnsafeFD(), CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL, exp,
+                                  VerifyingHasher::RunOptions{.skip_page_hash = true});
+    XCTAssertEqual(r.status, VerifyingHasher::Status::kMatchCDHash,
+                   @"tampered binary with skip must drive kMatchCDHash");
+    XCTAssertTrue(r.sha256.has_value());
+  }
+
+  // ScopedFile destructor closes the fd; mkstemp file was unlinked at
+  // creation. No explicit cleanup needed.
+}
+
 @end

--- a/Testing/OneOffs/VerifyingHasher.mm
+++ b/Testing/OneOffs/VerifyingHasher.mm
@@ -45,14 +45,17 @@ struct Args {
   std::string path;
   ArchSelector arch = kHostDefaultArch;
   size_t buf_size = 1u << 20;
+  bool skip_page_hash = false;
 };
 
 void PrintUsage(FILE* f) {
   std::fprintf(f,
-               "Usage: VerifyingHasher [-a ARCH] [-b BYTES] <path>\n"
+               "Usage: VerifyingHasher [-a ARCH] [-b BYTES] [-s] <path>\n"
                "  -a ARCH   architecture: arm64 | arm64e | x86_64\n"
                "            (default: host preferred — arm64e on Apple Silicon, x86_64 on Intel)\n"
                "  -b N      pread chunk size in bytes (default 1048576, minimum 512)\n"
+               "  -s        skip per-page CodeDirectory verification\n"
+               "            (cdhash and full-file SHA-256 still computed)\n"
                "  -h        show this help\n");
 }
 
@@ -81,7 +84,7 @@ const char* ArchName(const ArchSelector& a) {
 
 bool ParseArgs(int argc, char** argv, Args& out) {
   int opt;
-  while ((opt = getopt(argc, argv, "a:b:h")) != -1) {
+  while ((opt = getopt(argc, argv, "a:b:hs")) != -1) {
     switch (opt) {
       case 'a':
         if (!ParseArch(optarg, out.arch)) {
@@ -99,6 +102,7 @@ bool ParseArgs(int argc, char** argv, Args& out) {
         out.buf_size = static_cast<size_t>(v);
         break;
       }
+      case 's': out.skip_page_hash = true; break;
       case 'h': PrintUsage(stdout); std::exit(0);
       default: return false;
     }
@@ -145,6 +149,7 @@ int main(int argc, char** argv) {
   FdFileReader reader(fd, st.st_size);
   VerifyingHasherCore::Options opts;
   opts.buf_size = args.buf_size;
+  opts.skip_page_hash = args.skip_page_hash;
   VerifyingHasherCore v(reader, args.arch, opts);
   auto status = v.Run();
   ::close(fd);
@@ -177,7 +182,11 @@ int main(int argc, char** argv) {
   std::printf("full-file digest: %s\n", HexLower(digest.data(), digest.size()).c_str());
   auto cdhash = v.CDHash();
   std::printf("cdhash: %s\n", HexLower(cdhash.data(), cdhash.size()).c_str());
-  std::printf("page mismatches: %u\n", v.Mismatches());
+  if (v.PageHashSkipped()) {
+    std::printf("page mismatches: (skipped)\n");
+  } else {
+    std::printf("page mismatches: %u\n", *v.Mismatches());
+  }
 
   auto bad = v.MismatchedSlots();
   if (!bad.empty()) {

--- a/Testing/OneOffs/verifying_hasher_smoke.sh
+++ b/Testing/OneOffs/verifying_hasher_smoke.sh
@@ -104,6 +104,26 @@ if "$BIN" /etc/hosts >"$TMP/case4.out" 2>"$TMP/case4.err"; then
 fi
 assert_grep "not a Mach-O" "$TMP/case4.err"
 
+# Case 5: -s flag — same digest + cdhash as Case 1, plus the skip marker.
+echo "Case 5: -s flag on /usr/bin/yes"
+"$BIN" -s /usr/bin/yes >"$TMP/case5.out" 2>"$TMP/case5.err" || {
+    echo "FAIL: -s /usr/bin/yes returned non-zero" >&2
+    failures=$((failures + 1))
+}
+case1_digest=$(grep -E '^full-file digest:' "$TMP/case1.out" | awk '{print $3}')
+case5_digest=$(grep -E '^full-file digest:' "$TMP/case5.out" | awk '{print $3}')
+case1_cdhash=$(grep -E '^cdhash:' "$TMP/case1.out" | awk '{print $2}')
+case5_cdhash=$(grep -E '^cdhash:' "$TMP/case5.out" | awk '{print $2}')
+if [ -z "$case5_digest" ] || [ "$case1_digest" != "$case5_digest" ]; then
+    echo "FAIL: -s digest ($case5_digest) differs from no-flag digest ($case1_digest)" >&2
+    failures=$((failures + 1))
+fi
+if [ -z "$case5_cdhash" ] || [ "$case1_cdhash" != "$case5_cdhash" ]; then
+    echo "FAIL: -s cdhash ($case5_cdhash) differs from no-flag cdhash ($case1_cdhash)" >&2
+    failures=$((failures + 1))
+fi
+assert_grep "page mismatches: (skipped)" "$TMP/case5.out"
+
 if [ "$failures" -ne 0 ]; then
     echo "smoke: $failures FAILURES" >&2
     exit 1


### PR DESCRIPTION
Adds Options.skip_page_hash to VerifyingHasherCore and a corresponding RunOptions.skip_page_hash on the public VerifyingHasher facade. When set, per-page CodeDirectory verification is bypassed while cdhash, full-file SHA-256, signing-id, and team-id extraction are preserved. Intended for callers with independent assurance of page-hash integrity.

### Public surface

| Component | Field | Purpose |
| --- | --- | --- |
| `VerifyingHasherCore::Options` | `bool skip_page_hash` | per-`Run()` knob (default false) | | `VerifyingHasher::RunOptions` | `bool skip_page_hash` | facade-level mirror | | `VerifyingHasherCore::Mismatches()` | `std::optional<uint32_t>` | `std::nullopt` under skip | | `VerifyingHasherCore::PageHashSkipped()` | `bool` | returns `Options.skip_page_hash` |

`Mismatches()` returning `std::nullopt` under skip makes a caller that ignored `PageHashSkipped()` fail loudly (`.value()` throws) instead of silently consuming a falsely-clean count.

Two `Run()` overloads on the facade (4-arg forwarder + 5-arg primary) work around clang's complete-class-context restriction on a defaulted `const RunOptions& opts = {}` parameter inside the enclosing class.

### Implementation

Dispatch in `RunStreamingPhases<>` substitutes `NoopHashTraits` from `HashTraits.h` when `skip_page_hash` is set. The if-constexpr branch in `PageVerifierT::Update` performs an O(1) bulk-advance of `cur_slot_` / `cur_page_bytes_` instead of running the per-page hashing loop. The iterative loop is the if-constexpr discarded substatement under `NoopHashTraits` and is not instantiated, which lets the trait keep `kDigestSize = 0`. The gap-detect prologue and end-state arithmetic apply on both code paths, so `StreamCorrupt()` and `Complete()` defense-in-depth remain active under skip.

Apple's CodeDirectory only ships pow2 page sizes (4096, 16384), so the constructor detects pow2 via `std::has_single_bit` and stores `page_size_shift_` / `page_size_mask_`. The hot path uses shift+mask instead of `UDIV`/`UREM` — the latter would serialize against the SHA-256 stream in cold-cache regimes where OoO slack is tighter. A UDIV fallback covers hypothetical non-pow2 page sizes.

### Tests

- `PageVerifierTest`: bulk-advance Complete()/StreamCorrupt() invariants with partial-last-page, page-aligned, gap-detect, short-stream, and non-pow2 fallback cases.
- `HashTraitsTest`: `NoopHashTraits` size invariants.
- `VerifyingHasherCoreTest`: skip preserves digest equivalence with non-skip, bypasses tamper, preserves I/O and phase-1 errors, `PageHashSkipped()` reflects intent even on early failures.
- `VerifyingHasherTest`: facade-level skip on clean and tampered.
- `Testing/OneOffs/verifying_hasher_smoke.sh` Case 5: `-s` produces byte-identical cdhash and full-file digest vs. the no-flag run.
- Exerciser gains a `-s` flag and prints `page mismatches: (skipped)`.