### PR TITLE
common: put PassKey in santa namespace

### DIFF
--- a/Source/common/PassKey.h
+++ b/Source/common/PassKey.h
@@ -35,6 +35,9 @@
 //
 //   explicit Foo(PassKey) {}
 // };
+
+namespace santa {
+
 template <typename T>
 class PassKey {
   friend T;
@@ -43,5 +46,7 @@ class PassKey {
  protected:
   static PassKey<T> MakeKey() { return PassKey<T>{}; }
 };
+
+}  // namespace santa
 
 #endif  // SANTA_COMMON_PASSKEY_H


### PR DESCRIPTION
The `PassKey` CRTP mixin in `Source/common/PassKey.h` was declared in the global namespace; move it into `namespace santa` to match the rest of common. All existing usages already live inside `namespace santa`, so no call sites needed changes.