### PR TITLE
common: Add AuditTokenFromData and rewrite ProcessID::FromTokenData on top of it

### DIFF
--- a/Source/common/AuditUtilities.h
+++ b/Source/common/AuditUtilities.h
@@ -53,6 +53,9 @@ static inline std::pair<pid_t, int> PidPidversion(const audit_token_t& tok) {
   return {Pid(tok), Pidversion(tok)};
 }
 
+// nullopt if the data is too short to hold an audit_token_t
+std::optional<audit_token_t> AuditTokenFromData(NSData* tokenData);
+
 // Runtime identity of a process: pid + pidversion, so a recycled pid can't
 // alias a dead one. Value type; usable directly as a hash-map key.
 struct ProcessID {
@@ -60,9 +63,7 @@ struct ProcessID {
   int pidversion = 0;
 
   static ProcessID FromToken(const audit_token_t& tok) { return {Pid(tok), Pidversion(tok)}; }
-  // Defined in AuditUtilities.mm. nullopt if the data is too short to hold an
-  // audit_token_t. Used for NetworkExtension flows whose sourceAppAuditToken
-  // is delivered as NSData.
+  // nullopt if the data is too short to hold an audit_token_t.
   static std::optional<ProcessID> FromTokenData(NSData* tokenData);
 
   // Stable 64-bit packing for callers that need a scalar handle (e.g. the

--- a/Source/common/AuditUtilities.mm
+++ b/Source/common/AuditUtilities.mm
@@ -22,11 +22,17 @@
 
 namespace santa {
 
-std::optional<ProcessID> ProcessID::FromTokenData(NSData* tokenData) {
+std::optional<audit_token_t> AuditTokenFromData(NSData* tokenData) {
   if (tokenData.length < sizeof(audit_token_t)) return std::nullopt;
   audit_token_t tok;
   memcpy(&tok, tokenData.bytes, sizeof(tok));
-  return FromToken(tok);
+  return tok;
+}
+
+std::optional<ProcessID> ProcessID::FromTokenData(NSData* tokenData) {
+  std::optional<audit_token_t> tok = AuditTokenFromData(tokenData);
+  if (!tok) return std::nullopt;
+  return FromToken(*tok);
 }
 
 std::optional<audit_token_t> GetMyAuditToken() {

--- a/Source/common/AuditUtilitiesTest.mm
+++ b/Source/common/AuditUtilitiesTest.mm
@@ -22,6 +22,7 @@
 
 #include "absl/container/flat_hash_map.h"
 
+using santa::AuditTokenFromData;
 using santa::ProcessID;
 
 // ProcessID must stay an aggregate with trivial copy/move so it works as a
@@ -62,6 +63,25 @@ static_assert(std::is_aggregate_v<ProcessID>);
 
 - (void)testFromTokenDataNilIsNullopt {
   XCTAssertFalse(ProcessID::FromTokenData(nil).has_value());
+}
+
+- (void)testAuditTokenFromDataValid {
+  audit_token_t tok = santa::MakeStubAuditToken(1234, 9);
+  NSData* data = [NSData dataWithBytes:&tok length:sizeof(tok)];
+  std::optional<audit_token_t> got = AuditTokenFromData(data);
+  XCTAssertTrue(got.has_value());
+  XCTAssertEqual(santa::Pid(*got), 1234);
+  XCTAssertEqual(santa::Pidversion(*got), 9);
+}
+
+- (void)testAuditTokenFromDataTooShortIsNullopt {
+  uint8_t shortBytes[sizeof(audit_token_t) - 1] = {0};
+  NSData* data = [NSData dataWithBytes:shortBytes length:sizeof(shortBytes)];
+  XCTAssertFalse(AuditTokenFromData(data).has_value());
+}
+
+- (void)testAuditTokenFromDataNilIsNullopt {
+  XCTAssertFalse(AuditTokenFromData(nil).has_value());
 }
 
 - (void)testPackedScheme {


### PR DESCRIPTION
Factors the NSData length-check + memcpy into a reusable free function `AuditTokenFromData` for callers that need the raw `audit_token_t` rather than a `ProcessID`, and rewrites `ProcessID::FromTokenData` in terms of it.