### PR TITLE
santad: Remove stats-state.plist from tamper protection

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -72,7 +72,6 @@ constexpr std::pair<std::string_view, WatchItemPathType> kProtectedFiles[] = {
     {"/private/var/db/santa/events.db", WatchItemPathType::kLiteral},
     {"/private/var/db/santa/sync-state.plist", WatchItemPathType::kLiteral},
     {"/private/var/db/santa/state.plist", WatchItemPathType::kLiteral},
-    {"/private/var/db/santa/stats-state.plist", WatchItemPathType::kLiteral},
     {"/Applications/Santa.app", WatchItemPathType::kPrefix},
     {"/Library/LaunchAgents/com.northpolesec.santa.", WatchItemPathType::kPrefix},
     {"/Library/LaunchDaemons/com.northpolesec.santa.", WatchItemPathType::kPrefix},


### PR DESCRIPTION
This file has long been deprecated and is no longer used