### PR TITLE
santad: Make CEL fallback rules usable with platform binaries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "df6b5ea22bdfeb185b5a22d7090553ec80ce081f",
+    commit = "1f68b15c98e17322de017b8246795a7370bcc7aa",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -122,6 +122,7 @@ typedef NS_ENUM(uint64_t, SNTEventState) {
   SNTEventStateAllowCompilerSigningID = 1ULL << 52,
   SNTEventStateAllowCompilerCDHash = 1ULL << 53,
   SNTEventStateAllowCELFallback = 1ULL << 54,
+  SNTEventStateAllowPlatform = 1ULL << 55,
 
   // Block and Allow masks
   SNTEventStateBlock = 0xFFFFFFULL << 16,

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -317,6 +317,7 @@ message Execution {
     REASON_SIGNING_ID = 11;
     REASON_CDHASH = 12;
     REASON_CEL_FALLBACK = 13;
+    REASON_PLATFORM = 14;
   }
   optional Reason reason = 10;
 

--- a/Source/santactl/Commands/SNTCommandFileInfo.mm
+++ b/Source/santactl/Commands/SNTCommandFileInfo.mm
@@ -507,7 +507,10 @@ static void ResumeDaemonConnection(SNTCommandFileInfo* cmd) {
             : [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:identifiers
                                                  andSigningStatus:signingStatus];
 
-    __block NSString* output = @"None";
+    __block NSString* output =
+        csc.platformBinary
+            ? (cmd.prettyOutput ? @"\033[32mPlatform Binary\033[0m" : @"Platform Binary")
+            : @"None";
     id<SNTDaemonControlXPC> rop = [cmd.daemonConn remoteObjectProxy];
     [rop databaseRuleForIdentifiers:lookupIdentifiers
                               reply:^(SNTRule* r) {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -264,12 +264,17 @@ santa_unit_test(
     name = "SNTPolicyProcessorTest",
     srcs = ["SNTPolicyProcessorTest.mm"],
     deps = [
+        ":EntitlementsFilter",
         ":SNTPolicyProcessor",
+        ":SNTRuleTable",
         "//Source/common:SNTCELFallbackRule",
         "//Source/common:SNTCachedDecision",
+        "//Source/common:SNTConfigState",
         "//Source/common:SNTConfigurator",
+        "//Source/common:SNTFileInfo",
         "//Source/common:SNTRule",
         "//Source/common:TestUtils",
+        "@OCMock",
     ],
 )
 

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -513,14 +513,6 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     [rs close];
   }];
 
-  // Allow binaries signed by the "Software Signing" cert used to sign launchd
-  // if no existing rule has matched.
-  if (!rule && [identifiers.certificateSHA256 isEqual:self.launchdCSInfo.leafCertificate.SHA256]) {
-    rule = [[SNTRule alloc] initWithIdentifier:identifiers.certificateSHA256
-                                         state:SNTRuleStateAllow
-                                          type:SNTRuleTypeCertificate];
-  }
-
   return rule;
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -95,6 +95,7 @@ std::string GetReasonString(SNTEventState event_state) {
     case SNTEventStateAllowCDHash: return "CDHASH";
     case SNTEventStateAllowCompilerCDHash: return "CDHASH";
     case SNTEventStateAllowCELFallback: return "CEL_FALLBACK";
+    case SNTEventStateAllowPlatform: return "PLATFORM";
     case SNTEventStateAllowUnknown: return "UNKNOWN";
     case SNTEventStateBlockBinary: return "BINARY";
     case SNTEventStateBlockCertificate: return "CERT";

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -1450,6 +1450,7 @@ std::string BasicStringSerializeMessage(es_message_t* esMsg) {
       {SNTEventStateAllowPendingTransitive, "ALLOW"},
       {SNTEventStateAllowTeamID, "ALLOW"},
       {SNTEventStateAllowCELFallback, "ALLOW"},
+      {SNTEventStateAllowPlatform, "ALLOW"},
   };
 
   for (const auto& kv : stateToDecision) {
@@ -1489,6 +1490,7 @@ std::string BasicStringSerializeMessage(es_message_t* esMsg) {
       case SNTEventStateAllowCompilerSigningID: want = "SIGNINGID"; break;
       case SNTEventStateAllowCompilerCDHash: want = "CDHASH"; break;
       case SNTEventStateAllowCELFallback: want = "CEL_FALLBACK"; break;
+      case SNTEventStateAllowPlatform: want = "PLATFORM"; break;
       case SNTEventStateBlock: want = "UNKNOWN"; break;
       case SNTEventStateAllow: want = "UNKNOWN"; break;
     }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -347,6 +347,7 @@ static inline void EncodeCertificateInfo(::pbv1::CertificateInfo* pb_cert_info, 
     case SNTEventStateAllowCDHash: return ::pbv1::Execution::REASON_CDHASH;
     case SNTEventStateAllowCompilerCDHash: return ::pbv1::Execution::REASON_CDHASH;
     case SNTEventStateAllowCELFallback: return ::pbv1::Execution::REASON_CEL_FALLBACK;
+    case SNTEventStateAllowPlatform: return ::pbv1::Execution::REASON_PLATFORM;
     case SNTEventStateAllowUnknown: return ::pbv1::Execution::REASON_UNKNOWN;
     case SNTEventStateBlockBinary: return ::pbv1::Execution::REASON_BINARY;
     case SNTEventStateBlockCertificate: return ::pbv1::Execution::REASON_CERT;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -532,6 +532,7 @@ void SerializeAndCheckNonESEvents(
       {SNTEventStateAllowPendingTransitive, ::pbv1::Execution::DECISION_ALLOW},
       {SNTEventStateAllowTeamID, ::pbv1::Execution::DECISION_ALLOW},
       {SNTEventStateAllowCELFallback, ::pbv1::Execution::DECISION_ALLOW},
+      {SNTEventStateAllowPlatform, ::pbv1::Execution::DECISION_ALLOW},
   };
 
   for (const auto& kv : stateToDecision) {
@@ -573,6 +574,7 @@ void SerializeAndCheckNonESEvents(
       case SNTEventStateAllowCompilerSigningID: want = ::pbv1::Execution::REASON_SIGNING_ID; break;
       case SNTEventStateAllowCompilerCDHash: want = ::pbv1::Execution::REASON_CDHASH; break;
       case SNTEventStateAllowCELFallback: want = ::pbv1::Execution::REASON_CEL_FALLBACK; break;
+      case SNTEventStateAllowPlatform: want = ::pbv1::Execution::REASON_PLATFORM; break;
       case SNTEventStateBlock: want = ::pbv1::Execution::REASON_UNKNOWN; break;
       case SNTEventStateAllow: want = ::pbv1::Execution::REASON_UNKNOWN; break;
     }

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -327,6 +327,14 @@ double watchdogRAMPeak = 0;
   // SNTFileInfo object (not just a path). The fileinfo "Type" key already
   // shows whether the file is a Mach-O, so users can cross-reference.
 
+  // Platform binaries are allowlisted ahead of the client mode default
+  // (mirrors the corresponding check in SNTPolicyProcessor).
+  MOLCodesignChecker* csc = [[MOLCodesignChecker alloc] initWithBinaryPath:filePath error:nil];
+  if (csc.platformBinary) {
+    reply(nil, @"Allowlist");
+    return;
+  }
+
   // Default based on client mode
   switch (config.clientMode) {
     case SNTClientModeMonitor: reply(nil, @"Allowed (Unknown, Monitor mode)"); return;

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -299,6 +299,14 @@ double watchdogRAMPeak = 0;
     return;
   }
 
+  // Platform binaries are allowlisted ahead of the scope checks and client
+  // mode default (mirrors the corresponding check in SNTPolicyProcessor).
+  MOLCodesignChecker* csc = [[MOLCodesignChecker alloc] initWithBinaryPath:filePath error:nil];
+  if (csc.platformBinary) {
+    reply(nil, @"Allowlist");
+    return;
+  }
+
   // Check blocked path regex (mirrors SNTPolicyProcessor.fileIsScopeBlocked:)
   NSRegularExpression* blockedRe = config.blockedPathRegex;
   if (blockedRe && [blockedRe numberOfMatchesInString:filePath
@@ -326,14 +334,6 @@ double watchdogRAMPeak = 0;
   // for non-Mach-O files, effectively allowing them. This check requires an
   // SNTFileInfo object (not just a path). The fileinfo "Type" key already
   // shows whether the file is a Mach-O, so users can cross-reference.
-
-  // Platform binaries are allowlisted ahead of the client mode default
-  // (mirrors the corresponding check in SNTPolicyProcessor).
-  MOLCodesignChecker* csc = [[MOLCodesignChecker alloc] initWithBinaryPath:filePath error:nil];
-  if (csc.platformBinary) {
-    reply(nil, @"Allowlist");
-    return;
-  }
 
   // Default based on client mode
   switch (config.clientMode) {

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -49,6 +49,7 @@ const static NSString* kDenyNoFileInfo = @"DenyNoFileInfo";
 const static NSString* kBlockLongPath = @"BlockLongPath";
 const static NSString* kBlockCELFallback = @"BlockCELFallback";
 const static NSString* kAllowCELFallback = @"AllowCELFallback";
+const static NSString* kAllowPlatform = @"AllowPlatform";
 
 @class SNTCachedDecision;
 @class SNTEventTable;

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -176,6 +176,7 @@ static SNTEventState BlockToAllowDecision(SNTEventState blockDecision) {
     case SNTEventStateBlockLongPath: eventTypeStr = kBlockLongPath; break;
     case SNTEventStateBlockCELFallback: eventTypeStr = kBlockCELFallback; break;
     case SNTEventStateAllowCELFallback: eventTypeStr = kAllowCELFallback; break;
+    case SNTEventStateAllowPlatform: eventTypeStr = kAllowPlatform; break;
     default: eventTypeStr = kUnknownEventState; break;
   }
 

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -644,6 +644,12 @@ static void UpdateCachedDecisionSigningInfo(
     return cd;
   }
 
+  if (platformBinaryState == PlatformBinaryState::kRuntimeTrue) {
+    cd.decisionExtra = @"Platform Binary";
+    cd.decision = SNTEventStateAllowScope;
+    return cd;
+  }
+
   switch (configState.clientMode) {
     case SNTClientModeMonitor: cd.decision = SNTEventStateAllowUnknown; return cd;
     case SNTClientModeStandalone: cd.holdAndAsk = YES; [[fallthrough]];

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -630,6 +630,12 @@ static void UpdateCachedDecisionSigningInfo(
     return cd;
   }
 
+  if (platformBinaryState == PlatformBinaryState::kRuntimeTrue) {
+    cd.decisionExtra = @"Platform Binary";
+    cd.decision = SNTEventStateAllowPlatform;
+    return cd;
+  }
+
   NSString* msg = [self fileIsScopeBlocked:fileInfo];
   if (msg) {
     cd.decisionExtra = msg;
@@ -640,12 +646,6 @@ static void UpdateCachedDecisionSigningInfo(
   msg = [self fileIsScopeAllowed:fileInfo];
   if (msg) {
     cd.decisionExtra = msg;
-    cd.decision = SNTEventStateAllowScope;
-    return cd;
-  }
-
-  if (platformBinaryState == PlatformBinaryState::kRuntimeTrue) {
-    cd.decisionExtra = @"Platform Binary";
     cd.decision = SNTEventStateAllowScope;
     return cd;
   }

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -15,16 +15,24 @@
 
 #import "Source/santad/SNTPolicyProcessor.h"
 
+#import <EndpointSecurity/EndpointSecurity.h>
 #import <Foundation/Foundation.h>
+#include <Kernel/kern/cs_blobs.h>
+#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTCELFallbackRule.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTConfigState.h"
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
+#import "Source/common/TestUtils.h"
 #import "Source/common/cel/Activation.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
+#include "Source/santad/EntitlementsFilter.h"
 
 #include "cel/v1.pb.h"
 
@@ -1329,6 +1337,45 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   [self.processor decision:cd forRule:rule withTransitiveRules:YES andCELActivationCallback:nil];
   XCTAssertEqual(cd.decision, SNTEventStateAllowBinary);
   XCTAssertEqual(cd.ruleId, 0LL);
+}
+
+- (SNTCachedDecision*)decisionForPlatformBinary:(BOOL)isPlatformBinary {
+  // Class-mock the rule table so it returns nil for every lookup, leaving
+  // the platform-binary case as the only decision path that can fire.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+
+  // /bin/ls is an Apple-signed platform binary present on every macOS host.
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:@"/bin/ls"];
+  XCTAssertNotNil(fi);
+
+  es_file_t file = MakeESFile("/bin/ls");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = isPlatformBinary;
+  proc.codesigning_flags = CS_SIGNED | CS_VALID;
+
+  SNTConfigState* configState =
+      [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  return [processor decisionForFileInfo:fi
+                          targetProcess:&proc
+                            configState:configState
+                     activationCallback:nil
+                         cachedDecision:nil];
+}
+
+- (void)testDecisionAllowsPlatformBinaryViaScope {
+  SNTCachedDecision* cd = [self decisionForPlatformBinary:YES];
+  XCTAssertEqual(cd.decision, SNTEventStateAllowScope);
+  XCTAssertEqualObjects(cd.decisionExtra, @"Platform Binary");
+}
+
+- (void)testDecisionDoesNotApplyPlatformBinaryToNonPlatformBinaries {
+  SNTCachedDecision* cd = [self decisionForPlatformBinary:NO];
+  XCTAssertNotEqual(cd.decision, SNTEventStateAllowScope);
+  XCTAssertNotEqualObjects(cd.decisionExtra, @"Platform Binary");
 }
 
 @end

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1366,15 +1366,15 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
                          cachedDecision:nil];
 }
 
-- (void)testDecisionAllowsPlatformBinaryViaScope {
+- (void)testDecisionAllowsPlatformBinary {
   SNTCachedDecision* cd = [self decisionForPlatformBinary:YES];
-  XCTAssertEqual(cd.decision, SNTEventStateAllowScope);
+  XCTAssertEqual(cd.decision, SNTEventStateAllowPlatform);
   XCTAssertEqualObjects(cd.decisionExtra, @"Platform Binary");
 }
 
 - (void)testDecisionDoesNotApplyPlatformBinaryToNonPlatformBinaries {
   SNTCachedDecision* cd = [self decisionForPlatformBinary:NO];
-  XCTAssertNotEqual(cd.decision, SNTEventStateAllowScope);
+  XCTAssertNotEqual(cd.decision, SNTEventStateAllowPlatform);
   XCTAssertNotEqualObjects(cd.decisionExtra, @"Platform Binary");
 }
 

--- a/Source/santasyncservice/ProtoTraits.h
+++ b/Source/santasyncservice/ProtoTraits.h
@@ -77,6 +77,7 @@ struct ProtoTraits<false> {
   // v1 doesn't have CEL fallback decisions; fall back to UNKNOWN.
   static constexpr Decision ALLOW_CEL_FALLBACK = ::santa::sync::v1::ALLOW_UNKNOWN;
   static constexpr Decision BLOCK_CEL_FALLBACK = ::santa::sync::v1::BLOCK_UNKNOWN;
+  static constexpr Decision ALLOW_PLATFORM = ::santa::sync::v1::ALLOW_PLATFORM;
 
   using FileAccessAction = ::santa::sync::v1::FileAccessAction;
   static constexpr FileAccessAction FILE_ACCESS_ACTION_UNSPECIFIED = ::santa::sync::v1::FILE_ACCESS_ACTION_UNSPECIFIED;
@@ -175,6 +176,7 @@ struct ProtoTraits<true> {
   static constexpr Decision BUNDLE_BINARY = ::santa::sync::v2::BUNDLE_BINARY;
   static constexpr Decision ALLOW_CEL_FALLBACK = ::santa::sync::v2::ALLOW_CEL_FALLBACK;
   static constexpr Decision BLOCK_CEL_FALLBACK = ::santa::sync::v2::BLOCK_CEL_FALLBACK;
+  static constexpr Decision ALLOW_PLATFORM = ::santa::sync::v2::ALLOW_PLATFORM;
 
   using FileAccessAction = ::santa::sync::v2::FileAccessAction;
   static constexpr FileAccessAction FILE_ACCESS_ACTION_UNSPECIFIED = ::santa::sync::v2::FILE_ACCESS_ACTION_UNSPECIFIED;

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -229,6 +229,7 @@ typename santa::ProtoTraits<IsV2>::EventT* MessageForExecutionEvent(
     case SNTEventStateBlockCDHash: e->set_decision(Traits::BLOCK_CDHASH); break;
     case SNTEventStateBlockCELFallback: e->set_decision(Traits::BLOCK_CEL_FALLBACK); break;
     case SNTEventStateAllowCELFallback: e->set_decision(Traits::ALLOW_CEL_FALLBACK); break;
+    case SNTEventStateAllowPlatform: e->set_decision(Traits::ALLOW_PLATFORM); break;
     case SNTEventStateAllowTransitive: return nullptr;
     case SNTEventStateAllowLocalBinary: return nullptr;
     case SNTEventStateAllowLocalSigningID: return nullptr;


### PR DESCRIPTION
On the surface this is a very simple change: remove the synthetic certificate rule returned by SNTRuleTable and add a platform binary condition in SNTPolicyProcessor below the CEL fallback eval but this has a few implications:

1. We're now using the dynamic `is_platform_binary` field to determine what to allow instead of checking that the certificate for the binary is the same one that signed `launchd`. This should be a no-op in 99.9% of cases but there may be some binaries considered platform that weren't previously and vice-versa
2. This will have a very small performance penalty for platform binary execution
3. `santactl fileinfo` output will be slightly different
4. Uploaded events will no longer show executions as being allowed due to Certificate, they will instead be classified as Platform.