### PR TITLE
Don't clear the compiler PID mark on a pidversion mismatch

### DIFF
--- a/Source/santad/SNTCompilerController.mm
+++ b/Source/santad/SNTCompilerController.mm
@@ -67,12 +67,14 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
   if (pid < 0 || pid >= PID_MAX) return NO;
   int32_t stored = self->_compilerPIDs[pid].load(std::memory_order_relaxed);
   if (stored == 0) return NO;
-  int32_t pidversion = audit_token_to_pidversion(tok);
-  if (stored == pidversion) return YES;
-  // Stale entry: the original compiler exited and the PID was recycled.
-  // Clear it eagerly so subsequent checks short-circuit on 0.
-  self->_compilerPIDs[pid].store(0, std::memory_order_relaxed);
-  return NO;
+  // Only the exact compiler instance (matching pidversion) is a compiler. A
+  // mismatch means the event came from a different incarnation at the same PID:
+  // most commonly the process's own pre-exec image, which emits NOTIFY events at an
+  // earlier pidversion, or a recycled PID. Return NO, but do not clear the slot. A
+  // mismatched event can be delivered after the real compiler was marked, and
+  // clearing here would drop the still-valid mark and prevent the compiler's
+  // output from getting a transitive rule.
+  return stored == audit_token_to_pidversion(tok);
 }
 
 - (void)setProcess:(const audit_token_t&)tok isCompiler:(bool)isCompiler {

--- a/Source/santad/SNTCompilerControllerTest.mm
+++ b/Source/santad/SNTCompilerControllerTest.mm
@@ -97,12 +97,14 @@ static const pid_t PID_MAX = 99999;
   [cc setProcess:compilerTok isCompiler:true];
   XCTAssertTrue([cc isCompiler:compilerTok]);
 
-  // Same PID, different pidversion (simulates PID reuse after missed EXIT)
+  // Same PID, different pidversion (e.g. PID reuse after a missed EXIT, or the
+  // process's pre-exec incarnation) is not the marked compiler.
   audit_token_t reusedTok = MakeAuditToken(12, 99);
   XCTAssertFalse([cc isCompiler:reusedTok]);
 
-  // Stale entry should have been eagerly cleared — even the original token returns NO now
-  XCTAssertFalse([cc isCompiler:compilerTok]);
+  // The mismatched check must not have cleared the mark: the original instance is
+  // still recognized.
+  XCTAssertTrue([cc isCompiler:compilerTok]);
 
   // Negative pidversion should work normally
   audit_token_t negPidverTok = MakeAuditToken(50, -1);
@@ -113,8 +115,36 @@ static const pid_t PID_MAX = 99999;
   audit_token_t differentNegPidverTok = MakeAuditToken(50, -2);
   XCTAssertFalse([cc isCompiler:differentNegPidverTok]);
 
-  // Stale entry should have been eagerly cleared
-  XCTAssertFalse([cc isCompiler:negPidverTok]);
+  // Again, the mark survives the mismatched check.
+  XCTAssertTrue([cc isCompiler:negPidverTok]);
+}
+
+// Regression test for the transitive-allowlisting failure where a compiler's mark
+// was destroyed before its own output close could be processed.
+//
+// A compiler is marked using the pidversion value the process has *after* its
+// execve. The same PID also emits NOTIFY events from its pre-exec incarnation (the
+// forked-but-not-yet-exec'd parent image), which carry an earlier pidversion. Those
+// events are delivered on a separate, lower-priority notify client and can be
+// processed *after* the mark is set. An isCompiler: check for the earlier
+// pidversion must return NO without disturbing the mark; otherwise the compiler's
+// real output close finds no mark and no transitive rule is created.
+- (void)testIsCompilerMismatchDoesNotClearMark {
+  SNTCompilerController* cc = [[SNTCompilerController alloc] init];
+
+  // Compiler marked at its post-exec pidversion.
+  audit_token_t markTok = MakeAuditToken(12, 100);
+  [cc setProcess:markTok isCompiler:true];
+  XCTAssertTrue([cc isCompiler:markTok]);
+
+  // A close from the same PID's pre-exec incarnation (earlier pidversion) is not the
+  // marked compiler, so it returns NO.
+  audit_token_t preExecTok = MakeAuditToken(12, 99);
+  XCTAssertFalse([cc isCompiler:preExecTok]);
+
+  // Crucially, that mismatched check must not have cleared the mark: the compiler's
+  // own subsequent events must still be recognized so its output gets a rule.
+  XCTAssertTrue([cc isCompiler:markTok]);
 }
 
 - (void)testIsCompilerPidversionZeroEdgeCase {


### PR DESCRIPTION
`isCompiler:` cleared the watched-PID slot whenever it saw a notify event for that PID at a different pidversion. In practice that fires on nearly every compile: a process emits close/rename events from its pre-exec image (an earlier pidversion) which the notify client processes after the exec-time mark is set on the auth client. The mismatched check zeroed the mark before the compiler closed its own output, so no transitive rule was created and freshly built binaries were blocked.

The pidversion equality check alone already prevents a recycled PID from being treated as a compiler, so return the comparison without mutating. Regression from #915.

Fixes #1011 