### PR TITLE
common: ensure AUDIT execution events reach the sync server

### DIFF
--- a/Source/common/SNTStoredEventTest.mm
+++ b/Source/common/SNTStoredEventTest.mm
@@ -40,6 +40,24 @@
   faaEvent.accessedPath = @"/not/included";
   faaEvent.process.fileSHA256 = @"bar";
   XCTAssertEqualObjects([faaEvent uniqueID], @"MyRule|MyVersion|bar");
+
+  // Audit events dedup separately from ordinary executions of the same binary,
+  // so an audit-only match isn't merged with a normal allow/block event for the
+  // same hash.
+  SNTStoredExecutionEvent* auditEvent = [[SNTStoredExecutionEvent alloc] init];
+  auditEvent.fileSHA256 = @"foo";
+  auditEvent.decision = SNTEventStateAllowBinary;
+  auditEvent.auditReturn = YES;
+  XCTAssertEqualObjects([auditEvent uniqueID], @"foo:audit");
+  XCTAssertNotEqualObjects([auditEvent uniqueID], @"foo");
+
+  // Repeated audits of the same binary share a key -> at most one pending event
+  // per binary per sync cycle.
+  SNTStoredExecutionEvent* auditEvent2 = [[SNTStoredExecutionEvent alloc] init];
+  auditEvent2.fileSHA256 = @"foo";
+  auditEvent2.decision = SNTEventStateAllowBinary;
+  auditEvent2.auditReturn = YES;
+  XCTAssertEqualObjects([auditEvent2 uniqueID], [auditEvent uniqueID]);
 }
 
 - (void)testUnactionableEvent {
@@ -52,6 +70,12 @@
   execEvent.decision = SNTEventStateAllowBinary;
   XCTAssertTrue([execEvent unactionableEvent]);
   execEvent.decision = SNTEventStateBlockBinary;
+  XCTAssertFalse([execEvent unactionableEvent]);
+
+  // Audit events are allow decisions but are intentionally-collected telemetry,
+  // so they are treated as actionable to bypass the storage backoff.
+  execEvent.decision = SNTEventStateAllowBinary;
+  execEvent.auditReturn = YES;
   XCTAssertFalse([execEvent unactionableEvent]);
 
   // Spot check audit only/denied events

--- a/Source/common/SNTStoredExecutionEvent.mm
+++ b/Source/common/SNTStoredExecutionEvent.mm
@@ -180,11 +180,23 @@
 }
 
 - (NSString*)uniqueID {
-  return self.fileSHA256;
+  // Audit events dedup separately from ordinary executions of the same binary,
+  // so an audit-only match is neither merged into nor suppressed by a normal
+  // allow/block event for the same hash. Both still key on the file hash, so a
+  // binary audited repeatedly yields at most one pending event per sync cycle
+  // (the events table is drained on upload) rather than one per execution --
+  // which bounds table growth without needing a separate cap. The key is a pure
+  // function of already-stored fields, so it is stable and thread-safe.
+  return self.auditReturn ? [self.fileSHA256 stringByAppendingString:@":audit"] : self.fileSHA256;
 }
 
 - (BOOL)unactionableEvent {
-  return (self.decision & SNTEventStateAllow) != 0;
+  // Allow decisions are normally throttled as unactionable noise. Audit events
+  // are allow decisions too, but they are intentionally-collected telemetry, so
+  // they must not be suppressed by the storage backoff. Returning NO keeps them
+  // out of the backoff path entirely (see SNTEventTable -addStoredEvents:);
+  // they are instead deduped per sync cycle via -uniqueID's audit-specific key.
+  return !self.auditReturn && (self.decision & SNTEventStateAllow) != 0;
 }
 
 @end


### PR DESCRIPTION
Audit events are allow decisions, so they were throttled like noise: the 4-hour storage backoff plus dedup on uniqueID == fileSHA256 meant an audit rule surfaced at most one event per binary per 4 hours.

- unactionableEvent returns NO for audit events, so they skip the backoff.
- uniqueID returns "<fileSHA256>:audit" so they dedup separately from normal events -- bounding growth to one per binary per sync cycle.

A finer, context-aware key is left as follow-up.