### PR TITLE
santa: source DNS-proxy upstream timeout from MDM, not sync

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "689030dd1cfc1a1ba12df2c5e5fafc92248a36d7",
+    commit = "2cfabcb71333bfa9eabfaf2f5497efbc999bc4e0",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -423,6 +423,14 @@
 @property(readonly, nonatomic) BOOL enableMachineIDDecoration;
 
 ///
+///  Override for santanetd's DNS-proxy upstream cleanup timeout, in seconds.
+///  Surfaced only when we must run a live timeout experiment in an unexpected
+///  environment. 0/unset means "use the built-in default". The effective value
+///  (default + [1,60]s clamp) is applied by SNTNetworkExtensionSettings, not here.
+///
+@property(readonly, nonatomic) NSTimeInterval dnsUpstreamTimeoutSecs;
+
+///
 ///  Currently defined settings for Santa's network extension. Its value is set by a sync server.
 ///
 @property(nullable, readonly) SNTSyncNetworkExtensionSettings* syncNetworkExtensionSettings;

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -425,8 +425,9 @@
 ///
 ///  Override for santanetd's DNS-proxy upstream cleanup timeout, in seconds.
 ///  Surfaced only when we must run a live timeout experiment in an unexpected
-///  environment. 0/unset means "use the built-in default". The effective value
-///  (default + [1,60]s clamp) is applied by SNTNetworkExtensionSettings, not here.
+///  environment. 0/unset (or any sub-floor value) means "use the built-in default"; an in-range
+///  value is used as-is and an above-ceiling value is clamped down. The effective value is
+///  normalized by SNTNetworkExtensionSettings (default 30s, ceiling 60s), not here.
 ///
 @property(readonly, nonatomic) NSTimeInterval dnsUpstreamTimeoutSecs;
 

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -273,6 +273,7 @@ static NSString* const kSyncTypeRequired = @"SyncTypeRequired";
 static NSString* const kExportConfigurationKey = @"ExportConfiguration";
 static NSString* const kModeTransitionKey = @"ModeTransition";
 static NSString* const kNetworkExtensionSettingsKey = @"NetworkExtensionSettings";
+static NSString* const kDNSUpstreamTimeoutSecondsKey = @"DNSUpstreamTimeoutSeconds";
 static NSString* const kPushTokenChainKey = @"PushTokenChain";
 
 - (instancetype)init {
@@ -450,6 +451,7 @@ static NSString* const kPushTokenChainKey = @"PushTokenChain";
       kBrandingCompanyLogo : string,
       kBrandingCompanyLogoDark : string,
       kAllowedSantaCommandsKey : array,
+      kDNSUpstreamTimeoutSecondsKey : number,
     };
 
     _syncStateFilePath = syncStateFilePath;
@@ -797,6 +799,10 @@ static SNTConfigurator* sharedConfigurator = nil;
 }
 
 + (NSSet*)keyPathsForValuesAffectingIgnoreOtherEndpointSecurityClients {
+  return [self configStateSet];
+}
+
++ (NSSet*)keyPathsForValuesAffectingDnsUpstreamTimeoutSecs {
   return [self configStateSet];
 }
 
@@ -1668,6 +1674,11 @@ static SNTConfigurator* sharedConfigurator = nil;
 - (BOOL)ignoreOtherEndpointSecurityClients {
   NSNumber* number = self.configState[kIgnoreOtherEndpointSecurityClients];
   return number ? [number boolValue] : NO;
+}
+
+- (NSTimeInterval)dnsUpstreamTimeoutSecs {
+  NSNumber* v = self.configState[kDNSUpstreamTimeoutSecondsKey];
+  return v ? v.doubleValue : 0;  // 0 == unset
 }
 
 - (NSString*)fcmProject {

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -536,6 +536,7 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   NSArray<NSString*>* keyPaths = @[
     @"allowedPathRegex",
     @"blockedPathRegex",
+    @"dnsUpstreamTimeoutSecs",
     @"enableSilentTTYMode",
     @"exportMetrics",
     @"metricExportInterval",
@@ -552,6 +553,7 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   cfg.configState = [@{
     @"AllowedPathRegex" : @"a",
     @"BlockedPathRegex" : @"b",
+    @"DNSUpstreamTimeoutSeconds" : @(30.0),
     @"EnableSilentTTYMode" : @YES,
     @"ExportMetrics" : @YES,
     @"MetricExportInterval" : @123,

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -607,4 +607,13 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   }
 }
 
+- (void)testDNSUpstreamTimeoutSecsForcedConfig {
+  SNTConfigurator* sut = [[SNTConfigurator alloc] init];
+  // Unset -> 0, the "use built-in default" sentinel. The default + [1,60]s clamp live downstream
+  // in SNTNetworkExtensionSettings, so the configurator returns the raw forced value (or 0).
+  XCTAssertEqual(sut.dnsUpstreamTimeoutSecs, 0);
+  sut.configState[@"DNSUpstreamTimeoutSeconds"] = @(30.0);
+  XCTAssertEqualWithAccuracy(sut.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
+}
+
 @end

--- a/Source/common/ne/SNTNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTNetworkExtensionSettings.h
@@ -36,8 +36,8 @@ typedef NS_ENUM(NSInteger, SNTNetworkFlowDefaultAction) {
 @property(readonly) SNTNetworkFlowDefaultAction flowDefaultAction;
 
 /// Upstream DNS forward timeout used by santanetd's DNS proxy, in seconds.
-/// Normalized to [1.0, 15.0]; values below the floor (incl. unset/0) become the 7.0 default,
-/// values above the ceiling clamp to 15.0.
+/// Normalized to [1.0, 60.0]; values below the floor (incl. unset/0) become the 30.0 default,
+/// values above the ceiling clamp to 60.0.
 @property(readonly) NSTimeInterval dnsUpstreamTimeoutSecs;
 
 /// The network-flow ruleset for santanetd to apply. At registration this is the full ruleset
@@ -47,10 +47,10 @@ typedef NS_ENUM(NSInteger, SNTNetworkFlowDefaultAction) {
 /// network-flow rules.
 @property(readonly, copy) NSArray<SNTNetworkFlowRule*>* networkFlowRules;
 
-/// Defaults flowDefaultAction to Unspecified and dnsUpstreamTimeoutSecs to 7s.
+/// Defaults flowDefaultAction to Unspecified and dnsUpstreamTimeoutSecs to 30s.
 - (instancetype)initWithEnable:(BOOL)enable;
 
-/// Defaults dnsUpstreamTimeoutSecs to 7s.
+/// Defaults dnsUpstreamTimeoutSecs to 30s.
 - (instancetype)initWithEnable:(BOOL)enable
              flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
 

--- a/Source/common/ne/SNTNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettings.mm
@@ -21,9 +21,12 @@
 
 namespace {
 
-// Below the floor (incl. 0 from a missing archive key) means "not meaningfully set" -> default.
-// Above the ceiling is intentional -> clamp. This timeout is a resource-cleanup backstop for the
-// DNS proxy's per-query upstream connection, NOT a fast-fail trigger.
+// Normalization is deliberately asymmetric. Any value below the floor -- 0/unset (e.g. a missing
+// archive key), a negative, or an absurdly small positive like 0.5s -- is treated as "not
+// meaningfully set" and becomes the default; we intentionally do NOT clamp sub-floor values up to
+// the floor, because an aggressively short cleanup timeout is far more likely a mistake than an
+// intent. Above the ceiling IS clamped down to the max. This timeout is a resource-cleanup backstop
+// for the DNS proxy's per-query upstream connection, NOT a fast-fail trigger.
 const NSTimeInterval kDefaultDNSUpstreamTimeoutSecs = 30.0;
 const NSTimeInterval kMinDNSUpstreamTimeoutSecs = 1.0;
 const NSTimeInterval kMaxDNSUpstreamTimeoutSecs = 60.0;
@@ -32,6 +35,7 @@ NSTimeInterval NormalizeDNSUpstreamTimeout(NSTimeInterval v) {
   // Non-finite (NaN/±INF) is not a meaningful timeout; NaN also slips the </> clamp below because
   // every NaN comparison is false. Treat it as "not meaningfully set" -> default.
   if (!std::isfinite(v)) return kDefaultDNSUpstreamTimeoutSecs;
+  // sub-floor (incl. 0) -> default, not clamped to floor
   if (v < kMinDNSUpstreamTimeoutSecs) return kDefaultDNSUpstreamTimeoutSecs;
   if (v > kMaxDNSUpstreamTimeoutSecs) return kMaxDNSUpstreamTimeoutSecs;
   return v;

--- a/Source/common/ne/SNTNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettings.mm
@@ -22,11 +22,11 @@
 namespace {
 
 // Below the floor (incl. 0 from a missing archive key) means "not meaningfully set" -> default.
-// Above the ceiling is intentional -> clamp. The 15s ceiling stays well under mDNSResponder's
-// ~30s per-question patience so a santanetd SERVFAIL always lands first.
-const NSTimeInterval kDefaultDNSUpstreamTimeoutSecs = 7.0;
+// Above the ceiling is intentional -> clamp. This timeout is a resource-cleanup backstop for the
+// DNS proxy's per-query upstream connection, NOT a fast-fail trigger.
+const NSTimeInterval kDefaultDNSUpstreamTimeoutSecs = 30.0;
 const NSTimeInterval kMinDNSUpstreamTimeoutSecs = 1.0;
-const NSTimeInterval kMaxDNSUpstreamTimeoutSecs = 15.0;
+const NSTimeInterval kMaxDNSUpstreamTimeoutSecs = 60.0;
 
 NSTimeInterval NormalizeDNSUpstreamTimeout(NSTimeInterval v) {
   // Non-finite (NaN/±INF) is not a meaningful timeout; NaN also slips the </> clamp below because

--- a/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
@@ -182,9 +182,9 @@
 }
 
 - (void)testTimeoutDefaultFromEnableInit {
-  // initWithEnable: should default the timeout to 7s.
+  // initWithEnable: should default the timeout to 30s.
   SNTNetworkExtensionSettings* s = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES];
-  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 7.0, 0.0001);
+  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
 }
 
 - (void)testTimeoutInRangePreserved {
@@ -194,20 +194,20 @@
 }
 
 - (void)testTimeoutBelowFloorUsesDefault {
-  // Below the 1.0 floor (incl. 0 / negative) is treated as "unset" -> 7s default.
+  // Below the 1.0 floor (incl. 0 / negative) is treated as "unset" -> 30s default.
   NSTimeInterval belowFloor[] = {0.0, 0.5, -1.0};
   for (size_t i = 0; i < sizeof(belowFloor) / sizeof(belowFloor[0]); i++) {
     SNTNetworkExtensionSettings* s =
         [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
                                      dnsUpstreamTimeoutSecs:belowFloor[i]];
-    XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 7.0, 0.0001);
+    XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
   }
 }
 
 - (void)testTimeoutAboveCeilingClampsToMax {
   SNTNetworkExtensionSettings* s = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
-                                                                dnsUpstreamTimeoutSecs:60.0];
-  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 15.0, 0.0001);
+                                                                dnsUpstreamTimeoutSecs:100.0];
+  XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 60.0, 0.0001);
 }
 
 - (void)testTimeoutBoundaryValuesPreserved {
@@ -216,8 +216,8 @@
                                                                     dnsUpstreamTimeoutSecs:1.0];
   XCTAssertEqualWithAccuracy(floor.dnsUpstreamTimeoutSecs, 1.0, 0.0001);
   SNTNetworkExtensionSettings* ceiling = [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
-                                                                      dnsUpstreamTimeoutSecs:15.0];
-  XCTAssertEqualWithAccuracy(ceiling.dnsUpstreamTimeoutSecs, 15.0, 0.0001);
+                                                                      dnsUpstreamTimeoutSecs:60.0];
+  XCTAssertEqualWithAccuracy(ceiling.dnsUpstreamTimeoutSecs, 60.0, 0.0001);
 }
 
 - (void)testTimeoutNonFiniteUsesDefault {
@@ -229,7 +229,7 @@
     SNTNetworkExtensionSettings* s =
         [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
                                      dnsUpstreamTimeoutSecs:nonFinite[i]];
-    XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 7.0, 0.0001);
+    XCTAssertEqualWithAccuracy(s.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
   }
 }
 
@@ -246,7 +246,7 @@
 }
 
 - (void)testTimeoutMissingKeyDecodesToDefault {
-  // A legacy archive omitting the key must decode to the 7s default, not 0.
+  // A legacy archive omitting the key must decode to the 30s default, not 0.
   //
   // SNTNetworkExtensionSettingsLegacy encodes nothing, so the archive omits the
   // dnsUpstreamTimeoutSecs key. We remap the class name to SNTNetworkExtensionSettings during
@@ -269,11 +269,11 @@
                                forKey:NSKeyedArchiveRootObjectKey];
   [unarchiver finishDecoding];
 
-  XCTAssertEqualWithAccuracy(decoded.dnsUpstreamTimeoutSecs, 7.0, 0.0001);
+  XCTAssertEqualWithAccuracy(decoded.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
 }
 
 - (void)testEqualityAndHashDistinguishDNSUpstreamTimeout {
-  // isEqual: gates whether a sync-only timeout change is pushed to santanetd in
+  // isEqual: gates whether an MDM-sourced timeout change is pushed to santanetd in
   // SNTNetworkExtensionQueue's reconcileNetworkExtensionConfig, so settings that differ only in
   // the timeout must not compare equal. (3.0 and 7.5 are both in range, so they're preserved.)
   SNTNetworkExtensionSettings* a =

--- a/Source/common/ne/SNTSyncNetworkExtensionSettings.h
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettings.h
@@ -21,21 +21,9 @@
 @property(readonly) BOOL enable;
 @property(readonly) SNTNetworkFlowDefaultAction flowDefaultAction;
 
-/// Raw, unnormalized upstream DNS forward timeout from the sync server, in seconds, carried
-/// verbatim (0 == "unset"). This is NOT the effective value: the [1,15]s clamp and the 0 -> 5s
-/// default are applied only when SNTNetworkExtensionSettings is built from this carrier (see
-/// -[SNTNetworkExtensionQueue generateSettingsForProtocolVersion:]). Don't read this directly
-/// expecting an in-range value — go through SNTNetworkExtensionSettings for that.
-@property(readonly) NSTimeInterval dnsUpstreamTimeoutSecs;
-
-/// Defaults dnsUpstreamTimeoutSecs to 0 ("unset").
-- (instancetype)initWithEnable:(BOOL)enable
-             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
-
 /// Designated initializer.
 - (instancetype)initWithEnable:(BOOL)enable
-             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction
-        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs;
+             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction;
 
 - (NSData*)serialize;
 + (instancetype)deserialize:(NSData*)data;

--- a/Source/common/ne/SNTSyncNetworkExtensionSettings.mm
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettings.mm
@@ -20,24 +20,16 @@
 @interface SNTSyncNetworkExtensionSettings ()
 @property(readwrite) BOOL enable;
 @property(readwrite) SNTNetworkFlowDefaultAction flowDefaultAction;
-@property(readwrite) NSTimeInterval dnsUpstreamTimeoutSecs;
 @end
 
 @implementation SNTSyncNetworkExtensionSettings
 
 - (instancetype)initWithEnable:(BOOL)enable
              flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction {
-  return [self initWithEnable:enable flowDefaultAction:flowDefaultAction dnsUpstreamTimeoutSecs:0];
-}
-
-- (instancetype)initWithEnable:(BOOL)enable
-             flowDefaultAction:(SNTNetworkFlowDefaultAction)flowDefaultAction
-        dnsUpstreamTimeoutSecs:(NSTimeInterval)dnsUpstreamTimeoutSecs {
   self = [super init];
   if (self) {
     _enable = enable;
     _flowDefaultAction = flowDefaultAction;
-    _dnsUpstreamTimeoutSecs = dnsUpstreamTimeoutSecs;
   }
   return self;
 }
@@ -57,8 +49,7 @@
 
   SNTSyncNetworkExtensionSettings* otherSettings = (SNTSyncNetworkExtensionSettings*)other;
   return self.enable == otherSettings.enable &&
-         self.flowDefaultAction == otherSettings.flowDefaultAction &&
-         self.dnsUpstreamTimeoutSecs == otherSettings.dnsUpstreamTimeoutSecs;
+         self.flowDefaultAction == otherSettings.flowDefaultAction;
 }
 
 - (NSUInteger)hash {
@@ -66,7 +57,6 @@
   NSUInteger result = 1;
   result = prime * result + self.enable;
   result = prime * result + self.flowDefaultAction;
-  result = prime * result + (NSUInteger)self.dnsUpstreamTimeoutSecs;
   return result;
 }
 
@@ -77,7 +67,6 @@
 - (void)encodeWithCoder:(NSCoder*)coder {
   ENCODE_BOXABLE(coder, enable);
   ENCODE_BOXABLE(coder, flowDefaultAction);
-  ENCODE_BOXABLE(coder, dnsUpstreamTimeoutSecs);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
@@ -85,7 +74,6 @@
   if (self) {
     DECODE_SELECTOR(decoder, enable, NSNumber, boolValue);
     DECODE_SELECTOR(decoder, flowDefaultAction, NSNumber, integerValue);
-    DECODE_SELECTOR(decoder, dnsUpstreamTimeoutSecs, NSNumber, doubleValue);
   }
   return self;
 }

--- a/Source/common/ne/SNTSyncNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTSyncNetworkExtensionSettingsTest.mm
@@ -81,45 +81,4 @@
   XCTAssertNil(deserialized);
 }
 
-- (void)testDNSUpstreamTimeoutDefaultsToZeroWhenUnset {
-  // The 2-arg convenience init leaves the carrier timeout at 0 ("unset").
-  // Clamping/defaulting to 7s happens downstream in SNTNetworkExtensionSettings.
-  SNTSyncNetworkExtensionSettings* settings =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
-                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny];
-  XCTAssertEqual(settings.dnsUpstreamTimeoutSecs, 0);
-}
-
-- (void)testDNSUpstreamTimeoutPreservedByDesignatedInit {
-  SNTSyncNetworkExtensionSettings* settings =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
-                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
-                                       dnsUpstreamTimeoutSecs:7.5];
-  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
-}
-
-- (void)testDNSUpstreamTimeoutRoundTripsThroughCoder {
-  SNTSyncNetworkExtensionSettings* settings =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
-                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
-                                       dnsUpstreamTimeoutSecs:7.5];
-  SNTSyncNetworkExtensionSettings* deserialized =
-      [SNTSyncNetworkExtensionSettings deserialize:[settings serialize]];
-  XCTAssertNotNil(deserialized);
-  XCTAssertEqualWithAccuracy(deserialized.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
-  XCTAssertEqualObjects(deserialized, settings);
-}
-
-- (void)testDNSUpstreamTimeoutDifferentiatesEquality {
-  SNTSyncNetworkExtensionSettings* a =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
-                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
-                                       dnsUpstreamTimeoutSecs:7.5];
-  SNTSyncNetworkExtensionSettings* b =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:YES
-                                            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
-                                       dnsUpstreamTimeoutSecs:3.0];
-  XCTAssertNotEqualObjects(a, b);
-}
-
 @end

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -370,22 +370,19 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.0";
   }
 
   auto [majorVersion, _] = [self protocolVersionComponents:protocolVersion];
-  SNTSyncNetworkExtensionSettings* syncSettings =
-      [[SNTConfigurator configurator] syncNetworkExtensionSettings];
+  SNTConfigurator* config = [SNTConfigurator configurator];
+  SNTSyncNetworkExtensionSettings* syncSettings = [config syncNetworkExtensionSettings];
 
   BOOL enable = NO;
   SNTNetworkFlowDefaultAction flowDefaultAction = SNTNetworkFlowDefaultActionUnspecified;
-  NSTimeInterval dnsUpstreamTimeoutSecs = 0;
-
   if (majorVersion >= 1) {
     enable = syncSettings.enable;
     flowDefaultAction = syncSettings.flowDefaultAction;
-    dnsUpstreamTimeoutSecs = syncSettings.dnsUpstreamTimeoutSecs;
   }
 
   return [[SNTNetworkExtensionSettings alloc] initWithEnable:enable
                                            flowDefaultAction:flowDefaultAction
-                                      dnsUpstreamTimeoutSecs:dnsUpstreamTimeoutSecs];
+                                      dnsUpstreamTimeoutSecs:config.dnsUpstreamTimeoutSecs];
 }
 
 @end

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -81,15 +81,14 @@
   OCMStub([self.mockConfigurator syncNetworkExtensionSettings]).andReturn(settings);
 }
 
-// Like stubConfiguratorEnable:action: but also sets the sync-side DNS upstream timeout.
+// Like stubConfiguratorEnable:action: but also sets the MDM-sourced DNS upstream timeout.
 - (void)stubConfiguratorEnable:(BOOL)enable
                         action:(SNTNetworkFlowDefaultAction)action
                     dnsTimeout:(NSTimeInterval)dnsTimeout {
   SNTSyncNetworkExtensionSettings* settings =
-      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:enable
-                                            flowDefaultAction:action
-                                       dnsUpstreamTimeoutSecs:dnsTimeout];
+      [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:enable flowDefaultAction:action];
   OCMStub([self.mockConfigurator syncNetworkExtensionSettings]).andReturn(settings);
+  OCMStub([self.mockConfigurator dnsUpstreamTimeoutSecs]).andReturn(dnsTimeout);
 }
 
 // Make the rule table report the given network flow rules hash + ruleset.
@@ -276,19 +275,19 @@
   XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
 }
 
-- (void)testGenerateSettingsDefaultsDNSUpstreamTimeoutWhenSyncUnset {
-  // Carrier timeout 0 -> SNTNetworkExtensionSettings normalizes to the 7s default.
+- (void)testGenerateSettingsDefaultsDNSUpstreamTimeoutWhenUnset {
+  // MDM timeout 0 -> SNTNetworkExtensionSettings normalizes to the 30s default.
   [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny dnsTimeout:0];
   SNTNetworkExtensionSettings* settings = [self.sut generateSettingsForProtocolVersion:@"1.0"];
-  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.0, 0.0001);
+  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
 }
 
 - (void)testGenerateSettingsIgnoresSyncBelowProtocolV1 {
   [self stubConfiguratorEnable:YES action:SNTNetworkFlowDefaultActionDeny dnsTimeout:7.5];
   SNTNetworkExtensionSettings* settings = [self.sut generateSettingsForProtocolVersion:@"0.9"];
-  XCTAssertFalse(settings.enable);
-  // Sync timeout is ignored below protocol v1 -> 7s default.
-  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.0, 0.0001);
+  XCTAssertFalse(settings.enable);  // sync (enable/action) ignored below protocol v1
+  // The MDM timeout is local config, not a sync setting, so it applies regardless of version.
+  XCTAssertEqualWithAccuracy(settings.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
 }
 
 @end

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -490,16 +490,9 @@ void HandleV2Responses(const ::pbv2::PreflightResponse& resp, SNTSyncState* sync
     auto& ne = resp.network_extension();
     SNTNetworkFlowDefaultAction flowDefaultAction =
         NetworkFlowDefaultActionFromProto(ne.flow_default_action());
-    if (ne.has_dns_upstream_timeout_seconds()) {
-      syncState.networkExtensionSettings = [[SNTSyncNetworkExtensionSettings alloc]
-                  initWithEnable:ne.enable()
-               flowDefaultAction:flowDefaultAction
-          dnsUpstreamTimeoutSecs:ne.dns_upstream_timeout_seconds()];
-    } else {
-      syncState.networkExtensionSettings =
-          [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:ne.enable()
-                                                flowDefaultAction:flowDefaultAction];
-    }
+    syncState.networkExtensionSettings =
+        [[SNTSyncNetworkExtensionSettings alloc] initWithEnable:ne.enable()
+                                              flowDefaultAction:flowDefaultAction];
   }
 
   if (resp.has_file_access_event_detail_url()) {

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -431,31 +431,9 @@
   XCTAssertNil(self.syncState.overrideFileAccessAction);
 }
 
-- (void)testPreflightNetworkExtensionDNSUpstreamTimeout {
-  // network_extension is only parsed on the v2 sync path (HandleV2Responses).
-  if (!self.syncState.isSyncV2) return;
-
-  [self setupDefaultDaemonConnResponses];
-  SNTSyncPreflight* sut = [[SNTSyncPreflight alloc] initWithState:self.syncState];
-
-  NSData* respData =
-      [@"{\"client_mode\": \"MONITOR\", \"batch_size\": 100, \"network_extension\": "
-       @"{\"enable\": true, \"flow_default_action\": \"NETWORK_FLOW_DEFAULT_ACTION_DENY\", "
-       @"\"dns_upstream_timeout_seconds\": 7.5}}" dataUsingEncoding:NSUTF8StringEncoding];
-
-  [self stubRequestBody:respData response:nil error:nil validateBlock:nil];
-
-  XCTAssertTrue([sut sync]);
-  XCTAssertNotNil(self.syncState.networkExtensionSettings);
-  XCTAssertTrue(self.syncState.networkExtensionSettings.enable);
-  XCTAssertEqualWithAccuracy(self.syncState.networkExtensionSettings.dnsUpstreamTimeoutSecs, 7.5,
-                             0.0001);
-}
-
-- (void)testPreflightNetworkExtensionDNSUpstreamTimeoutAbsent {
-  // network_extension present but dns_upstream_timeout_seconds omitted: the carrier records the
-  // unset sentinel (0). SNTNetworkExtensionSettings applies the [1,15]s clamp / 5s default
-  // downstream, so the carrier stays 0 here.
+- (void)testPreflightNetworkExtension {
+  // network_extension is only parsed on the v2 sync path (HandleV2Responses). The DNS upstream
+  // timeout is no longer a sync field; only enable + flow_default_action are carried.
   if (!self.syncState.isSyncV2) return;
 
   [self setupDefaultDaemonConnResponses];
@@ -471,7 +449,6 @@
   XCTAssertTrue([sut sync]);
   XCTAssertNotNil(self.syncState.networkExtensionSettings);
   XCTAssertTrue(self.syncState.networkExtensionSettings.enable);
-  XCTAssertEqual(self.syncState.networkExtensionSettings.dnsUpstreamTimeoutSecs, 0);
 }
 
 - (void)testReschedulePreflightFail {

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -449,6 +449,8 @@
   XCTAssertTrue([sut sync]);
   XCTAssertNotNil(self.syncState.networkExtensionSettings);
   XCTAssertTrue(self.syncState.networkExtensionSettings.enable);
+  XCTAssertEqual(self.syncState.networkExtensionSettings.flowDefaultAction,
+                 SNTNetworkFlowDefaultActionDeny);
 }
 
 - (void)testReschedulePreflightFail {


### PR DESCRIPTION
The DNS-proxy upstream timeout is no longer a sync setting; it is now a local, config override, and is reframed as a resource-cleanup backstop rather than a fast-fail trigger.

- SNTConfigurator: add the DNSUpstreamTimeoutSeconds forced-config key / dnsUpstreamTimeoutSecs getter (0/unset == use the built-in default).
- SNTNetworkExtensionSettings: default 30s, clamp [1,60] (was 7s, [1,15]).
- SNTNetworkExtensionQueue: source the timeout from SNTConfigurator, independent of the sync protocol version.
- SNTSyncPreflight + SNTSyncNetworkExtensionSettings: stop reading/carrying the timeout on the sync path (carries only enable + flow_default_action).
- deps: bump northpolesec_protos to drop NetworkExtension.dns_upstream_timeout_seconds.