### PR TITLE
Use `name` as the primary key for network flow rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "e67324c445656be373286ea5a8a8ac7b9debe496",
+    commit = "2e30a3ef15ec6fb793838ce3366d89aa7575c238",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/SNTNetworkFlowRule.h
+++ b/Source/common/SNTNetworkFlowRule.h
@@ -22,19 +22,26 @@ typedef NS_ENUM(NSInteger, SNTNetworkFlowRuleState) {
 
 /// Wire-format wrapper for a single NetworkFlowRule from the sync server.
 /// Carries the raw serialized NetworkFlowRule.Add proto bytes when state == Add.
-/// Carries only ruleId when state == Remove.
+/// Carries only ruleName when state == Remove.
+///
+/// ruleName is the primary key. ruleId is the rule's version; it is carried on
+/// Add rules (and stored, unique, alongside the name) but is not part of a
+/// Remove, which identifies the rule to delete by name alone.
 @interface SNTNetworkFlowRule : NSObject <NSSecureCoding>
 
+@property(readonly, copy) NSString* ruleName;
 @property(readonly) int64_t ruleId;
 @property(readonly) SNTNetworkFlowRuleState state;
 
 /// Serialized NetworkFlowRule.Add proto bytes. Nil for Remove rules.
 @property(readonly, copy) NSData* protoBlob;
 
-/// Construct an Add rule. Returns nil if protoBlob is nil.
-- (instancetype)initAddRuleWithId:(int64_t)ruleId protoBlob:(NSData*)protoBlob;
+/// Construct an Add rule. Returns nil if ruleName is empty or protoBlob is nil.
+- (instancetype)initAddRuleWithName:(NSString*)ruleName
+                             ruleId:(int64_t)ruleId
+                          protoBlob:(NSData*)protoBlob;
 
-/// Construct a Remove rule.
-- (instancetype)initRemoveRuleWithId:(int64_t)ruleId;
+/// Construct a Remove rule. Returns nil if ruleName is empty.
+- (instancetype)initRemoveRuleWithName:(NSString*)ruleName;
 
 @end

--- a/Source/common/SNTNetworkFlowRule.mm
+++ b/Source/common/SNTNetworkFlowRule.mm
@@ -58,7 +58,10 @@
   if (ruleName.length == 0) {
     return nil;
   }
-  return [self initWithState:SNTNetworkFlowRuleStateRemove ruleName:ruleName ruleId:0 protoBlob:nil];
+  return [self initWithState:SNTNetworkFlowRuleStateRemove
+                    ruleName:ruleName
+                      ruleId:0
+                   protoBlob:nil];
 }
 
 + (BOOL)supportsSecureCoding {

--- a/Source/common/SNTNetworkFlowRule.mm
+++ b/Source/common/SNTNetworkFlowRule.mm
@@ -17,6 +17,7 @@
 #import "Source/common/CoderMacros.h"
 
 @interface SNTNetworkFlowRule ()
+@property(readwrite, copy) NSString* ruleName;
 @property(readwrite) int64_t ruleId;
 @property(readwrite) SNTNetworkFlowRuleState state;
 @property(readwrite, copy) NSData* protoBlob;
@@ -25,6 +26,7 @@
 @implementation SNTNetworkFlowRule
 
 - (instancetype)initWithState:(SNTNetworkFlowRuleState)state
+                     ruleName:(NSString*)ruleName
                        ruleId:(int64_t)ruleId
                     protoBlob:(NSData*)protoBlob {
   if (state != SNTNetworkFlowRuleStateAdd && state != SNTNetworkFlowRuleStateRemove) {
@@ -33,21 +35,30 @@
   self = [super init];
   if (self) {
     _state = state;
+    _ruleName = [ruleName copy];
     _ruleId = ruleId;
     _protoBlob = [protoBlob copy];
   }
   return self;
 }
 
-- (instancetype)initAddRuleWithId:(int64_t)ruleId protoBlob:(NSData*)protoBlob {
-  if (!protoBlob) {
+- (instancetype)initAddRuleWithName:(NSString*)ruleName
+                             ruleId:(int64_t)ruleId
+                          protoBlob:(NSData*)protoBlob {
+  if (ruleName.length == 0 || !protoBlob) {
     return nil;
   }
-  return [self initWithState:SNTNetworkFlowRuleStateAdd ruleId:ruleId protoBlob:protoBlob];
+  return [self initWithState:SNTNetworkFlowRuleStateAdd
+                    ruleName:ruleName
+                      ruleId:ruleId
+                   protoBlob:protoBlob];
 }
 
-- (instancetype)initRemoveRuleWithId:(int64_t)ruleId {
-  return [self initWithState:SNTNetworkFlowRuleStateRemove ruleId:ruleId protoBlob:nil];
+- (instancetype)initRemoveRuleWithName:(NSString*)ruleName {
+  if (ruleName.length == 0) {
+    return nil;
+  }
+  return [self initWithState:SNTNetworkFlowRuleStateRemove ruleName:ruleName ruleId:0 protoBlob:nil];
 }
 
 + (BOOL)supportsSecureCoding {
@@ -55,6 +66,7 @@
 }
 
 - (void)encodeWithCoder:(NSCoder*)coder {
+  ENCODE(coder, ruleName);
   ENCODE_BOXABLE(coder, ruleId);
   ENCODE_BOXABLE(coder, state);
   ENCODE(coder, protoBlob);
@@ -63,6 +75,7 @@
 - (instancetype)initWithCoder:(NSCoder*)decoder {
   self = [super init];
   if (self) {
+    DECODE(decoder, ruleName, NSString);
     DECODE_SELECTOR(decoder, ruleId, NSNumber, longLongValue);
     DECODE_SELECTOR(decoder, state, NSNumber, integerValue);
     DECODE(decoder, protoBlob, NSData);

--- a/Source/common/SNTNetworkFlowRuleTest.mm
+++ b/Source/common/SNTNetworkFlowRuleTest.mm
@@ -32,8 +32,8 @@
 - (void)testAddRuleCarriesBlob {
   NSData* blob = [@"fake-proto-bytes" dataUsingEncoding:NSUTF8StringEncoding];
   SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-a"
-                                                                     ruleId:42
-                                                                  protoBlob:blob];
+                                                                      ruleId:42
+                                                                   protoBlob:blob];
   XCTAssertNotNil(rule);
   XCTAssertEqualObjects(rule.ruleName, @"rule-a");
   XCTAssertEqual(rule.ruleId, 42);
@@ -43,8 +43,8 @@
 
 - (void)testAddRuleRejectsNilBlob {
   SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-a"
-                                                                     ruleId:42
-                                                                  protoBlob:nil];
+                                                                      ruleId:42
+                                                                   protoBlob:nil];
   XCTAssertNil(rule);
 }
 
@@ -70,8 +70,8 @@
 - (void)testNSSecureCodingRoundTripAdd {
   NSData* blob = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
   SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-c"
-                                                                     ruleId:7
-                                                                  protoBlob:blob];
+                                                                      ruleId:7
+                                                                   protoBlob:blob];
   NSError* err = nil;
   NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
                                            requiringSecureCoding:YES
@@ -112,8 +112,8 @@
 - (void)testProtoBlobIsCopied {
   NSMutableData* blob = [[@"abc" dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
   SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-e"
-                                                                     ruleId:1
-                                                                  protoBlob:blob];
+                                                                      ruleId:1
+                                                                   protoBlob:blob];
   [blob appendBytes:"xyz" length:3];
   XCTAssertEqual(rule.protoBlob.length, 3u);
 }

--- a/Source/common/SNTNetworkFlowRuleTest.mm
+++ b/Source/common/SNTNetworkFlowRuleTest.mm
@@ -18,6 +18,7 @@
 #import <XCTest/XCTest.h>
 
 @interface SNTNetworkFlowRule (Testing)
+@property(readwrite, copy) NSString* ruleName;
 @property(readwrite) int64_t ruleId;
 @property(readwrite) SNTNetworkFlowRuleState state;
 @property(readwrite, copy) NSData* protoBlob;
@@ -30,29 +31,47 @@
 
 - (void)testAddRuleCarriesBlob {
   NSData* blob = [@"fake-proto-bytes" dataUsingEncoding:NSUTF8StringEncoding];
-  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:42 protoBlob:blob];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-a"
+                                                                     ruleId:42
+                                                                  protoBlob:blob];
   XCTAssertNotNil(rule);
+  XCTAssertEqualObjects(rule.ruleName, @"rule-a");
   XCTAssertEqual(rule.ruleId, 42);
   XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateAdd);
   XCTAssertEqualObjects(rule.protoBlob, blob);
 }
 
 - (void)testAddRuleRejectsNilBlob {
-  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:42 protoBlob:nil];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-a"
+                                                                     ruleId:42
+                                                                  protoBlob:nil];
   XCTAssertNil(rule);
 }
 
+- (void)testAddRuleRejectsEmptyName {
+  NSData* blob = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
+  XCTAssertNil([[SNTNetworkFlowRule alloc] initAddRuleWithName:@"" ruleId:42 protoBlob:blob]);
+  XCTAssertNil([[SNTNetworkFlowRule alloc] initAddRuleWithName:nil ruleId:42 protoBlob:blob]);
+}
+
 - (void)testRemoveRuleHasNilBlob {
-  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:99];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"rule-b"];
   XCTAssertNotNil(rule);
-  XCTAssertEqual(rule.ruleId, 99);
+  XCTAssertEqualObjects(rule.ruleName, @"rule-b");
   XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateRemove);
   XCTAssertNil(rule.protoBlob);
 }
 
+- (void)testRemoveRuleRejectsEmptyName {
+  XCTAssertNil([[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@""]);
+  XCTAssertNil([[SNTNetworkFlowRule alloc] initRemoveRuleWithName:nil]);
+}
+
 - (void)testNSSecureCodingRoundTripAdd {
   NSData* blob = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
-  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initAddRuleWithId:7 protoBlob:blob];
+  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-c"
+                                                                     ruleId:7
+                                                                  protoBlob:blob];
   NSError* err = nil;
   NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
                                            requiringSecureCoding:YES
@@ -65,13 +84,14 @@
                                         fromData:archived
                                            error:&err];
   XCTAssertNil(err);
+  XCTAssertEqualObjects(decoded.ruleName, @"rule-c");
   XCTAssertEqual(decoded.ruleId, 7);
   XCTAssertEqual(decoded.state, SNTNetworkFlowRuleStateAdd);
   XCTAssertEqualObjects(decoded.protoBlob, blob);
 }
 
 - (void)testNSSecureCodingRoundTripRemove {
-  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:INT64_MAX];
+  SNTNetworkFlowRule* orig = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"rule-d"];
   NSError* err = nil;
   NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:orig
                                            requiringSecureCoding:YES
@@ -84,14 +104,16 @@
                                         fromData:archived
                                            error:&err];
   XCTAssertNil(err);
-  XCTAssertEqual(decoded.ruleId, INT64_MAX);
+  XCTAssertEqualObjects(decoded.ruleName, @"rule-d");
   XCTAssertEqual(decoded.state, SNTNetworkFlowRuleStateRemove);
   XCTAssertNil(decoded.protoBlob);
 }
 
 - (void)testProtoBlobIsCopied {
   NSMutableData* blob = [[@"abc" dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
-  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob];
+  SNTNetworkFlowRule* rule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-e"
+                                                                     ruleId:1
+                                                                  protoBlob:blob];
   [blob appendBytes:"xyz" length:3];
   XCTAssertEqual(rule.protoBlob.length, 3u);
 }
@@ -99,7 +121,7 @@
 - (void)testDecodeRejectsUnspecifiedState {
   // Build a valid rule, stomp its state to Unspecified, archive, and verify
   // that decode refuses to reconstruct it.
-  SNTNetworkFlowRule* corrupt = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:1];
+  SNTNetworkFlowRule* corrupt = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"rule-f"];
   corrupt.state = SNTNetworkFlowRuleStateUnspecified;
   NSError* err = nil;
   NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:corrupt

--- a/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
@@ -370,7 +370,9 @@
               initWithEnable:YES
            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
       dnsUpstreamTimeoutSecs:7.5
-            networkFlowRules:@[ [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-1" ruleId:1 protoBlob:blob] ]];
+            networkFlowRules:@[ [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-1"
+                                                                         ruleId:1
+                                                                      protoBlob:blob] ]];
 
   SNTNetworkExtensionSettings* attached = [base settingsByAttachingNetworkFlowRules:@[
     [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-2" ruleId:2 protoBlob:blob],

--- a/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
+++ b/Source/common/ne/SNTNetworkExtensionSettingsTest.mm
@@ -303,8 +303,8 @@
            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
       dnsUpstreamTimeoutSecs:7.5
             networkFlowRules:@[
-              [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob],
-              [[SNTNetworkFlowRule alloc] initAddRuleWithId:2 protoBlob:blob],
+              [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-1" ruleId:1 protoBlob:blob],
+              [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-2" ruleId:2 protoBlob:blob],
             ]];
   NSData* data = [NSKeyedArchiver archivedDataWithRootObject:settings
                                        requiringSecureCoding:YES
@@ -320,6 +320,7 @@
   XCTAssertEqual(decoded.flowDefaultAction, SNTNetworkFlowDefaultActionDeny);
   XCTAssertEqualWithAccuracy(decoded.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
   XCTAssertEqual(decoded.networkFlowRules.count, 2u);
+  XCTAssertEqualObjects(decoded.networkFlowRules[0].ruleName, @"rule-1");
   XCTAssertEqual(decoded.networkFlowRules[0].ruleId, 1);
   XCTAssertEqualObjects(decoded.networkFlowRules[0].protoBlob, blob);
 }
@@ -352,7 +353,7 @@
            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
       dnsUpstreamTimeoutSecs:5.0
             networkFlowRules:@[
-              [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob],
+              [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-1" ruleId:1 protoBlob:blob],
             ]];
   SNTNetworkExtensionSettings* withoutRules =
       [[SNTNetworkExtensionSettings alloc] initWithEnable:YES
@@ -369,11 +370,11 @@
               initWithEnable:YES
            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
       dnsUpstreamTimeoutSecs:7.5
-            networkFlowRules:@[ [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob] ]];
+            networkFlowRules:@[ [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-1" ruleId:1 protoBlob:blob] ]];
 
   SNTNetworkExtensionSettings* attached = [base settingsByAttachingNetworkFlowRules:@[
-    [[SNTNetworkFlowRule alloc] initAddRuleWithId:2 protoBlob:blob],
-    [[SNTNetworkFlowRule alloc] initAddRuleWithId:3 protoBlob:blob],
+    [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-2" ruleId:2 protoBlob:blob],
+    [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-3" ruleId:3 protoBlob:blob],
   ]];
 
   // Scalars are carried forward from the receiver.
@@ -382,6 +383,7 @@
   XCTAssertEqualWithAccuracy(attached.dnsUpstreamTimeoutSecs, 7.5, 0.0001);
   // The rules are set from the argument, not merged with the receiver's.
   XCTAssertEqual(attached.networkFlowRules.count, 2u);
+  XCTAssertEqualObjects(attached.networkFlowRules[0].ruleName, @"rule-2");
   XCTAssertEqual(attached.networkFlowRules[0].ruleId, 2);
   // networkFlowRules is excluded from equality, so the copy compares equal to the receiver — the
   // property that lets it stand in as cached last-pushed state.
@@ -399,8 +401,8 @@
            flowDefaultAction:SNTNetworkFlowDefaultActionDeny
       dnsUpstreamTimeoutSecs:7.5
             networkFlowRules:@[
-              [[SNTNetworkFlowRule alloc] initAddRuleWithId:1 protoBlob:blob],
-              [[SNTNetworkFlowRule alloc] initAddRuleWithId:2 protoBlob:blob],
+              [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-1" ruleId:1 protoBlob:blob],
+              [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-2" ruleId:2 protoBlob:blob],
             ]];
   NSData* data = [NSKeyedArchiver archivedDataWithRootObject:newFormat
                                        requiringSecureCoding:YES

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -633,9 +633,10 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
       // UNIQUE, an Add whose rule_id collides with a different existing name
       // evicts that other row; a correct server never reuses a rule_id across
       // names, so this is acceptable defensive behavior.
-      if (![db executeUpdate:@"INSERT OR REPLACE INTO network_flow_rules (name, rule_id, rule_blob) "
-                             @"VALUES (?, ?, ?)",
-                             rule.ruleName, @(rule.ruleId), rule.protoBlob]) {
+      if (![db
+              executeUpdate:@"INSERT OR REPLACE INTO network_flow_rules (name, rule_id, rule_blob) "
+                            @"VALUES (?, ?, ?)",
+                            rule.ruleName, @(rule.ruleId), rule.protoBlob]) {
         [errors addObject:[SNTError createErrorWithCode:SNTErrorCodeInsertOrReplaceRuleFailed
                                                 message:@"A database error occurred while "
                                                         @"inserting/replacing a network flow rule"
@@ -972,8 +973,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
       // NSData materializes an owned deep copy — so the rule safely outlives this result set
       // and `[rs close]` (e.g. when later serialized over XPC to santanetd).
       [outRules addObject:[[SNTNetworkFlowRule alloc] initAddRuleWithName:ruleName
-                                                                  ruleId:ruleId
-                                                               protoBlob:blob]];
+                                                                   ruleId:ruleId
+                                                                protoBlob:blob]];
     }
   }
   [rs close];

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -339,8 +339,13 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   }
 
   if (version < 13) {
+    // `name` is the primary key (the sync server's identity for the rule).
+    // `rule_id` is the rule's version; it is kept UNIQUE because santanetd still
+    // uses it as the unique in-memory identity / precedence tiebreak, reading it
+    // out of the serialized Add blob.
     [db executeUpdate:@"CREATE TABLE 'network_flow_rules' ("
-                      @"'rule_id' INTEGER PRIMARY KEY, "
+                      @"'name' TEXT NOT NULL PRIMARY KEY, "
+                      @"'rule_id' INTEGER NOT NULL UNIQUE, "
                       @"'rule_blob' BLOB NOT NULL"
                       @")"];
     newVersion = 13;
@@ -606,6 +611,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     // 3. If an Add rule, must have a non-empty blob (init enforces this on the model side too)
     if (![rule isKindOfClass:[SNTNetworkFlowRule class]] ||
         (rule.state != SNTNetworkFlowRuleStateAdd && rule.state != SNTNetworkFlowRuleStateRemove) ||
+        rule.ruleName.length == 0 ||
         (rule.state == SNTNetworkFlowRuleStateAdd && rule.protoBlob.length == 0)) {
       [errors
           addObject:[SNTError createErrorWithCode:SNTErrorCodeRuleInvalid
@@ -615,7 +621,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     }
 
     if (rule.state == SNTNetworkFlowRuleStateRemove) {
-      if (![db executeUpdate:@"DELETE FROM network_flow_rules WHERE rule_id=?", @(rule.ruleId)]) {
+      if (![db executeUpdate:@"DELETE FROM network_flow_rules WHERE name=?", rule.ruleName]) {
         [errors addObject:[SNTError createErrorWithCode:SNTErrorCodeRemoveRuleFailed
                                                 message:@"A database error occurred while deleting "
                                                         @"a network flow rule"
@@ -623,9 +629,13 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
         return NO;
       }
     } else {
-      if (![db executeUpdate:@"INSERT OR REPLACE INTO network_flow_rules (rule_id, rule_blob) "
-                             @"VALUES (?, ?)",
-                             @(rule.ruleId), rule.protoBlob]) {
+      // Upsert keyed on `name` (the primary key). Because `rule_id` is also
+      // UNIQUE, an Add whose rule_id collides with a different existing name
+      // evicts that other row; a correct server never reuses a rule_id across
+      // names, so this is acceptable defensive behavior.
+      if (![db executeUpdate:@"INSERT OR REPLACE INTO network_flow_rules (name, rule_id, rule_blob) "
+                             @"VALUES (?, ?, ?)",
+                             rule.ruleName, @(rule.ruleId), rule.protoBlob]) {
         [errors addObject:[SNTError createErrorWithCode:SNTErrorCodeInsertOrReplaceRuleFailed
                                                 message:@"A database error occurred while "
                                                         @"inserting/replacing a network flow rule"
@@ -923,15 +933,15 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   return faaRules;
 }
 
-// Single source of truth for scanning network_flow_rules in rule_id order. On a cold cache
+// Single source of truth for scanning network_flow_rules in name order. On a cold cache
 // it computes and caches the digest; when `outRules` is non-nil it also materializes the Add
 // rules into it. The hash covers exactly the blobs of the rows added to `outRules`, so a
 // snapshot's `rules` and `networkFlowRulesHash` agree by construction, and the hash-only
 // callers (hashOfHashes) and the array caller (the snapshot) can never diverge.
 //
 // INVARIANT: a row is included iff its rule_blob is non-nil (the column is NOT NULL, so in
-// practice every row). SNTNetworkFlowRule.initAddRuleWithId: must keep rejecting ONLY nil
-// blobs.
+// practice every row). SNTNetworkFlowRule.initAddRuleWithName:ruleId:protoBlob: must keep rejecting
+// nil blobs (and empty names).
 //
 // Must be called inside an inDatabase:/inTransaction: block.
 - (NSString*)networkFlowRulesHashSerializedInDB:(FMDatabase*)db
@@ -942,25 +952,28 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     return self.cachedNetworkFlowRulesHash;
   }
 
-  // Column order: 0=rule_id, 1=rule_blob. rule_id is field 1
-  // of the NetworkFlowRule.Add proto and is therefore already part of rule_blob, so the hash
-  // need only fold in the blob bytes; ordering by rule_id ASC makes it deterministic.
+  // Column order: 0=name, 1=rule_id, 2=rule_blob. Both `name` (field 1) and `rule_id` (field 2)
+  // of the NetworkFlowRule.Add proto are already part of rule_blob, so the hash need only fold in
+  // the blob bytes; ordering by name ASC makes it deterministic.
   santa::Xxhash128 h;
-  FMResultSet* rs = [db executeQuery:@"SELECT rule_id, rule_blob FROM network_flow_rules "
-                                     @"ORDER BY rule_id ASC"];
+  FMResultSet* rs = [db executeQuery:@"SELECT name, rule_id, rule_blob FROM network_flow_rules "
+                                     @"ORDER BY name ASC"];
   while ([rs next]) {
-    NSData* blob = [rs dataNoCopyForColumnIndex:1];
+    NSData* blob = [rs dataNoCopyForColumnIndex:2];
     if (!blob) continue;
     if (!haveCachedHash) {
       h.Update(blob.bytes, blob.length);
     }
     if (outRules) {
-      int64_t ruleId = [rs longLongIntForColumnIndex:0];
+      NSString* ruleName = [rs stringForColumnIndex:0];
+      int64_t ruleId = [rs longLongIntForColumnIndex:1];
       // `blob` is a no-copy view into SQLite's buffer (invalid after the next step), but
       // SNTNetworkFlowRule's `protoBlob` is a `copy` property and -[NSData copy] of a no-copy
       // NSData materializes an owned deep copy — so the rule safely outlives this result set
       // and `[rs close]` (e.g. when later serialized over XPC to santanetd).
-      [outRules addObject:[[SNTNetworkFlowRule alloc] initAddRuleWithId:ruleId protoBlob:blob]];
+      [outRules addObject:[[SNTNetworkFlowRule alloc] initAddRuleWithName:ruleName
+                                                                  ruleId:ruleId
+                                                               protoBlob:blob]];
     }
   }
   [rs close];

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -798,7 +798,7 @@
   removeRule.state = SNTRuleStateRemove;
   SNTFileAccessRule* faaRemoveRule =
       [[SNTFileAccessRule alloc] initRemoveRuleWithName:@"AnotherRule"];
-  SNTNetworkFlowRule* nfRemoveRule = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:2];
+  SNTNetworkFlowRule* nfRemoveRule = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"rule-2"];
   [self.sut addExecutionRules:@[ removeRule ]
               fileAccessRules:@[ faaRemoveRule ]
              networkFlowRules:@[ nfRemoveRule ]
@@ -824,9 +824,12 @@
 }
 
 - (SNTNetworkFlowRule*)_exampleNetworkFlowAddRuleWithId:(int64_t)ruleId blob:(NSString*)blob {
-  return
-      [[SNTNetworkFlowRule alloc] initAddRuleWithId:ruleId
-                                          protoBlob:[blob dataUsingEncoding:NSUTF8StringEncoding]];
+  // `name` is the primary key; derive a unique one from the id so id and name stay 1:1 and the
+  // existing id-keyed test bodies keep their upsert/dedup semantics.
+  return [[SNTNetworkFlowRule alloc]
+      initAddRuleWithName:[NSString stringWithFormat:@"rule-%lld", ruleId]
+                   ruleId:ruleId
+                protoBlob:[blob dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
 - (BOOL)_addNetworkFlowRules:(NSArray<SNTNetworkFlowRule*>*)rules
@@ -870,7 +873,7 @@
 
 - (void)testRemoveNetworkFlowRule {
   SNTNetworkFlowRule* add = [self _exampleNetworkFlowAddRuleWithId:7 blob:@"x"];
-  SNTNetworkFlowRule* remove = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:7];
+  SNTNetworkFlowRule* remove = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"rule-7"];
   XCTAssertTrue([self _addNetworkFlowRules:@[ add ] ruleCleanup:SNTRuleCleanupNone errors:nil]);
   XCTAssertEqual(self.sut.networkFlowRuleCount, 1);
   XCTAssertTrue([self _addNetworkFlowRules:@[ remove ] ruleCleanup:SNTRuleCleanupNone errors:nil]);
@@ -878,13 +881,59 @@
 }
 
 - (void)testRemoveNetworkFlowRuleNonexistentIsNotAnError {
-  SNTNetworkFlowRule* remove = [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:999];
+  SNTNetworkFlowRule* remove = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"rule-999"];
   NSArray<NSError*>* errors;
   XCTAssertTrue([self _addNetworkFlowRules:@[ remove ]
                                ruleCleanup:SNTRuleCleanupNone
                                     errors:&errors]);
   XCTAssertNil(errors);
   XCTAssertEqual(self.sut.networkFlowRuleCount, 0);
+}
+
+- (void)testNetworkFlowRulesKeyedByNameNotRuleId {
+  // Two rules with distinct names and distinct rule_ids coexist; removing one by name leaves the
+  // other untouched.
+  SNTNetworkFlowRule* a = [[SNTNetworkFlowRule alloc]
+      initAddRuleWithName:@"alpha"
+                   ruleId:1
+                protoBlob:[@"a" dataUsingEncoding:NSUTF8StringEncoding]];
+  SNTNetworkFlowRule* b = [[SNTNetworkFlowRule alloc]
+      initAddRuleWithName:@"beta"
+                   ruleId:2
+                protoBlob:[@"b" dataUsingEncoding:NSUTF8StringEncoding]];
+  XCTAssertTrue(([self _addNetworkFlowRules:@[ a, b ] ruleCleanup:SNTRuleCleanupNone errors:nil]));
+  XCTAssertEqual(self.sut.networkFlowRuleCount, 2);
+
+  SNTNetworkFlowRule* removeAlpha = [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:@"alpha"];
+  XCTAssertTrue([self _addNetworkFlowRules:@[ removeAlpha ]
+                               ruleCleanup:SNTRuleCleanupNone
+                                    errors:nil]);
+  NSArray<SNTNetworkFlowRule*>* all = [self.sut retrieveAllNetworkFlowRulesSnapshot].rules;
+  XCTAssertEqual(all.count, 1u);
+  XCTAssertEqualObjects(all.firstObject.ruleName, @"beta");
+}
+
+- (void)testNetworkFlowRuleIdUniqueAcrossNames {
+  // rule_id carries a UNIQUE constraint (santanetd relies on rule_id uniqueness). Under
+  // INSERT OR REPLACE, an Add reusing an existing rule_id under a different name evicts the prior
+  // row rather than producing two rows that share a rule_id.
+  SNTNetworkFlowRule* a = [[SNTNetworkFlowRule alloc]
+      initAddRuleWithName:@"alpha"
+                   ruleId:5
+                protoBlob:[@"a" dataUsingEncoding:NSUTF8StringEncoding]];
+  XCTAssertTrue([self _addNetworkFlowRules:@[ a ] ruleCleanup:SNTRuleCleanupNone errors:nil]);
+  XCTAssertEqual(self.sut.networkFlowRuleCount, 1);
+
+  SNTNetworkFlowRule* b = [[SNTNetworkFlowRule alloc]
+      initAddRuleWithName:@"beta"
+                   ruleId:5
+                protoBlob:[@"b" dataUsingEncoding:NSUTF8StringEncoding]];
+  XCTAssertTrue([self _addNetworkFlowRules:@[ b ] ruleCleanup:SNTRuleCleanupNone errors:nil]);
+
+  NSArray<SNTNetworkFlowRule*>* all = [self.sut retrieveAllNetworkFlowRulesSnapshot].rules;
+  XCTAssertEqual(all.count, 1u);
+  XCTAssertEqualObjects(all.firstObject.ruleName, @"beta");
+  XCTAssertEqual(all.firstObject.ruleId, 5);
 }
 
 - (void)testCleanAllTruncatesNetworkFlowRules {
@@ -987,7 +1036,7 @@
 
 - (void)testNetworkFlowRulesHashIsOrderIndependent {
   // Inserting the same two rules in different orders yields the same hash, since
-  // the hash sorts by rule_id ASC.
+  // the hash sorts by name ASC.
   SNTNetworkFlowRule* a = [self _exampleNetworkFlowAddRuleWithId:1 blob:@"a"];
   SNTNetworkFlowRule* b = [self _exampleNetworkFlowAddRuleWithId:2 blob:@"b"];
 
@@ -1016,7 +1065,9 @@
 
   SNTNetworkFlowRulesSnapshot* snapshot = [self.sut retrieveAllNetworkFlowRulesSnapshot];
   XCTAssertEqual(snapshot.rules.count, 2u);
+  XCTAssertEqualObjects(snapshot.rules[0].ruleName, @"rule-1");
   XCTAssertEqual(snapshot.rules[0].ruleId, 1);
+  XCTAssertEqualObjects(snapshot.rules[1].ruleName, @"rule-2");
   XCTAssertEqual(snapshot.rules[1].ruleId, 2);
   // The snapshot's hash must match the hash hashOfHashes computes for the same state.
   XCTAssertEqualObjects(snapshot.networkFlowRulesHash,

--- a/Source/santad/SNTDaemonControlControllerTest.mm
+++ b/Source/santad/SNTDaemonControlControllerTest.mm
@@ -296,7 +296,9 @@ static NSString* const kBinarySHA256 =
 
 - (void)testRuleAddForwardsNetworkFlowRules {
   NSData* blob = [@"blob" dataUsingEncoding:NSUTF8StringEncoding];
-  SNTNetworkFlowRule* nfRule = [[SNTNetworkFlowRule alloc] initAddRuleWithId:101 protoBlob:blob];
+  SNTNetworkFlowRule* nfRule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-101"
+                                                                       ruleId:101
+                                                                    protoBlob:blob];
 
   __block NSArray<SNTNetworkFlowRule*>* forwarded = nil;
   OCMStub([self.mockRuleTable addExecutionRules:OCMOCK_ANY
@@ -323,6 +325,7 @@ static NSString* const kBinarySHA256 =
 
   XCTAssertTrue(replySuccess);
   XCTAssertEqual(forwarded.count, 1u);
+  XCTAssertEqualObjects(forwarded.firstObject.ruleName, @"rule-101");
   XCTAssertEqual(forwarded.firstObject.ruleId, 101);
 }
 

--- a/Source/santad/SNTDaemonControlControllerTest.mm
+++ b/Source/santad/SNTDaemonControlControllerTest.mm
@@ -297,8 +297,8 @@ static NSString* const kBinarySHA256 =
 - (void)testRuleAddForwardsNetworkFlowRules {
   NSData* blob = [@"blob" dataUsingEncoding:NSUTF8StringEncoding];
   SNTNetworkFlowRule* nfRule = [[SNTNetworkFlowRule alloc] initAddRuleWithName:@"rule-101"
-                                                                       ruleId:101
-                                                                    protoBlob:blob];
+                                                                        ruleId:101
+                                                                     protoBlob:blob];
 
   __block NSArray<SNTNetworkFlowRule*>* forwarded = nil;
   OCMStub([self.mockRuleTable addExecutionRules:OCMOCK_ANY

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -102,8 +102,9 @@
 
 - (SNTNetworkFlowRule*)rule:(int64_t)ruleId {
   return [[SNTNetworkFlowRule alloc]
-      initAddRuleWithId:ruleId
-              protoBlob:[@"blob" dataUsingEncoding:NSUTF8StringEncoding]];
+      initAddRuleWithName:[NSString stringWithFormat:@"rule-%lld", ruleId]
+                   ruleId:ruleId
+                protoBlob:[@"blob" dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
 - (void)testReconcileSeedsFullConfigWhenNothingPushedYet {

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -327,7 +327,8 @@ SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRule& nr) 
       // `name` is the primary key. santanetd's validator only checks the proto's
       // rule_id/matchers, so guard the empty-name case here.
       if (add.name().empty()) {
-        SLOGW(@"Dropping network flow rule with empty name (rule_id %lld)", (long long)add.rule_id());
+        SLOGW(@"Dropping network flow rule with empty name (rule_id %lld)",
+              (long long)add.rule_id());
         return nil;
       }
 

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -324,9 +324,17 @@ SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRule& nr) 
     case ::pbv2::NetworkFlowRule::kAdd: {
       const ::pbv2::NetworkFlowRule::Add& add = nr.add();
 
+      // `name` is the primary key. santanetd's validator only checks the proto's
+      // rule_id/matchers, so guard the empty-name case here.
+      if (add.name().empty()) {
+        SLOGW(@"Dropping network flow rule with empty name (rule_id %lld)", (long long)add.rule_id());
+        return nil;
+      }
+
       NSError* err;
       if (!santanetd::ValidateNetworkFlowRule(add, &err)) {
-        SLOGW(@"Dropping invalid network flow rule %lld: %@", (long long)add.rule_id(),
+        SLOGW(@"Dropping invalid network flow rule %@ (rule_id %lld): %@",
+              StringToNSString(add.name()), (long long)add.rule_id(),
               err.localizedDescription ?: @"validation failed");
         return nil;
       }
@@ -335,10 +343,18 @@ SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRule& nr) 
       std::string serialized;
       add.SerializeToString(&serialized);
       NSData* blob = [NSData dataWithBytes:serialized.data() length:serialized.size()];
-      return [[SNTNetworkFlowRule alloc] initAddRuleWithId:add.rule_id() protoBlob:blob];
+      return [[SNTNetworkFlowRule alloc] initAddRuleWithName:StringToNSString(add.name())
+                                                      ruleId:add.rule_id()
+                                                   protoBlob:blob];
     }
-    case ::pbv2::NetworkFlowRule::kRemove:
-      return [[SNTNetworkFlowRule alloc] initRemoveRuleWithId:nr.remove().rule_id()];
+    case ::pbv2::NetworkFlowRule::kRemove: {
+      const std::string& name = nr.remove().name();
+      if (name.empty()) {
+        SLOGW(@"Dropping network flow remove rule with empty name");
+        return nil;
+      }
+      return [[SNTNetworkFlowRule alloc] initRemoveRuleWithName:StringToNSString(name)];
+    }
     default: return nil;
   }
 }

--- a/Source/santasyncservice/SNTSyncRuleDownloadTest.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownloadTest.mm
@@ -335,12 +335,14 @@ extern SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRul
 - (void)testNetworkFlowRuleFromProtoAdd {
   ::pbv2::NetworkFlowRule nr;
   ::pbv2::NetworkFlowRule::Add* add = nr.mutable_add();
+  add->set_name("block-egress");
   add->set_rule_id(42);
   add->set_action(::pbv2::NetworkFlowRule::ACTION_DENY);
   add->set_direction(::pbv2::NETWORK_FLOW_DIRECTION_OUTGOING);
 
   SNTNetworkFlowRule* rule = NetworkFlowRuleFromProto(nr);
   XCTAssertNotNil(rule);
+  XCTAssertEqualObjects(rule.ruleName, @"block-egress");
   XCTAssertEqual(rule.ruleId, 42);
   XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateAdd);
   XCTAssertNotNil(rule.protoBlob);
@@ -348,19 +350,35 @@ extern SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRul
   // The blob round-trips back to the originating Add.
   ::pbv2::NetworkFlowRule::Add parsed;
   XCTAssertTrue(parsed.ParseFromArray(rule.protoBlob.bytes, (int)rule.protoBlob.length));
+  XCTAssertEqual(parsed.name(), "block-egress");
   XCTAssertEqual(parsed.rule_id(), 42);
   XCTAssertEqual(parsed.action(), ::pbv2::NetworkFlowRule::ACTION_DENY);
 }
 
+- (void)testNetworkFlowRuleFromProtoAddEmptyNameIsNil {
+  ::pbv2::NetworkFlowRule nr;
+  ::pbv2::NetworkFlowRule::Add* add = nr.mutable_add();
+  add->set_rule_id(42);
+  add->set_action(::pbv2::NetworkFlowRule::ACTION_DENY);
+  add->set_direction(::pbv2::NETWORK_FLOW_DIRECTION_OUTGOING);
+  XCTAssertNil(NetworkFlowRuleFromProto(nr));
+}
+
 - (void)testNetworkFlowRuleFromProtoRemove {
   ::pbv2::NetworkFlowRule nr;
-  nr.mutable_remove()->set_rule_id(99);
+  nr.mutable_remove()->set_name("block-egress");
 
   SNTNetworkFlowRule* rule = NetworkFlowRuleFromProto(nr);
   XCTAssertNotNil(rule);
-  XCTAssertEqual(rule.ruleId, 99);
+  XCTAssertEqualObjects(rule.ruleName, @"block-egress");
   XCTAssertEqual(rule.state, SNTNetworkFlowRuleStateRemove);
   XCTAssertNil(rule.protoBlob);
+}
+
+- (void)testNetworkFlowRuleFromProtoRemoveEmptyNameIsNil {
+  ::pbv2::NetworkFlowRule nr;
+  nr.mutable_remove();
+  XCTAssertNil(NetworkFlowRuleFromProto(nr));
 }
 
 - (void)testNetworkFlowRuleFromProtoEmptyIsNil {


### PR DESCRIPTION
## Use `name` as the primary key for network flow rules

  Network flow rules now key on the sync server's `name` (the rule's stable slot
  identity) instead of the integer `rule_id`. `rule_id` is retained as the version
  field — it still rides on every Add and is still what gets reported when a rule
  trips.

  This matches the upstreamed proto change ([protos #130](https://github.com/northpolesec/protos/pull/130)):
  `NetworkFlowRule.Add` now carries `name` (field 1) + `rule_id` (field 2), and
  `Remove` carries only `name`.

  ### Notes

  - Because `rule_id` carries a `UNIQUE` constraint, an Add reusing an existing
    `rule_id` under a different name evicts the prior row via `INSERT OR REPLACE`.
    A correct server never reuses a `rule_id` across names; documented in-code.
  - Name length/pattern validation (≤63 bytes, C-identifier) lives in santanetd's
    `ValidateNetworkFlowRule`.