### PR TITLE
Handle anti-tamper ops asynchronously

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -214,8 +214,23 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message& esMsg) {
   return @"Tamper Resistance";
 }
 
+- (BOOL)shouldHandleMessage:(const Message&)esMsg {
+  return YES;
+}
+
 - (void)handleMessage:(Message&&)esMsg
     recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {
+  [self processMessage:std::move(esMsg)
+               handler:^(Message msg) {
+                 es_auth_result_t result = [self processAuthMessage:std::move(msg)];
+                 // For this client, a processed event is one that was found
+                 // to be violating anti-tamper policy.
+                 recordEventMetrics(result == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                                  : EventDisposition::kDropped);
+               }];
+}
+
+- (es_auth_result_t)processAuthMessage:(Message)esMsg {
   es_auth_result_t result = ES_AUTH_RESULT_ALLOW;
   bool cacheable = true;
   switch (esMsg->event_type) {
@@ -356,9 +371,7 @@ std::pair<es_auth_result_t, bool> ValidateLaunchctlExec(const Message& esMsg) {
           withAuthResult:result
                cacheable:(cacheable && result == ES_AUTH_RESULT_ALLOW)];
 
-  // For this client, a processed event is one that was found to be violating anti-tamper policy
-  recordEventMetrics(result == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
-                                                   : EventDisposition::kDropped);
+  return result;
 }
 
 - (void)enable {

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -47,6 +47,7 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 
 @interface SNTEndpointSecurityTamperResistance (Testing)
 + (bool)isProtectedPath:(std::string_view)path;
+- (es_auth_result_t)processAuthMessage:(santa::Message)esMsg;
 @end
 
 @interface SNTEndpointSecurityTamperResistanceTest : XCTestCase
@@ -261,14 +262,11 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
         [inv getArgument:&gotCachable atIndex:4];
       });
 
-  // First check unhandled event types will crash
-  {
-    Message msg(mockESApi, &esMsg);
-    XCTAssertThrows([tamperClient handleMessage:Message(mockESApi, &esMsg)
-                             recordEventMetrics:^(EventDisposition d) {
-                               XCTFail("Unhandled event types shouldn't call metrics recorder");
-                             }]);
-  }
+  // First check unhandled event types will crash. Test against
+  // `processAuthMessage:` directly: the dispatched switch lives there, so the
+  // synchronous throw cannot be observed through `handleMessage:` after the
+  // work moved to the auth queue.
+  XCTAssertThrows([tamperClient processAuthMessage:Message(mockESApi, &esMsg)]);
 
   // Check UNLINK tamper events
   {


### PR DESCRIPTION
Handle anti-tamper ops async in order to not trip ES deadlock scenarios.