### PR TITLE
Add running process force-kill rule action

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -83,6 +83,12 @@ typedef NS_ENUM(NSInteger, SNTRuleState) {
   SNTRuleStateSeatbelt = 11,
 };
 
+typedef NS_ENUM(NSInteger, SNTRuleRunningProcessAction) {
+  SNTRuleRunningProcessActionUnset = 0,
+  SNTRuleRunningProcessActionNone = 1,
+  SNTRuleRunningProcessActionForceKill = 2,
+};
+
 typedef NS_ENUM(NSInteger, SNTClientMode) {
   SNTClientModeUnknown,
   SNTClientModeMonitor = 1,

--- a/Source/common/SNTRule.h
+++ b/Source/common/SNTRule.h
@@ -79,6 +79,11 @@
 @property(readonly) int64_t ruleId;
 
 ///
+///  The action that should be taken for matching running processes.
+///
+@property(readonly) SNTRuleRunningProcessAction runningProcessAction;
+
+///
 ///  Designated initializer.
 ///
 - (instancetype)initWithIdentifier:(NSString*)identifier
@@ -93,6 +98,19 @@
                             ruleId:(int64_t)ruleId
                              error:(NSError**)error;
 
+- (instancetype)initWithIdentifier:(NSString*)identifier
+                             state:(SNTRuleState)state
+                              type:(SNTRuleType)type
+                         customMsg:(NSString*)customMsg
+                         customURL:(NSString*)customURL
+                         timestamp:(NSUInteger)timestamp
+                           comment:(NSString*)comment
+                           celExpr:(NSString*)celExpr
+                    seatbeltPolicy:(NSString*)seatbeltPolicy
+                            ruleId:(int64_t)ruleId
+              runningProcessAction:(SNTRuleRunningProcessAction)runningProcessAction
+                             error:(NSError**)error;
+
 ///
 ///  Initialize with a default timestamp: current time if rule state is transitive, 0 otherwise.
 ///
@@ -104,6 +122,16 @@
                            celExpr:(NSString*)celExpr
                     seatbeltPolicy:(NSString*)seatbeltPolicy
                             ruleId:(int64_t)ruleId;
+
+- (instancetype)initWithIdentifier:(NSString*)identifier
+                             state:(SNTRuleState)state
+                              type:(SNTRuleType)type
+                         customMsg:(NSString*)customMsg
+                         customURL:(NSString*)customURL
+                           celExpr:(NSString*)celExpr
+                    seatbeltPolicy:(NSString*)seatbeltPolicy
+                            ruleId:(int64_t)ruleId
+              runningProcessAction:(SNTRuleRunningProcessAction)runningProcessAction;
 
 ///
 ///  Initialize with a default timestamp: current time if rule state is transitive, 0 otherwise.

--- a/Source/common/SNTRule.mm
+++ b/Source/common/SNTRule.mm
@@ -37,6 +37,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
 @property(readwrite) NSString* celExpr;
 @property(readwrite) NSString* seatbeltPolicy;
 @property(readwrite) int64_t ruleId;
+@property(readwrite) SNTRuleRunningProcessAction runningProcessAction;
 @end
 
 @implementation SNTRule
@@ -51,6 +52,32 @@ static const NSUInteger kExpectedTeamIDLength = 10;
                            celExpr:(NSString*)celExpr
                     seatbeltPolicy:(NSString*)seatbeltPolicy
                             ruleId:(int64_t)ruleId
+                             error:(NSError**)error {
+  return [self initWithIdentifier:identifier
+                            state:state
+                             type:type
+                        customMsg:customMsg
+                        customURL:customURL
+                        timestamp:timestamp
+                          comment:comment
+                          celExpr:celExpr
+                   seatbeltPolicy:seatbeltPolicy
+                           ruleId:ruleId
+             runningProcessAction:SNTRuleRunningProcessActionUnset
+                            error:error];
+}
+
+- (instancetype)initWithIdentifier:(NSString*)identifier
+                             state:(SNTRuleState)state
+                              type:(SNTRuleType)type
+                         customMsg:(NSString*)customMsg
+                         customURL:(NSString*)customURL
+                         timestamp:(NSUInteger)timestamp
+                           comment:(NSString*)comment
+                           celExpr:(NSString*)celExpr
+                    seatbeltPolicy:(NSString*)seatbeltPolicy
+                            ruleId:(int64_t)ruleId
+              runningProcessAction:(SNTRuleRunningProcessAction)runningProcessAction
                              error:(NSError**)error {
   self = [super init];
   if (self) {
@@ -194,6 +221,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     _celExpr = celExpr;
     _seatbeltPolicy = seatbeltPolicy;
     _ruleId = ruleId;
+    _runningProcessAction = runningProcessAction;
   }
   return self;
 }
@@ -206,6 +234,26 @@ static const NSUInteger kExpectedTeamIDLength = 10;
                            celExpr:(NSString*)celExpr
                     seatbeltPolicy:(NSString*)seatbeltPolicy
                             ruleId:(int64_t)ruleId {
+  return [self initWithIdentifier:identifier
+                            state:state
+                             type:type
+                        customMsg:customMsg
+                        customURL:customURL
+                          celExpr:celExpr
+                   seatbeltPolicy:seatbeltPolicy
+                           ruleId:ruleId
+             runningProcessAction:SNTRuleRunningProcessActionUnset];
+}
+
+- (instancetype)initWithIdentifier:(NSString*)identifier
+                             state:(SNTRuleState)state
+                              type:(SNTRuleType)type
+                         customMsg:(NSString*)customMsg
+                         customURL:(NSString*)customURL
+                           celExpr:(NSString*)celExpr
+                    seatbeltPolicy:(NSString*)seatbeltPolicy
+                            ruleId:(int64_t)ruleId
+              runningProcessAction:(SNTRuleRunningProcessAction)runningProcessAction {
   self = [self initWithIdentifier:identifier
                             state:state
                              type:type
@@ -216,6 +264,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
                           celExpr:celExpr
                    seatbeltPolicy:seatbeltPolicy
                            ruleId:ruleId
+             runningProcessAction:runningProcessAction
                             error:nil];
   // Initialize timestamp to current time if rule is transitive.
   if (self && state == SNTRuleStateAllowTransitive) {
@@ -260,7 +309,8 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     if (![rawKey isKindOfClass:[NSString class]]) continue;
     NSString* key = (NSString*)rawKey;
     NSString* newKey = [key lowercaseString];
-    if (([newKey isEqualToString:kRulePolicy] || [newKey isEqualToString:kRuleType]) &&
+    if (([newKey isEqualToString:kRulePolicy] || [newKey isEqualToString:kRuleType] ||
+         [newKey isEqualToString:kRuleRunningProcessAction]) &&
         [dict[key] isKindOfClass:[NSString class]]) {
       newDict[newKey] = [dict[key] uppercaseString];
     } else {
@@ -372,6 +422,23 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     celExpr = nil;
   }
 
+  NSString* runningProcessActionString = dict[kRuleRunningProcessAction];
+  SNTRuleRunningProcessAction runningProcessAction = SNTRuleRunningProcessActionUnset;
+  if ([runningProcessActionString isKindOfClass:[NSString class]] &&
+      runningProcessActionString.length > 0) {
+    if ([runningProcessActionString isEqual:kRuleRunningProcessActionNone]) {
+      runningProcessAction = SNTRuleRunningProcessActionNone;
+    } else if ([runningProcessActionString isEqual:kRuleRunningProcessActionForceKill]) {
+      runningProcessAction = SNTRuleRunningProcessActionForceKill;
+    } else {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeRuleInvalid
+                       format:@"Rule received with invalid running process action '%@'",
+                              runningProcessActionString];
+      return nil;
+    }
+  }
+
   return [self initWithIdentifier:identifier
                             state:state
                              type:type
@@ -382,6 +449,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
                           celExpr:celExpr
                    seatbeltPolicy:nil
                            ruleId:0
+             runningProcessAction:runningProcessAction
                             error:error];
 }
 
@@ -411,6 +479,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   ENCODE(coder, seatbeltPolicy);
   ENCODE_BOXABLE(coder, staticRule);
   ENCODE_BOXABLE(coder, ruleId);
+  ENCODE_BOXABLE(coder, runningProcessAction);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
@@ -427,6 +496,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     DECODE(decoder, seatbeltPolicy, NSString);
     DECODE_SELECTOR(decoder, staticRule, NSNumber, boolValue);
     DECODE_SELECTOR(decoder, ruleId, NSNumber, longLongValue);
+    DECODE_SELECTOR(decoder, runningProcessAction, NSNumber, intValue);
   }
   return self;
 }
@@ -460,6 +530,15 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   }
 }
 
+- (NSString*)runningProcessActionToString:(SNTRuleRunningProcessAction)action {
+  switch (action) {
+    case SNTRuleRunningProcessActionNone: return kRuleRunningProcessActionNone;
+    case SNTRuleRunningProcessActionForceKill: return kRuleRunningProcessActionForceKill;
+    case SNTRuleRunningProcessActionUnset: OS_FALLTHROUGH;
+    default: return @"";
+  }
+}
+
 // Returns an NSDictionary representation of the rule. Primarily use for
 // exporting rules.
 - (NSDictionary*)dictionaryRepresentation {
@@ -471,6 +550,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
     kRuleCustomURL : self.customURL ?: @"",
     kRuleComment : self.comment ?: @"",
     kRuleCELExpr : self.celExpr ?: @"",
+    kRuleRunningProcessAction : [self runningProcessActionToString:self.runningProcessAction],
   };
 }
 
@@ -480,6 +560,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   SNTRule* o = other;
   return (
       [self.identifier isEqual:o.identifier] && self.state == o.state && self.type == o.type &&
+      self.runningProcessAction == o.runningProcessAction &&
       (self.celExpr == o.celExpr || [self.celExpr isEqual:o.celExpr]) &&
       (self.seatbeltPolicy == o.seatbeltPolicy || [self.seatbeltPolicy isEqual:o.seatbeltPolicy]));
 }
@@ -490,6 +571,7 @@ static const NSUInteger kExpectedTeamIDLength = 10;
   result = prime * result + [self.identifier hash];
   result = prime * result + self.state;
   result = prime * result + self.type;
+  result = prime * result + self.runningProcessAction;
   result = prime * result + [self.celExpr hash];
   result = prime * result + [self.seatbeltPolicy hash];
   return result;

--- a/Source/common/SNTRuleTest.mm
+++ b/Source/common/SNTRuleTest.mm
@@ -123,6 +123,27 @@
   XCTAssertEqual(sut.state, SNTRuleStateAllow);
   XCTAssertEqualObjects(sut.customMsg, @"A custom block message");
   XCTAssertEqualObjects(sut.customURL, @"https://example.com");
+  XCTAssertEqual(sut.runningProcessAction, SNTRuleRunningProcessActionUnset);
+
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"ABCDEFGHIJ",
+    @"policy" : @"BLOCKLIST",
+    @"rule_type" : @"TEAMID",
+    @"running_process_action" : @"force_kill",
+  }
+                                      error:nil];
+  XCTAssertNotNil(sut);
+  XCTAssertEqual(sut.runningProcessAction, SNTRuleRunningProcessActionForceKill);
+
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"ABCDEFGHIJ",
+    @"policy" : @"BLOCKLIST",
+    @"rule_type" : @"TEAMID",
+    @"running_process_action" : @"NONE",
+  }
+                                      error:nil];
+  XCTAssertNotNil(sut);
+  XCTAssertEqual(sut.runningProcessAction, SNTRuleRunningProcessActionNone);
 
   // TeamIDs must be 10 chars in length
   sut = [[SNTRule alloc] initWithDictionary:@{
@@ -279,6 +300,17 @@
   XCTAssertNil(sut);
   XCTAssertNotNil(error);
   XCTAssertEqual(error.code, SNTErrorCodeRuleInvalidRuleType);
+
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"ABCDEFGHIJ",
+    @"policy" : @"ALLOWLIST",
+    @"rule_type" : @"TEAMID",
+    @"running_process_action" : @"gently",
+  }
+                                      error:&error];
+  XCTAssertNil(sut);
+  XCTAssertNotNil(error);
+  XCTAssertEqual(error.code, SNTErrorCodeRuleInvalid);
 }
 
 - (void)testRuleDictionaryRepresentation {
@@ -290,6 +322,7 @@
     @"custom_url" : @"https://example.com",
     @"comment" : @"",
     @"cel_expr" : @"",
+    @"running_process_action" : @"",
   };
 
   SNTRule* sut = [[SNTRule alloc] initWithDictionary:expectedTeamID error:nil];
@@ -304,6 +337,7 @@
     @"custom_url" : @"",
     @"comment" : @"",
     @"cel_expr" : @"",
+    @"running_process_action" : @"",
   };
 
   sut = [[SNTRule alloc] initWithDictionary:expectedBinary error:nil];
@@ -320,6 +354,7 @@
     @"custom_msg" : @"A custom block message",
     @"custom_url" : @"https://example.com",
     @"cel_expr" : @"",
+    @"running_process_action" : @"",
   };
 
   SNTRule* sut = [[SNTRule alloc] initWithDictionary:expected error:nil];
@@ -337,8 +372,10 @@
 }
 
 - (void)testKeyCaseForInitWithDictionary {
-  for (NSString* key in
-       @[ kRulePolicy, kRuleIdentifier, kRuleType, kRuleCustomMsg, kRuleCustomURL, kRuleComment ]) {
+  for (NSString* key in @[
+         kRulePolicy, kRuleIdentifier, kRuleType, kRuleCustomMsg, kRuleCustomURL, kRuleComment,
+         kRuleRunningProcessAction
+       ]) {
     NSDictionary* expected = @{
       @"cel_expr" : @"",
       @"identifier" : @"84de9c61777ca36b13228e2446d53e966096e78db7a72c632b5c185b2ffe68a6",
@@ -347,6 +384,7 @@
       @"custom_msg" : @"A custom block message",
       @"custom_url" : @"https://example.com",
       @"comment" : @"",
+      @"running_process_action" : @"FORCE_KILL",
     };
 
     NSMutableDictionary* dict = [expected mutableCopy];

--- a/Source/common/SNTSyncConstants.h
+++ b/Source/common/SNTSyncConstants.h
@@ -138,6 +138,9 @@ extern NSString* const kRuleCustomMsg;
 extern NSString* const kRuleCustomURL;
 extern NSString* const kRuleComment;
 extern NSString* const kRuleCELExpr;
+extern NSString* const kRuleRunningProcessAction;
+extern NSString* const kRuleRunningProcessActionNone;
+extern NSString* const kRuleRunningProcessActionForceKill;
 extern NSString* const kCursor;
 
 extern NSString* const kBackoffInterval;

--- a/Source/common/SNTSyncConstants.mm
+++ b/Source/common/SNTSyncConstants.mm
@@ -139,6 +139,9 @@ NSString* const kRuleCustomMsg = @"custom_msg";
 NSString* const kRuleCustomURL = @"custom_url";
 NSString* const kRuleComment = @"comment";
 NSString* const kRuleCELExpr = @"cel_expr";
+NSString* const kRuleRunningProcessAction = @"running_process_action";
+NSString* const kRuleRunningProcessActionNone = @"NONE";
+NSString* const kRuleRunningProcessActionForceKill = @"FORCE_KILL";
 NSString* const kCursor = @"cursor";
 
 NSString* const kBackoffInterval = @"backoff";

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -924,6 +924,44 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTRunningProcessRuleEvaluator",
+    srcs = ["SNTRunningProcessRuleEvaluator.mm"],
+    hdrs = ["SNTRunningProcessRuleEvaluator.h"],
+    deps = [
+        ":KillingMachine",
+        ":SNTDecisionCache",
+        ":SNTRuleTable",
+        "//Source/common:AuditUtilities",
+        "//Source/common:CertificateHelpers",
+        "//Source/common:MOLCodesignChecker",
+        "//Source/common:SNTCachedDecision",
+        "//Source/common:SNTFileInfo",
+        "//Source/common:SNTKillCommand",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
+        "//Source/common:SNTSystemInfo",
+        "//Source/common:SystemResources",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTRunningProcessRuleEvaluatorTest",
+    srcs = ["SNTRunningProcessRuleEvaluatorTest.mm"],
+    deps = [
+        ":SNTRunningProcessRuleEvaluator",
+        ":SNTDecisionCache",
+        ":SNTRuleTable",
+        "//Source/common:AuditUtilities",
+        "//Source/common:SNTCachedDecision",
+        "//Source/common:SNTKillCommand",
+        "//Source/common:SNTRule",
+        "//Source/common:TestUtils",
+        "@OCMock",
+    ],
+)
+
+objc_library(
     name = "SandboxExpectations",
     srcs = ["SandboxExpectations.mm"],
     hdrs = ["SandboxExpectations.h"],
@@ -952,6 +990,7 @@ santa_unit_test(
     deps = [
         ":SNTDaemonControlController",
         ":SNTDatabaseController",
+        ":SNTRunningProcessRuleEvaluator",
         ":SNTRuleTable",
         ":SandboxExpectations",
         "//Source/common:AuditUtilities",
@@ -995,6 +1034,7 @@ objc_library(
         ":SNTEventTable",
         ":SNTNetworkExtensionQueue",
         ":SNTNotificationQueue",
+        ":SNTRunningProcessRuleEvaluator",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
         ":SandboxExpectations",
@@ -1069,6 +1109,7 @@ objc_library(
         ":SNTExecutionController",
         ":SNTNetworkExtensionQueue",
         ":SNTNotificationQueue",
+        ":SNTRunningProcessRuleEvaluator",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
         ":SandboxExpectations",
@@ -1792,6 +1833,7 @@ test_suite(
         ":SNTNetworkExtensionQueueTest",
         ":SNTNotificationQueueTest",
         ":SNTPolicyProcessorTest",
+        ":SNTRunningProcessRuleEvaluatorTest",
         ":SNTRuleTableTest",
         ":SNTSyncdQueueTest",
         ":SandboxExpectationsTest",

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -34,7 +34,7 @@
 #include "Source/common/String.h"
 #include "Source/common/cel/Evaluator.h"
 
-static const uint32_t kRuleTableCurrentVersion = 13;
+static const uint32_t kRuleTableCurrentVersion = 14;
 
 // How many rules must be in database before we start trying to remove transitive rules.
 static const int64_t kTransitiveRuleCullingThreshold = 500000;
@@ -346,6 +346,12 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     newVersion = 13;
   }
 
+  if (version < 14) {
+    [db executeUpdate:@"ALTER TABLE 'execution_rules' ADD 'running_process_action' INTEGER "
+                      @"DEFAULT 0"];
+    newVersion = 14;
+  }
+
   // Save signing info for launchd and santad. Used to ensure they are always allowed.
   self.santadCSInfo = [[MOLCodesignChecker alloc] initWithSelf];
   self.launchdCSInfo = [[MOLCodesignChecker alloc] initWithPID:1];
@@ -482,6 +488,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
                                      celExpr:[rs stringForColumn:@"cel_expr"]
                               seatbeltPolicy:[rs stringForColumn:@"seatbelt_policy"]
                                       ruleId:[rs longLongIntForColumn:@"rule_id"]
+                        runningProcessAction:static_cast<SNTRuleRunningProcessAction>(
+                                                 [rs intForColumn:@"running_process_action"])
                                        error:nil];
 }
 
@@ -682,11 +690,12 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     } else {
       if (![db executeUpdate:@"INSERT OR REPLACE INTO execution_rules "
                              @"(identifier, state, type, custommsg, customurl, timestamp, "
-                             @"comment, cel_expr, seatbelt_policy, rule_id) "
-                             @"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+                             @"comment, cel_expr, seatbelt_policy, rule_id, "
+                             @"running_process_action) "
+                             @"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
                              rule.identifier, @(rule.state), @(rule.type), rule.customMsg,
                              rule.customURL, @(rule.timestamp), rule.comment, rule.celExpr,
-                             rule.seatbeltPolicy, @(rule.ruleId)]) {
+                             rule.seatbeltPolicy, @(rule.ruleId), @(rule.runningProcessAction)]) {
         [errors addObject:[SNTError createErrorWithCode:SNTErrorCodeInsertOrReplaceRuleFailed
                                                 message:@"A database error occurred while "
                                                         @"inserting/replacing a rule"
@@ -1033,8 +1042,10 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   santa::Xxhash128 hash;
 
   // Indexed-column access keeps this loop cheap; column order matches the SELECT below.
-  // Columns: 0=identifier, 1=state, 2=type, 3=cel_expr, 4=seatbelt_policy.
-  FMResultSet* rs = [db executeQuery:@"SELECT identifier, state, type, cel_expr, seatbelt_policy "
+  // Columns: 0=identifier, 1=state, 2=type, 3=cel_expr, 4=seatbelt_policy,
+  // 5=running_process_action.
+  FMResultSet* rs = [db executeQuery:@"SELECT identifier, state, type, cel_expr, seatbelt_policy, "
+                                     @"running_process_action "
                                      @"FROM execution_rules WHERE state != ?",
                                      @(SNTRuleStateAllowTransitive)];
   while ([rs next]) {
@@ -1043,6 +1054,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     int type = [rs intForColumnIndex:2];
     NSString* cel = [rs stringForColumnIndex:3];
     NSString* seatbeltPolicy = [rs stringForColumnIndex:4];
+    int runningProcessAction = [rs intForColumnIndex:5];
 
     hash.Update(identifier.UTF8String,
                 [identifier lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
@@ -1051,6 +1063,9 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
                 [seatbeltPolicy lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
     hash.Update(static_cast<void*>(&state), sizeof(state));
     hash.Update(static_cast<void*>(&type), sizeof(type));
+    if (runningProcessAction != SNTRuleRunningProcessActionUnset) {
+      hash.Update(static_cast<void*>(&runningProcessAction), sizeof(runningProcessAction));
+    }
   }
   [rs close];
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -47,6 +47,7 @@
 @property(readwrite) NSString* customMsg;
 @property(readwrite) NSString* identifier;
 @property(readwrite) NSString* celExpr;
+@property(readwrite) SNTRuleRunningProcessAction runningProcessAction;
 @end
 
 @implementation SNTRuleTableTest
@@ -144,6 +145,33 @@
   XCTAssertEqual(self.sut.executionRuleCount, executionRuleCount + 1);
   XCTAssertEqual(self.sut.binaryRuleCount, binaryRuleCount + 1);
   XCTAssertNil(errors);
+}
+
+- (void)testRunningProcessActionPersists {
+  SNTRule* rule = [self _exampleBinaryRule];
+  rule.runningProcessAction = SNTRuleRunningProcessActionForceKill;
+
+  NSArray<NSError*>* errors;
+  XCTAssertTrue([self.sut addExecutionRules:@[ rule ]
+                                ruleCleanup:SNTRuleCleanupNone
+                                     errors:&errors]);
+  XCTAssertNil(errors);
+
+  NSArray<SNTRule*>* rules = [self.sut retrieveAllExecutionRules];
+  XCTAssertEqual(rules.count, 1u);
+  XCTAssertEqual(rules.firstObject.runningProcessAction, SNTRuleRunningProcessActionForceKill);
+}
+
+- (void)testRunningProcessActionAffectsRulesHash {
+  SNTRule* rule = [self _exampleBinaryRule];
+  [self.sut addExecutionRules:@[ rule ] ruleCleanup:SNTRuleCleanupAll errors:nil];
+  NSString* defaultHash = self.sut.hashOfHashes.executionRulesHash;
+
+  rule = [self _exampleBinaryRule];
+  rule.runningProcessAction = SNTRuleRunningProcessActionForceKill;
+  [self.sut addExecutionRules:@[ rule ] ruleCleanup:SNTRuleCleanupAll errors:nil];
+
+  XCTAssertNotEqualObjects(self.sut.hashOfHashes.executionRulesHash, defaultHash);
 }
 
 - (void)testAddRulesClean {

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -27,24 +27,26 @@
 @class SNTNotificationQueue;
 @class SNTSyncdQueue;
 @class SNTNetworkExtensionQueue;
+@class SNTRunningProcessRuleEvaluator;
 
 ///
 ///  SNTDaemonControlController handles all of the RPCs from santactl
 ///
 @interface SNTDaemonControlController : NSObject <SNTDaemonControlXPC>
 
-- (instancetype)initWithNotificationQueue:(SNTNotificationQueue*)notQueue
-                               syncdQueue:(SNTSyncdQueue*)syncdQueue
-                        netExtensionQueue:(SNTNetworkExtensionQueue*)netExtQueue
-                                   logger:(std::shared_ptr<santa::Logger>)logger
-                               watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
-                      sandboxExpectations:
-                          (std::shared_ptr<santa::SandboxExpectations>)sandboxExpectations
-                          flushCacheBlock:(void (^)(santa::FlushCacheMode,
-                                                    santa::FlushCacheReason))flushCacheBlock
-                          cacheCountBlock:(NSArray<NSNumber*>* (^)(void))cacheCountBlock
-                          checkCacheBlock:(SNTAction (^)(SantaVnode))checkCacheBlock
-                       metricsExportBlock:(void (^)(void (^reply)(BOOL)))metricsExportBlock;
+- (instancetype)
+      initWithNotificationQueue:(SNTNotificationQueue*)notQueue
+                     syncdQueue:(SNTSyncdQueue*)syncdQueue
+              netExtensionQueue:(SNTNetworkExtensionQueue*)netExtQueue
+                         logger:(std::shared_ptr<santa::Logger>)logger
+                     watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
+            sandboxExpectations:(std::shared_ptr<santa::SandboxExpectations>)sandboxExpectations
+    runningProcessRuleEvaluator:(SNTRunningProcessRuleEvaluator*)runningProcessRuleEvaluator
+                flushCacheBlock:(void (^)(santa::FlushCacheMode,
+                                          santa::FlushCacheReason))flushCacheBlock
+                cacheCountBlock:(NSArray<NSNumber*>* (^)(void))cacheCountBlock
+                checkCacheBlock:(SNTAction (^)(SantaVnode))checkCacheBlock
+             metricsExportBlock:(void (^)(void (^reply)(BOOL)))metricsExportBlock;
 
 /// Install the network extension, optionally checking whether an upgrade is needed first.
 /// When force is YES, delegates to installNetworkExtension: as long as installation is authorized.

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -57,6 +57,7 @@
 #import "Source/santad/SNTDatabaseController.h"
 #import "Source/santad/SNTNetworkExtensionQueue.h"
 #import "Source/santad/SNTNotificationQueue.h"
+#import "Source/santad/SNTRunningProcessRuleEvaluator.h"
 #import "Source/santad/SNTSyncdQueue.h"
 #include "Source/santad/TemporaryMonitorMode.h"
 #import "src/santanetd/SNDProcessFlows.h"
@@ -77,6 +78,7 @@ double watchdogRAMPeak = 0;
 @property SNTNotificationQueue* notQueue;
 @property SNTSyncdQueue* syncdQueue;
 @property SNTNetworkExtensionQueue* netExtQueue;
+@property SNTRunningProcessRuleEvaluator* runningProcessRuleEvaluator;
 @property dispatch_queue_t generalQ;
 @property dispatch_queue_t commandQ;
 @property dispatch_queue_t netFlowQ;
@@ -108,18 +110,19 @@ double watchdogRAMPeak = 0;
   std::shared_ptr<santa::SandboxExpectations> _sandboxExpectations;
 }
 
-- (instancetype)initWithNotificationQueue:(SNTNotificationQueue*)notQueue
-                               syncdQueue:(SNTSyncdQueue*)syncdQueue
-                        netExtensionQueue:(SNTNetworkExtensionQueue*)netExtQueue
-                                   logger:(std::shared_ptr<santa::Logger>)logger
-                               watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
-                      sandboxExpectations:
-                          (std::shared_ptr<santa::SandboxExpectations>)sandboxExpectations
-                          flushCacheBlock:(void (^)(santa::FlushCacheMode,
-                                                    santa::FlushCacheReason))flushCacheBlock
-                          cacheCountBlock:(NSArray<NSNumber*>* (^)(void))cacheCountBlock
-                          checkCacheBlock:(SNTAction (^)(SantaVnode))checkCacheBlock
-                       metricsExportBlock:(void (^)(void (^reply)(BOOL)))metricsExportBlock {
+- (instancetype)
+      initWithNotificationQueue:(SNTNotificationQueue*)notQueue
+                     syncdQueue:(SNTSyncdQueue*)syncdQueue
+              netExtensionQueue:(SNTNetworkExtensionQueue*)netExtQueue
+                         logger:(std::shared_ptr<santa::Logger>)logger
+                     watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
+            sandboxExpectations:(std::shared_ptr<santa::SandboxExpectations>)sandboxExpectations
+    runningProcessRuleEvaluator:(SNTRunningProcessRuleEvaluator*)runningProcessRuleEvaluator
+                flushCacheBlock:(void (^)(santa::FlushCacheMode,
+                                          santa::FlushCacheReason))flushCacheBlock
+                cacheCountBlock:(NSArray<NSNumber*>* (^)(void))cacheCountBlock
+                checkCacheBlock:(SNTAction (^)(SantaVnode))checkCacheBlock
+             metricsExportBlock:(void (^)(void (^reply)(BOOL)))metricsExportBlock {
   self = [super init];
   if (self) {
     _logger = logger;
@@ -128,6 +131,7 @@ double watchdogRAMPeak = 0;
     _notQueue = notQueue;
     _syncdQueue = syncdQueue;
     _netExtQueue = netExtQueue;
+    _runningProcessRuleEvaluator = runningProcessRuleEvaluator;
     _flushCacheBlock = flushCacheBlock;
     _cacheCountsBlock = cacheCountBlock;
     _checkCacheBlock = checkCacheBlock;
@@ -252,6 +256,13 @@ double watchdogRAMPeak = 0;
     if (self.flushCacheBlock) {
       self.flushCacheBlock(FlushCacheMode::kAllCaches, FlushCacheReason::kRulesChanged);
     }
+  }
+
+  BOOL executionRulesChanged = executionRules.count > 0 || cleanupType == SNTRuleCleanupAll ||
+                               cleanupType == SNTRuleCleanupNonTransitive ||
+                               cleanupType == SNTRuleCleanupExecutionRules;
+  if (success && executionRulesChanged) {
+    [self.runningProcessRuleEvaluator reevaluateRunningProcesses];
   }
 
   reply(success, errors);

--- a/Source/santad/SNTDaemonControlControllerTest.mm
+++ b/Source/santad/SNTDaemonControlControllerTest.mm
@@ -30,6 +30,7 @@
 #import "Source/common/SNTSandboxExecRequest.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTDatabaseController.h"
+#import "Source/santad/SNTRunningProcessRuleEvaluator.h"
 #include "Source/santad/SandboxExpectations.h"
 
 using santa::SandboxExpectations;
@@ -49,6 +50,7 @@ static NSString* const kBinarySHA256 =
 @property id mockDatabaseController;
 @property id mockRuleTable;
 @property id mockMOLXPC;
+@property id mockRunningProcessRuleEvaluator;
 @property SNTDaemonControlController* sut;
 @end
 
@@ -63,6 +65,7 @@ static NSString* const kBinarySHA256 =
   self.mockDatabaseController = OCMClassMock([SNTDatabaseController class]);
   self.mockRuleTable = OCMClassMock([SNTRuleTable class]);
   OCMStub([self.mockDatabaseController ruleTable]).andReturn(self.mockRuleTable);
+  self.mockRunningProcessRuleEvaluator = OCMClassMock([SNTRunningProcessRuleEvaluator class]);
 
   // Class-mocked so positive-path tests can stub `currentPeerAuditToken` to
   // return a non-zero token. Unstubbed calls fall through to the real
@@ -76,6 +79,7 @@ static NSString* const kBinarySHA256 =
       logger:nullptr
       watchItems:nullptr
       sandboxExpectations:_sandboxExpectations
+      runningProcessRuleEvaluator:self.mockRunningProcessRuleEvaluator
       flushCacheBlock:^(santa::FlushCacheMode, santa::FlushCacheReason) {
       }
       cacheCountBlock:^NSArray<NSNumber*>*() {
@@ -93,6 +97,7 @@ static NSString* const kBinarySHA256 =
   [self.mockDatabaseController stopMocking];
   [self.mockRuleTable stopMocking];
   [self.mockMOLXPC stopMocking];
+  [self.mockRunningProcessRuleEvaluator stopMocking];
   [super tearDown];
 }
 
@@ -298,6 +303,7 @@ static NSString* const kBinarySHA256 =
   SNTNetworkFlowRule* nfRule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:101 protoBlob:blob];
 
   __block NSArray<SNTNetworkFlowRule*>* forwarded = nil;
+  OCMReject([self.mockRunningProcessRuleEvaluator reevaluateRunningProcesses]);
   OCMStub([self.mockRuleTable addExecutionRules:OCMOCK_ANY
                                 fileAccessRules:OCMOCK_ANY
                                networkFlowRules:OCMOCK_ANY
@@ -323,6 +329,30 @@ static NSString* const kBinarySHA256 =
   XCTAssertTrue(replySuccess);
   XCTAssertEqual(forwarded.count, 1u);
   XCTAssertEqual(forwarded.firstObject.ruleId, 101);
+}
+
+- (void)testRuleAddReevaluatesRunningProcessesForExecutionRules {
+  SNTRule* rule = [[SNTRule alloc] initWithIdentifier:kBinarySHA256
+                                                state:SNTRuleStateBlock
+                                                 type:SNTRuleTypeBinary];
+  OCMStub([self.mockRuleTable addExecutionRules:OCMOCK_ANY
+                                fileAccessRules:OCMOCK_ANY
+                               networkFlowRules:OCMOCK_ANY
+                                    ruleCleanup:SNTRuleCleanupNone
+                                         errors:[OCMArg anyObjectRef]])
+      .andReturn(YES);
+
+  OCMExpect([self.mockRunningProcessRuleEvaluator reevaluateRunningProcesses]);
+
+  [self.sut databaseRuleAddExecutionRules:@[ rule ]
+                          fileAccessRules:@[]
+                         networkFlowRules:@[]
+                              ruleCleanup:SNTRuleCleanupNone
+                                   source:SNTRuleAddSourceSyncService
+                                    reply:^(BOOL, NSArray<NSError*>*){
+                                    }];
+
+  OCMVerifyAll(self.mockRunningProcessRuleEvaluator);
 }
 
 // ---- databaseRulesHash: returns three hashes -------------------------

--- a/Source/santad/SNTRunningProcessRuleEvaluator.h
+++ b/Source/santad/SNTRunningProcessRuleEvaluator.h
@@ -1,0 +1,46 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <bsm/libbsm.h>
+
+@class SNTDecisionCache;
+@class SNTKillRequestRunningProcess;
+@class SNTKillResponse;
+@class SNTRuleTable;
+
+typedef NSArray<NSNumber*>* _Nullable (^SNTRunningProcessListBlock)(void);
+typedef NSString* _Nullable (^SNTRunningProcessPathBlock)(pid_t pid);
+typedef BOOL (^SNTRunningProcessAuditTokenBlock)(pid_t pid, audit_token_t* token);
+typedef SNTKillResponse* _Nullable (^SNTRunningProcessKillBlock)(
+    SNTKillRequestRunningProcess* request);
+
+@interface SNTRunningProcessRuleEvaluator : NSObject
+
+- (instancetype)initWithRuleTable:(SNTRuleTable*)ruleTable decisionCache:(SNTDecisionCache*)cache;
+
+- (void)reevaluateRunningProcesses;
+
+#ifdef DEBUG
+- (instancetype)initWithRuleTable:(SNTRuleTable*)ruleTable
+                    decisionCache:(SNTDecisionCache*)cache
+                 processListBlock:(SNTRunningProcessListBlock)processListBlock
+                     pathForBlock:(SNTRunningProcessPathBlock)pathForBlock
+                  auditTokenBlock:(SNTRunningProcessAuditTokenBlock)auditTokenBlock
+                        killBlock:(SNTRunningProcessKillBlock)killBlock;
+- (void)reevaluateRunningProcessesSyncForTesting;
+#endif
+
+@end

--- a/Source/santad/SNTRunningProcessRuleEvaluator.mm
+++ b/Source/santad/SNTRunningProcessRuleEvaluator.mm
@@ -1,0 +1,246 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/SNTRunningProcessRuleEvaluator.h"
+
+#include <libproc.h>
+#include <sys/param.h>
+#include <sys/qos.h>
+
+#include <optional>
+#include <vector>
+
+#import "Source/common/AuditUtilities.h"
+#import "Source/common/CertificateHelpers.h"
+#import "Source/common/MOLCodesignChecker.h"
+#import "Source/common/SNTCachedDecision.h"
+#import "Source/common/SNTFileInfo.h"
+#import "Source/common/SNTKillCommand.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTRule.h"
+#import "Source/common/SNTRuleIdentifiers.h"
+#import "Source/common/SNTSystemInfo.h"
+#include "Source/common/SystemResources.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
+#include "Source/santad/KillingMachine.h"
+#import "Source/santad/SNTDecisionCache.h"
+
+namespace {
+
+NSArray<NSNumber*>* RunningProcessList() {
+  std::optional<std::vector<pid_t>> pids = santa::GetPidList();
+  if (!pids) {
+    return nil;
+  }
+
+  NSMutableArray<NSNumber*>* result = [NSMutableArray arrayWithCapacity:pids->size()];
+  for (pid_t pid : *pids) {
+    [result addObject:@(pid)];
+  }
+  return result;
+}
+
+NSString* PathForPid(pid_t pid) {
+  char pathBuf[MAXPATHLEN] = {};
+  if (proc_pidpath(pid, pathBuf, sizeof(pathBuf)) <= 0) {
+    return nil;
+  }
+  return @(pathBuf);
+}
+
+BOOL RuleRequestsForceKill(SNTRule* rule) {
+  if (rule.runningProcessAction != SNTRuleRunningProcessActionForceKill) {
+    return NO;
+  }
+
+  switch (rule.state) {
+    case SNTRuleStateBlock:
+    case SNTRuleStateSilentBlock: return YES;
+    default: return NO;
+  }
+}
+
+struct RuleIdentifiers RuleIdentifiersForDecision(SNTCachedDecision* cd) {
+  SNTRuleIdentifiers* identifiers =
+      [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:{
+                                                              .cdhash = cd.cdhash,
+                                                              .binarySHA256 = cd.sha256,
+                                                              .signingID = cd.signingID,
+                                                              .certificateSHA256 = cd.certSHA256,
+                                                              .teamID = cd.teamID,
+                                                          }
+                                         andSigningStatus:cd.signingStatus];
+  return [identifiers toStruct];
+}
+
+}  // namespace
+
+@interface SNTRunningProcessRuleEvaluator ()
+@property SNTRuleTable* ruleTable;
+@property SNTDecisionCache* decisionCache;
+@property dispatch_queue_t queue;
+@property(copy) SNTRunningProcessListBlock processListBlock;
+@property(copy) SNTRunningProcessPathBlock pathForBlock;
+@property(copy) SNTRunningProcessAuditTokenBlock auditTokenBlock;
+@property(copy) SNTRunningProcessKillBlock killBlock;
+- (instancetype)initWithRuleTable:(SNTRuleTable*)ruleTable
+                    decisionCache:(SNTDecisionCache*)cache
+                 processListBlock:(SNTRunningProcessListBlock)processListBlock
+                     pathForBlock:(SNTRunningProcessPathBlock)pathForBlock
+                  auditTokenBlock:(SNTRunningProcessAuditTokenBlock)auditTokenBlock
+                        killBlock:(SNTRunningProcessKillBlock)killBlock;
+- (void)reevaluateRunningProcessesSync;
+@end
+
+@implementation SNTRunningProcessRuleEvaluator
+
+- (instancetype)initWithRuleTable:(SNTRuleTable*)ruleTable decisionCache:(SNTDecisionCache*)cache {
+  return [self initWithRuleTable:ruleTable
+      decisionCache:cache
+      processListBlock:^NSArray<NSNumber*>* {
+        return RunningProcessList();
+      }
+      pathForBlock:^NSString*(pid_t pid) {
+        return PathForPid(pid);
+      }
+      auditTokenBlock:^BOOL(pid_t pid, audit_token_t* token) {
+        return santa::AuditTokenForPid(pid, token);
+      }
+      killBlock:^SNTKillResponse*(SNTKillRequestRunningProcess* request) {
+        return santa::KillingMachine(request);
+      }];
+}
+
+- (instancetype)initWithRuleTable:(SNTRuleTable*)ruleTable
+                    decisionCache:(SNTDecisionCache*)cache
+                 processListBlock:(SNTRunningProcessListBlock)processListBlock
+                     pathForBlock:(SNTRunningProcessPathBlock)pathForBlock
+                  auditTokenBlock:(SNTRunningProcessAuditTokenBlock)auditTokenBlock
+                        killBlock:(SNTRunningProcessKillBlock)killBlock {
+  self = [super init];
+  if (self) {
+    _ruleTable = ruleTable;
+    _decisionCache = cache;
+    _processListBlock = [processListBlock copy];
+    _pathForBlock = [pathForBlock copy];
+    _auditTokenBlock = [auditTokenBlock copy];
+    _killBlock = [killBlock copy];
+    _queue = dispatch_queue_create_with_target("com.northpolesec.santa.running-process-rules",
+                                               DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
+                                               dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+  }
+  return self;
+}
+
+- (void)reevaluateRunningProcesses {
+  dispatch_async(self.queue, ^{
+    [self reevaluateRunningProcessesSync];
+  });
+}
+
+#ifdef DEBUG
+- (void)reevaluateRunningProcessesSyncForTesting {
+  [self reevaluateRunningProcessesSync];
+}
+#endif
+
+- (void)reevaluateRunningProcessesSync {
+  NSArray<NSNumber*>* pids = self.processListBlock();
+  if (!pids) {
+    LOGW(@"Unable to evaluate running processes: process list unavailable");
+    return;
+  }
+
+  NSUInteger evaluated = 0;
+  NSUInteger matched = 0;
+  NSUInteger killed = 0;
+  NSUInteger failed = 0;
+
+  for (NSNumber* pidNum in pids) {
+    @autoreleasepool {
+      pid_t pid = [pidNum intValue];
+      if (pid == 0) {
+        continue;
+      }
+
+      audit_token_t tokenBefore;
+      if (!self.auditTokenBlock(pid, &tokenBefore)) {
+        continue;
+      }
+
+      NSString* path = self.pathForBlock(pid);
+      if (path.length == 0) {
+        continue;
+      }
+
+      SNTFileInfo* fileInfo = [[SNTFileInfo alloc] initWithPath:path];
+      if (!fileInfo) {
+        continue;
+      }
+
+      SNTCachedDecision* cd = [self.decisionCache rehydrateAndCacheDecisionForFileInfo:fileInfo];
+      if (!cd) {
+        continue;
+      }
+
+      NSError* csError = nil;
+      MOLCodesignChecker* csInfo = [fileInfo codesignCheckerWithError:&csError];
+      cd.signingStatus =
+          (csInfo || csError) ? SigningStatus(csInfo, csError) : SNTSigningStatusInvalid;
+
+      if (cd.signingID && self.ruleTable.criticalSystemBinaries[cd.signingID]) {
+        continue;
+      }
+
+      SNTRule* rule = [self.ruleTable executionRuleForIdentifiers:RuleIdentifiersForDecision(cd)];
+      evaluated++;
+      if (!RuleRequestsForceKill(rule)) {
+        continue;
+      }
+      matched++;
+
+      audit_token_t tokenAfter;
+      if (!self.auditTokenBlock(pid, &tokenAfter) ||
+          santa::Pidversion(tokenBefore) != santa::Pidversion(tokenAfter)) {
+        continue;
+      }
+
+      SNTKillRequestRunningProcess* request =
+          [[SNTKillRequestRunningProcess alloc] initWithUUID:[[NSUUID UUID] UUIDString]
+                                                         pid:pid
+                                                  pidversion:santa::Pidversion(tokenAfter)
+                                             bootSessionUUID:[SNTSystemInfo bootSessionUUID]];
+      SNTKillResponse* response = self.killBlock(request);
+      if (response.error != SNTKillResponseErrorNone) {
+        failed++;
+        continue;
+      }
+
+      for (SNTKilledProcess* proc in response.killedProcesses) {
+        if (proc.error == SNTKilledProcessErrorNone) {
+          killed++;
+        } else {
+          failed++;
+        }
+      }
+    }
+  }
+
+  LOGI(@"Running process rule evaluation complete. %lu evaluated, %lu matched, %lu killed, "
+       @"%lu failed",
+       static_cast<unsigned long>(evaluated), static_cast<unsigned long>(matched),
+       static_cast<unsigned long>(killed), static_cast<unsigned long>(failed));
+}
+
+@end

--- a/Source/santad/SNTRunningProcessRuleEvaluatorTest.mm
+++ b/Source/santad/SNTRunningProcessRuleEvaluatorTest.mm
@@ -1,0 +1,160 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/AuditUtilities.h"
+#import "Source/common/SNTCachedDecision.h"
+#import "Source/common/SNTKillCommand.h"
+#import "Source/common/SNTRule.h"
+#import "Source/common/TestUtils.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
+#import "Source/santad/SNTDecisionCache.h"
+#import "Source/santad/SNTRunningProcessRuleEvaluator.h"
+
+static NSString* const kBinarySHA256 =
+    @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+@interface SNTRunningProcessRuleEvaluatorTest : XCTestCase
+@property id mockRuleTable;
+@property id mockDecisionCache;
+@end
+
+@implementation SNTRunningProcessRuleEvaluatorTest
+
+- (void)setUp {
+  [super setUp];
+  self.mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  self.mockDecisionCache = OCMClassMock([SNTDecisionCache class]);
+  OCMStub([self.mockRuleTable criticalSystemBinaries]).andReturn(@{});
+}
+
+- (void)tearDown {
+  [self.mockRuleTable stopMocking];
+  [self.mockDecisionCache stopMocking];
+  [super tearDown];
+}
+
+- (SNTRule*)ruleWithState:(SNTRuleState)state
+     runningProcessAction:(SNTRuleRunningProcessAction)runningProcessAction {
+  return [[SNTRule alloc] initWithIdentifier:kBinarySHA256
+                                       state:state
+                                        type:SNTRuleTypeBinary
+                                   customMsg:nil
+                                   customURL:nil
+                                   timestamp:0
+                                     comment:nil
+                                     celExpr:nil
+                              seatbeltPolicy:nil
+                                      ruleId:0
+                        runningProcessAction:runningProcessAction
+                                       error:nil];
+}
+
+- (SNTRunningProcessRuleEvaluator*)evaluatorWithRule:(SNTRule*)rule
+                                           killBlock:(SNTRunningProcessKillBlock)killBlock {
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.sha256 = kBinarySHA256;
+  OCMStub([self.mockDecisionCache rehydrateAndCacheDecisionForFileInfo:OCMOCK_ANY]).andReturn(cd);
+  OCMStub([self.mockRuleTable executionRuleForIdentifiers:(struct RuleIdentifiers){}])
+      .ignoringNonObjectArgs()
+      .andReturn(rule);
+
+  return [[SNTRunningProcessRuleEvaluator alloc] initWithRuleTable:self.mockRuleTable
+      decisionCache:self.mockDecisionCache
+      processListBlock:^NSArray<NSNumber*>* {
+        return @[ @42 ];
+      }
+      pathForBlock:^NSString*(pid_t) {
+        return @"/bin/ls";
+      }
+      auditTokenBlock:^BOOL(pid_t pid, audit_token_t* token) {
+        *token = MakeAuditToken(pid, 7);
+        return YES;
+      }
+      killBlock:killBlock];
+}
+
+- (void)testForceKillRuleKillsMatchingProcess {
+  __block SNTKillRequestRunningProcess* killedRequest = nil;
+  SNTRunningProcessRuleEvaluator* evaluator =
+      [self evaluatorWithRule:[self ruleWithState:SNTRuleStateBlock
+                                  runningProcessAction:SNTRuleRunningProcessActionForceKill]
+                    killBlock:^SNTKillResponse*(SNTKillRequestRunningProcess* request) {
+                      killedRequest = request;
+                      SNTKilledProcess* proc =
+                          [[SNTKilledProcess alloc] initWithPid:request.pid
+                                                     pidversion:request.pidversion
+                                                          error:SNTKilledProcessErrorNone];
+                      return [[SNTKillResponse alloc] initWithKilledProcesses:@[ proc ]];
+                    }];
+
+  [evaluator reevaluateRunningProcessesSyncForTesting];
+
+  XCTAssertNotNil(killedRequest);
+  XCTAssertEqual(killedRequest.pid, 42);
+  XCTAssertEqual(killedRequest.pidversion, 7);
+}
+
+- (void)testUnsetActionDoesNotKill {
+  __block NSUInteger killCount = 0;
+  SNTRunningProcessRuleEvaluator* evaluator =
+      [self evaluatorWithRule:[self ruleWithState:SNTRuleStateBlock
+                                  runningProcessAction:SNTRuleRunningProcessActionUnset]
+                    killBlock:^SNTKillResponse*(SNTKillRequestRunningProcess*) {
+                      killCount++;
+                      return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+                    }];
+
+  [evaluator reevaluateRunningProcessesSyncForTesting];
+
+  XCTAssertEqual(killCount, 0u);
+}
+
+- (void)testPidversionChangeSkipsKill {
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.sha256 = kBinarySHA256;
+  OCMStub([self.mockDecisionCache rehydrateAndCacheDecisionForFileInfo:OCMOCK_ANY]).andReturn(cd);
+  OCMStub([self.mockRuleTable executionRuleForIdentifiers:(struct RuleIdentifiers){}])
+      .ignoringNonObjectArgs()
+      .andReturn([self ruleWithState:SNTRuleStateBlock
+                runningProcessAction:SNTRuleRunningProcessActionForceKill]);
+
+  __block NSUInteger tokenCalls = 0;
+  __block NSUInteger killCount = 0;
+  SNTRunningProcessRuleEvaluator* evaluator =
+      [[SNTRunningProcessRuleEvaluator alloc] initWithRuleTable:self.mockRuleTable
+          decisionCache:self.mockDecisionCache
+          processListBlock:^NSArray<NSNumber*>* {
+            return @[ @42 ];
+          }
+          pathForBlock:^NSString*(pid_t) {
+            return @"/bin/ls";
+          }
+          auditTokenBlock:^BOOL(pid_t pid, audit_token_t* token) {
+            *token = MakeAuditToken(pid, tokenCalls++ == 0 ? 7 : 8);
+            return YES;
+          }
+          killBlock:^SNTKillResponse*(SNTKillRequestRunningProcess*) {
+            killCount++;
+            return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+          }];
+
+  [evaluator reevaluateRunningProcessesSyncForTesting];
+
+  XCTAssertEqual(killCount, 0u);
+}
+
+@end

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -50,6 +50,7 @@
 #import "Source/santad/SNTDaemonControlController.h"
 #import "Source/santad/SNTDatabaseController.h"
 #import "Source/santad/SNTDecisionCache.h"
+#import "Source/santad/SNTRunningProcessRuleEvaluator.h"
 #include "Source/santad/TTYWriter.h"
 
 using santa::AuthResultCache;
@@ -86,6 +87,9 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                 std::shared_ptr<santa::EntitlementsFilter> entitlements_filter,
                 std::shared_ptr<santa::SandboxExpectations> sandbox_expectations) {
   SNTConfigurator* configurator = [SNTConfigurator configurator];
+  SNTRunningProcessRuleEvaluator* running_process_rule_evaluator =
+      [[SNTRunningProcessRuleEvaluator alloc] initWithRuleTable:exec_controller.ruleTable
+                                                  decisionCache:[SNTDecisionCache sharedCache]];
 
   std::weak_ptr<Metrics> weak_metrics(metrics);
   SNTDaemonControlController* dc =
@@ -95,6 +99,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
           logger:logger
           watchItems:watch_items
           sandboxExpectations:sandbox_expectations
+          runningProcessRuleEvaluator:running_process_rule_evaluator
           flushCacheBlock:^(FlushCacheMode mode, FlushCacheReason reason) {
             auth_result_cache->FlushCache(mode, reason);
             [exec_controller flushTouchIDApprovalCache];
@@ -508,6 +513,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                 LOGI(@"StaticRules changed. Flushing caches.");
                 auth_result_cache->FlushCache(FlushCacheMode::kAllCaches,
                                               FlushCacheReason::kStaticRulesChanged);
+                [running_process_rule_evaluator reevaluateRunningProcesses];
               }],
     [[SNTKVOManager alloc]
         initWithObject:configurator


### PR DESCRIPTION
## Summary
- add a `running_process_action` execution-rule field with unset/default, `NONE`, and `FORCE_KILL` values
- persist the field in the rules DB while keeping existing hashes unchanged for unset rules
- re-evaluate running processes after execution-rule and StaticRules updates, using the existing kill-command path for matching block/silent block rules marked `FORCE_KILL`
- add focused coverage for parsing, persistence, hashing, pidversion guarding, and rule-change triggers

## Notes
- This is intentionally the force-kill primitive only. It does not implement soft stop, grace periods, or camera/microphone/screen-sharing special handling.
- The pinned sync protobuf schema does not yet carry this field. A protos update is needed before sync servers can deliver it through RuleDownload. Static rules and local rule dictionaries can exercise the field now.

## Testing
- `git diff --check origin/main...HEAD`
- `git diff --name-only origin/main...HEAD -- '*.h' '*.m' '*.mm' '*.cc' | xargs xcrun clang-format --Werror --dry-run`
- `swift format lint -s -r /Users/ahyde/GitHub/hydazz/santa`
- `make test` fails locally because `bazel` is not installed
