### PR TITLE
Validate network flow rules from the proto, not a serialized blob

### DIFF
--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -322,17 +322,20 @@ SNTFileAccessRule* FAARuleFromProtoFileAccessRule(const ::pbv2::FileAccessRule& 
 SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRule& nr) {
   switch (nr.action_case()) {
     case ::pbv2::NetworkFlowRule::kAdd: {
-      std::string serialized;
-      nr.add().SerializeToString(&serialized);
-      NSData* blob = [NSData dataWithBytes:serialized.data() length:serialized.size()];
+      const ::pbv2::NetworkFlowRule::Add& add = nr.add();
 
       NSError* err;
-      if (!SNDValidateNetworkFlowRule(blob, &err)) {
-        SLOGW(@"Dropping invalid network flow rule %lld: %@", (long long)nr.add().rule_id(),
+      if (!SNDValidateNetworkFlowRule(add, &err)) {
+        SLOGW(@"Dropping invalid network flow rule %lld: %@", (long long)add.rule_id(),
               err.localizedDescription ?: @"validation failed");
         return nil;
       }
-      return [[SNTNetworkFlowRule alloc] initAddRuleWithId:nr.add().rule_id() protoBlob:blob];
+
+      // Serialize only valid rules.
+      std::string serialized;
+      add.SerializeToString(&serialized);
+      NSData* blob = [NSData dataWithBytes:serialized.data() length:serialized.size()];
+      return [[SNTNetworkFlowRule alloc] initAddRuleWithId:add.rule_id() protoBlob:blob];
     }
     case ::pbv2::NetworkFlowRule::kRemove:
       return [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:nr.remove().rule_id()];

--- a/stubs/santanetd/MODULE.bazel
+++ b/stubs/santanetd/MODULE.bazel
@@ -6,4 +6,5 @@ module(
 )
 
 bazel_dep(name = "protobuf", version = "33.1")
+bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 bazel_dep(name = "rules_cc", version = "0.2.14")

--- a/stubs/santanetd/src/santanetd/BUILD
+++ b/stubs/santanetd/src/santanetd/BUILD
@@ -15,6 +15,9 @@ objc_library(
     name = "SNDNetworkFlowRuleValidator",
     srcs = ["SNDNetworkFlowRuleValidator.mm"],
     hdrs = ["SNDNetworkFlowRuleValidator.h"],
+    deps = [
+        "@northpolesec_protos//syncv2:v2_cc_proto",
+    ],
 )
 
 objc_library(

--- a/stubs/santanetd/src/santanetd/SNDNetworkFlowRuleValidator.h
+++ b/stubs/santanetd/src/santanetd/SNDNetworkFlowRuleValidator.h
@@ -14,7 +14,10 @@
 
 #import <Foundation/Foundation.h>
 
-/// Validates a serialized NetworkFlowRule.Add proto blob. Returns YES if valid;
-/// otherwise NO with a populated *error. This stub always returns YES; the real
-/// santanetd implementation performs full validation.
-BOOL SNDValidateNetworkFlowRule(NSData* blob, NSError** error);
+#include "syncv2/v2.pb.h"
+
+/// Validates a NetworkFlowRule.Add proto. Returns YES if valid; otherwise NO
+/// with a populated *error. This stub always returns YES; the real santanetd
+/// implementation performs full validation.
+BOOL SNDValidateNetworkFlowRule(const ::santa::sync::v2::NetworkFlowRule::Add& add,
+                                NSError** error);

--- a/stubs/santanetd/src/santanetd/SNDNetworkFlowRuleValidator.mm
+++ b/stubs/santanetd/src/santanetd/SNDNetworkFlowRuleValidator.mm
@@ -15,6 +15,7 @@
 #import "src/santanetd/SNDNetworkFlowRuleValidator.h"
 
 // Stub validator for santanetd-less santa builds; always accepts.
-BOOL SNDValidateNetworkFlowRule(NSData* blob, NSError** error) {
+BOOL SNDValidateNetworkFlowRule(const ::santa::sync::v2::NetworkFlowRule::Add& add,
+                                NSError** error) {
   return YES;
 }


### PR DESCRIPTION
`SNDValidateNetworkFlowRule` now takes the live `NetworkFlowRule.Add` proto instead of a serialized `NSData` blob. Validation runs in-process in santasyncservice where the proto is already in hand, so the prior serialize-then-deserialize round trip per rule was pure overhead. The blob is now built only for rules that pass, purely for XPC transport, and the stub santanetd module gains a proto dependency to match the new signature.