### PR TITLE
cel: Update caching of fallback rules, prevent UNSPECIFIED in non-fallback

### DIFF
--- a/Source/common/cel/Activation.h
+++ b/Source/common/cel/Activation.h
@@ -74,12 +74,12 @@ class Activation : public ::google::api::expr::runtime::BaseActivation {
   std::vector<const ::google::api::expr::runtime::CelFunction*> FindFunctionOverloads(
       absl::string_view name) const override;
 
-  // Reset per-evaluation state. Called by the Evaluator before each evaluation
-  // so a reused activation reflects only the current expression.
-  void ResetEvalState() const { usedRelativeTime_ = false; }
-
+  // includeUnspecified registers the UNSPECIFIED return value as a usable
+  // identifier. Only fallback expressions may return UNSPECIFIED (to fall
+  // through to the next rule), so regular rules pass false and any use of
+  // UNSPECIFIED then fails to compile.
   static std::vector<std::pair<absl::string_view, ::cel::Type>> GetVariables(
-      google::protobuf::Arena* arena);
+      google::protobuf::Arena* arena, bool includeUnspecified);
 
   template <bool V2>
   friend class Evaluator;

--- a/Source/common/cel/Activation.mm
+++ b/Source/common/cel/Activation.mm
@@ -207,17 +207,17 @@ std::vector<const cel_runtime::CelFunction*> Activation<IsV2>::FindFunctionOverl
 
 template <bool IsV2>
 std::vector<std::pair<absl::string_view, ::cel::Type>> Activation<IsV2>::GetVariables(
-    google::protobuf::Arena* arena) {
+    google::protobuf::Arena* arena, bool includeUnspecified) {
   std::vector<std::pair<absl::string_view, ::cel::Type>> v;
 
   // Add variables for all of the return values so that users can use names like
   // ALLOWLIST or BLOCKLIST in their CEL expressions without having to use the
   // proto package name prefix.
   auto retDescriptor = Traits::ReturnValue_descriptor();
-  // For V2, start from value 0 to include UNSPECIFIED — needed for fallback
-  // expressions where UNSPECIFIED means "no decision, try next expression".
-  // For V1, start from 1 to skip UNSPECIFIED.
-  int startIdx = IsV2 ? 0 : 1;
+  // UNSPECIFIED (value 0) means "no decision, try next expression" and is only
+  // valid for fallback expressions, so only register it when includeUnspecified
+  // is set. V1 has no UNSPECIFIED return value, so always skip it there.
+  int startIdx = (IsV2 && includeUnspecified) ? 0 : 1;
   for (int i = startIdx; i < retDescriptor->value_count(); i++) {
     auto value = retDescriptor->value(i);
     if constexpr (IsV2) {

--- a/Source/common/cel/Evaluator.h
+++ b/Source/common/cel/Evaluator.h
@@ -61,7 +61,11 @@ class Evaluator {
   using ActivationT = Activation<IsV2>;
   using EvaluationResultT = EvaluationResult<IsV2>;
 
-  static absl::StatusOr<std::unique_ptr<Evaluator>> Create();
+  // allowUnspecified permits the expression to return UNSPECIFIED (fall through
+  // to the next rule). Only fallback expressions should set this; regular rules
+  // leave it false so a UNSPECIFIED return fails to compile. No-op for V1.
+  static absl::StatusOr<std::unique_ptr<Evaluator>> Create(
+      bool allowUnspecified = false);
 
   Evaluator(std::unique_ptr<::cel::Compiler> compiler,
             std::unique_ptr<google::protobuf::Arena> arena)

--- a/Source/common/cel/Evaluator.mm
+++ b/Source/common/cel/Evaluator.mm
@@ -41,7 +41,7 @@ namespace cel {
 
 template <bool IsV2>
 static absl::StatusOr<std::unique_ptr<::cel::Compiler>> CreateCompiler(
-    google::protobuf::Arena* arena) {
+    google::protobuf::Arena* arena, bool allowUnspecified) {
   // Create a compiler builder with the generated descriptor pool for protos.
   absl::StatusOr<std::unique_ptr<::cel::CompilerBuilder>> builderStatus =
       ::cel::NewCompilerBuilder(google::protobuf::DescriptorPool::generated_pool());
@@ -83,7 +83,7 @@ static absl::StatusOr<std::unique_ptr<::cel::Compiler>> CreateCompiler(
 
   // Add all the possible variables to the type checker.
   ::cel::TypeCheckerBuilder& checker_builder = builder->GetCheckerBuilder();
-  for (const auto& variable : Activation<IsV2>::GetVariables(arena)) {
+  for (const auto& variable : Activation<IsV2>::GetVariables(arena, allowUnspecified)) {
     if (auto result =
             checker_builder.AddVariable(::cel::MakeVariableDecl(variable.first, variable.second));
         !result.ok()) {
@@ -96,10 +96,10 @@ static absl::StatusOr<std::unique_ptr<::cel::Compiler>> CreateCompiler(
 }
 
 template <bool IsV2>
-absl::StatusOr<std::unique_ptr<Evaluator<IsV2>>> Evaluator<IsV2>::Create() {
+absl::StatusOr<std::unique_ptr<Evaluator<IsV2>>> Evaluator<IsV2>::Create(bool allowUnspecified) {
   auto arena = std::make_unique<google::protobuf::Arena>();
 
-  auto compiler = CreateCompiler<IsV2>(arena.get());
+  auto compiler = CreateCompiler<IsV2>(arena.get(), allowUnspecified);
   if (!compiler.ok()) {
     return compiler.status();
   }
@@ -172,10 +172,6 @@ template <bool IsV2>
 absl::StatusOr<typename Evaluator<IsV2>::EvaluationResultT> Evaluator<IsV2>::Evaluate(
     const ::cel_runtime::CelExpression* expression_plan, const ActivationT& activation,
     google::protobuf::Arena* arena) {
-  // Clear any per-evaluation state (e.g. the relative-time flag set by today())
-  // so a reused activation reflects only this expression's result.
-  activation.ResetEvalState();
-
   absl::StatusOr<cel_runtime::CelValue> result = expression_plan->Evaluate(activation, arena);
 
   if (!result.ok()) {

--- a/Source/common/cel/Test.mm
+++ b/Source/common/cel/Test.mm
@@ -311,6 +311,19 @@
   XCTAssertTrue(sut.ok());
 
   {
+    // Expressions that don't use today() are cacheable. Checked first, on a
+    // fresh activation: the relative-time flag is sticky, so once a today()
+    // expression below marks the activation non-cacheable it stays that way.
+    auto result =
+        sut.value()->CompileAndEvaluate("target.secure_signing_time >= timestamp(0)", activation);
+    if (!result.ok()) {
+      XCTFail(@"Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
+      XCTAssertTrue(result.value().cacheable);
+    }
+  }
+  {
     // Signed within the last 5 days? No (signed 10 days ago) -> BLOCKLIST.
     // Using today() must make the result non-cacheable.
     auto result = sut.value()->CompileAndEvaluate("target.secure_signing_time > today() - days(5)",
@@ -335,14 +348,15 @@
     }
   }
   {
-    // Expressions that don't use today() remain cacheable.
+    // The relative-time flag is sticky: reusing this activation for a non-today()
+    // expression still yields a non-cacheable result.
     auto result =
         sut.value()->CompileAndEvaluate("target.secure_signing_time >= timestamp(0)", activation);
     if (!result.ok()) {
       XCTFail(@"Failed to evaluate: %s", result.status().message().data());
     } else {
       XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
-      XCTAssertTrue(result.value().cacheable);
+      XCTAssertFalse(result.value().cacheable);
     }
   }
 }

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -104,7 +104,9 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
            std::string(evaluatorV1.status().message()).c_str());
     }
 
-    auto evaluatorV2 = santa::cel::Evaluator<true>::Create();
+    // This evaluator also handles CEL fallback expressions, which may return
+    // UNSPECIFIED to fall through to the next rule.
+    auto evaluatorV2 = santa::cel::Evaluator<true>::Create(/*allowUnspecified=*/true);
     if (evaluatorV2.ok()) {
       celEvaluatorV2_ = std::move(*evaluatorV2);
     } else {
@@ -286,6 +288,12 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     // V1 doesn't support TouchID, so cooldown is always nullopt
   }
 
+  // Apply cacheability before the switch below so that an early return from a
+  // particular return value doesn't drop a non-cacheable result.
+  if (!cacheable) {
+    cd.cacheable = NO;
+  }
+
   SNTRuleState resultState;
   if (useV2) {
     using ReturnValue = santa::cel::CELProtoTraits<true>::ReturnValue;
@@ -355,10 +363,6 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
   }
 
   ApplySilentBlock(cd, resultState);
-
-  if (!cacheable) {
-    cd.cacheable = NO;
-  }
 
   return {.succeeded = true, .decisionMade = false, .resultState = resultState};
 }

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1240,6 +1240,68 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   XCTAssertEqual(cd.decision, SNTEventStateAllowCELFallback);
 }
 
+// A fallback chain's cacheability is the AND of every rule evaluated, not just
+// the one that produces the decision. If an earlier rule reads per-execution
+// context (args here) and then falls through with UNSPECIFIED, a later constant
+// ALLOWLIST must not be cached: the ES cache is keyed by vnode, so a different
+// exec with different args could be wrongly auto-allowed. This depends on
+// cd.cacheable being applied before the early UNSPECIFIED return and on the
+// shared activation's memoizer state persisting across the chain.
+- (void)testCELFallbackChainContextFallThroughIsNotCacheable {
+  [[SNTConfigurator configurator] setSyncServerCELFallbackRules:@[
+    [self ruleWithExpr:@"size(args) > 100 ? ALLOWLIST : UNSPECIFIED"],
+    [self ruleWithExpr:@"ALLOWLIST"],
+  ]];
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.sha256 = @"aabbccdd";
+  XCTAssertTrue(cd.cacheable);  // sanity: starts cacheable
+
+  BOOL handled =
+      [self.processor evaluateCELFallbackExpressions:cd
+                                  activationCallback:[self fallbackTestActivationCallback]];
+  XCTAssertTrue(handled);
+  XCTAssertEqual(cd.decision, SNTEventStateAllowCELFallback);
+  XCTAssertFalse(cd.cacheable);
+}
+
+// As above, but the earlier rule uses today() (relative time) before falling
+// through. today() makes the result non-cacheable, and that must stick through
+// to the constant ALLOWLIST that follows.
+- (void)testCELFallbackChainRelativeTimeFallThroughIsNotCacheable {
+  [[SNTConfigurator configurator] setSyncServerCELFallbackRules:@[
+    [self ruleWithExpr:@"today() == today() ? UNSPECIFIED : ALLOWLIST"],
+    [self ruleWithExpr:@"ALLOWLIST"],
+  ]];
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.sha256 = @"aabbccdd";
+
+  BOOL handled =
+      [self.processor evaluateCELFallbackExpressions:cd
+                                  activationCallback:[self fallbackTestActivationCallback]];
+  XCTAssertTrue(handled);
+  XCTAssertEqual(cd.decision, SNTEventStateAllowCELFallback);
+  XCTAssertFalse(cd.cacheable);
+}
+
+// Control: a constant-only chain (no per-exec context, no today()) stays
+// cacheable, proving the assertions above flip due to the context touch and not
+// merely because the chain fell through.
+- (void)testCELFallbackChainConstantFallThroughStaysCacheable {
+  [[SNTConfigurator configurator] setSyncServerCELFallbackRules:@[
+    [self ruleWithExpr:@"UNSPECIFIED"],
+    [self ruleWithExpr:@"ALLOWLIST"],
+  ]];
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.sha256 = @"aabbccdd";
+
+  BOOL handled =
+      [self.processor evaluateCELFallbackExpressions:cd
+                                  activationCallback:[self fallbackTestActivationCallback]];
+  XCTAssertTrue(handled);
+  XCTAssertEqual(cd.decision, SNTEventStateAllowCELFallback);
+  XCTAssertTrue(cd.cacheable);
+}
+
 - (void)testCELFallbackAllUnspecifiedFallsThrough {
   [[SNTConfigurator configurator] setSyncServerCELFallbackRules:@[
     [self ruleWithExpr:@"UNSPECIFIED"],


### PR DESCRIPTION
1. Don't reset activation state between fallback evaluations - if an earlier fallback rule has read an un-cacheable field it should be evaluated on the next run regardless of which rule matched
2. Move application of cacheability to prevent early returns from unsetting the cacheable field
3. Add tests of CEL fallback evaluation to verify caching
4. In RuleDownload, ignore CEL rules that use `UNSPECIFIED` as a return value - this is only allowed in fallback rules. This is enforced on the Workshop side but it should also be enforced in Santa as a backstop.