### PR TITLE
common: add SNTNetworkFlowRule wire model class

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -684,6 +684,23 @@ objc_library(
     ],
 )
 
+objc_library(
+    name = "SNTNetworkFlowRule",
+    srcs = ["SNTNetworkFlowRule.mm"],
+    hdrs = ["SNTNetworkFlowRule.h"],
+    deps = [
+        ":CoderMacros",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTNetworkFlowRuleTest",
+    srcs = ["SNTNetworkFlowRuleTest.mm"],
+    deps = [
+        ":SNTNetworkFlowRule",
+    ],
+)
+
 santa_unit_test(
     name = "SNTRuleTest",
     srcs = ["SNTRuleTest.mm"],
@@ -1141,6 +1158,7 @@ test_suite(
         ":SNTKillCommandTest",
         ":SNTMetricSetTest",
         ":SNTModeTransitionTest",
+        ":SNTNetworkFlowRuleTest",
         ":SNTProcessChainTest",
         ":SNTRuleTest",
         ":SNTSandboxExecRequestTest",

--- a/Source/common/SNTNetworkFlowRule.h
+++ b/Source/common/SNTNetworkFlowRule.h
@@ -28,11 +28,13 @@ typedef NS_ENUM(NSInteger, SNTNetworkFlowRuleState) {
 @property(readonly) int64_t ruleId;
 @property(readonly) SNTNetworkFlowRuleState state;
 
-/// Serialized NetworkFlowRule.Add proto bytes. Nil for Remove.
+/// Serialized NetworkFlowRule.Add proto bytes. Nil for Remove rules.
 @property(readonly, copy) NSData* protoBlob;
 
-- (instancetype)initWithRuleId:(int64_t)ruleId
-                         state:(SNTNetworkFlowRuleState)state
-                     protoBlob:(NSData*)protoBlob;
+/// Construct an Add rule. Returns nil if protoBlob is nil.
+- (instancetype)initAddRuleWithId:(int64_t)ruleId protoBlob:(NSData*)protoBlob;
+
+/// Construct a Remove rule.
+- (instancetype)initRemoveRuleWithId:(int64_t)ruleId;
 
 @end

--- a/Source/common/SNTNetworkFlowRule.h
+++ b/Source/common/SNTNetworkFlowRule.h
@@ -1,0 +1,38 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, SNTNetworkFlowRuleState) {
+  SNTNetworkFlowRuleStateUnspecified = 0,
+  SNTNetworkFlowRuleStateAdd = 1,
+  SNTNetworkFlowRuleStateRemove = 2,
+};
+
+/// Wire-format wrapper for a single NetworkFlowRule from the sync server.
+/// Carries the raw serialized NetworkFlowRule.Add proto bytes when state == Add.
+/// Carries only ruleId when state == Remove.
+@interface SNTNetworkFlowRule : NSObject <NSSecureCoding>
+
+@property(readonly) int64_t ruleId;
+@property(readonly) SNTNetworkFlowRuleState state;
+
+/// Serialized NetworkFlowRule.Add proto bytes. Nil for Remove.
+@property(readonly, copy) NSData* protoBlob;
+
+- (instancetype)initWithRuleId:(int64_t)ruleId
+                         state:(SNTNetworkFlowRuleState)state
+                     protoBlob:(NSData*)protoBlob;
+
+@end

--- a/Source/common/SNTNetworkFlowRule.mm
+++ b/Source/common/SNTNetworkFlowRule.mm
@@ -24,16 +24,30 @@
 
 @implementation SNTNetworkFlowRule
 
-- (instancetype)initWithRuleId:(int64_t)ruleId
-                         state:(SNTNetworkFlowRuleState)state
-                     protoBlob:(NSData*)protoBlob {
+- (instancetype)initWithState:(SNTNetworkFlowRuleState)state
+                       ruleId:(int64_t)ruleId
+                    protoBlob:(NSData*)protoBlob {
+  if (state != SNTNetworkFlowRuleStateAdd && state != SNTNetworkFlowRuleStateRemove) {
+    return nil;
+  }
   self = [super init];
   if (self) {
-    _ruleId = ruleId;
     _state = state;
+    _ruleId = ruleId;
     _protoBlob = [protoBlob copy];
   }
   return self;
+}
+
+- (instancetype)initAddRuleWithId:(int64_t)ruleId protoBlob:(NSData*)protoBlob {
+  if (!protoBlob) {
+    return nil;
+  }
+  return [self initWithState:SNTNetworkFlowRuleStateAdd ruleId:ruleId protoBlob:protoBlob];
+}
+
+- (instancetype)initRemoveRuleWithId:(int64_t)ruleId {
+  return [self initWithState:SNTNetworkFlowRuleStateRemove ruleId:ruleId protoBlob:nil];
 }
 
 + (BOOL)supportsSecureCoding {
@@ -52,6 +66,10 @@
     DECODE_SELECTOR(decoder, ruleId, NSNumber, longLongValue);
     DECODE_SELECTOR(decoder, state, NSNumber, integerValue);
     DECODE(decoder, protoBlob, NSData);
+
+    if (_state != SNTNetworkFlowRuleStateAdd && _state != SNTNetworkFlowRuleStateRemove) {
+      return nil;
+    }
   }
   return self;
 }

--- a/Source/common/SNTNetworkFlowRule.mm
+++ b/Source/common/SNTNetworkFlowRule.mm
@@ -1,0 +1,59 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTNetworkFlowRule.h"
+
+#import "Source/common/CoderMacros.h"
+
+@interface SNTNetworkFlowRule ()
+@property(readwrite) int64_t ruleId;
+@property(readwrite) SNTNetworkFlowRuleState state;
+@property(readwrite, copy) NSData* protoBlob;
+@end
+
+@implementation SNTNetworkFlowRule
+
+- (instancetype)initWithRuleId:(int64_t)ruleId
+                         state:(SNTNetworkFlowRuleState)state
+                     protoBlob:(NSData*)protoBlob {
+  self = [super init];
+  if (self) {
+    _ruleId = ruleId;
+    _state = state;
+    _protoBlob = [protoBlob copy];
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  ENCODE_BOXABLE(coder, ruleId);
+  ENCODE_BOXABLE(coder, state);
+  ENCODE(coder, protoBlob);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super init];
+  if (self) {
+    DECODE_SELECTOR(decoder, ruleId, NSNumber, longLongValue);
+    DECODE_SELECTOR(decoder, state, NSNumber, integerValue);
+    DECODE(decoder, protoBlob, NSData);
+  }
+  return self;
+}
+
+@end

--- a/Source/common/SNTNetworkFlowRuleTest.mm
+++ b/Source/common/SNTNetworkFlowRuleTest.mm
@@ -1,0 +1,98 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTNetworkFlowRule.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+@interface SNTNetworkFlowRuleTest : XCTestCase
+@end
+
+@implementation SNTNetworkFlowRuleTest
+
+- (void)testAddRuleCarriesBlob {
+  NSData* blob = [@"fake-proto-bytes" dataUsingEncoding:NSUTF8StringEncoding];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initWithRuleId:42
+                                                                  state:SNTNetworkFlowRuleStateAdd
+                                                              protoBlob:blob];
+  XCTAssertEqual(rule.ruleId, 42);
+  XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateAdd);
+  XCTAssertEqualObjects(rule.protoBlob, blob);
+}
+
+- (void)testRemoveRuleHasNilBlob {
+  SNTNetworkFlowRule* rule =
+      [[SNTNetworkFlowRule alloc] initWithRuleId:99
+                                           state:SNTNetworkFlowRuleStateRemove
+                                       protoBlob:nil];
+  XCTAssertEqual(rule.ruleId, 99);
+  XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateRemove);
+  XCTAssertNil(rule.protoBlob);
+}
+
+- (void)testNSSecureCodingRoundTripAdd {
+  NSData* blob = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
+  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initWithRuleId:7
+                                                                  state:SNTNetworkFlowRuleStateAdd
+                                                              protoBlob:blob];
+  NSError* err = nil;
+  NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
+                                           requiringSecureCoding:YES
+                                                           error:&err];
+  XCTAssertNil(err);
+  XCTAssertNotNil(archived);
+
+  SNTNetworkFlowRule* decoded =
+      [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTNetworkFlowRule class]
+                                        fromData:archived
+                                           error:&err];
+  XCTAssertNil(err);
+  XCTAssertEqual(decoded.ruleId, 7);
+  XCTAssertEqual(decoded.state, SNTNetworkFlowRuleStateAdd);
+  XCTAssertEqualObjects(decoded.protoBlob, blob);
+}
+
+- (void)testNSSecureCodingRoundTripRemove {
+  SNTNetworkFlowRule* orig =
+      [[SNTNetworkFlowRule alloc] initWithRuleId:INT64_MAX
+                                           state:SNTNetworkFlowRuleStateRemove
+                                       protoBlob:nil];
+  NSError* err = nil;
+  NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
+                                           requiringSecureCoding:YES
+                                                           error:&err];
+  XCTAssertNil(err);
+  XCTAssertNotNil(archived);
+
+  SNTNetworkFlowRule* decoded =
+      [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTNetworkFlowRule class]
+                                        fromData:archived
+                                           error:&err];
+  XCTAssertNil(err);
+  XCTAssertEqual(decoded.ruleId, INT64_MAX);
+  XCTAssertEqual(decoded.state, SNTNetworkFlowRuleStateRemove);
+  XCTAssertNil(decoded.protoBlob);
+}
+
+- (void)testProtoBlobIsCopied {
+  NSMutableData* blob = [[@"abc" dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initWithRuleId:1
+                                                                  state:SNTNetworkFlowRuleStateAdd
+                                                              protoBlob:blob];
+  [blob appendBytes:"xyz" length:3];
+  XCTAssertEqual(rule.protoBlob.length, 3u);
+}
+
+@end

--- a/Source/common/SNTNetworkFlowRuleTest.mm
+++ b/Source/common/SNTNetworkFlowRuleTest.mm
@@ -17,6 +17,12 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
+@interface SNTNetworkFlowRule (Testing)
+@property(readwrite) int64_t ruleId;
+@property(readwrite) SNTNetworkFlowRuleState state;
+@property(readwrite, copy) NSData* protoBlob;
+@end
+
 @interface SNTNetworkFlowRuleTest : XCTestCase
 @end
 
@@ -24,19 +30,21 @@
 
 - (void)testAddRuleCarriesBlob {
   NSData* blob = [@"fake-proto-bytes" dataUsingEncoding:NSUTF8StringEncoding];
-  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initWithRuleId:42
-                                                                  state:SNTNetworkFlowRuleStateAdd
-                                                              protoBlob:blob];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:42 protoBlob:blob];
+  XCTAssertNotNil(rule);
   XCTAssertEqual(rule.ruleId, 42);
   XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateAdd);
   XCTAssertEqualObjects(rule.protoBlob, blob);
 }
 
+- (void)testAddRuleRejectsNilBlob {
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:42 protoBlob:nil];
+  XCTAssertNil(rule);
+}
+
 - (void)testRemoveRuleHasNilBlob {
-  SNTNetworkFlowRule* rule =
-      [[SNTNetworkFlowRule alloc] initWithRuleId:99
-                                           state:SNTNetworkFlowRuleStateRemove
-                                       protoBlob:nil];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:99];
+  XCTAssertNotNil(rule);
   XCTAssertEqual(rule.ruleId, 99);
   XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateRemove);
   XCTAssertNil(rule.protoBlob);
@@ -44,9 +52,7 @@
 
 - (void)testNSSecureCodingRoundTripAdd {
   NSData* blob = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
-  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initWithRuleId:7
-                                                                  state:SNTNetworkFlowRuleStateAdd
-                                                              protoBlob:blob];
+  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initAddRuleWithId:7 protoBlob:blob];
   NSError* err = nil;
   NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
                                            requiringSecureCoding:YES
@@ -65,10 +71,7 @@
 }
 
 - (void)testNSSecureCodingRoundTripRemove {
-  SNTNetworkFlowRule* orig =
-      [[SNTNetworkFlowRule alloc] initWithRuleId:INT64_MAX
-                                           state:SNTNetworkFlowRuleStateRemove
-                                       protoBlob:nil];
+  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:INT64_MAX];
   NSError* err = nil;
   NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
                                            requiringSecureCoding:YES
@@ -88,11 +91,28 @@
 
 - (void)testProtoBlobIsCopied {
   NSMutableData* blob = [[@"abc" dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
-  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initWithRuleId:1
-                                                                  state:SNTNetworkFlowRuleStateAdd
-                                                              protoBlob:blob];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob];
   [blob appendBytes:"xyz" length:3];
   XCTAssertEqual(rule.protoBlob.length, 3u);
+}
+
+- (void)testDecodeRejectsUnspecifiedState {
+  // Build a valid rule, stomp its state to Unspecified, archive, and verify
+  // that decode refuses to reconstruct it.
+  SNTNetworkFlowRule* corrupt = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:1];
+  corrupt.state = SNTNetworkFlowRuleStateUnspecified;
+  NSError* err = nil;
+  NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:corrupt
+                                           requiringSecureCoding:YES
+                                                           error:&err];
+  XCTAssertNil(err);
+  XCTAssertNotNil(archived);
+
+  SNTNetworkFlowRule* decoded =
+      [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTNetworkFlowRule class]
+                                        fromData:archived
+                                           error:&err];
+  XCTAssertNil(decoded);
 }
 
 @end


### PR DESCRIPTION
NSSecureCoding wrapper that carries a serialized NetworkFlowRule.Add proto blob (or just a rule_id for Remove) across XPC and into SNTRuleTable. Mirrors the SNTFileAccessRule pattern.

This PR is only for the new wire wrapper, it is not yet hooked up to anything.