### PR TITLE
sync: Remove debug log that prints CEL fallback expressions

### DIFF
--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -513,8 +513,6 @@ void HandleV2Responses(const ::pbv2::PreflightResponse& resp, SNTSyncState* sync
       NSString* celExpr = StringToNSString(rule.cel_expr());
       NSString* customMsg = !rule.custom_msg().empty() ? StringToNSString(rule.custom_msg()) : nil;
       NSString* customURL = !rule.custom_url().empty() ? StringToNSString(rule.custom_url()) : nil;
-      SLOGD(@"CEL fallback rule %d: expr='%@' customMsg='%@' customURL='%@'", i, celExpr, customMsg,
-            customURL);
       [rules addObject:[[SNTCELFallbackRule alloc] initWithCELExpr:celExpr
                                                          customMsg:customMsg
                                                          customURL:customURL]];


### PR DESCRIPTION
Removes the `SLOGD` line in `SNTSyncPreflight.mm` that printed CEL fallback rule expressions (and their custom message / URL) to the sync debug log on every preflight.

Fixes SNT-418.