### PR TITLE
santad: push network rules + settings to santanetd via combined XPC

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1001,6 +1001,7 @@ objc_library(
         ":SNTStoredEvent",
         ":SNTStoredExecutionEvent",
         ":SNTXPCUnprivilegedControlInterface",
+        "//Source/common/ne:SNTNetworkExtensionConfig",
         "//Source/common/ne:SNTNetworkExtensionSettings",
         "@santanetd//src/santanetd:SNDFlowInfo",
         "@santanetd//src/santanetd:SNDProcessFlows",

--- a/Source/common/SNTConfigBundle.h
+++ b/Source/common/SNTConfigBundle.h
@@ -50,6 +50,9 @@
 - (void)fileAccessEventDetailText:(void (^)(NSString*))block;
 - (void)enableNotificationSilences:(void (^)(BOOL))block;
 - (void)networkExtensionSettings:(void (^)(SNTSyncNetworkExtensionSettings*))block;
+/// Set only by PostflightConfigBundle. Signals the daemon that a sync just
+/// completed and it should reconcile santanetd's settings + rules.
+- (void)reconcileNetworkExtension:(void (^)(BOOL))block;
 - (void)pushTokenChain:(void (^)(NSArray<NSString*>*))block;
 - (void)telemetryFilterExpressions:(void (^)(NSArray<NSString*>*))block;
 - (void)celFallbackRules:(void (^)(NSArray<SNTCELFallbackRule*>*))block;

--- a/Source/common/SNTConfigBundle.mm
+++ b/Source/common/SNTConfigBundle.mm
@@ -47,6 +47,7 @@
 @property NSString* fileAccessEventDetailText;
 @property NSNumber* enableNotificationSilences;
 @property SNTSyncNetworkExtensionSettings* networkExtensionSettings;
+@property NSNumber* reconcileNetworkExtension;
 @property NSArray<NSString*>* pushTokenChain;
 @property NSArray<NSString*>* telemetryFilterExpressions;
 @property NSArray<SNTCELFallbackRule*>* celFallbackRules;
@@ -88,6 +89,7 @@
   ENCODE(coder, fileAccessEventDetailText);
   ENCODE(coder, enableNotificationSilences);
   ENCODE(coder, networkExtensionSettings);
+  ENCODE(coder, reconcileNetworkExtension);
   ENCODE(coder, pushTokenChain);
   ENCODE(coder, telemetryFilterExpressions);
   ENCODE(coder, celFallbackRules);
@@ -125,6 +127,7 @@
     DECODE(decoder, fileAccessEventDetailText, NSString);
     DECODE(decoder, enableNotificationSilences, NSNumber);
     DECODE(decoder, networkExtensionSettings, SNTSyncNetworkExtensionSettings);
+    DECODE(decoder, reconcileNetworkExtension, NSNumber);
     DECODE_ARRAY(decoder, pushTokenChain, NSString);
     DECODE_ARRAY(decoder, telemetryFilterExpressions, NSString);
     DECODE_ARRAY(decoder, celFallbackRules, SNTCELFallbackRule);
@@ -287,6 +290,12 @@
 - (void)networkExtensionSettings:(void (^)(SNTSyncNetworkExtensionSettings*))block {
   if (self.networkExtensionSettings) {
     block(self.networkExtensionSettings);
+  }
+}
+
+- (void)reconcileNetworkExtension:(void (^)(BOOL))block {
+  if (self.reconcileNetworkExtension) {
+    block([self.reconcileNetworkExtension boolValue]);
   }
 }
 

--- a/Source/common/SNTConfigBundleTest.mm
+++ b/Source/common/SNTConfigBundleTest.mm
@@ -49,6 +49,7 @@
 @property NSString* fileAccessEventDetailText;
 @property NSNumber* enableNotificationSilences;
 @property SNTSyncNetworkExtensionSettings* networkExtensionSettings;
+@property NSNumber* reconcileNetworkExtension;
 @property NSArray<NSString*>* pushTokenChain;
 @property NSArray<SNTCELFallbackRule*>* celFallbackRules;
 @property NSNumber* fullSyncInterval;
@@ -63,7 +64,7 @@
 
 - (void)testGettersWithValues {
   __block XCTestExpectation* exp = [self expectationWithDescription:@"Result Blocks"];
-  exp.expectedFulfillmentCount = 29;
+  exp.expectedFulfillmentCount = 30;
   NSDate* nowDate = [NSDate now];
 
   SNTConfigBundle* bundle = [[SNTConfigBundle alloc] init];
@@ -94,7 +95,10 @@
   bundle.fileAccessEventDetailURL = @"https://example.com/faa-details";
   bundle.fileAccessEventDetailText = @"View FAA Details";
   bundle.enableNotificationSilences = @(YES);
-  bundle.networkExtensionSettings = [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES];
+  bundle.networkExtensionSettings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+  bundle.reconcileNetworkExtension = @(YES);
   bundle.pushTokenChain = @[ @"issuerJWT", @"userJWT" ];
   bundle.fullSyncInterval = @(600);
   bundle.pushNotificationsFullSyncInterval = @(21600);
@@ -234,6 +238,11 @@
     [exp fulfill];
   }];
 
+  [bundle reconcileNetworkExtension:^(BOOL val) {
+    XCTAssertTrue(val);
+    [exp fulfill];
+  }];
+
   [bundle pushTokenChain:^(NSArray<NSString*>* val) {
     XCTAssertEqualObjects(val, (@[ @"issuerJWT", @"userJWT" ]));
     [exp fulfill];
@@ -360,6 +369,10 @@
     XCTFail(@"This shouldn't be called");
   }];
 
+  [bundle reconcileNetworkExtension:^(BOOL val) {
+    XCTFail(@"This shouldn't be called");
+  }];
+
   [bundle pushTokenChain:^(NSArray<NSString*>* val) {
     XCTFail(@"This shouldn't be called");
   }];
@@ -410,6 +423,47 @@
 
   __block BOOL unsetFired = NO;
   [unsetDecoded clearSyncStateBeforeApply:^(BOOL v) {
+    unsetFired = YES;
+  }];
+  XCTAssertFalse(unsetFired);
+}
+
+- (void)testReconcileNetworkExtensionRoundTrips {
+  SNTConfigBundle* set = [[SNTConfigBundle alloc] init];
+  set.reconcileNetworkExtension = @(YES);
+
+  NSError* error = nil;
+  NSData* setData = [NSKeyedArchiver archivedDataWithRootObject:set
+                                          requiringSecureCoding:YES
+                                                          error:&error];
+  XCTAssertNil(error);
+  SNTConfigBundle* setDecoded = [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTConfigBundle class]
+                                                                  fromData:setData
+                                                                     error:&error];
+  XCTAssertNil(error);
+
+  __block BOOL setFired = NO;
+  __block BOOL setValue = NO;
+  [setDecoded reconcileNetworkExtension:^(BOOL v) {
+    setFired = YES;
+    setValue = v;
+  }];
+  XCTAssertTrue(setFired);
+  XCTAssertTrue(setValue);
+
+  // Unset: accessor block must not fire after a round-trip.
+  SNTConfigBundle* unset = [[SNTConfigBundle alloc] init];
+  NSData* unsetData = [NSKeyedArchiver archivedDataWithRootObject:unset
+                                            requiringSecureCoding:YES
+                                                            error:&error];
+  XCTAssertNil(error);
+  SNTConfigBundle* unsetDecoded = [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTConfigBundle class]
+                                                                    fromData:unsetData
+                                                                       error:&error];
+  XCTAssertNil(error);
+
+  __block BOOL unsetFired = NO;
+  [unsetDecoded reconcileNetworkExtension:^(BOOL v) {
     unsetFired = YES;
   }];
   XCTAssertFalse(unsetFired);

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -20,6 +20,7 @@
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCUnprivilegedControlInterface.h"
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
 #import "Source/common/ne/SNTNetworkExtensionSettings.h"
 
 @class SNDProcessFlows;
@@ -84,7 +85,7 @@ typedef NS_ENUM(NSInteger, SNTRuleAddSource) {
 - (void)installNetworkExtension:(void (^)(BOOL))reply;
 
 - (void)registerNetworkExtensionWithProtocolVersion:(NSString*)protocolVersion
-                                              reply:(void (^)(SNTNetworkExtensionSettings* settings,
+                                              reply:(void (^)(SNTNetworkExtensionConfig* config,
                                                               NSString* santaProtocolVersion,
                                                               NSError* error))reply;
 

--- a/Source/common/SNTXPCControlInterface.mm
+++ b/Source/common/SNTXPCControlInterface.mm
@@ -99,7 +99,9 @@ static NSString* const kSantanetdExtensionBundleID = @"com.northpolesec.santa.ne
       argumentIndex:0
             ofReply:NO];
 
-  [r setClasses:[NSSet setWithObject:[SNTNetworkExtensionSettings class]]
+  [r setClasses:[NSSet setWithObjects:[SNTNetworkExtensionConfig class],
+                                      [SNTNetworkExtensionSettings class], [NSArray class],
+                                      [SNTNetworkFlowRule class], [NSData class], nil]
         forSelector:@selector(registerNetworkExtensionWithProtocolVersion:reply:)
       argumentIndex:0
             ofReply:YES];

--- a/Source/common/ne/BUILD
+++ b/Source/common/ne/BUILD
@@ -17,10 +17,21 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTNetworkExtensionConfig",
+    srcs = ["SNTNetworkExtensionConfig.mm"],
+    hdrs = ["SNTNetworkExtensionConfig.h"],
+    deps = [
+        ":SNTNetworkExtensionSettings",
+        "//Source/common:CoderMacros",
+        "//Source/common:SNTNetworkFlowRule",
+    ],
+)
+
+objc_library(
     name = "SNDXPCNetworkExtensionInterface",
     hdrs = ["SNDXPCNetworkExtensionInterface.h"],
     deps = [
-        ":SNTNetworkExtensionSettings",
+        ":SNTNetworkExtensionConfig",
     ],
 )
 
@@ -30,9 +41,11 @@ objc_library(
     hdrs = ["SNTXPCNetworkExtensionInterface.h"],
     deps = [
         ":SNDXPCNetworkExtensionInterface",
+        ":SNTNetworkExtensionConfig",
         ":SNTNetworkExtensionSettings",
         "//Source/common:MOLCodesignChecker",
         "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTNetworkFlowRule",
     ],
 )
 
@@ -41,6 +54,7 @@ objc_library(
     srcs = ["SNTSyncNetworkExtensionSettings.mm"],
     hdrs = ["SNTSyncNetworkExtensionSettings.h"],
     deps = [
+        ":SNTNetworkExtensionSettings",
         "//Source/common:CoderMacros",
         "//Source/common:SNTLogging",
     ],
@@ -62,9 +76,20 @@ santa_unit_test(
     ],
 )
 
+santa_unit_test(
+    name = "SNTNetworkExtensionConfigTest",
+    srcs = ["SNTNetworkExtensionConfigTest.mm"],
+    deps = [
+        ":SNTNetworkExtensionConfig",
+        ":SNTNetworkExtensionSettings",
+        "//Source/common:SNTNetworkFlowRule",
+    ],
+)
+
 test_suite(
     name = "unit_tests",
     tests = [
+        ":SNTNetworkExtensionConfigTest",
         ":SNTNetworkExtensionSettingsTest",
         ":SNTSyncNetworkExtensionSettingsTest",
     ],

--- a/Source/common/ne/SNDXPCNetworkExtensionInterface.h
+++ b/Source/common/ne/SNDXPCNetworkExtensionInterface.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class SNTNetworkExtensionSettings;
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
 
 ///
 ///  Protocol implemented by the network extension (santanetd) and utilized by daemon
@@ -22,8 +22,10 @@
 ///
 @protocol SNDNetworkExtensionXPC
 
-- (void)updateNetworkExtensionSettings:(SNTNetworkExtensionSettings*)settings
-                                 reply:(void (^)(BOOL))reply;
+/// Apply a network extension config. `config.settings` is always applied; `config.networkFlowRules`
+/// replaces the ruleset when non-nil, or leaves it untouched when nil (see
+/// SNTNetworkExtensionConfig).
+- (void)updateNetworkExtensionConfig:(SNTNetworkExtensionConfig*)config reply:(void (^)(BOOL))reply;
 
 - (void)bundleVersionInfo:(void (^)(NSDictionary* bundleInfo))reply;
 

--- a/Source/common/ne/SNDXPCNetworkExtensionInterface.h
+++ b/Source/common/ne/SNDXPCNetworkExtensionInterface.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Source/common/ne/SNTNetworkExtensionConfig.h"
+@class SNTNetworkExtensionConfig;
 
 ///
 ///  Protocol implemented by the network extension (santanetd) and utilized by daemon

--- a/Source/common/ne/SNTNetworkExtensionConfig.h
+++ b/Source/common/ne/SNTNetworkExtensionConfig.h
@@ -1,0 +1,34 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTNetworkFlowRule.h"
+#import "Source/common/ne/SNTNetworkExtensionSettings.h"
+
+/// The full network-extension config santad hands to santanetd: settings plus the network-flow
+/// ruleset. Delivered both in the registration reply (seeding a freshly-started santanetd) and as
+/// the runtime update payload.
+@interface SNTNetworkExtensionConfig : NSObject <NSSecureCoding>
+
+@property(readonly) SNTNetworkExtensionSettings* settings;
+
+/// At registration this is the full ruleset. On a runtime update, nil means "rules unchanged —
+/// keep the existing index" (vs. an empty array, which means "no rules").
+@property(readonly, copy) NSArray<SNTNetworkFlowRule*>* networkFlowRules;
+
+- (instancetype)initWithSettings:(SNTNetworkExtensionSettings*)settings
+                networkFlowRules:(NSArray<SNTNetworkFlowRule*>*)networkFlowRules;
+
+@end

--- a/Source/common/ne/SNTNetworkExtensionConfig.mm
+++ b/Source/common/ne/SNTNetworkExtensionConfig.mm
@@ -1,0 +1,54 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
+
+#import "Source/common/CoderMacros.h"
+
+@interface SNTNetworkExtensionConfig ()
+@property(readwrite) SNTNetworkExtensionSettings* settings;
+@property(readwrite, copy) NSArray<SNTNetworkFlowRule*>* networkFlowRules;
+@end
+
+@implementation SNTNetworkExtensionConfig
+
+- (instancetype)initWithSettings:(SNTNetworkExtensionSettings*)settings
+                networkFlowRules:(NSArray<SNTNetworkFlowRule*>*)networkFlowRules {
+  self = [super init];
+  if (self) {
+    _settings = settings;
+    _networkFlowRules = [networkFlowRules copy];
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  ENCODE(coder, settings);
+  ENCODE(coder, networkFlowRules);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super init];
+  if (self) {
+    DECODE(decoder, settings, SNTNetworkExtensionSettings);
+    DECODE_ARRAY(decoder, networkFlowRules, SNTNetworkFlowRule);
+  }
+  return self;
+}
+
+@end

--- a/Source/common/ne/SNTNetworkExtensionConfigTest.mm
+++ b/Source/common/ne/SNTNetworkExtensionConfigTest.mm
@@ -1,0 +1,89 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTNetworkFlowRule.h"
+#import "Source/common/ne/SNTNetworkExtensionSettings.h"
+
+@interface SNTNetworkExtensionConfigTest : XCTestCase
+@end
+
+@implementation SNTNetworkExtensionConfigTest
+
+- (SNTNetworkExtensionConfig*)roundTrip:(SNTNetworkExtensionConfig*)config {
+  NSData* data = [NSKeyedArchiver archivedDataWithRootObject:config
+                                       requiringSecureCoding:YES
+                                                       error:nil];
+  XCTAssertNotNil(data);
+  return [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTNetworkExtensionConfig class]
+                                           fromData:data
+                                              error:nil];
+}
+
+- (void)testInitializerStoresValues {
+  SNTNetworkExtensionSettings* settings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+  NSArray<SNTNetworkFlowRule*>* rules = @[
+    [[SNTNetworkFlowRule alloc] initAddRuleWithId:1
+                                        protoBlob:[@"x" dataUsingEncoding:NSUTF8StringEncoding]],
+  ];
+
+  SNTNetworkExtensionConfig* config = [[SNTNetworkExtensionConfig alloc] initWithSettings:settings
+                                                                         networkFlowRules:rules];
+  XCTAssertEqualObjects(config.settings, settings);
+  XCTAssertEqual(config.networkFlowRules.count, 1u);
+}
+
+- (void)testRoundTripWithRules {
+  SNTNetworkExtensionSettings* settings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+  NSData* blob = [@"rule" dataUsingEncoding:NSUTF8StringEncoding];
+  NSArray<SNTNetworkFlowRule*>* rules = @[
+    [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob],
+    [[SNTNetworkFlowRule alloc] initAddRuleWithId:2 protoBlob:blob],
+  ];
+
+  SNTNetworkExtensionConfig* decoded =
+      [self roundTrip:[[SNTNetworkExtensionConfig alloc] initWithSettings:settings
+                                                         networkFlowRules:rules]];
+
+  XCTAssertNotNil(decoded);
+  XCTAssertTrue(decoded.settings.enable);
+  XCTAssertEqual(decoded.settings.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
+  XCTAssertEqual(decoded.networkFlowRules.count, 2u);
+  XCTAssertEqual(decoded.networkFlowRules[0].ruleId, 1);
+  XCTAssertEqualObjects(decoded.networkFlowRules[0].protoBlob, blob);
+}
+
+- (void)testRoundTripWithNilRules {
+  // nil rules (the "unchanged" runtime signal) must survive a round-trip as nil.
+  SNTNetworkExtensionSettings* settings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:NO
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
+
+  SNTNetworkExtensionConfig* decoded = [self
+      roundTrip:[[SNTNetworkExtensionConfig alloc] initWithSettings:settings networkFlowRules:nil]];
+
+  XCTAssertNotNil(decoded);
+  XCTAssertFalse(decoded.settings.enable);
+  XCTAssertNil(decoded.networkFlowRules);
+}
+
+@end

--- a/Source/common/ne/SNTNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTNetworkExtensionSettings.h
@@ -14,9 +14,10 @@
 
 #import <Foundation/Foundation.h>
 
-/// Action applied to network flows that match no NetworkFlowRule.
+/// Action applied to network flows that match no NetworkFlowRule. Values mirror
+/// pbv2::NetworkFlowDefaultAction (see NetworkFlowDefaultActionFromProto in SNTSyncPreflight).
 typedef NS_ENUM(NSInteger, SNTNetworkFlowDefaultAction) {
-  SNTNetworkFlowDefaultActionUnspecified = 0,  // treated as Allow
+  SNTNetworkFlowDefaultActionUnspecified = 0,
   SNTNetworkFlowDefaultActionAllow = 1,
   SNTNetworkFlowDefaultActionDeny = 2,
 };

--- a/Source/common/ne/SNTNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTNetworkExtensionSettings.h
@@ -14,6 +14,13 @@
 
 #import <Foundation/Foundation.h>
 
+/// Action applied to network flows that match no NetworkFlowRule.
+typedef NS_ENUM(NSInteger, SNTNetworkFlowDefaultAction) {
+  SNTNetworkFlowDefaultActionUnspecified = 0,  // treated as Allow
+  SNTNetworkFlowDefaultActionAllow = 1,
+  SNTNetworkFlowDefaultActionDeny = 2,
+};
+
 /// Settings passed from the daemon (santa) to the network extension (santanetd) over XPC.
 ///
 /// This class conforms to NSSecureCoding, allowing it to be passed directly as a typed
@@ -23,7 +30,9 @@
 @interface SNTNetworkExtensionSettings : NSObject <NSSecureCoding>
 
 @property(readonly) BOOL enable;
+@property(readonly) SNTNetworkFlowDefaultAction flowDefaultAction;
 
-- (instancetype)initWithEnable:(BOOL)enable;
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
 
 @end

--- a/Source/common/ne/SNTNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettings.mm
@@ -18,16 +18,34 @@
 
 @interface SNTNetworkExtensionSettings ()
 @property(readwrite) BOOL enable;
+@property(readwrite) SNTNetworkFlowDefaultAction flowDefaultAction;
 @end
 
 @implementation SNTNetworkExtensionSettings
 
-- (instancetype)initWithEnable:(BOOL)enable {
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction {
   self = [super init];
   if (self) {
     _enable = enable;
+    _flowDefaultAction = flowDefaultAction;
   }
   return self;
+}
+
+- (BOOL)isEqual:(id)other {
+  if (self == other) {
+    return YES;
+  }
+  if (![other isKindOfClass:[SNTNetworkExtensionSettings class]]) {
+    return NO;
+  }
+  SNTNetworkExtensionSettings* o = other;
+  return self.enable == o.enable && self.flowDefaultAction == o.flowDefaultAction;
+}
+
+- (NSUInteger)hash {
+  return (NSUInteger)self.enable * 31 + (NSUInteger)self.flowDefaultAction;
 }
 
 + (BOOL)supportsSecureCoding {
@@ -36,12 +54,14 @@
 
 - (void)encodeWithCoder:(NSCoder*)coder {
   ENCODE_BOXABLE(coder, enable);
+  ENCODE_BOXABLE(coder, flowDefaultAction);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
   self = [self init];
   if (self) {
     DECODE_SELECTOR(decoder, enable, NSNumber, boolValue);
+    DECODE_SELECTOR(decoder, flowDefaultAction, NSNumber, integerValue);
   }
   return self;
 }

--- a/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
@@ -19,6 +19,7 @@
 
 @interface SNTNetworkExtensionSettings (Testing)
 @property(readwrite) BOOL enable;
+@property(readwrite) SNTNetworkFlowDefaultAction flowDefaultAction;
 @end
 
 // Simulates a future version of SNTNetworkExtensionSettings that encodes an additional
@@ -50,17 +51,24 @@
 @implementation SNTNetworkExtensionSettingsTest
 
 - (void)testInitialization {
-  SNTNetworkExtensionSettings* settings = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES];
+  SNTNetworkExtensionSettings* settings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
   XCTAssertNotNil(settings);
   XCTAssertTrue(settings.enable);
+  XCTAssertEqual(settings.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
 
-  settings = [[SNTNetworkExtensionSettings alloc] initWithEnable:NO];
+  settings = [[SNTNetworkExtensionSettings alloc] initWithEnable:NO
+                                               flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
   XCTAssertNotNil(settings);
   XCTAssertFalse(settings.enable);
+  XCTAssertEqual(settings.flowDefaultAction, SNTNetworkFlowDefaultActionAllow);
 }
 
 - (void)testRoundtripEncodeDecode {
-  SNTNetworkExtensionSettings* settings = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES];
+  SNTNetworkExtensionSettings* settings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
   NSData* data = [NSKeyedArchiver archivedDataWithRootObject:settings
                                        requiringSecureCoding:YES
                                                        error:nil];
@@ -72,8 +80,10 @@
                                            error:nil];
   XCTAssertNotNil(deserialized);
   XCTAssertTrue(deserialized.enable);
+  XCTAssertEqual(deserialized.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
 
-  settings = [[SNTNetworkExtensionSettings alloc] initWithEnable:NO];
+  settings = [[SNTNetworkExtensionSettings alloc] initWithEnable:NO
+                                               flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
   data = [NSKeyedArchiver archivedDataWithRootObject:settings requiringSecureCoding:YES error:nil];
   XCTAssertNotNil(data);
 
@@ -82,6 +92,7 @@
                                                       error:nil];
   XCTAssertNotNil(deserialized);
   XCTAssertFalse(deserialized.enable);
+  XCTAssertEqual(deserialized.flowDefaultAction, SNTNetworkFlowDefaultActionAllow);
 }
 
 - (void)testForwardCompatibility {
@@ -93,7 +104,8 @@
   // class name back to SNTNetworkExtensionSettings during decode to simulate an old receiver
   // processing data produced by a new sender.
   SNTNetworkExtensionSettingsFuture* future =
-      [[SNTNetworkExtensionSettingsFuture alloc] initWithEnable:YES];
+      [[SNTNetworkExtensionSettingsFuture alloc] initWithEnable:YES
+                                              flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
 
   NSData* data = [NSKeyedArchiver archivedDataWithRootObject:future
                                        requiringSecureCoding:YES

--- a/Source/common/ne/SNTSyncNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettings.h
@@ -14,11 +14,15 @@
 
 #import <Foundation/Foundation.h>
 
+#import "Source/common/ne/SNTNetworkExtensionSettings.h"
+
 @interface SNTSyncNetworkExtensionSettings : NSObject <NSSecureCoding>
 
 @property(readonly) BOOL enable;
+@property(readonly) SNTNetworkFlowDefaultAction flowDefaultAction;
 
-- (instancetype)initWithEnable:(BOOL)enable;
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
 
 - (NSData*)serialize;
 + (instancetype)deserialize:(NSData*)data;

--- a/Source/common/ne/SNTSyncNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettings.mm
@@ -19,14 +19,17 @@
 
 @interface SNTSyncNetworkExtensionSettings ()
 @property(readwrite) BOOL enable;
+@property(readwrite) SNTNetworkFlowDefaultAction flowDefaultAction;
 @end
 
 @implementation SNTSyncNetworkExtensionSettings
 
-- (instancetype)initWithEnable:(BOOL)enable {
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction {
   self = [super init];
   if (self) {
     _enable = enable;
+    _flowDefaultAction = flowDefaultAction;
   }
   return self;
 }
@@ -45,13 +48,15 @@
   }
 
   SNTSyncNetworkExtensionSettings* otherSettings = (SNTSyncNetworkExtensionSettings*)other;
-  return self.enable == otherSettings.enable;
+  return self.enable == otherSettings.enable &&
+         self.flowDefaultAction == otherSettings.flowDefaultAction;
 }
 
 - (NSUInteger)hash {
   NSUInteger prime = 31;
   NSUInteger result = 1;
   result = prime * result + self.enable;
+  result = prime * result + self.flowDefaultAction;
   return result;
 }
 
@@ -61,12 +66,14 @@
 
 - (void)encodeWithCoder:(NSCoder*)coder {
   ENCODE_BOXABLE(coder, enable);
+  ENCODE_BOXABLE(coder, flowDefaultAction);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
   self = [self init];
   if (self) {
     DECODE_SELECTOR(decoder, enable, NSNumber, boolValue);
+    DECODE_SELECTOR(decoder, flowDefaultAction, NSNumber, integerValue);
   }
   return self;
 }

--- a/Source/common/ne/SNTSyncNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettingsTest.mm
@@ -29,20 +29,26 @@
 - (void)testInitialization {
   // Test initialization with enable=YES
   SNTSyncNetworkExtensionSettings* settings =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES];
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
   XCTAssertNotNil(settings);
   XCTAssertTrue(settings.enable);
+  XCTAssertEqual(settings.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
 
   // Test initialization with enable=NO
-  settings = [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:NO];
+  settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:NO
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
   XCTAssertNotNil(settings);
   XCTAssertFalse(settings.enable);
+  XCTAssertEqual(settings.flowDefaultAction, SNTNetworkFlowDefaultActionAllow);
 }
 
 - (void)testEncodeDecodeSecureCoding {
   // Test with enable=YES
   SNTSyncNetworkExtensionSettings* settings =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES];
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
   NSData* serialized = [settings serialize];
   XCTAssertNotNil(serialized);
 
@@ -51,9 +57,13 @@
   XCTAssertNotNil(deserialized);
   XCTAssertTrue(deserialized.enable);
   XCTAssertEqual(deserialized.enable, settings.enable);
+  XCTAssertEqual(deserialized.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
+  XCTAssertEqualObjects(deserialized, settings);
 
   // Test with enable=NO
-  settings = [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:NO];
+  settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:NO
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
   serialized = [settings serialize];
   XCTAssertNotNil(serialized);
 
@@ -61,6 +71,8 @@
   XCTAssertNotNil(deserialized);
   XCTAssertFalse(deserialized.enable);
   XCTAssertEqual(deserialized.enable, settings.enable);
+  XCTAssertEqual(deserialized.flowDefaultAction, SNTNetworkFlowDefaultActionAllow);
+  XCTAssertEqualObjects(deserialized, settings);
 }
 
 - (void)testDeserializeNilData {

--- a/Source/common/ne/SNTXPCNetworkExtensionInterface.mm
+++ b/Source/common/ne/SNTXPCNetworkExtensionInterface.mm
@@ -16,7 +16,9 @@
 
 #import "Source/common/MOLCodesignChecker.h"
 #import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTNetworkFlowRule.h"
 #import "Source/common/ne/SNDXPCNetworkExtensionInterface.h"
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
 #import "Source/common/ne/SNTNetworkExtensionSettings.h"
 
 static NSString* const kSantanetdExtensionBundleID = @"com.northpolesec.santa.netd";
@@ -26,8 +28,10 @@ static NSString* const kSantanetdExtensionBundleID = @"com.northpolesec.santa.ne
 + (NSXPCInterface*)networkExtensionInterface {
   NSXPCInterface* r = [NSXPCInterface interfaceWithProtocol:@protocol(SNDNetworkExtensionXPC)];
 
-  [r setClasses:[NSSet setWithObject:[SNTNetworkExtensionSettings class]]
-        forSelector:@selector(updateNetworkExtensionSettings:reply:)
+  [r setClasses:[NSSet setWithObjects:[SNTNetworkExtensionConfig class],
+                                      [SNTNetworkExtensionSettings class], [NSArray class],
+                                      [SNTNetworkFlowRule class], [NSData class], nil]
+        forSelector:@selector(updateNetworkExtensionConfig:reply:)
       argumentIndex:0
             ofReply:NO];
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -211,6 +211,7 @@ objc_library(
     deps = [
         ":EndpointSecurityLogger",
         ":SNTNotificationQueue",
+        ":SNTRuleTable",
         ":SNTSyncdQueue",
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTCommonEnums",
@@ -219,12 +220,32 @@ objc_library(
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTKVOManager",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTNetworkFlowRule",
         "//Source/common:SNTStrengthify",
         "//Source/common:SNTXPCNotifierInterface",
+        "//Source/common/ne:SNDXPCNetworkExtensionInterface",
+        "//Source/common/ne:SNTNetworkExtensionConfig",
         "//Source/common/ne:SNTNetworkExtensionSettings",
         "//Source/common/ne:SNTSyncNetworkExtensionSettings",
         "//Source/common/ne:SNTXPCNetworkExtensionInterface",
         "@santanetd//src/santanetd:SNDProcessFlows",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTNetworkExtensionQueueTest",
+    srcs = ["SNTNetworkExtensionQueueTest.mm"],
+    deps = [
+        ":SNTNetworkExtensionQueue",
+        ":SNTRuleTable",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTNetworkFlowRule",
+        "//Source/common/ne:SNDXPCNetworkExtensionInterface",
+        "//Source/common/ne:SNTNetworkExtensionConfig",
+        "//Source/common/ne:SNTNetworkExtensionSettings",
+        "//Source/common/ne:SNTSyncNetworkExtensionSettings",
+        "@OCMock",
     ],
 )
 
@@ -1768,6 +1789,7 @@ test_suite(
         ":SNTEndpointSecurityTreeAwareClientTest",
         ":SNTEventTableTest",
         ":SNTExecutionControllerTest",
+        ":SNTNetworkExtensionQueueTest",
         ":SNTNotificationQueueTest",
         ":SNTPolicyProcessorTest",
         ":SNTRuleTableTest",

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -32,6 +32,16 @@
 @property(readonly) NSString* networkFlowRulesHash;
 @end
 
+/// Atomic point-in-time view of the network flow ruleset. Returned from
+/// `retrieveAllNetworkFlowRulesSnapshot`; `rules` and `networkFlowRulesHash` correspond to the
+/// same DB state.
+@interface SNTNetworkFlowRulesSnapshot : NSObject
+@property(readonly) NSArray<SNTNetworkFlowRule*>* rules;
+@property(readonly) NSString* networkFlowRulesHash;
+- (instancetype)initWithRules:(NSArray<SNTNetworkFlowRule*>*)rules
+         networkFlowRulesHash:(NSString*)networkFlowRulesHash;
+@end
+
 ///
 ///  Responsible for managing the rule tables.
 ///
@@ -152,10 +162,11 @@
 - (NSDictionary<NSString*, NSDictionary*>*)retrieveAllFileAccessRules;
 
 ///
-///  Retrieve all stored network flow rules as Add rules, ordered by rule_id ASC.
-///  Intended for export and for assembling the full-set XPC push to santanetd.
+///  Atomic snapshot of all stored network flow rules (as Add rules, ordered by rule_id ASC)
+///  and the hash that identifies them, read inside a single database transaction so the two
+///  correspond to the same state. Intended for assembling the full-set XPC push to santanetd.
 ///
-- (NSArray<SNTNetworkFlowRule*>*)retrieveAllNetworkFlowRules;
+- (SNTNetworkFlowRulesSnapshot*)retrieveAllNetworkFlowRulesSnapshot;
 
 ///
 ///  Update the static rules from the configuration.

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -169,6 +169,14 @@
 - (SNTNetworkFlowRulesSnapshot*)retrieveAllNetworkFlowRulesSnapshot;
 
 ///
+///  Hash identifying the current network-flow ruleset — the same value carried in
+///  `hashOfHashes.networkFlowRulesHash` and `retrieveAllNetworkFlowRulesSnapshot`, computed from
+///  a single DB read (and cached). Cheaper than `hashOfHashes` when only the network-flow ruleset
+///  matters, since it avoids recomputing the execution and file-access digests.
+///
+- (NSString*)networkFlowRulesHash;
+
+///
 ///  Update the static rules from the configuration.
 ///
 - (void)updateStaticRules:(NSArray<NSDictionary*>*)staticRules;

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -82,6 +82,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 @property NSDictionary* criticalSystemBinaries;
 @property(readonly) NSArray* criticalSystemBinaryPaths;
 @property(readwrite) NSDictionary<NSString*, SNTRule*>* cachedStaticRules;
+// Cached digest of each rule sub-table. Read/write ONLY inside an inDatabase:/inTransaction:
+// block — FMDB's serial queue is what keeps the cache consistent with the DB. Clears must be
+// colocated with the rule write that invalidated them; recomputes must be colocated with the
+// DB read used to produce them. A non-nil cache at the start of a block therefore corresponds
+// to the current DB state by construction.
 @property(atomic) NSString* executionRulesHash;
 @property(atomic) NSString* fileAccessRulesHash;
 @property(atomic) NSString* networkFlowRulesHash;
@@ -96,6 +101,18 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     _executionRulesHash = executionRulesHash;
     _fileAccessRulesHash = fileAccessRulesHash;
     _networkFlowRulesHash = networkFlowRulesHash;
+  }
+  return self;
+}
+@end
+
+@implementation SNTNetworkFlowRulesSnapshot
+- (instancetype)initWithRules:(NSArray<SNTNetworkFlowRule*>*)rules
+         networkFlowRulesHash:(NSString*)networkFlowRulesHash {
+  self = [super init];
+  if (self) {
+    _rules = [rules copy];
+    _networkFlowRulesHash = [networkFlowRulesHash copy];
   }
   return self;
 }
@@ -906,11 +923,15 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   return faaRules;
 }
 
-- (NSArray<SNTNetworkFlowRule*>*)retrieveAllNetworkFlowRules {
+- (SNTNetworkFlowRulesSnapshot*)retrieveAllNetworkFlowRulesSnapshot {
   NSMutableArray<SNTNetworkFlowRule*>* rules = [NSMutableArray array];
+  __block NSString* digest;
   [self inDatabase:^(FMDatabase* db) {
-    // Indexed-column access (rather than named) to keep this loop cheap when the
-    // network ruleset is large. Column order: 0=rule_id, 1=rule_blob.
+    // Single iteration: build the rules array and compute the hash from the same blob
+    // bytes, so they correspond to the same DB state by construction. Indexed-column
+    // access keeps the loop cheap for large rulesets. Column order: 0=rule_id, 1=rule_blob.
+    BOOL haveCachedHash = self.networkFlowRulesHash.length > 0;
+    santa::Xxhash128 h;
     FMResultSet* rs = [db executeQuery:@"SELECT rule_id, rule_blob FROM network_flow_rules "
                                        @"ORDER BY rule_id ASC"];
     while ([rs next]) {
@@ -919,13 +940,22 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
       if (!blob) continue;
       SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:ruleId
                                                                      protoBlob:blob];
-      if (rule) {
-        [rules addObject:rule];
+      if (!rule) continue;
+      [rules addObject:rule];
+      if (!haveCachedHash) {
+        h.Update(blob.bytes, blob.length);
       }
     }
     [rs close];
+
+    if (haveCachedHash) {
+      digest = self.networkFlowRulesHash;
+    } else {
+      digest = santa::StringToNSString(h.HexDigest());
+      self.networkFlowRulesHash = digest;
+    }
   }];
-  return rules;
+  return [[SNTNetworkFlowRulesSnapshot alloc] initWithRules:rules networkFlowRulesHash:digest];
 }
 
 #pragma mark Caching Static Rules
@@ -972,15 +1002,17 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 
   santa::Xxhash128 hash;
 
+  // Indexed-column access keeps this loop cheap; column order matches the SELECT below.
+  // Columns: 0=identifier, 1=state, 2=type, 3=cel_expr, 4=seatbelt_policy.
   FMResultSet* rs = [db executeQuery:@"SELECT identifier, state, type, cel_expr, seatbelt_policy "
                                      @"FROM execution_rules WHERE state != ?",
                                      @(SNTRuleStateAllowTransitive)];
   while ([rs next]) {
-    NSString* identifier = [rs stringForColumn:@"identifier"];
-    NSString* cel = [rs stringForColumn:@"cel_expr"];
-    NSString* seatbeltPolicy = [rs stringForColumn:@"seatbelt_policy"];
-    int state = [rs intForColumn:@"state"];
-    int type = [rs intForColumn:@"type"];
+    NSString* identifier = [rs stringForColumnIndex:0];
+    int state = [rs intForColumnIndex:1];
+    int type = [rs intForColumnIndex:2];
+    NSString* cel = [rs stringForColumnIndex:3];
+    NSString* seatbeltPolicy = [rs stringForColumnIndex:4];
 
     hash.Update(identifier.UTF8String,
                 [identifier lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
@@ -1007,10 +1039,12 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 
   santa::Xxhash128 hash;
 
+  // Indexed-column access keeps this loop cheap; column order matches the SELECT below.
+  // Columns: 0=name, 1=rule_data.
   FMResultSet* rs = [db executeQuery:@"SELECT name, rule_data FROM file_access_rules"];
   while ([rs next]) {
-    NSString* name = [rs stringForColumn:@"name"];
-    NSData* blob = [rs dataNoCopyForColumn:@"rule_data"];
+    NSString* name = [rs stringForColumnIndex:0];
+    NSData* blob = [rs dataNoCopyForColumnIndex:1];
 
     hash.Update(name.UTF8String, [name lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
     hash.Update(blob.bytes, blob.length);

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -87,9 +87,9 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 // colocated with the rule write that invalidated them; recomputes must be colocated with the
 // DB read used to produce them. A non-nil cache at the start of a block therefore corresponds
 // to the current DB state by construction.
-@property(atomic) NSString* executionRulesHash;
-@property(atomic) NSString* fileAccessRulesHash;
-@property(atomic) NSString* networkFlowRulesHash;
+@property(atomic) NSString* cachedExecutionRulesHash;
+@property(atomic) NSString* cachedFileAccessRulesHash;
+@property(atomic) NSString* cachedNetworkFlowRulesHash;
 @end
 
 @implementation SNTRuleTableRulesHash
@@ -774,9 +774,9 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     }
 
     // Clear the rules hashes
-    self.executionRulesHash = nil;
-    self.fileAccessRulesHash = nil;
-    self.networkFlowRulesHash = nil;
+    self.cachedExecutionRulesHash = nil;
+    self.cachedFileAccessRulesHash = nil;
+    self.cachedNetworkFlowRulesHash = nil;
 
     faaRulesHashAfter = [self fileAccessRulesHashSerialized:db];
     faaRuleCount = [self fileAccessRuleCountSerialized:db];
@@ -923,39 +923,69 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   return faaRules;
 }
 
+// Single source of truth for scanning network_flow_rules in rule_id order. On a cold cache
+// it computes and caches the digest; when `outRules` is non-nil it also materializes the Add
+// rules into it. The hash covers exactly the blobs of the rows added to `outRules`, so a
+// snapshot's `rules` and `networkFlowRulesHash` agree by construction, and the hash-only
+// callers (hashOfHashes) and the array caller (the snapshot) can never diverge.
+//
+// INVARIANT: a row is included iff its rule_blob is non-nil (the column is NOT NULL, so in
+// practice every row). SNTNetworkFlowRule.initAddRuleWithId: must keep rejecting ONLY nil
+// blobs.
+//
+// Must be called inside an inDatabase:/inTransaction: block.
+- (NSString*)networkFlowRulesHashSerializedInDB:(FMDatabase*)db
+                                    collectInto:(NSMutableArray<SNTNetworkFlowRule*>*)outRules {
+  BOOL haveCachedHash = self.cachedNetworkFlowRulesHash.length > 0;
+  if (haveCachedHash && !outRules) {
+    // Hash-only request and the cache is warm: no scan needed.
+    return self.cachedNetworkFlowRulesHash;
+  }
+
+  // Column order: 0=rule_id, 1=rule_blob. rule_id is field 1
+  // of the NetworkFlowRule.Add proto and is therefore already part of rule_blob, so the hash
+  // need only fold in the blob bytes; ordering by rule_id ASC makes it deterministic.
+  santa::Xxhash128 h;
+  FMResultSet* rs = [db executeQuery:@"SELECT rule_id, rule_blob FROM network_flow_rules "
+                                     @"ORDER BY rule_id ASC"];
+  while ([rs next]) {
+    NSData* blob = [rs dataNoCopyForColumnIndex:1];
+    if (!blob) continue;
+    if (!haveCachedHash) {
+      h.Update(blob.bytes, blob.length);
+    }
+    if (outRules) {
+      int64_t ruleId = [rs longLongIntForColumnIndex:0];
+      // `blob` is a no-copy view into SQLite's buffer (invalid after the next step), but
+      // SNTNetworkFlowRule's `protoBlob` is a `copy` property and -[NSData copy] of a no-copy
+      // NSData materializes an owned deep copy — so the rule safely outlives this result set
+      // and `[rs close]` (e.g. when later serialized over XPC to santanetd).
+      [outRules addObject:[[SNTNetworkFlowRule alloc] initAddRuleWithId:ruleId protoBlob:blob]];
+    }
+  }
+  [rs close];
+
+  if (!haveCachedHash) {
+    self.cachedNetworkFlowRulesHash = santa::StringToNSString(h.HexDigest());
+  }
+  return self.cachedNetworkFlowRulesHash;
+}
+
 - (SNTNetworkFlowRulesSnapshot*)retrieveAllNetworkFlowRulesSnapshot {
   NSMutableArray<SNTNetworkFlowRule*>* rules = [NSMutableArray array];
   __block NSString* digest;
   [self inDatabase:^(FMDatabase* db) {
-    // Single iteration: build the rules array and compute the hash from the same blob
-    // bytes, so they correspond to the same DB state by construction. Indexed-column
-    // access keeps the loop cheap for large rulesets. Column order: 0=rule_id, 1=rule_blob.
-    BOOL haveCachedHash = self.networkFlowRulesHash.length > 0;
-    santa::Xxhash128 h;
-    FMResultSet* rs = [db executeQuery:@"SELECT rule_id, rule_blob FROM network_flow_rules "
-                                       @"ORDER BY rule_id ASC"];
-    while ([rs next]) {
-      int64_t ruleId = [rs longLongIntForColumnIndex:0];
-      NSData* blob = [rs dataNoCopyForColumnIndex:1];
-      if (!blob) continue;
-      SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:ruleId
-                                                                     protoBlob:blob];
-      if (!rule) continue;
-      [rules addObject:rule];
-      if (!haveCachedHash) {
-        h.Update(blob.bytes, blob.length);
-      }
-    }
-    [rs close];
-
-    if (haveCachedHash) {
-      digest = self.networkFlowRulesHash;
-    } else {
-      digest = santa::StringToNSString(h.HexDigest());
-      self.networkFlowRulesHash = digest;
-    }
+    digest = [self networkFlowRulesHashSerializedInDB:db collectInto:rules];
   }];
   return [[SNTNetworkFlowRulesSnapshot alloc] initWithRules:rules networkFlowRulesHash:digest];
+}
+
+- (NSString*)networkFlowRulesHash {
+  __block NSString* digest;
+  [self inDatabase:^(FMDatabase* db) {
+    digest = [self networkFlowRulesHashSerializedInDB:db collectInto:nil];
+  }];
+  return digest;
 }
 
 #pragma mark Caching Static Rules
@@ -996,8 +1026,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // If santad has previously computed the hash and stored it in memory, return it.
   // When a rule is added or removed the hash will be cleared so that the next
   // request for the hash will recompute it.
-  if (self.executionRulesHash.length) {
-    return self.executionRulesHash;
+  if (self.cachedExecutionRulesHash.length) {
+    return self.cachedExecutionRulesHash;
   }
 
   santa::Xxhash128 hash;
@@ -1025,7 +1055,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   [rs close];
 
   NSString* digest = santa::StringToNSString(hash.HexDigest());
-  self.executionRulesHash = digest;
+  self.cachedExecutionRulesHash = digest;
   return digest;
 }
 
@@ -1033,8 +1063,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // If santad has previously computed the hash and stored it in memory, return it.
   // When a rule is added or removed the hash will be cleared so that the next
   // request for the hash will recompute it.
-  if (self.fileAccessRulesHash.length) {
-    return self.fileAccessRulesHash;
+  if (self.cachedFileAccessRulesHash.length) {
+    return self.cachedFileAccessRulesHash;
   }
 
   santa::Xxhash128 hash;
@@ -1052,33 +1082,14 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   [rs close];
 
   NSString* digest = santa::StringToNSString(hash.HexDigest());
-  self.fileAccessRulesHash = digest;
+  self.cachedFileAccessRulesHash = digest;
   return digest;
 }
 
 - (NSString*)networkFlowRulesHashSerialized:(FMDatabase*)db {
-  if (self.networkFlowRulesHash.length) {
-    return self.networkFlowRulesHash;
-  }
-
-  santa::Xxhash128 hash;
-
-  // rule_id is field 1 of the NetworkFlowRule.Add proto and is therefore already
-  // part of rule_blob; no need to feed it into the hash separately. Ordering by
-  // rule_id ASC gives a deterministic update order. Indexed-column access (rather
-  // than named) keeps this loop cheap when the network ruleset is large
-  // (enterprise blocklists are expected to reach 100k+ rules).
-  FMResultSet* rs =
-      [db executeQuery:@"SELECT rule_blob FROM network_flow_rules ORDER BY rule_id ASC"];
-  while ([rs next]) {
-    NSData* blob = [rs dataNoCopyForColumnIndex:0];
-    hash.Update(blob.bytes, blob.length);
-  }
-  [rs close];
-
-  NSString* digest = santa::StringToNSString(hash.HexDigest());
-  self.networkFlowRulesHash = digest;
-  return digest;
+  // Shares the single scan/filter used to materialize the ruleset, so this hash and the
+  // snapshot's hash can never drift apart. See -networkFlowRulesHashSerializedInDB:collectInto:.
+  return [self networkFlowRulesHashSerializedInDB:db collectInto:nil];
 }
 
 - (SNTRuleTableRulesHash*)hashOfHashes {

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -848,7 +848,7 @@
   XCTAssertNil(errors);
   XCTAssertEqual(self.sut.networkFlowRuleCount, 1);
 
-  NSArray<SNTNetworkFlowRule*>* all = [self.sut retrieveAllNetworkFlowRules];
+  NSArray<SNTNetworkFlowRule*>* all = [self.sut retrieveAllNetworkFlowRulesSnapshot].rules;
   XCTAssertEqual(all.count, 1u);
   XCTAssertEqual(all.firstObject.ruleId, 101);
   XCTAssertEqual(all.firstObject.state, SNTNetworkFlowRuleStateAdd);
@@ -864,7 +864,7 @@
   SNTNetworkFlowRule* v2 = [self _exampleNetworkFlowAddRuleWithId:42 blob:@"v2"];
   XCTAssertTrue([self _addNetworkFlowRules:@[ v2 ] ruleCleanup:SNTRuleCleanupNone errors:nil]);
   XCTAssertEqual(self.sut.networkFlowRuleCount, 1);
-  NSArray<SNTNetworkFlowRule*>* all = [self.sut retrieveAllNetworkFlowRules];
+  NSArray<SNTNetworkFlowRule*>* all = [self.sut retrieveAllNetworkFlowRulesSnapshot].rules;
   XCTAssertEqualObjects(all.firstObject.protoBlob, [@"v2" dataUsingEncoding:NSUTF8StringEncoding]);
 }
 
@@ -1004,6 +1004,44 @@
   // Sanity: empty table still produces a stable 32-char Xxhash128 hex.
   NSString* h = [self.sut hashOfHashes].networkFlowRulesHash;
   XCTAssertEqual(h.length, 32u);
+}
+
+- (void)testRetrieveAllNetworkFlowRulesSnapshotReturnsConsistentRulesAndHash {
+  [self _addNetworkFlowRules:@[
+    [self _exampleNetworkFlowAddRuleWithId:1 blob:@"a"],
+    [self _exampleNetworkFlowAddRuleWithId:2 blob:@"b"],
+  ]
+                 ruleCleanup:SNTRuleCleanupNone
+                      errors:nil];
+
+  SNTNetworkFlowRulesSnapshot* snapshot = [self.sut retrieveAllNetworkFlowRulesSnapshot];
+  XCTAssertEqual(snapshot.rules.count, 2u);
+  XCTAssertEqual(snapshot.rules[0].ruleId, 1);
+  XCTAssertEqual(snapshot.rules[1].ruleId, 2);
+  // The snapshot's hash must match the hash hashOfHashes computes for the same state.
+  XCTAssertEqualObjects(snapshot.networkFlowRulesHash,
+                        [self.sut hashOfHashes].networkFlowRulesHash);
+}
+
+- (void)testRetrieveAllNetworkFlowRulesSnapshotEmptyTable {
+  SNTNetworkFlowRulesSnapshot* snapshot = [self.sut retrieveAllNetworkFlowRulesSnapshot];
+  XCTAssertEqual(snapshot.rules.count, 0u);
+  XCTAssertEqual(snapshot.networkFlowRulesHash.length, 32u);
+  XCTAssertEqualObjects(snapshot.networkFlowRulesHash,
+                        [self.sut hashOfHashes].networkFlowRulesHash);
+}
+
+- (void)testRetrieveAllNetworkFlowRulesSnapshotReflectsWrites {
+  SNTNetworkFlowRulesSnapshot* before = [self.sut retrieveAllNetworkFlowRulesSnapshot];
+
+  [self _addNetworkFlowRules:@[ [self _exampleNetworkFlowAddRuleWithId:42 blob:@"x"] ]
+                 ruleCleanup:SNTRuleCleanupNone
+                      errors:nil];
+
+  SNTNetworkFlowRulesSnapshot* after = [self.sut retrieveAllNetworkFlowRulesSnapshot];
+  XCTAssertEqual(after.rules.count, before.rules.count + 1);
+  XCTAssertNotEqualObjects(after.networkFlowRulesHash, before.networkFlowRulesHash);
+  XCTAssertEqualObjects(after.networkFlowRulesHash, [self.sut hashOfHashes].networkFlowRulesHash);
 }
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -1044,4 +1044,30 @@
   XCTAssertEqualObjects(after.networkFlowRulesHash, [self.sut hashOfHashes].networkFlowRulesHash);
 }
 
+// Guards the invariant that the network-flow hash and the materialized ruleset are derived
+// from the same set of rows: every stored (non-nil) blob both produces a rule in the snapshot
+// array and is folded into the hash. The hash-only path (-networkFlowRulesHash / hashOfHashes)
+// and the array path (the snapshot) share one scan, so if a future change ever dropped a row
+// from one but not the other (e.g. SNTNetworkFlowRule began rejecting a non-nil blob), the
+// counts or hashes below would disagree — catching it before it caused perpetual full
+// re-pushes to santanetd.
+- (void)testNetworkFlowRulesHashCoversEveryStoredBlob {
+  NSArray<SNTNetworkFlowRule*>* inserted = @[
+    [self _exampleNetworkFlowAddRuleWithId:1 blob:@"alpha"],
+    [self _exampleNetworkFlowAddRuleWithId:2 blob:@"beta"],
+    [self _exampleNetworkFlowAddRuleWithId:3 blob:@"alpha"],  // duplicate content, distinct id
+  ];
+  [self _addNetworkFlowRules:inserted ruleCleanup:SNTRuleCleanupNone errors:nil];
+
+  // Cold cache: the snapshot (array path) computes the hash. Every inserted row must be present.
+  SNTNetworkFlowRulesSnapshot* snapshot = [self.sut retrieveAllNetworkFlowRulesSnapshot];
+  XCTAssertEqual(snapshot.rules.count, inserted.count);
+
+  // Hash-only paths must agree with the array path's recorded hash — i.e. all cover exactly
+  // the same blobs.
+  XCTAssertEqualObjects(snapshot.networkFlowRulesHash, [self.sut networkFlowRulesHash]);
+  XCTAssertEqualObjects(snapshot.networkFlowRulesHash,
+                        [self.sut hashOfHashes].networkFlowRulesHash);
+}
+
 @end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -654,6 +654,15 @@ double watchdogRAMPeak = 0;
     if (![oldCELData isEqualToData:newCELData] && self.flushCacheBlock) {
       self.flushCacheBlock(FlushCacheMode::kAllCaches, FlushCacheReason::kCELFallbackRulesChanged);
     }
+
+    // Postflight marks the sync boundary. Now that settings and rules (committed earlier in
+    // the rule-download phase) are both final, reconcile santanetd once — the queue figures
+    // out what actually changed and pushes only that, or nothing.
+    [result reconcileNetworkExtension:^(BOOL reconcile) {
+      if (reconcile) {
+        [self.netExtQueue reconcileNetworkExtensionConfig];
+      }
+    }];
   }
 
   reply();
@@ -1059,7 +1068,7 @@ static const char* const kAllowedCanonicalBundlePaths[] = {
 }
 
 - (void)registerNetworkExtensionWithProtocolVersion:(NSString*)protocolVersion
-                                              reply:(void (^)(SNTNetworkExtensionSettings* settings,
+                                              reply:(void (^)(SNTNetworkExtensionConfig* config,
                                                               NSString* santaProtocolVersion,
                                                               NSError* error))reply {
   NSError* error;
@@ -1072,14 +1081,14 @@ static const char* const kAllowedCanonicalBundlePaths[] = {
     return;
   }
 
-  SNTNetworkExtensionSettings* settings =
+  SNTNetworkExtensionConfig* config =
       [self.netExtQueue handleRegistrationWithProtocolVersion:protocolVersion error:&error];
-  reply(settings, kSantaNetworkExtensionProtocolVersion, error);
+  reply(config, kSantaNetworkExtensionProtocolVersion, error);
 
   // When the network extension registers, it may have just been enabled which can
   // reset network connections. Trigger a NATS reconnect to ensure push notifications
   // are working immediately.
-  if (settings) {
+  if (config) {
     LOGI(@"Network extension registered, triggering push notification reconnect");
     [self.syncdQueue pushNotificationReconnect];
   }

--- a/Source/santad/SNTNetworkExtensionQueue.h
+++ b/Source/santad/SNTNetworkExtensionQueue.h
@@ -19,8 +19,10 @@
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
 
 @class SNDProcessFlows;
+@class SNTNetworkExtensionConfig;
 @class SNTNetworkExtensionSettings;
 @class SNTNotificationQueue;
+@class SNTRuleTable;
 @class SNTSyncdQueue;
 
 extern NSString* const kSantaNetworkExtensionProtocolVersion;
@@ -31,13 +33,22 @@ extern NSString* const kSantaNetworkExtensionProtocolVersion;
 
 - (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
                            syncdQueue:(SNTSyncdQueue*)syncdQueue
+                            ruleTable:(SNTRuleTable*)ruleTable
                                logger:(std::shared_ptr<santa::Logger>)logger
     NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (SNTNetworkExtensionSettings*)handleRegistrationWithProtocolVersion:(NSString*)protocolVersion
-                                                                error:(NSError**)error;
+/// Reconcile santanetd with the current settings + network-flow ruleset, pushing only
+/// what changed since the last push (settings always, rules only if their hash moved,
+/// nothing if neither changed). Safe to call when santanetd is not connected (no-op).
+- (void)reconcileNetworkExtensionConfig;
+
+/// Handle a santanetd registration. Returns the config (settings + full current ruleset) to seed
+/// it with — the caller returns it in the registration reply so santanetd applies both atomically.
+/// Records it as the last-pushed state so the next reconcile only sends deltas.
+- (SNTNetworkExtensionConfig*)handleRegistrationWithProtocolVersion:(NSString*)protocolVersion
+                                                              error:(NSError**)error;
 
 - (void)handleNetworkFlows:(NSArray<SNDProcessFlows*>*)processFlows
                windowStart:(NSDate*)windowStart

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -120,8 +120,9 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
     }
 
     // Fast-path hash check: cheap (cached) and avoids materializing the ruleset when nothing
-    // changed.
-    NSString* currentHash = [[self.ruleTable hashOfHashes] networkFlowRulesHash];
+    // changed. Uses the narrow network-flow getter rather than hashOfHashes so we don't
+    // recompute the execution + file-access digests we don't need here.
+    NSString* currentHash = [self.ruleTable networkFlowRulesHash];
     BOOL settingsChanged = ![settings isEqual:self.lastPushedSettings];
     BOOL rulesChanged = ![currentHash isEqualToString:self.lastPushedNetworkFlowRulesHash];
     if (!settingsChanged && !rulesChanged) {

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -25,12 +25,15 @@
 #import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTKVOManager.h"
 #import "Source/common/SNTLogging.h"
+#import "Source/common/SNTNetworkFlowRule.h"
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/common/ne/SNDXPCNetworkExtensionInterface.h"
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
 #import "Source/common/ne/SNTNetworkExtensionSettings.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 #import "Source/common/ne/SNTXPCNetworkExtensionInterface.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTNotificationQueue.h"
 #import "Source/santad/SNTSyncdQueue.h"
 #import "src/santanetd/SNDProcessFlows.h"
@@ -45,39 +48,34 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
 @property NSArray<SNTKVOManager*>* kvoWatchers;
 @property(weak) SNTNotificationQueue* notifierQueue;
 @property(weak) SNTSyncdQueue* syncdQueue;
+@property SNTRuleTable* ruleTable;
+// What santanetd was last told. Reset when the connection drops so a fresh santanetd
+// (which persists nothing) is re-seeded with the full config on its next registration.
+@property SNTNetworkExtensionSettings* lastPushedSettings;
+@property NSString* lastPushedNetworkFlowRulesHash;
 @end
 
 @implementation SNTNetworkExtensionQueue
 
 - (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
                            syncdQueue:(SNTSyncdQueue*)syncdQueue
+                            ruleTable:(SNTRuleTable*)ruleTable
                                logger:(std::shared_ptr<santa::Logger>)logger {
   self = [super init];
   if (self) {
     _notifierQueue = notifierQueue;
     _syncdQueue = syncdQueue;
+    _ruleTable = ruleTable;
     _logger = std::move(logger);
 
     WEAKIFY(self);
 
+    // Sync-path settings changes reach santanetd via the postflight marker reconcile in
+    // SNTDaemonControlController.updateSyncSettings:, so we don't observe
+    // syncNetworkExtensionSettings directly — that would double-fire and race with the
+    // marker reconcile. The only non-sync mutation is the syncBaseURL-driven revoke below,
+    // which clears settings and triggers a reconcile explicitly.
     _kvoWatchers = @[
-      [[SNTKVOManager alloc] initWithObject:[SNTConfigurator configurator]
-                                   selector:@selector(syncNetworkExtensionSettings)
-                                       type:[SNTSyncNetworkExtensionSettings class]
-                                   callback:^(SNTSyncNetworkExtensionSettings* oldValue,
-                                              SNTSyncNetworkExtensionSettings* newValue) {
-                                     // Treat nil as equivalent to enable == NO (the default state).
-                                     if (oldValue.enable == newValue.enable) {
-                                       return;
-                                     }
-
-                                     STRONGIFY(self);
-
-                                     LOGI(@"SyncNetworkExtensionSettings changed: enable %d -> %d",
-                                          oldValue.enable, newValue.enable);
-
-                                     [self handleSettingsChanged:newValue];
-                                   }],
       [[SNTKVOManager alloc]
           initWithObject:[SNTConfigurator configurator]
                 selector:@selector(syncBaseURL)
@@ -94,43 +92,74 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
                   }
 
                   [[SNTConfigurator configurator] setSyncServerSyncNetworkExtensionSettings:nil];
-                }],
 
+                  STRONGIFY(self);
+                  [self reconcileNetworkExtensionConfig];
+                }],
     ];
   }
   return self;
 }
 
-- (void)handleSettingsChanged:(SNTSyncNetworkExtensionSettings*)settings {
-  MOLXPCConnection* conn = self.netExtConnection;
-  if (!conn) {
-    LOGW(@"Network extension connection unavailable; skipping settings update");
-    return;
-  }
+- (void)reconcileNetworkExtensionConfig {
+  // Serialize the read-compare-dispatch-update sequence so concurrent triggers (e.g. the
+  // postflight marker on the controller's XPC thread vs. the syncBaseURL revoke on the
+  // configurator's KVO thread) don't see stale lastPushed and emit duplicate pushes.
+  @synchronized(self) {
+    MOLXPCConnection* conn = self.netExtConnection;
+    if (!conn) {
+      // santanetd isn't connected; it will be re-seeded in full when it next registers.
+      return;
+    }
 
-  SNTNetworkExtensionSettings* netExtSettings =
-      [self generateSettingsForProtocolVersion:self.connectedProtocolVersion];
-  if (!netExtSettings) {
-    LOGW(@"Failed to generate settings for protocol version %@", self.connectedProtocolVersion);
-    return;
-  }
+    SNTNetworkExtensionSettings* settings =
+        [self generateSettingsForProtocolVersion:self.connectedProtocolVersion];
+    if (!settings) {
+      LOGW(@"Failed to generate settings for protocol version %@", self.connectedProtocolVersion);
+      return;
+    }
 
-  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    // Fast-path hash check: cheap (cached) and avoids materializing the ruleset when nothing
+    // changed.
+    NSString* currentHash = [[self.ruleTable hashOfHashes] networkFlowRulesHash];
+    BOOL settingsChanged = ![settings isEqual:self.lastPushedSettings];
+    BOOL rulesChanged = ![currentHash isEqualToString:self.lastPushedNetworkFlowRulesHash];
+    if (!settingsChanged && !rulesChanged) {
+      return;
+    }
 
-  [[conn remoteObjectProxy]
-      updateNetworkExtensionSettings:netExtSettings
+    // When rules changed, take an atomic snapshot so the array and the hash we record both
+    // correspond to the same DB state (a concurrent sync could commit between the fast-path
+    // read above and the materialization below). `nil` rules means "rules unchanged" to
+    // santanetd, so settings-only changes skip the snapshot allocation entirely.
+    NSArray<SNTNetworkFlowRule*>* rules = nil;
+    NSString* hashToRecord = currentHash;
+    if (rulesChanged) {
+      SNTNetworkFlowRulesSnapshot* snapshot = [self.ruleTable retrieveAllNetworkFlowRulesSnapshot];
+      rules = snapshot.rules;
+      hashToRecord = snapshot.networkFlowRulesHash;
+    }
+    SNTNetworkExtensionConfig* config = [[SNTNetworkExtensionConfig alloc] initWithSettings:settings
+                                                                           networkFlowRules:rules];
+
+    // Record lastPushed only on a successful reply, so a netd-side rejection leaves our
+    // recorded state matching netd's actual state and the next reconcile retries. The reply
+    // block fires asynchronously off this lock, so it re-enters @synchronized for the write;
+    // WEAKIFY/STRONGIFY breaks the transient self <-> connection <-> reply-block cycle.
+    WEAKIFY(self);
+    [(id<SNDNetworkExtensionXPC>)[conn remoteObjectProxy]
+        updateNetworkExtensionConfig:config
                                reply:^(BOOL success) {
-                                 if (success) {
-                                   LOGI(@"Successfully updated network extension settings");
-                                 } else {
-                                   LOGW(@"Failed to update network extension settings");
+                                 if (!success) {
+                                   LOGW(@"Failed to update network extension config");
+                                   return;
                                  }
-
-                                 dispatch_semaphore_signal(sema);
+                                 STRONGIFY(self);
+                                 @synchronized(self) {
+                                   self.lastPushedSettings = settings;
+                                   self.lastPushedNetworkFlowRulesHash = hashToRecord;
+                                 }
                                }];
-
-  if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC))) {
-    LOGW(@"Timeout when attempting to update network extension settings");
   }
 }
 
@@ -157,8 +186,8 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
   }
 }
 
-- (SNTNetworkExtensionSettings*)handleRegistrationWithProtocolVersion:(NSString*)protocolVersion
-                                                                error:(NSError**)error {
+- (SNTNetworkExtensionConfig*)handleRegistrationWithProtocolVersion:(NSString*)protocolVersion
+                                                              error:(NSError**)error {
   if (self.netExtConnection) {
     LOGW(@"Network extension attempting to register but already connected, clearing stale "
          @"connection");
@@ -206,11 +235,30 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
   }
 
   // At this point we've successfully validated the client. Store important information
-  // and go ahead and establish a connection back to the network extension daemon.
-  self.connectedProtocolVersion = protocolVersion;
-  [self establishNetworkExtensionConnection];
+  // and go ahead and establish a connection back to the network extension daemon (used for
+  // runtime config updates after registration).
+  //
+  // Same monitor as reconcileNetworkExtensionConfig: a concurrent reconcile must not see a
+  // half-set-up state (connection established but lastPushed not yet recorded), which would
+  // emit a redundant push of the values we're about to seed in the reply.
+  @synchronized(self) {
+    self.connectedProtocolVersion = protocolVersion;
+    [self establishNetworkExtensionConnection];
 
-  return [self generateSettingsForProtocolVersion:self.connectedProtocolVersion];
+    // santanetd persists nothing, so a registration means it just (re)started empty. Seed it
+    // with the full current settings + ruleset in the registration reply (returned here),
+    // letting it apply both atomically. The snapshot reads rules + hash in one DB transaction
+    // so a concurrent sync can't desync what we put in the reply from what we record as
+    // last-pushed.
+    SNTNetworkExtensionSettings* settings =
+        [self generateSettingsForProtocolVersion:self.connectedProtocolVersion];
+    SNTNetworkFlowRulesSnapshot* snapshot = [self.ruleTable retrieveAllNetworkFlowRulesSnapshot];
+    self.lastPushedSettings = settings;
+    self.lastPushedNetworkFlowRulesHash = snapshot.networkFlowRulesHash;
+
+    return [[SNTNetworkExtensionConfig alloc] initWithSettings:settings
+                                              networkFlowRules:snapshot.rules];
+  }
 }
 
 - (void)establishNetworkExtensionConnection {
@@ -230,10 +278,18 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
 }
 
 - (void)clearNetworkExtensionConnection {
-  self.netExtConnection.invalidationHandler = nil;
-  [self.netExtConnection invalidate];
-  self.netExtConnection = nil;
-  self.connectedProtocolVersion = nil;
+  // Holds the same monitor as reconcileNetworkExtensionConfig so the {connection, lastPushed}
+  // pair stays consistent — reconcile never sees a non-nil connection paired with
+  // already-cleared lastPushed (or vice versa).
+  @synchronized(self) {
+    self.netExtConnection.invalidationHandler = nil;
+    [self.netExtConnection invalidate];
+    self.netExtConnection = nil;
+    self.connectedProtocolVersion = nil;
+    // Forget what we told the old santanetd; the next one starts empty and must be re-seeded.
+    self.lastPushedSettings = nil;
+    self.lastPushedNetworkFlowRulesHash = nil;
+  }
 }
 
 - (std::pair<int, int>)protocolVersionComponents:(NSString*)protocolVersion {
@@ -312,11 +368,14 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
       [[SNTConfigurator configurator] syncNetworkExtensionSettings];
 
   BOOL enable = NO;
+  SNTNetworkFlowDefaultAction flowDefaultAction = SNTNetworkFlowDefaultActionUnspecified;
   if (majorVersion >= 1) {
     enable = syncSettings.enable;
+    flowDefaultAction = syncSettings.flowDefaultAction;
   }
 
-  return [[SNTNetworkExtensionSettings alloc] initWithEnable:enable];
+  return [[SNTNetworkExtensionSettings alloc] initWithEnable:enable
+                                           flowDefaultAction:flowDefaultAction];
 }
 
 @end

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -1,0 +1,260 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/SNTNetworkExtensionQueue.h"
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#include <memory>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTNetworkFlowRule.h"
+#import "Source/common/ne/SNDXPCNetworkExtensionInterface.h"
+#import "Source/common/ne/SNTNetworkExtensionConfig.h"
+#import "Source/common/ne/SNTNetworkExtensionSettings.h"
+#import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
+
+@interface SNTNetworkExtensionQueue (Testing)
+@property MOLXPCConnection* netExtConnection;
+@property SNTRuleTable* ruleTable;
+@property SNTNetworkExtensionSettings* lastPushedSettings;
+@property NSString* lastPushedNetworkFlowRulesHash;
+@property(readwrite) NSString* connectedProtocolVersion;
+- (void)establishNetworkExtensionConnection;
+- (void)clearNetworkExtensionConnection;
+@end
+
+@interface SNTNetworkExtensionQueueTest : XCTestCase
+@property SNTNetworkExtensionQueue* sut;
+@property id mockRuleTable;
+@property id mockConfigurator;
+@property id mockConnection;
+@property id mockProxy;
+@end
+
+@implementation SNTNetworkExtensionQueueTest
+
+- (void)setUp {
+  self.mockRuleTable = OCMClassMock([SNTRuleTable class]);
+
+  // Construct the SUT before mocking the configurator so its init-time KVO watchers attach
+  // to the real configurator singleton (KVO on a class mock is unreliable).
+  self.sut = [[SNTNetworkExtensionQueue alloc] initWithNotifierQueue:nil
+                                                          syncdQueue:nil
+                                                           ruleTable:self.mockRuleTable
+                                                              logger:nullptr];
+
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+
+  self.mockConnection = OCMClassMock([MOLXPCConnection class]);
+  self.mockProxy = OCMProtocolMock(@protocol(SNDNetworkExtensionXPC));
+  OCMStub([self.mockConnection remoteObjectProxy]).andReturn(self.mockProxy);
+
+  self.sut.netExtConnection = self.mockConnection;
+  self.sut.connectedProtocolVersion = @"1.0";
+}
+
+- (void)tearDown {
+  [self.mockConfigurator stopMocking];
+}
+
+// Make the configurator report the given sync-side network extension settings.
+- (void)stubConfiguratorEnable:(BOOL)enable action:(SNTNetworkFlowDefaultAction)action {
+  SNTSyncNetworkExtensionSettings* settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:enable flowDefaultAction:action];
+  OCMStub([self.mockConfigurator syncNetworkExtensionSettings]).andReturn(settings);
+}
+
+// Make the rule table report the given network flow rules hash + ruleset.
+- (void)stubRuleTableHash:(NSString*)hash rules:(NSArray<SNTNetworkFlowRule*>*)rules {
+  id mockHash = OCMClassMock([SNTRuleTableRulesHash class]);
+  OCMStub([mockHash networkFlowRulesHash]).andReturn(hash);
+  OCMStub([self.mockRuleTable hashOfHashes]).andReturn(mockHash);
+  SNTNetworkFlowRulesSnapshot* snapshot = [[SNTNetworkFlowRulesSnapshot alloc] initWithRules:rules
+                                                                        networkFlowRulesHash:hash];
+  OCMStub([self.mockRuleTable retrieveAllNetworkFlowRulesSnapshot]).andReturn(snapshot);
+}
+
+- (SNTNetworkFlowRule*)rule:(int64_t)ruleId {
+  return [[SNTNetworkFlowRule alloc]
+      initAddRuleWithId:ruleId
+              protoBlob:[@"blob" dataUsingEncoding:NSUTF8StringEncoding]];
+}
+
+- (void)testReconcileSeedsFullConfigWhenNothingPushedYet {
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny];
+  [self stubRuleTableHash:@"h1" rules:@[ [self rule:1], [self rule:2] ]];
+
+  OCMExpect([self.mockProxy
+      updateNetworkExtensionConfig:[OCMArg checkWithBlock:^BOOL(SNTNetworkExtensionConfig* c) {
+        return c.settings.enable &&
+               c.settings.flowDefaultAction == SNTNetworkFlowDefaultActionDeny &&
+               c.networkFlowRules.count == 2;
+      }]
+                             reply:[OCMArg invokeBlock]]);
+
+  [self.sut reconcileNetworkExtensionConfig];
+  OCMVerifyAll(self.mockProxy);
+}
+
+- (void)testReconcileSettingsOnlyChangePushesNilRules {
+  // Rules already pushed (hash matches), only settings differ.
+  self.sut.lastPushedNetworkFlowRulesHash = @"h1";
+  self.sut.lastPushedSettings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:NO
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionAllow];
+  [self stubRuleTableHash:@"h1" rules:@[ [self rule:1] ]];
+
+  OCMExpect([self.mockProxy
+      updateNetworkExtensionConfig:[OCMArg checkWithBlock:^BOOL(SNTNetworkExtensionConfig* c) {
+        return c.settings.enable && c.networkFlowRules == nil;
+      }]
+                             reply:[OCMArg invokeBlock]]);
+  // Settings-only change must not materialize the ruleset.
+  OCMReject([self.mockRuleTable retrieveAllNetworkFlowRulesSnapshot]);
+
+  [self.sut reconcileNetworkExtensionConfig];
+  OCMVerifyAll(self.mockProxy);
+}
+
+- (void)testReconcileRulesOnlyChangePushesRules {
+  self.sut.lastPushedNetworkFlowRulesHash = @"h1";
+  self.sut.lastPushedSettings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny];  // settings unchanged
+  [self stubRuleTableHash:@"h2" rules:@[ [self rule:1] ]];                   // rules changed
+
+  OCMExpect([self.mockProxy
+      updateNetworkExtensionConfig:[OCMArg checkWithBlock:^BOOL(SNTNetworkExtensionConfig* c) {
+        return c.networkFlowRules.count == 1;
+      }]
+                             reply:[OCMArg invokeBlock]]);
+
+  [self.sut reconcileNetworkExtensionConfig];
+  OCMVerifyAll(self.mockProxy);
+}
+
+- (void)testReconcileNoChangeDoesNotPush {
+  self.sut.lastPushedNetworkFlowRulesHash = @"h1";
+  self.sut.lastPushedSettings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny];
+  [self stubRuleTableHash:@"h1" rules:@[ [self rule:1] ]];
+
+  OCMReject([self.mockProxy updateNetworkExtensionConfig:OCMOCK_ANY reply:OCMOCK_ANY]);
+
+  [self.sut reconcileNetworkExtensionConfig];
+  OCMVerifyAll(self.mockProxy);
+}
+
+- (void)testReconcileNoConnectionIsNoOp {
+  self.sut.netExtConnection = nil;
+  OCMReject([self.mockProxy updateNetworkExtensionConfig:OCMOCK_ANY reply:OCMOCK_ANY]);
+  [self.sut reconcileNetworkExtensionConfig];
+  OCMVerifyAll(self.mockProxy);
+}
+
+- (void)testReconcileSuccessReplyRecordsLastPushed {
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny];
+  [self stubRuleTableHash:@"h1" rules:@[ [self rule:1] ]];
+
+  OCMStub([self.mockProxy updateNetworkExtensionConfig:OCMOCK_ANY reply:OCMOCK_ANY])
+      .andDo(^(NSInvocation* invocation) {
+        void (^__unsafe_unretained replyBlock)(BOOL);
+        [invocation getArgument:&replyBlock atIndex:3];
+        replyBlock(YES);
+      });
+
+  [self.sut reconcileNetworkExtensionConfig];
+
+  XCTAssertEqualObjects(self.sut.lastPushedNetworkFlowRulesHash, @"h1");
+  XCTAssertTrue(self.sut.lastPushedSettings.enable);
+  XCTAssertEqual(self.sut.lastPushedSettings.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
+}
+
+- (void)testReconcileFailureReplyDoesNotRecordLastPushed {
+  // Pre-existing state so we can verify it isn't overwritten on failure.
+  self.sut.lastPushedNetworkFlowRulesHash = @"h0";
+  self.sut.lastPushedSettings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:NO
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionAllow];
+
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny];
+  [self stubRuleTableHash:@"h1" rules:@[ [self rule:1] ]];
+
+  OCMStub([self.mockProxy updateNetworkExtensionConfig:OCMOCK_ANY reply:OCMOCK_ANY])
+      .andDo(^(NSInvocation* invocation) {
+        void (^__unsafe_unretained replyBlock)(BOOL);
+        [invocation getArgument:&replyBlock atIndex:3];
+        replyBlock(NO);
+      });
+
+  [self.sut reconcileNetworkExtensionConfig];
+
+  // Stale lastPushed preserved so the next reconcile retries.
+  XCTAssertEqualObjects(self.sut.lastPushedNetworkFlowRulesHash, @"h0");
+  XCTAssertFalse(self.sut.lastPushedSettings.enable);
+}
+
+- (void)testRegistrationSeedsViaReplyAndRecordsLastPushed {
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny];
+  [self stubRuleTableHash:@"h1" rules:@[ [self rule:1], [self rule:2] ]];
+
+  // santanetd builds a real reverse connection on registration; stub that out. Registration
+  // must seed via the reply and must NOT push over the reverse channel.
+  id sutMock = OCMPartialMock(self.sut);
+  OCMStub([sutMock establishNetworkExtensionConnection]).andDo(^(NSInvocation* inv) {
+    self.sut.netExtConnection = self.mockConnection;
+  });
+  OCMReject([self.mockProxy updateNetworkExtensionConfig:OCMOCK_ANY reply:OCMOCK_ANY]);
+
+  NSError* err = nil;
+  SNTNetworkExtensionConfig* config = [self.sut handleRegistrationWithProtocolVersion:@"1.0"
+                                                                                error:&err];
+
+  // Reply carries both settings and the full ruleset for atomic application.
+  XCTAssertNil(err);
+  XCTAssertTrue(config.settings.enable);
+  XCTAssertEqual(config.settings.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
+  XCTAssertEqual(config.networkFlowRules.count, 2);
+
+  // last-pushed reflects what the reply seeded, so an immediate no-change reconcile is a no-op.
+  XCTAssertEqualObjects(self.sut.lastPushedSettings, config.settings);
+  XCTAssertEqualObjects(self.sut.lastPushedNetworkFlowRulesHash, @"h1");
+
+  OCMVerifyAll(self.mockProxy);
+  [sutMock stopMocking];
+}
+
+- (void)testConnectionClearResetsLastPushedSoNextSeedIsFull {
+  self.sut.lastPushedNetworkFlowRulesHash = @"h1";
+  self.sut.lastPushedSettings =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+
+  [self.sut clearNetworkExtensionConnection];
+
+  XCTAssertNil(self.sut.lastPushedSettings);
+  XCTAssertNil(self.sut.lastPushedNetworkFlowRulesHash);
+}
+
+@end

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -124,7 +124,9 @@
 
   OCMExpect([self.mockProxy
       updateNetworkExtensionConfig:[OCMArg checkWithBlock:^BOOL(SNTNetworkExtensionConfig* c) {
-        return c.settings.enable && c.networkFlowRules == nil;
+        return c.settings.enable &&
+               c.settings.flowDefaultAction == SNTNetworkFlowDefaultActionAllow &&
+               c.networkFlowRules == nil;
       }]
                              reply:[OCMArg invokeBlock]]);
   // Settings-only change must not materialize the ruleset.
@@ -144,7 +146,9 @@
 
   OCMExpect([self.mockProxy
       updateNetworkExtensionConfig:[OCMArg checkWithBlock:^BOOL(SNTNetworkExtensionConfig* c) {
-        return c.networkFlowRules.count == 1;
+        return c.settings.enable &&
+               c.settings.flowDefaultAction == SNTNetworkFlowDefaultActionDeny &&
+               c.networkFlowRules.count == 1;
       }]
                              reply:[OCMArg invokeBlock]]);
 

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -83,9 +83,8 @@
 
 // Make the rule table report the given network flow rules hash + ruleset.
 - (void)stubRuleTableHash:(NSString*)hash rules:(NSArray<SNTNetworkFlowRule*>*)rules {
-  id mockHash = OCMClassMock([SNTRuleTableRulesHash class]);
-  OCMStub([mockHash networkFlowRulesHash]).andReturn(hash);
-  OCMStub([self.mockRuleTable hashOfHashes]).andReturn(mockHash);
+  // reconcile reads the hash via the narrow -networkFlowRulesHash getter.
+  OCMStub([self.mockRuleTable networkFlowRulesHash]).andReturn(hash);
   SNTNetworkFlowRulesSnapshot* snapshot = [[SNTNetworkFlowRulesSnapshot alloc] initWithRules:rules
                                                                         networkFlowRulesHash:hash];
   OCMStub([self.mockRuleTable retrieveAllNetworkFlowRulesSnapshot]).andReturn(snapshot);

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -171,6 +171,7 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator* configurator,
   SNTNetworkExtensionQueue* netext_queue =
       [[SNTNetworkExtensionQueue alloc] initWithNotifierQueue:notifier_queue
                                                    syncdQueue:syncd_queue
+                                                    ruleTable:rule_table
                                                        logger:logger];
   if (!netext_queue) {
     LOGE(@"Failed to initialize network extension queue.");

--- a/Source/santasyncservice/SNTSyncConfigBundle.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundle.mm
@@ -47,6 +47,7 @@
 @property NSString* fileAccessEventDetailURL;
 @property NSString* fileAccessEventDetailText;
 @property SNTSyncNetworkExtensionSettings* networkExtensionSettings;
+@property NSNumber* reconcileNetworkExtension;
 @property NSArray<NSString*>* pushTokenChain;
 @property NSArray<NSString*>* telemetryFilterExpressions;
 @property NSArray<SNTCELFallbackRule*>* celFallbackRules;
@@ -91,6 +92,9 @@ SNTConfigBundle* PostflightConfigBundle(SNTSyncState* syncState) {
   bundle.fileAccessEventDetailURL = syncState.fileAccessEventDetailURL;
   bundle.fileAccessEventDetailText = syncState.fileAccessEventDetailText;
   bundle.networkExtensionSettings = syncState.networkExtensionSettings;
+  // Always set: marks the sync boundary so the daemon reconciles santanetd (settings +
+  // rules) once, after both have been applied. The daemon detects what actually changed.
+  bundle.reconcileNetworkExtension = @(YES);
   bundle.telemetryFilterExpressions = syncState.telemetryFilterExpressions;
   bundle.celFallbackRules = syncState.celFallbackRules;
   bundle.fullSyncInterval = syncState.fullSyncInterval;

--- a/Source/santasyncservice/SNTSyncConfigBundleTest.mm
+++ b/Source/santasyncservice/SNTSyncConfigBundleTest.mm
@@ -50,6 +50,7 @@
 @property NSString* fileAccessEventDetailURL;
 @property NSString* fileAccessEventDetailText;
 @property SNTSyncNetworkExtensionSettings* networkExtensionSettings;
+@property NSNumber* reconcileNetworkExtension;
 @property NSArray<NSString*>* pushTokenChain;
 @property NSArray<NSString*>* telemetryFilterExpressions;
 @property NSArray<SNTCELFallbackRule*>* celFallbackRules;
@@ -158,10 +159,18 @@
                         syncState.bannedNetworkMountBlockMessage);
   XCTAssertEqualObjects(bundle.allowedNetworkMountHosts, syncState.allowedNetworkMountHosts);
 
-  syncState.networkExtensionSettings = [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES];
+  syncState.networkExtensionSettings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
   bundle = PostflightConfigBundle(syncState);
   XCTAssertNotNil(bundle.networkExtensionSettings);
   XCTAssertTrue(bundle.networkExtensionSettings.enable);
+  XCTAssertEqual(bundle.networkExtensionSettings.flowDefaultAction,
+                 SNTNetworkFlowDefaultActionDeny);
+
+  // Postflight always sets the reconcile marker (the daemon's sync-boundary signal for
+  // reconciling santanetd).
+  XCTAssertEqualObjects(bundle.reconcileNetworkExtension, @(YES));
 
   syncState.telemetryFilterExpressions = @[ @"expr1", @"expr2" ];
   bundle = PostflightConfigBundle(syncState);

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -84,6 +84,15 @@ namespace {
 
 void HandleV2Responses(const ::pbv2::PreflightResponse& resp, SNTSyncState* syncState);
 
+SNTNetworkFlowDefaultAction NetworkFlowDefaultActionFromProto(
+    ::pbv2::NetworkFlowDefaultAction action) {
+  switch (action) {
+    case ::pbv2::NETWORK_FLOW_DEFAULT_ACTION_ALLOW: return SNTNetworkFlowDefaultActionAllow;
+    case ::pbv2::NETWORK_FLOW_DEFAULT_ACTION_DENY: return SNTNetworkFlowDefaultActionDeny;
+    default: return SNTNetworkFlowDefaultActionUnspecified;
+  }
+}
+
 template <bool IsV2>
 BOOL Preflight(SNTSyncPreflight* self, google::protobuf::Arena* arena,
                SNTSyncType requestSyncType) {
@@ -478,8 +487,10 @@ void HandleV2Responses(const ::pbv2::PreflightResponse& resp, SNTSyncState* sync
   }
 
   if (resp.has_network_extension()) {
-    syncState.networkExtensionSettings =
-        [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:resp.network_extension().enable()];
+    syncState.networkExtensionSettings = [[SNTSyncNetworkExtensionSettings alloc]
+           initWithEnable:resp.network_extension().enable()
+        flowDefaultAction:NetworkFlowDefaultActionFromProto(
+                              resp.network_extension().flow_default_action())];
   }
 
   if (resp.has_file_access_event_detail_url()) {


### PR DESCRIPTION
Lands the santad-side machinery for delivering server-pushed network flow rules and NetworkExtension settings to santanetd; the santanetd receiver and engine integration land separately in the santanetd repo.

- New SNTNetworkExtensionConfig (Source/common/ne/): NSSecureCoding composite of settings + networkFlowRules, used as the single payload for both the santanetd registration reply and the runtime push (nil rules == unchanged).
- SNDNetworkExtensionXPC collapses to one method updateNetworkExtensionConfig:; registration reply widened to return a config so santanetd applies settings and the full ruleset atomically on startup.
- SNTNetworkFlowDefaultAction enum on SNTNetworkExtensionSettings / SNTSyncNetworkExtensionSettings; preflight reads flow_default_action from the NetworkExtension config message.
- SNTConfigBundle gains a reconcileNetworkExtension marker set only by PostflightConfigBundle. SNTDaemonControlController.updateSyncSettings: triggers SNTNetworkExtensionQueue reconcileNetworkExtensionConfig when set (after the performSyncStateBatch commit), mirroring the CEL post-commit pattern.
- Reconcile is the single push path: detects deltas against last-pushed state the queue owns, sends settings always + rules only on hash change, or no message at all if neither changed. lastPushed is recorded only on a successful reply so failures retry naturally on the next reconcile. Body and the last-pushed writes in clearNetworkExtensionConnection and handleRegistration are wrapped in @synchronized(self).
- Atomic rules + hash read via SNTNetworkFlowRulesSnapshot returned from SNTRuleTable.retrieveAllNetworkFlowRulesSnapshot — single inDatabase: block, one iteration builds the array and computes the hash from the same blob bytes. Documents the rule-hash cache invariant (writes only inside DB blocks). retrieveAllNetworkFlowRules removed (sole caller migrated).
- Drop the redundant syncNetworkExtensionSettings KVO watcher; the syncBaseURL revoke watcher now triggers reconcile directly after clearing.
- Index-based FMDB column access for execution + file access hash compute loops (matches the network flow hash compute pattern).
- Tests added: SNTNetworkExtensionConfigTest (round-trip incl. nil rules), SNTNetworkExtensionQueueTest (reconcile branches, registration seed, success/failure last-pushed semantics), SNTRuleTable snapshot tests, marker round-trip + getter coverage in SNTConfigBundle/SNTSyncConfigBundle tests.