### PR TITLE
Allow test GUI to configure username

### DIFF
--- a/Source/gui/SNTTestGUI.swift
+++ b/Source/gui/SNTTestGUI.swift
@@ -142,6 +142,7 @@ struct BinaryView: View {
   @State var teamID: String = "9X9633G7QW"
   @State var path: String = "/Applications/Malware.app/Contents/MacOS"
   @State var parent: String = "launchd"
+  @State var executingUser: String = NSUserName()
 
   @State var unknownBlockMessage: String = ""
   @State var eventDetailURL: String = "http://sync-server-hostname/blockables/%bundle_or_file_identifier%"
@@ -167,6 +168,7 @@ struct BinaryView: View {
           TextField(text: $teamID, label: { Text(verbatim: "TeamID") })
           TextField(text: $path, label: { Text(verbatim: "Path") })
           TextField(text: $parent, label: { Text(verbatim: "Parent") })
+          TextField(text: $executingUser, label: { Text(verbatim: "Executing User") })
         }
       }
 
@@ -262,7 +264,7 @@ struct BinaryView: View {
         event.parentName = parent
         event.pid = 12345
         event.ppid = 2511
-        event.executingUser = NSUserName()
+        event.executingUser = executingUser
 
         switch dateOverride {
         case .Apr1: Date.overrideDate = Date(timeIntervalSince1970: 1711980915)


### PR DESCRIPTION
Previously, the test GUI always shows the current user's username in the test dialog. This change makes it configurable.

<img width="2416" height="1660" alt="CleanShot 2026-05-15 at 15 44 59@2x" src="https://github.com/user-attachments/assets/56096467-6891-4850-82c2-38a119f1c23a" />
<img width="1208" height="946" alt="CleanShot 2026-05-15 at 15 45 16@2x" src="https://github.com/user-attachments/assets/8da9e234-e247-4985-8561-c21a3a0b06c6" />
