### PR TITLE
sync: commit mode transition atomically with sync-state batch

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -1161,10 +1161,14 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 ///  returns, the working dictionary is assigned to `syncState` (single
 ///  KVO fire) and saved to disk (single `writeToFile:atomically:YES`).
 ///
-///  Must be called outside any other batch on this configurator.
-///  Asserts in debug; logs and skips in release.
+///  Returns `YES` when both the in-memory commit and the disk write
+///  succeed. Returns `NO` when nested inside another batch (asserts in
+///  debug, logs and skips in release) or when the disk write fails. The
+///  block is not expected to raise exceptions; if one escapes it will
+///  crash the daemon, by design. Callers should gate any post-commit
+///  work that depends on durable state on the return value.
 ///
-- (void)performSyncStateBatch:(nonnull void(NS_NOESCAPE ^)(void))block;
+- (BOOL)performSyncStateBatch:(nonnull void(NS_NOESCAPE ^)(void))block;
 
 ///
 ///  Validate the configuration profile.

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -1983,7 +1983,8 @@ static SNTConfigurator* sharedConfigurator = nil;
   }
 }
 
-- (void)performSyncStateBatch:(void(NS_NOESCAPE ^)(void))block {
+- (BOOL)performSyncStateBatch:(void(NS_NOESCAPE ^)(void))block {
+  __block BOOL committed = NO;
   void (^run)(void) = ^{
     if (self.batchedSyncState != nil) {
       NSAssert(NO, @"Sync-state batches do not nest");
@@ -1991,19 +1992,17 @@ static SNTConfigurator* sharedConfigurator = nil;
       return;
     }
     self.batchedSyncState = self.syncState.mutableCopy;
-    @try {
-      block();
-      self.syncState = self.batchedSyncState;
-      [self saveSyncStateToDisk];
-    } @finally {
-      self.batchedSyncState = nil;
-    }
+    block();
+    self.syncState = self.batchedSyncState;
+    self.batchedSyncState = nil;
+    committed = [self saveSyncStateToDisk];
   };
   if ([NSThread isMainThread]) {
     run();
   } else {
     dispatch_sync(dispatch_get_main_queue(), run);
   }
+  return committed;
 }
 
 ///
@@ -2075,27 +2074,35 @@ static SNTConfigurator* sharedConfigurator = nil;
 }
 
 ///
-///  Saves the current effective syncState to disk.
+///  Saves the current effective syncState to disk. Returns YES if the write
+///  succeeded; NO if the authorizer denied the operation or the underlying
+///  file write failed.
 ///
-- (void)saveSyncStateToDisk {
+- (BOOL)saveSyncStateToDisk {
   if (!self.syncStateAccessAuthorizerBlock()) {
-    return;
+    return NO;
   }
 
   NSMutableDictionary* syncState = self.syncState.mutableCopy;
   syncState[kAllowedPathRegexKey] = [syncState[kAllowedPathRegexKey] pattern];
   syncState[kBlockedPathRegexKey] = [syncState[kBlockedPathRegexKey] pattern];
-  [syncState writeToFile:self.syncStateFilePath atomically:YES];
+  if (![syncState writeToFile:self.syncStateFilePath atomically:YES]) {
+    LOGE(@"Failed to write sync state to %@", self.syncStateFilePath);
+    return NO;
+  }
   [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0600}
                                    ofItemAtPath:self.syncStateFilePath
                                           error:NULL];
+  return YES;
 }
 
 - (void)clearSyncState {
+  // Intentionally not gated on `syncStateAccessAuthorizerBlock`: the authorizer
+  // requires `syncBaseURL != nil`, but the SNTSyncdQueue caller invokes this
+  // method precisely *because* `syncBaseURL` went to nil. Gating here would
+  // make the cleanup unreachable in production. Disk removal still requires
+  // root, which santad already has.
   void (^block)(void) = ^{
-    if (!self.syncStateAccessAuthorizerBlock()) {
-      return;
-    }
     if (self.batchedSyncState) {
       [self.batchedSyncState removeAllObjects];
       return;

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -319,7 +319,7 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
            options:NSKeyValueObservingOptionNew
            context:&kvoCount];
 
-  [cfg performSyncStateBatch:^{
+  BOOL committed = [cfg performSyncStateBatch:^{
     [cfg setSyncServerClientMode:SNTClientModeLockdown];
     [cfg setEnableBundles:YES];
     [cfg setEnableTransitiveRules:YES];
@@ -327,6 +327,7 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
 
   [cfg removeObserver:self forKeyPath:@"syncState" context:&kvoCount];
 
+  XCTAssertTrue(committed, @"A successful batch must report committed=YES");
   XCTAssertEqual(kvoCount, (NSUInteger)1,
                  @"Expected exactly one KVO fire on syncState across the batch; got %lu",
                  (unsigned long)kvoCount);
@@ -335,6 +336,31 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   XCTAssertTrue(cfg.enableTransitiveRules);
 
   XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
+- (void)testPerformSyncStateBatchReturnsNoWhenDiskWriteFails {
+  // Pointing the configurator at an unwritable path forces saveSyncStateToDisk
+  // to fail. The in-memory commit still happens (KVO still fires) but the
+  // BOOL return signals that durability was not achieved.
+  NSString* plistPath = @"/this/directory/definitely/does/not/exist/batch.plist";
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  __block NSUInteger kvoCount = 0;
+  [cfg addObserver:self
+        forKeyPath:@"syncState"
+           options:NSKeyValueObservingOptionNew
+           context:&kvoCount];
+
+  BOOL committed = [cfg performSyncStateBatch:^{
+    [cfg setSyncServerClientMode:SNTClientModeLockdown];
+  }];
+
+  [cfg removeObserver:self forKeyPath:@"syncState" context:&kvoCount];
+
+  XCTAssertFalse(committed, @"Batch must report committed=NO when the disk write fails");
+  XCTAssertEqual(kvoCount, (NSUInteger)1,
+                 @"In-memory state still commits before the disk write is attempted");
+  XCTAssertEqual(cfg.clientMode, SNTClientModeLockdown);
 }
 
 - (void)testPerformSyncStateBatchWithClearAndWritesPersistsOnlyPostClearWrites {
@@ -392,6 +418,39 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
 
   // A second call is also a no-op.
   XCTAssertNoThrow([cfg clearSyncState]);
+}
+
+- (void)testClearSyncStateBypassesSyncStateAccessAuthorizer {
+  // The production authorizer requires `syncBaseURL != nil`, but the
+  // SNTSyncdQueue caller invokes clearSyncState precisely when SyncBaseURL
+  // went to nil. Gating cleanup on the authorizer would make this caller a
+  // no-op. Lock the bypass in with a configurator whose authorizer always
+  // denies — clearSyncState must still drop in-memory state and the plist.
+  NSString* plistPath = [NSString stringWithFormat:@"%@/clear-authdenied.plist", self.testDir];
+
+  // Force a state file to exist on disk using a permissive configurator.
+  SNTConfigurator* writer = [self configuratorWithEmptySyncStateAtPath:plistPath];
+  [writer setSyncServerClientMode:SNTClientModeLockdown];
+  XCTAssertTrue([self.fileMgr fileExistsAtPath:plistPath]);
+
+  // Now construct a new configurator over the same path with a denying
+  // authorizer and verify clearSyncState still cleans up.
+  SNTConfigurator* cfg = [[SNTConfigurator alloc] initWithSyncStateFile:plistPath
+      stateFile:@"/does/not/need/to/exist"
+      oldStateFile:@"/does/not/need/to/exist"
+      syncStateAccessAuthorizer:^BOOL {
+        return NO;
+      }
+      stateAccessAuthorizer:^BOOL {
+        return NO;
+      }];
+
+  [cfg clearSyncState];
+
+  XCTAssertEqual(cfg.syncState.count, (NSUInteger)0,
+                 @"clearSyncState must reset in-memory state even when authorizer denies");
+  XCTAssertFalse([self.fileMgr fileExistsAtPath:plistPath],
+                 @"clearSyncState must remove the plist even when authorizer denies");
 }
 
 @end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -485,11 +485,19 @@ double watchdogRAMPeak = 0;
   // and rules-newly-added cases.
   NSData* oldCELData = [SNTCELFallbackRule serializeArray:[configurator celFallbackRules]];
 
-  [configurator performSyncStateBatch:^{
+  BOOL committed = [configurator performSyncStateBatch:^{
     [result clearSyncStateBeforeApply:^(BOOL clear) {
       if (clear) {
         [configurator clearSyncState];
       }
+    }];
+
+    // Persist the mode transition inside the batch so it commits atomically
+    // with the rest of sync-derived state. TMM's enforcement side effects
+    // (Revoke + GUI notify) run after the batch via NewModeTransitionReceived
+    // so that `Available(nil)` reads consistent post-commit state.
+    [result modeTransition:^(SNTModeTransition* val) {
+      [configurator setSyncServerModeTransition:val];
     }];
 
     [result clientMode:^(SNTClientMode m) {
@@ -616,19 +624,20 @@ double watchdogRAMPeak = 0;
     }];
   }];
 
-  // Mode-transition handler runs post-commit so the GUI notification its
-  // internal Available(nil) computes reads from the just-committed state
-  // rather than from the batch's pre-commit snapshot. TMM's combined
-  // persistence-and-side-effects contract stays as-is — accommodated by
-  // call ordering rather than refactored.
+  // Mode-transition enforcement and GUI notification run after the batch so
+  // Available(nil) reads from the just-committed state. Bundle accessors are
+  // pure synchronous reads (see SNTConfigBundle.mm), so re-invoking the same
+  // callback shape is safe and short-circuits when the bundle carries no
+  // modeTransition.
   [result modeTransition:^(SNTModeTransition* val) {
-    // The _temporaryMonitorMode object is responsible for updating configurator as appropriate
     _temporaryMonitorMode->NewModeTransitionReceived(val);
   }];
 
-  NSData* newCELData = [SNTCELFallbackRule serializeArray:[configurator celFallbackRules]];
-  if (![oldCELData isEqualToData:newCELData] && self.flushCacheBlock) {
-    self.flushCacheBlock(FlushCacheMode::kAllCaches, FlushCacheReason::kCELFallbackRulesChanged);
+  if (committed) {
+    NSData* newCELData = [SNTCELFallbackRule serializeArray:[configurator celFallbackRules]];
+    if (![oldCELData isEqualToData:newCELData] && self.flushCacheBlock) {
+      self.flushCacheBlock(FlushCacheMode::kAllCaches, FlushCacheReason::kCELFallbackRulesChanged);
+    }
   }
 
   reply();

--- a/Source/santad/TemporaryMonitorMode.mm
+++ b/Source/santad/TemporaryMonitorMode.mm
@@ -149,15 +149,17 @@ uint64_t TemporaryMonitorMode::GetSecondsRemainingFromInitialStateLocked(
 }
 
 void TemporaryMonitorMode::NewModeTransitionReceived(SNTModeTransition* mode_transition) {
+  // Persistence of the received mode_transition is the caller's responsibility
+  // (the daemon controller writes it inside a sync-state batch so that all
+  // sync-derived state lands in a single commit). This method handles
+  // enforcement side effects for Revoke and the GUI availability notification,
+  // both of which must run regardless of how persistence was sequenced.
   if (mode_transition.type == SNTModeTransitionTypeRevoke) {
     if (Revoke(SNTTemporaryMonitorModeLeaveReasonRevoked)) {
       LOGI(@"Temporary Monitor Mode session revoked due to policy change.");
     }
-  } else {
-    [configurator_ setSyncServerModeTransition:mode_transition];
   }
 
-  // Notify the GUI about policy availability
   [[notification_queue_.notifierConnection remoteObjectProxy]
       temporaryMonitorModePolicyAvailable:Available(nil)];
 }
@@ -287,7 +289,14 @@ bool TemporaryMonitorMode::Revoke(SNTTemporaryMonitorModeLeaveReason reason) {
 }
 
 bool TemporaryMonitorMode::RevokeLocked(SNTTemporaryMonitorModeLeaveReason reason) {
-  [configurator_ setSyncServerModeTransition:[[SNTModeTransition alloc] initRevocation]];
+  // Skip the persistence write if the current effective transition is already
+  // a revoke. On the sync-update path the daemon controller writes the revoke
+  // inside its batch, so this would otherwise produce a second `syncState`
+  // KVO fire. On all other Revoke entry points (sync URL change, etc.) the
+  // current transition will not be a revoke and this writes as before.
+  if ([configurator_ modeTransition].type != SNTModeTransitionTypeRevoke) {
+    [configurator_ setSyncServerModeTransition:[[SNTModeTransition alloc] initRevocation]];
+  }
   if (EndLocked()) {
     handle_audit_event_block_([[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
         initWithUUID:[current_uuid_ UUIDString]


### PR DESCRIPTION
Builds on #944. Three connected changes:

1. Pull modeTransition persistence into performSyncStateBatch so it commits atomically with the rest of sync-derived state. TMM's enforcement side effects (Revoke + GUI notify) run after the batch via NewModeTransitionReceived so Available(nil) reads consistent post-commit state.

   To avoid a second syncState KVO fire on the Revoke path, RevokeLocked skips its own setSyncServerModeTransition: when the current transition is already a revoke. Other Revoke entry points (sync URL change, etc.) keep their existing behavior.

2. performSyncStateBatch: and saveSyncStateToDisk return BOOL so callers can gate post-commit work on durable persistence. Used to skip the CEL cache flush on disk failure. Removed the @try/@finally wrapper around the batch block; runtime exceptions are fatal by design.

3. Drop the syncStateAccessAuthorizerBlock guard from clearSyncState. The production authorizer requires syncBaseURL != nil, but SNTSyncdQueue invokes clearSyncState precisely when syncBaseURL went to nil. Gating cleanup there would make it unreachable.

Tests cover the BOOL return on disk failure and lock in clearSyncState's authorizer bypass.