### PR TITLE
Plumb sync-configured DNS upstream timeout to the network extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ compile_commands.json
 .cache/
 .vscode/*
 .zed**
+.scratch/
 docs/superpowers/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "0a3f4215e8de7bbd01ec7473f48e98377e8ea850",
+    commit = "689030dd1cfc1a1ba12df2c5e5fafc92248a36d7",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/ne/SNTNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTNetworkExtensionSettings.h
@@ -33,7 +33,25 @@ typedef NS_ENUM(NSInteger, SNTNetworkFlowDefaultAction) {
 @property(readonly) BOOL enable;
 @property(readonly) SNTNetworkFlowDefaultAction flowDefaultAction;
 
+/// Upstream DNS forward timeout used by santanetd's DNS proxy, in seconds.
+/// Normalized to [1.0, 15.0]; values below the floor (incl. unset/0) become the 5.0 default,
+/// values above the ceiling clamp to 15.0.
+@property(readonly) NSTimeInterval dnsUpstreamTimeoutSecs;
+
+/// Defaults flowDefaultAction to Unspecified and dnsUpstreamTimeoutSecs to 5s.
+- (instancetype)initWithEnable:(BOOL)enable;
+
+/// Defaults dnsUpstreamTimeoutSecs to 5s.
 - (instancetype)initWithEnable:(BOOL)enable
              flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
+
+/// Defaults flowDefaultAction to Unspecified.
+- (instancetype)initWithEnable:(BOOL)enable
+        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs;
+
+/// Designated initializer.
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction
+        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs;
 
 @end

--- a/Source/common/ne/SNTNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettings.mm
@@ -16,19 +16,59 @@
 
 #import "Source/common/CoderMacros.h"
 
+namespace {
+
+// Below the floor (incl. 0 from a missing archive key) means "not meaningfully set" -> default.
+// Above the ceiling is intentional -> clamp. The 15s ceiling stays well under mDNSResponder's
+// ~30s per-question patience so a santanetd SERVFAIL always lands first.
+const NSTimeInterval kDefaultDNSUpstreamTimeoutSecs = 5.0;
+const NSTimeInterval kMinDNSUpstreamTimeoutSecs = 1.0;
+const NSTimeInterval kMaxDNSUpstreamTimeoutSecs = 15.0;
+
+NSTimeInterval NormalizeDNSUpstreamTimeout(NSTimeInterval v) {
+  if (v < kMinDNSUpstreamTimeoutSecs) return kDefaultDNSUpstreamTimeoutSecs;
+  if (v > kMaxDNSUpstreamTimeoutSecs) return kMaxDNSUpstreamTimeoutSecs;
+  return v;
+}
+
+}  // namespace
+
 @interface SNTNetworkExtensionSettings ()
 @property(readwrite) BOOL enable;
 @property(readwrite) SNTNetworkFlowDefaultAction flowDefaultAction;
+@property(readwrite) NSTimeInterval dnsUpstreamTimeoutSecs;
 @end
 
 @implementation SNTNetworkExtensionSettings
 
+- (instancetype)initWithEnable:(BOOL)enable {
+  return [self initWithEnable:enable
+            flowDefaultAction:SNTNetworkFlowDefaultActionUnspecified
+       dnsUpstreamTimeoutSecs:kDefaultDNSUpstreamTimeoutSecs];
+}
+
 - (instancetype)initWithEnable:(BOOL)enable
              flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction {
+  return [self initWithEnable:enable
+            flowDefaultAction:flowDefaultAction
+       dnsUpstreamTimeoutSecs:kDefaultDNSUpstreamTimeoutSecs];
+}
+
+- (instancetype)initWithEnable:(BOOL)enable
+        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs {
+  return [self initWithEnable:enable
+            flowDefaultAction:SNTNetworkFlowDefaultActionUnspecified
+       dnsUpstreamTimeoutSecs:dnsUpstreamTimeoutSecs];
+}
+
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction
+        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs {
   self = [super init];
   if (self) {
     _enable = enable;
     _flowDefaultAction = flowDefaultAction;
+    _dnsUpstreamTimeoutSecs = NormalizeDNSUpstreamTimeout(dnsUpstreamTimeoutSecs);
   }
   return self;
 }
@@ -41,11 +81,17 @@
     return NO;
   }
   SNTNetworkExtensionSettings* o = other;
-  return self.enable == o.enable && self.flowDefaultAction == o.flowDefaultAction;
+  return self.enable == o.enable && self.flowDefaultAction == o.flowDefaultAction &&
+         self.dnsUpstreamTimeoutSecs == o.dnsUpstreamTimeoutSecs;
 }
 
 - (NSUInteger)hash {
-  return (NSUInteger)self.enable * 31 + (NSUInteger)self.flowDefaultAction;
+  NSUInteger prime = 31;
+  NSUInteger result = 1;
+  result = prime * result + self.enable;
+  result = prime * result + self.flowDefaultAction;
+  result = prime * result + (NSUInteger)self.dnsUpstreamTimeoutSecs;
+  return result;
 }
 
 + (BOOL)supportsSecureCoding {
@@ -55,6 +101,7 @@
 - (void)encodeWithCoder:(NSCoder*)coder {
   ENCODE_BOXABLE(coder, enable);
   ENCODE_BOXABLE(coder, flowDefaultAction);
+  ENCODE_BOXABLE(coder, dnsUpstreamTimeoutSecs);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
@@ -62,6 +109,9 @@
   if (self) {
     DECODE_SELECTOR(decoder, enable, NSNumber, boolValue);
     DECODE_SELECTOR(decoder, flowDefaultAction, NSNumber, integerValue);
+    DECODE_SELECTOR(decoder, dnsUpstreamTimeoutSecs, NSNumber, doubleValue);
+    // Missing key decodes to 0 -> NormalizeDNSUpstreamTimeout turns it into the default.
+    _dnsUpstreamTimeoutSecs = NormalizeDNSUpstreamTimeout(_dnsUpstreamTimeoutSecs);
   }
   return self;
 }

--- a/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
@@ -154,4 +154,104 @@
   XCTAssertFalse(deserialized.enable);
 }
 
+- (void)testTimeoutDefaultFromEnableInit {
+  // initWithEnable: should default the timeout to 5s.
+  SNTNetworkExtensionSettings* s = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES];
+  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 5.0, 0.0001);
+}
+
+- (void)testTimeoutInRangePreserved {
+  SNTNetworkExtensionSettings* s = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                                                dnsUpstreamTimeoutSecs:3.0];
+  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 3.0, 0.0001);
+}
+
+- (void)testTimeoutBelowFloorUsesDefault {
+  // Below the 1.0 floor (incl. 0 / negative) is treated as "unset" -> 5s default.
+  NSTimeInterval belowFloor[] = {0.0, 0.5, -1.0};
+  for (size_t i = 0; i < sizeof(belowFloor) / sizeof(belowFloor[0]); i++) {
+    SNTNetworkExtensionSettings* s =
+        [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                     dnsUpstreamTimeoutSecs:belowFloor[i]];
+    XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 5.0, 0.0001);
+  }
+}
+
+- (void)testTimeoutAboveCeilingClampsToMax {
+  SNTNetworkExtensionSettings* s = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                                                dnsUpstreamTimeoutSecs:60.0];
+  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 15.0, 0.0001);
+}
+
+- (void)testTimeoutBoundaryValuesPreserved {
+  // The clamp is inclusive: exactly the floor and exactly the ceiling pass through unchanged.
+  SNTNetworkExtensionSettings* floor = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                                                    dnsUpstreamTimeoutSecs:1.0];
+  XCTAssertEqualWithAccuracy(floor.dnsUpstreamTimeoutSecs, 1.0, 0.0001);
+  SNTNetworkExtensionSettings* ceiling = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                                                      dnsUpstreamTimeoutSecs:15.0];
+  XCTAssertEqualWithAccuracy(ceiling.dnsUpstreamTimeoutSecs, 15.0, 0.0001);
+}
+
+- (void)testTimeoutRoundTripsThroughCoder {
+  SNTNetworkExtensionSettings* s = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                                                dnsUpstreamTimeoutSecs:7.5];
+  NSData* data = [NSKeyedArchiver archivedDataWithRootObject:s requiringSecureCoding:YES error:nil];
+  SNTNetworkExtensionSettings* decoded =
+      [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTNetworkExtensionSettings class]
+                                        fromData:data
+                                           error:nil];
+  XCTAssertTrue(decoded.enable);
+  XCTAssertEqualWithAccuracy(decoded.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
+}
+
+- (void)testTimeoutMissingKeyDecodesToDefault {
+  // A legacy archive omitting the key must decode to the 5s default, not 0.
+  //
+  // SNTNetworkExtensionSettingsLegacy encodes nothing, so the archive omits the
+  // dnsUpstreamTimeoutSecs key. We remap the class name to SNTNetworkExtensionSettings during
+  // decode to faithfully simulate a new receiver processing data from a legacy sender (whose
+  // archive records the base class name).
+  SNTNetworkExtensionSettingsLegacy* legacy =
+      [[SNTNetworkExtensionSettingsLegacy alloc] initWithEnable:YES];
+  NSData* data = [NSKeyedArchiver archivedDataWithRootObject:legacy
+                                       requiringSecureCoding:YES
+                                                       error:nil];
+  XCTAssertNotNil(data);
+
+  NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nil];
+  unarchiver.requiresSecureCoding = YES;
+  [unarchiver setClass:[SNTNetworkExtensionSettings class]
+          forClassName:NSStringFromClass([SNTNetworkExtensionSettingsLegacy class])];
+
+  SNTNetworkExtensionSettings* decoded =
+      [unarchiver decodeObjectOfClass:[SNTNetworkExtensionSettings class]
+                               forKey:NSKeyedArchiveRootObjectKey];
+  [unarchiver finishDecoding];
+
+  XCTAssertEqualWithAccuracy(decoded.dnsUpstreamTimeoutSecs, 5.0, 0.0001);
+}
+
+- (void)testEqualityAndHashDistinguishDNSUpstreamTimeout {
+  // isEqual: gates whether a sync-only timeout change is pushed to santanetd in
+  // SNTNetworkExtensionQueue's reconcileNetworkExtensionConfig, so settings that differ only in
+  // the timeout must not compare equal. (3.0 and 7.5 are both in range, so they're preserved.)
+  SNTNetworkExtensionSettings* a =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                   dnsUpstreamTimeoutSecs:3.0];
+  SNTNetworkExtensionSettings* b =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                   dnsUpstreamTimeoutSecs:7.5];
+  XCTAssertNotEqualObjects(a, b);
+
+  SNTNetworkExtensionSettings* c =
+      [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
+                                        flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                   dnsUpstreamTimeoutSecs:7.5];
+  XCTAssertEqualObjects(b, c);
+  XCTAssertEqual(b.hash, c.hash);
+}
+
 @end

--- a/Source/common/ne/SNTSyncNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettings.h
@@ -21,8 +21,21 @@
 @property(readonly) BOOL enable;
 @property(readonly) SNTNetworkFlowDefaultAction flowDefaultAction;
 
+/// Raw, unnormalized upstream DNS forward timeout from the sync server, in seconds, carried
+/// verbatim (0 == "unset"). This is NOT the effective value: the [1,15]s clamp and the 0 -> 5s
+/// default are applied only when SNTNetworkExtensionSettings is built from this carrier (see
+/// -[SNTNetworkExtensionQueue generateSettingsForProtocolVersion:]). Don't read this directly
+/// expecting an in-range value — go through SNTNetworkExtensionSettings for that.
+@property(readonly) NSTimeInterval dnsUpstreamTimeoutSecs;
+
+/// Defaults dnsUpstreamTimeoutSecs to 0 ("unset").
 - (instancetype)initWithEnable:(BOOL)enable
              flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
+
+/// Designated initializer.
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction
+        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs;
 
 - (NSData*)serialize;
 + (instancetype)deserialize:(NSData*)data;

--- a/Source/common/ne/SNTSyncNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettings.mm
@@ -20,16 +20,24 @@
 @interface SNTSyncNetworkExtensionSettings ()
 @property(readwrite) BOOL enable;
 @property(readwrite) SNTNetworkFlowDefaultAction flowDefaultAction;
+@property(readwrite) NSTimeInterval dnsUpstreamTimeoutSecs;
 @end
 
 @implementation SNTSyncNetworkExtensionSettings
 
 - (instancetype)initWithEnable:(BOOL)enable
              flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction {
+  return [self initWithEnable:enable flowDefaultAction:flowDefaultAction dnsUpstreamTimeoutSecs:0];
+}
+
+- (instancetype)initWithEnable:(BOOL)enable
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction
+        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs {
   self = [super init];
   if (self) {
     _enable = enable;
     _flowDefaultAction = flowDefaultAction;
+    _dnsUpstreamTimeoutSecs = dnsUpstreamTimeoutSecs;
   }
   return self;
 }
@@ -49,7 +57,8 @@
 
   SNTSyncNetworkExtensionSettings* otherSettings = (SNTSyncNetworkExtensionSettings*)other;
   return self.enable == otherSettings.enable &&
-         self.flowDefaultAction == otherSettings.flowDefaultAction;
+         self.flowDefaultAction == otherSettings.flowDefaultAction &&
+         self.dnsUpstreamTimeoutSecs == otherSettings.dnsUpstreamTimeoutSecs;
 }
 
 - (NSUInteger)hash {
@@ -57,6 +66,7 @@
   NSUInteger result = 1;
   result = prime * result + self.enable;
   result = prime * result + self.flowDefaultAction;
+  result = prime * result + (NSUInteger)self.dnsUpstreamTimeoutSecs;
   return result;
 }
 
@@ -67,6 +77,7 @@
 - (void)encodeWithCoder:(NSCoder*)coder {
   ENCODE_BOXABLE(coder, enable);
   ENCODE_BOXABLE(coder, flowDefaultAction);
+  ENCODE_BOXABLE(coder, dnsUpstreamTimeoutSecs);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
@@ -74,6 +85,7 @@
   if (self) {
     DECODE_SELECTOR(decoder, enable, NSNumber, boolValue);
     DECODE_SELECTOR(decoder, flowDefaultAction, NSNumber, integerValue);
+    DECODE_SELECTOR(decoder, dnsUpstreamTimeoutSecs, NSNumber, doubleValue);
   }
   return self;
 }

--- a/Source/common/ne/SNTSyncNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettingsTest.mm
@@ -81,4 +81,45 @@
   XCTAssertNil(deserialized);
 }
 
+- (void)testDNSUpstreamTimeoutDefaultsToZeroWhenUnset {
+  // The 2-arg convenience init leaves the carrier timeout at 0 ("unset").
+  // Clamping/defaulting to 5s happens downstream in SNTNetworkExtensionSettings.
+  SNTSyncNetworkExtensionSettings* settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
+  XCTAssertEqual(settings.dnsUpstreamTimeoutSecs, 0);
+}
+
+- (void)testDNSUpstreamTimeoutPreservedByDesignatedInit {
+  SNTSyncNetworkExtensionSettings* settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                       dnsUpstreamTimeoutSecs:7.5];
+  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
+}
+
+- (void)testDNSUpstreamTimeoutRoundTripsThroughCoder {
+  SNTSyncNetworkExtensionSettings* settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                       dnsUpstreamTimeoutSecs:7.5];
+  SNTSyncNetworkExtensionSettings* deserialized =
+      [SNTSyncNetworkExtensionSettings deserialize:[settings serialize]];
+  XCTAssertNotNil(deserialized);
+  XCTAssertEqualWithAccuracy(deserialized.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
+  XCTAssertEqualObjects(deserialized, settings);
+}
+
+- (void)testDNSUpstreamTimeoutDifferentiatesEquality {
+  SNTSyncNetworkExtensionSettings* a =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                       dnsUpstreamTimeoutSecs:7.5];
+  SNTSyncNetworkExtensionSettings* b =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
+                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
+                                       dnsUpstreamTimeoutSecs:3.0];
+  XCTAssertNotEqualObjects(a, b);
+}
+
 @end

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -370,13 +370,17 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
 
   BOOL enable = NO;
   SNTNetworkFlowDefaultAction flowDefaultAction = SNTNetworkFlowDefaultActionUnspecified;
+  NSTimeInterval dnsUpstreamTimeoutSecs = 0;
+
   if (majorVersion >= 1) {
     enable = syncSettings.enable;
     flowDefaultAction = syncSettings.flowDefaultAction;
+    dnsUpstreamTimeoutSecs = syncSettings.dnsUpstreamTimeoutSecs;
   }
 
   return [[SNTNetworkExtensionSettings alloc] initWithEnable:enable
-                                           flowDefaultAction:flowDefaultAction];
+                                           flowDefaultAction:flowDefaultAction
+                                      dnsUpstreamTimeoutSecs:dnsUpstreamTimeoutSecs];
 }
 
 @end

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -37,6 +37,7 @@
 @property(readwrite) NSString* connectedProtocolVersion;
 - (void)establishNetworkExtensionConnection;
 - (void)clearNetworkExtensionConnection;
+- (SNTNetworkExtensionSettings*)generateSettingsForProtocolVersion:(NSString*)protocolVersion;
 @end
 
 @interface SNTNetworkExtensionQueueTest : XCTestCase
@@ -78,6 +79,17 @@
 - (void)stubConfiguratorEnable:(BOOL)enable action:(SNTNetworkFlowDefaultAction)action {
   SNTSyncNetworkExtensionSettings* settings =
       [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:enable flowDefaultAction:action];
+  OCMStub([self.mockConfigurator syncNetworkExtensionSettings]).andReturn(settings);
+}
+
+// Like stubConfiguratorEnable:action: but also sets the sync-side DNS upstream timeout.
+- (void)stubConfiguratorEnable:(BOOL)enable
+                        action:(SNTNetworkFlowDefaultAction)action
+                    dnsTimeout:(NSTimeInterval)dnsTimeout {
+  SNTSyncNetworkExtensionSettings* settings =
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:enable
+                                            flowDefaultAction:action
+                                       dnsUpstreamTimeoutSecs:dnsTimeout];
   OCMStub([self.mockConfigurator syncNetworkExtensionSettings]).andReturn(settings);
 }
 
@@ -258,6 +270,27 @@
 
   XCTAssertNil(self.sut.lastPushedSettings);
   XCTAssertNil(self.sut.lastPushedNetworkFlowRulesHash);
+}
+
+- (void)testGenerateSettingsPropagatesDNSUpstreamTimeout {
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny dnsTimeout:7.5];
+  SNTNetworkExtensionSettings* settings = [self.sut generateSettingsForProtocolVersion:@"1.0"];
+  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
+}
+
+- (void)testGenerateSettingsDefaultsDNSUpstreamTimeoutWhenSyncUnset {
+  // Carrier timeout 0 -> SNTNetworkExtensionSettings normalizes to the 5s default.
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny dnsTimeout:0];
+  SNTNetworkExtensionSettings* settings = [self.sut generateSettingsForProtocolVersion:@"1.0"];
+  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 5.0, 0.0001);
+}
+
+- (void)testGenerateSettingsIgnoresSyncBelowProtocolV1 {
+  [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny dnsTimeout:7.5];
+  SNTNetworkExtensionSettings* settings = [self.sut generateSettingsForProtocolVersion:@"0.9"];
+  XCTAssertFalse(settings.enable);
+  // Sync timeout is ignored below protocol v1 -> 5s default.
+  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 5.0, 0.0001);
 }
 
 @end

--- a/Source/santasyncservice/SNTPushClientNATS+Commands.mm
+++ b/Source/santasyncservice/SNTPushClientNATS+Commands.mm
@@ -372,6 +372,9 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
     case ::pbv1::SantaCommandRequest::kPing: commandName = @"ping"; break;
     case ::pbv1::SantaCommandRequest::kKill: commandName = @"kill"; break;
     case ::pbv1::SantaCommandRequest::kEventUpload: commandName = @"event_upload"; break;
+    // Binary upload is adopted by a separate in-flight change. Leave it unrecognized here so it
+    // falls through to the dispatch switch's default and is rejected as an unknown command.
+    case ::pbv1::SantaCommandRequest::kBinaryUpload:
     case ::pbv1::SantaCommandRequest::COMMAND_NOT_SET: break;
   }
 

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -487,10 +487,19 @@ void HandleV2Responses(const ::pbv2::PreflightResponse& resp, SNTSyncState* sync
   }
 
   if (resp.has_network_extension()) {
-    syncState.networkExtensionSettings = [[SNTSyncNetworkExtensionSettings alloc]
-           initWithEnable:resp.network_extension().enable()
-        flowDefaultAction:NetworkFlowDefaultActionFromProto(
-                              resp.network_extension().flow_default_action())];
+    auto& ne = resp.network_extension();
+    SNTNetworkFlowDefaultAction flowDefaultAction =
+        NetworkFlowDefaultActionFromProto(ne.flow_default_action());
+    if (ne.has_dns_upstream_timeout_seconds()) {
+      syncState.networkExtensionSettings = [[SNTSyncNetworkExtensionSettings alloc]
+                  initWithEnable:ne.enable()
+               flowDefaultAction:flowDefaultAction
+          dnsUpstreamTimeoutSecs:ne.dns_upstream_timeout_seconds()];
+    } else {
+      syncState.networkExtensionSettings =
+          [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:ne.enable()
+                                                flowDefaultAction:flowDefaultAction];
+    }
   }
 
   if (resp.has_file_access_event_detail_url()) {

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -431,6 +431,49 @@
   XCTAssertNil(self.syncState.overrideFileAccessAction);
 }
 
+- (void)testPreflightNetworkExtensionDNSUpstreamTimeout {
+  // network_extension is only parsed on the v2 sync path (HandleV2Responses).
+  if (!self.syncState.isSyncV2) return;
+
+  [self setupDefaultDaemonConnResponses];
+  SNTSyncPreflight* sut = [[SNTSyncPreflight alloc] initWithState:self.syncState];
+
+  NSData* respData =
+      [@"{\"client_mode\": \"MONITOR\", \"batch_size\": 100, \"network_extension\": "
+       @"{\"enable\": true, \"flow_default_action\": \"NETWORK_FLOW_DEFAULT_ACTION_DENY\", "
+       @"\"dns_upstream_timeout_seconds\": 7.5}}" dataUsingEncoding:NSUTF8StringEncoding];
+
+  [self stubRequestBody:respData response:nil error:nil validateBlock:nil];
+
+  XCTAssertTrue([sut sync]);
+  XCTAssertNotNil(self.syncState.networkExtensionSettings);
+  XCTAssertTrue(self.syncState.networkExtensionSettings.enable);
+  XCTAssertEqualWithAccuracy(self.syncState.networkExtensionSettings.dnsUpstreamTimeoutSecs, 7.5,
+                             0.0001);
+}
+
+- (void)testPreflightNetworkExtensionDNSUpstreamTimeoutAbsent {
+  // network_extension present but dns_upstream_timeout_seconds omitted: the carrier records the
+  // unset sentinel (0). SNTNetworkExtensionSettings applies the [1,15]s clamp / 5s default
+  // downstream, so the carrier stays 0 here.
+  if (!self.syncState.isSyncV2) return;
+
+  [self setupDefaultDaemonConnResponses];
+  SNTSyncPreflight* sut = [[SNTSyncPreflight alloc] initWithState:self.syncState];
+
+  NSData* respData =
+      [@"{\"client_mode\": \"MONITOR\", \"batch_size\": 100, \"network_extension\": "
+       @"{\"enable\": true, \"flow_default_action\": \"NETWORK_FLOW_DEFAULT_ACTION_DENY\"}}"
+          dataUsingEncoding:NSUTF8StringEncoding];
+
+  [self stubRequestBody:respData response:nil error:nil validateBlock:nil];
+
+  XCTAssertTrue([sut sync]);
+  XCTAssertNotNil(self.syncState.networkExtensionSettings);
+  XCTAssertTrue(self.syncState.networkExtensionSettings.enable);
+  XCTAssertEqual(self.syncState.networkExtensionSettings.dnsUpstreamTimeoutSecs, 0);
+}
+
 - (void)testReschedulePreflightFail {
   // Have SNTSyncPreflight return mock obejcts
   id mockPreflight = OCMClassMock([SNTSyncPreflight class]);


### PR DESCRIPTION
Wire dnsUpstreamTimeoutSecs end to end: consume the new NetworkExtension.dns_upstream_timeout_seconds sync field in preflight, carry it verbatim through SNTSyncNetworkExtensionSettings, and forward it into the SNTNetworkExtensionSettings handed to santanetd on registration and reconcile. SNTNetworkExtensionSettings stays the single source of truth for the [1,15]s clamp and the 5s default.

Bump the protos pin to pick up the new field. That also pulls in the binary-upload command proto, so handle the new kBinaryUpload case in the NATS command switch (recognized but unsupported, pending its own adoption) to keep the -Werror build green.