### PR TITLE
bump protos to pick up NetworkFlowSocketFamily enum rename

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "03eeb9e04601ead6a3db02670ef07cb862035f80",
+    commit = "0a3f4215e8de7bbd01ec7473f48e98377e8ea850",
     remote = "https://github.com/northpolesec/protos",
 )
 


### PR DESCRIPTION
Bumps protos to 0a3f4215 (northpolesec/protos#116), which prefixes the NetworkFlowSocketFamily enum values so they no longer collide with the AF_INET/AF_INET6 macros from <sys/socket.h> and break compilation of generated v2.pb.h.