### PR TITLE
common: add ProcessID for pid+pidversion process identity

### DIFF
--- a/Source/common/AuditUtilities.h
+++ b/Source/common/AuditUtilities.h
@@ -17,8 +17,11 @@
 
 #include <bsm/libbsm.h>
 
+#include <cstdint>
 #include <optional>
 #include <utility>
+
+@class NSData;
 
 namespace santa {
 
@@ -49,6 +52,34 @@ static inline gid_t EffectiveGroup(const audit_token_t& tok) {
 static inline std::pair<pid_t, int> PidPidversion(const audit_token_t& tok) {
   return {Pid(tok), Pidversion(tok)};
 }
+
+// Runtime identity of a process: pid + pidversion, so a recycled pid can't
+// alias a dead one. Value type; usable directly as a hash-map key.
+struct ProcessID {
+  pid_t pid = 0;
+  int pidversion = 0;
+
+  static ProcessID FromToken(const audit_token_t& tok) { return {Pid(tok), Pidversion(tok)}; }
+  // Defined in AuditUtilities.mm. nullopt if the data is too short to hold an
+  // audit_token_t. Used for NetworkExtension flows whose sourceAppAuditToken
+  // is delivered as NSData.
+  static std::optional<ProcessID> FromTokenData(NSData* tokenData);
+
+  // Stable 64-bit packing for callers that need a scalar handle (e.g. the
+  // NSNumber on the flow-event wire). Not needed to use this as a key.
+  constexpr uint64_t Packed() const {
+    return (static_cast<uint64_t>(static_cast<uint32_t>(pid)) << 32) |
+           static_cast<uint32_t>(pidversion);
+  }
+
+  friend bool operator==(const ProcessID& a, const ProcessID& b) {
+    return a.pid == b.pid && a.pidversion == b.pidversion;
+  }
+  template <typename H>
+  friend H AbslHashValue(H h, const ProcessID& p) {
+    return H::combine(std::move(h), p.pid, p.pidversion);
+  }
+};
 
 static inline audit_token_t MakeStubAuditToken(pid_t pid, int pidver) {
   return audit_token_t{

--- a/Source/common/AuditUtilities.mm
+++ b/Source/common/AuditUtilities.mm
@@ -14,10 +14,20 @@
 
 #include "Source/common/AuditUtilities.h"
 
+#import <Foundation/Foundation.h>
 #include <assert.h>
 #include <mach/mach.h>
 
+#include <cstring>
+
 namespace santa {
+
+std::optional<ProcessID> ProcessID::FromTokenData(NSData* tokenData) {
+  if (tokenData.length < sizeof(audit_token_t)) return std::nullopt;
+  audit_token_t tok;
+  memcpy(&tok, tokenData.bytes, sizeof(tok));
+  return FromToken(tok);
+}
 
 std::optional<audit_token_t> GetMyAuditToken() {
   audit_token_t tok;

--- a/Source/common/AuditUtilitiesTest.mm
+++ b/Source/common/AuditUtilitiesTest.mm
@@ -1,0 +1,97 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/common/AuditUtilities.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include <optional>
+#include <type_traits>
+
+#include "absl/container/flat_hash_map.h"
+
+using santa::ProcessID;
+
+// ProcessID must stay an aggregate with trivial copy/move so it works as a
+// braced initializer and a flat_hash_map key.
+static_assert(std::is_trivially_copyable_v<ProcessID>);
+static_assert(std::is_aggregate_v<ProcessID>);
+
+@interface AuditUtilitiesTest : XCTestCase
+@end
+
+@implementation AuditUtilitiesTest
+
+- (void)setUp {
+  self.continueAfterFailure = NO;
+}
+
+- (void)testFromToken {
+  audit_token_t tok = santa::MakeStubAuditToken(42, 7);
+  ProcessID proc = ProcessID::FromToken(tok);
+  XCTAssertEqual(proc.pid, 42);
+  XCTAssertEqual(proc.pidversion, 7);
+}
+
+- (void)testFromTokenDataValid {
+  audit_token_t tok = santa::MakeStubAuditToken(1234, 9);
+  NSData* data = [NSData dataWithBytes:&tok length:sizeof(tok)];
+  std::optional<ProcessID> proc = ProcessID::FromTokenData(data);
+  XCTAssertTrue(proc.has_value());
+  XCTAssertEqual(proc->pid, 1234);
+  XCTAssertEqual(proc->pidversion, 9);
+}
+
+- (void)testFromTokenDataTooShortIsNullopt {
+  uint8_t shortBytes[sizeof(audit_token_t) - 1] = {0};
+  NSData* data = [NSData dataWithBytes:shortBytes length:sizeof(shortBytes)];
+  XCTAssertFalse(ProcessID::FromTokenData(data).has_value());
+}
+
+- (void)testFromTokenDataNilIsNullopt {
+  XCTAssertFalse(ProcessID::FromTokenData(nil).has_value());
+}
+
+- (void)testPackedScheme {
+  ProcessID proc{42, 7};
+  XCTAssertEqual(proc.Packed(), ((uint64_t)42 << 32) | 7);
+}
+
+- (void)testPackedRoundTripsThroughToken {
+  audit_token_t tok = santa::MakeStubAuditToken(100, 3);
+  ProcessID proc = ProcessID::FromToken(tok);
+  XCTAssertEqual(proc.Packed(), ((uint64_t)100 << 32) | 3);
+}
+
+- (void)testEquality {
+  XCTAssertTrue((ProcessID{5, 1} == ProcessID{5, 1}));
+  XCTAssertFalse((ProcessID{5, 1} == ProcessID{5, 2}));
+  XCTAssertFalse((ProcessID{6, 1} == ProcessID{5, 1}));
+}
+
+- (void)testUsableAsFlatHashMapKey {
+  absl::flat_hash_map<ProcessID, NSString*> m;
+  m[ProcessID{42, 7}] = @"a";
+  m[ProcessID{42, 8}] = @"b";  // same pid, different pidversion: distinct key
+
+  XCTAssertEqualObjects(m[(ProcessID{42, 7})], @"a");
+  XCTAssertEqualObjects(m[(ProcessID{42, 8})], @"b");
+  XCTAssertEqual(m.size(), 2u);
+
+  audit_token_t tok = santa::MakeStubAuditToken(42, 7);
+  XCTAssertEqualObjects(m[ProcessID::FromToken(tok)], @"a");
+}
+
+@end

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -154,6 +154,15 @@ objc_library(
     sdk_dylibs = ["bsm"],
 )
 
+santa_unit_test(
+    name = "AuditUtilitiesTest",
+    srcs = ["AuditUtilitiesTest.mm"],
+    deps = [
+        ":AuditUtilities",
+        "@abseil-cpp//absl/container:flat_hash_map",
+    ],
+)
+
 # This target shouldn't be used directly.
 # Use a more specific scoped type instead.
 objc_library(
@@ -1149,6 +1158,7 @@ santa_unit_test(
 test_suite(
     name = "unit_tests",
     tests = [
+        ":AuditUtilitiesTest",
         ":CodeSigningIdentifierUtilsTest",
         ":EncodeEntitlementsTest",
         ":KeychainTest",


### PR DESCRIPTION
ProcessID is a small aggregate {pid, pidversion} that callers can use directly as a hash-map key (operator== + AbslHashValue) or pack into a stable uint64 via Packed() when a scalar handle is needed. FromToken builds it from an audit_token_t; FromTokenData parses one from NSData (e.g. a NetworkExtension flow's sourceAppAuditToken), returning nullopt when the data is too short to hold an audit_token_t.

Additive: existing PidPidversion callers are unchanged.