### PR TITLE
santad: Evict oldest spool files when full & add spool metrics

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -270,7 +270,7 @@
 ///
 ///  If eventLogType is set to protobuf, spoolDirectorySizeThresholdMB sets the total size
 ///  limit for all files saved in the spoolDirectory.
-///  Defaults to 100.
+///  Defaults to 250.
 ///
 ///  @note: This property is KVO compliant, but should only be read once at santad startup.
 ///

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -1517,7 +1517,7 @@ static SNTConfigurator* sharedConfigurator = nil;
 - (NSUInteger)spoolDirectorySizeThresholdMB {
   return self.configState[kSpoolDirectorySizeThresholdMB]
              ? [self.configState[kSpoolDirectorySizeThresholdMB] unsignedIntegerValue]
-             : 100;
+             : 250;
 }
 
 - (float)spoolDirectoryEventMaxFlushTimeSec {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -839,6 +839,7 @@ objc_library(
     deps = [
         ":EndpointSecurityWriter",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTMetricSet",
         "//Source/common:santa_cc_proto",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
@@ -125,8 +125,16 @@ class FsSpoolWriter {
       // Over the limit: rather than dropping all new telemetry, erase the
       // oldest spool files to make room. This keeps the freshest data flowing
       // (and lets signal processing continue) at the cost of the oldest,
-      // not-yet-exported files.
+      // not-yet-exported files. Updates spool_size_estimate_ to the
+      // post-eviction total.
       EvictOldestSpoolFiles(files, *estimate);
+
+      // If eviction couldn't free enough space (e.g. unlinks failing on a
+      // read-only remount or immutable files), keep the spool bounded by
+      // refusing the write rather than letting it grow without limit.
+      if (spool_size_estimate_ > max_spool_size_) {
+        return absl::ResourceExhaustedError("No space left in spool directory");
+      }
     }
 
     return absl::OkStatus();
@@ -279,14 +287,14 @@ class FsSpoolWriter {
   }
 
   // Deletes the oldest spool files until the estimated on-disk size of the
-  // spool directory drops below the high-water mark (90% of max_spool_size_).
-  // Evicting to a high-water mark rather than to exactly the limit frees ~10%
+  // spool directory drops below the low-water mark (90% of max_spool_size_).
+  // Evicting to a low-water mark rather than to exactly the limit frees ~10%
   // of headroom so eviction doesn't immediately recur on the next few writes.
   // `files`/`total` come from the caller's directory walk, so no second walk is
   // needed. Updates spool_size_estimate_ to the post-eviction total.
   // Best-effort: a file that fails to unlink is left in place and skipped.
   void EvictOldestSpoolFiles(std::vector<DirEntryInfo>& files, size_t total) {
-    const size_t high_water_mark = max_spool_size_ - max_spool_size_ / 10;
+    const size_t low_water_mark = max_spool_size_ - max_spool_size_ / 10;
 
     // Oldest first.
     std::sort(files.begin(), files.end(),
@@ -296,7 +304,7 @@ class FsSpoolWriter {
 
     size_t evicted = 0;
     for (const DirEntryInfo& file : files) {
-      if (total <= high_water_mark) {
+      if (total <= low_water_mark) {
         break;
       }
       if (Unlink(file.path.c_str()) == 0) {

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
@@ -22,7 +22,10 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <algorithm>
+#include <functional>
 #include <string>
+#include <vector>
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/AnyBatcher.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/StreamBatcher.h"
@@ -66,13 +69,19 @@ class FsSpoolWriter {
   // The base, spool, and temporary directory will be created as needed on the
   // first call to Write() - however the base directory can be created into an
   // existing path (i.e. this class will not do an `mkdir -p`).
-  FsSpoolWriter(T batcher, absl::string_view base_dir, size_t max_spool_size)
+  // `eviction_callback`, when set, is invoked with the number of spool files
+  // erased whenever the spool exceeds its size limit and the oldest files are
+  // evicted to make room. Used to surface an eviction metric without coupling
+  // this generic spool library to a particular metrics implementation.
+  FsSpoolWriter(T batcher, absl::string_view base_dir, size_t max_spool_size,
+                std::function<void(size_t)> eviction_callback = nullptr)
       : batcher_(std::move(batcher)),
         base_dir_(base_dir),
         spool_dir_(SpoolNewDirectory(base_dir)),
         tmp_dir_(SpoolTempDirectory(base_dir)),
         space_check_failure_since_last_flush_(false),
         max_spool_size_(max_spool_size),
+        eviction_callback_(std::move(eviction_callback)),
         id_(absl::StrFormat(
             "%016x",
             absl::Uniform<uint64_t>(absl::BitGen(), 0,
@@ -98,23 +107,25 @@ class FsSpoolWriter {
   ~FsSpoolWriter() { (void)Flush(); };
 
   absl::Status SpaceAvailable() {
-    if (spool_size_estimate_ > max_spool_size_) {
-      absl::StatusOr<size_t> estimate = EstimateSpoolDirSize();
-      if (!estimate.ok()) {
-        return estimate.status();  // failed to recompute spool size
-      }
-
-      spool_size_estimate_ = *estimate;
-      if (spool_size_estimate_ > max_spool_size_) {
-        // Still over the limit: avoid writing.
-        return absl::ResourceExhaustedError(
-            "Spool size estimate greater than max allowed");
-      } else {
-        return absl::OkStatus();
-      }
-    } else {
+    if (spool_size_estimate_ <= max_spool_size_) {
       return absl::OkStatus();
     }
+
+    absl::StatusOr<size_t> estimate = EstimateSpoolDirSize();
+    if (!estimate.ok()) {
+      return estimate.status();  // failed to recompute spool size
+    }
+    spool_size_estimate_ = *estimate;
+
+    if (spool_size_estimate_ > max_spool_size_) {
+      // Over the limit: rather than dropping all new telemetry, erase the
+      // oldest spool files to make room. This keeps the freshest data flowing
+      // (and lets signal processing continue) at the cost of the oldest,
+      // not-yet-exported files.
+      EvictOldestSpoolFiles();
+    }
+
+    return absl::OkStatus();
   }
 
   absl::Status InitializeCurrentSpoolStateIfNeeded() {
@@ -276,6 +287,60 @@ class FsSpoolWriter {
     }
   }
 
+  // Deletes the oldest spool files until the estimated on-disk size of the
+  // spool directory is back under max_spool_size_ (or no files remain). Updates
+  // spool_size_estimate_ to the post-eviction total. Best-effort: a file that
+  // fails to unlink is left in place and skipped.
+  void EvictOldestSpoolFiles() {
+    struct SpoolFile {
+      time_t mtime;
+      std::string path;
+      size_t occupancy;
+    };
+
+    std::vector<SpoolFile> files;
+    size_t total = 0;
+    (void)IterateDirectory(spool_dir_, [this, &files, &total](
+                                           const std::string& file_name,
+                                           bool* stop) {
+      if (file_name == std::string(".") || file_name == std::string("..")) {
+        return;
+      }
+      std::string file_path =
+          absl::StrCat(spool_dir_, PathSeparator(), file_name);
+      struct stat stats;
+      if (stat(file_path.c_str(), &stats) < 0 || !StatIsReg(stats.st_mode)) {
+        return;
+      }
+      size_t occupancy = EstimateDiskOccupation(stats.st_size);
+      files.push_back({stats.st_mtime, std::move(file_path), occupancy});
+      total += occupancy;
+    });
+
+    // Oldest first.
+    std::sort(files.begin(), files.end(),
+              [](const SpoolFile& a, const SpoolFile& b) {
+                return a.mtime < b.mtime;
+              });
+
+    size_t evicted = 0;
+    for (const SpoolFile& file : files) {
+      if (total <= max_spool_size_) {
+        break;
+      }
+      if (Unlink(file.path.c_str()) == 0) {
+        total -= file.occupancy;
+        evicted++;
+      }
+    }
+
+    spool_size_estimate_ = total;
+
+    if (evicted > 0 && eviction_callback_) {
+      eviction_callback_(evicted);
+    }
+  }
+
   struct CurrentSpoolState {
     CurrentSpoolState() : tmp_fd(-1) {}
 
@@ -308,6 +373,10 @@ class FsSpoolWriter {
   // file gets deleted from the spool while the estimate is being computed, the
   // final estimate is likely to still include the size of that file).
   const size_t max_spool_size_;
+
+  // Invoked (when set) with the number of spool files erased during an
+  // eviction.
+  std::function<void(size_t)> eviction_callback_;
 
   // 64bit hex ID for this writer. Used in combination with the sequence
   // number to generate unique names for files. This is generated through

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
@@ -114,7 +114,7 @@ class FsSpoolWriter {
     // Recompute the spool size with a single directory walk, also collecting
     // per-file metadata so eviction (below) can reuse it instead of walking and
     // stat()ing every file a second time.
-    std::vector<SpoolFile> files;
+    std::vector<DirEntryInfo> files;
     absl::StatusOr<size_t> estimate = EstimateSpoolDirSize(&files);
     if (!estimate.ok()) {
       return estimate.status();  // failed to recompute spool size
@@ -269,57 +269,13 @@ class FsSpoolWriter {
     return result;
   }
 
-  struct SpoolFile {
-    time_t mtime;
-    std::string path;
-    size_t occupancy;
-  };
-
-  // Estimate the size of the spool directory. However, only recompute a new
-  // estimate if the spool directory has had a change to its modification time.
-  // When `files` is non-null and a recompute happens, it is populated with the
-  // per-file metadata gathered during the walk, so callers needing to evict can
-  // avoid a second walk (and a second stat() of every file).
+  // Returns the on-disk size of the spool directory via a single bulk scan
+  // (no stat() per file). When `files` is non-null it is also populated with
+  // the per-file metadata gathered during that scan, so callers needing to
+  // evict can avoid a second scan of the directory.
   absl::StatusOr<size_t> EstimateSpoolDirSize(
-      std::vector<SpoolFile>* files = nullptr) {
-    struct stat stats;
-    if (stat(spool_dir_.c_str(), &stats) < 0) {
-      return absl::ErrnoToStatus(errno, "failed to stat spool directory");
-    }
-
-    if (stats.st_mtimespec.tv_sec == spool_dir_last_mtime_.tv_sec &&
-        stats.st_mtimespec.tv_nsec == spool_dir_last_mtime_.tv_nsec) {
-      // If the spool's last modification time hasn't changed then
-      // re-use the current estimate.
-      return spool_size_estimate_;
-    }
-
-    // Store the updated mtime
-    spool_dir_last_mtime_ = stats.st_mtimespec;
-
-    // Single pass over the spool directory: accumulate the total occupancy and,
-    // when requested, collect per-file metadata for eviction.
-    size_t total = 0;
-    (void)IterateDirectory(
-        spool_dir_, [this, files, &total](const std::string& file_name, bool*) {
-          if (file_name == std::string(".") || file_name == std::string("..")) {
-            return;
-          }
-          std::string file_path =
-              absl::StrCat(spool_dir_, PathSeparator(), file_name);
-          struct stat file_stats;
-          if (stat(file_path.c_str(), &file_stats) < 0 ||
-              !StatIsReg(file_stats.st_mode)) {
-            return;
-          }
-          size_t occupancy = EstimateDiskOccupation(file_stats.st_size);
-          total += occupancy;
-          if (files != nullptr) {
-            files->push_back(
-                {file_stats.st_mtime, std::move(file_path), occupancy});
-          }
-        });
-    return total;
+      std::vector<DirEntryInfo>* files = nullptr) {
+    return BulkStatRegularFiles(spool_dir_, files);
   }
 
   // Deletes the oldest spool files until the estimated on-disk size of the
@@ -329,17 +285,17 @@ class FsSpoolWriter {
   // `files`/`total` come from the caller's directory walk, so no second walk is
   // needed. Updates spool_size_estimate_ to the post-eviction total.
   // Best-effort: a file that fails to unlink is left in place and skipped.
-  void EvictOldestSpoolFiles(std::vector<SpoolFile>& files, size_t total) {
+  void EvictOldestSpoolFiles(std::vector<DirEntryInfo>& files, size_t total) {
     const size_t high_water_mark = max_spool_size_ - max_spool_size_ / 10;
 
     // Oldest first.
     std::sort(files.begin(), files.end(),
-              [](const SpoolFile& a, const SpoolFile& b) {
+              [](const DirEntryInfo& a, const DirEntryInfo& b) {
                 return a.mtime < b.mtime;
               });
 
     size_t evicted = 0;
-    for (const SpoolFile& file : files) {
+    for (const DirEntryInfo& file : files) {
       if (total <= high_water_mark) {
         break;
       }
@@ -370,7 +326,6 @@ class FsSpoolWriter {
   const std::string base_dir_;
   const std::string spool_dir_;
   const std::string tmp_dir_;
-  struct timespec spool_dir_last_mtime_ = {};
   CurrentSpoolState current_spool_state_;
 
   // This acts as an optimization when initializing a CurrentSpoolState to help

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h
@@ -111,7 +111,11 @@ class FsSpoolWriter {
       return absl::OkStatus();
     }
 
-    absl::StatusOr<size_t> estimate = EstimateSpoolDirSize();
+    // Recompute the spool size with a single directory walk, also collecting
+    // per-file metadata so eviction (below) can reuse it instead of walking and
+    // stat()ing every file a second time.
+    std::vector<SpoolFile> files;
+    absl::StatusOr<size_t> estimate = EstimateSpoolDirSize(&files);
     if (!estimate.ok()) {
       return estimate.status();  // failed to recompute spool size
     }
@@ -122,7 +126,7 @@ class FsSpoolWriter {
       // oldest spool files to make room. This keeps the freshest data flowing
       // (and lets signal processing continue) at the cost of the oldest,
       // not-yet-exported files.
-      EvictOldestSpoolFiles();
+      EvictOldestSpoolFiles(files, *estimate);
     }
 
     return absl::OkStatus();
@@ -265,9 +269,19 @@ class FsSpoolWriter {
     return result;
   }
 
+  struct SpoolFile {
+    time_t mtime;
+    std::string path;
+    size_t occupancy;
+  };
+
   // Estimate the size of the spool directory. However, only recompute a new
   // estimate if the spool directory has had a change to its modification time.
-  absl::StatusOr<size_t> EstimateSpoolDirSize() {
+  // When `files` is non-null and a recompute happens, it is populated with the
+  // per-file metadata gathered during the walk, so callers needing to evict can
+  // avoid a second walk (and a second stat() of every file).
+  absl::StatusOr<size_t> EstimateSpoolDirSize(
+      std::vector<SpoolFile>* files = nullptr) {
     struct stat stats;
     if (stat(spool_dir_.c_str(), &stats) < 0) {
       return absl::ErrnoToStatus(errno, "failed to stat spool directory");
@@ -278,44 +292,45 @@ class FsSpoolWriter {
       // If the spool's last modification time hasn't changed then
       // re-use the current estimate.
       return spool_size_estimate_;
-    } else {
-      // Store the updated mtime
-      spool_dir_last_mtime_ = stats.st_mtimespec;
-
-      // Recompute the current estimated size
-      return EstimateDirSize(spool_dir_);
     }
+
+    // Store the updated mtime
+    spool_dir_last_mtime_ = stats.st_mtimespec;
+
+    // Single pass over the spool directory: accumulate the total occupancy and,
+    // when requested, collect per-file metadata for eviction.
+    size_t total = 0;
+    (void)IterateDirectory(
+        spool_dir_, [this, files, &total](const std::string& file_name, bool*) {
+          if (file_name == std::string(".") || file_name == std::string("..")) {
+            return;
+          }
+          std::string file_path =
+              absl::StrCat(spool_dir_, PathSeparator(), file_name);
+          struct stat file_stats;
+          if (stat(file_path.c_str(), &file_stats) < 0 ||
+              !StatIsReg(file_stats.st_mode)) {
+            return;
+          }
+          size_t occupancy = EstimateDiskOccupation(file_stats.st_size);
+          total += occupancy;
+          if (files != nullptr) {
+            files->push_back(
+                {file_stats.st_mtime, std::move(file_path), occupancy});
+          }
+        });
+    return total;
   }
 
   // Deletes the oldest spool files until the estimated on-disk size of the
-  // spool directory is back under max_spool_size_ (or no files remain). Updates
-  // spool_size_estimate_ to the post-eviction total. Best-effort: a file that
-  // fails to unlink is left in place and skipped.
-  void EvictOldestSpoolFiles() {
-    struct SpoolFile {
-      time_t mtime;
-      std::string path;
-      size_t occupancy;
-    };
-
-    std::vector<SpoolFile> files;
-    size_t total = 0;
-    (void)IterateDirectory(spool_dir_, [this, &files, &total](
-                                           const std::string& file_name,
-                                           bool* stop) {
-      if (file_name == std::string(".") || file_name == std::string("..")) {
-        return;
-      }
-      std::string file_path =
-          absl::StrCat(spool_dir_, PathSeparator(), file_name);
-      struct stat stats;
-      if (stat(file_path.c_str(), &stats) < 0 || !StatIsReg(stats.st_mode)) {
-        return;
-      }
-      size_t occupancy = EstimateDiskOccupation(stats.st_size);
-      files.push_back({stats.st_mtime, std::move(file_path), occupancy});
-      total += occupancy;
-    });
+  // spool directory drops below the high-water mark (90% of max_spool_size_).
+  // Evicting to a high-water mark rather than to exactly the limit frees ~10%
+  // of headroom so eviction doesn't immediately recur on the next few writes.
+  // `files`/`total` come from the caller's directory walk, so no second walk is
+  // needed. Updates spool_size_estimate_ to the post-eviction total.
+  // Best-effort: a file that fails to unlink is left in place and skipped.
+  void EvictOldestSpoolFiles(std::vector<SpoolFile>& files, size_t total) {
+    const size_t high_water_mark = max_spool_size_ - max_spool_size_ / 10;
 
     // Oldest first.
     std::sort(files.begin(), files.end(),
@@ -325,7 +340,7 @@ class FsSpoolWriter {
 
     size_t evicted = 0;
     for (const SpoolFile& file : files) {
-      if (total <= max_spool_size_) {
+      if (total <= high_water_mark) {
         break;
       }
       if (Unlink(file.path.c_str()) == 0) {
@@ -355,7 +370,7 @@ class FsSpoolWriter {
   const std::string base_dir_;
   const std::string spool_dir_;
   const std::string tmp_dir_;
-  struct timespec spool_dir_last_mtime_;
+  struct timespec spool_dir_last_mtime_ = {};
   CurrentSpoolState current_spool_state_;
 
   // This acts as an optimization when initializing a CurrentSpoolState to help

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_nowindows.cc
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_nowindows.cc
@@ -23,6 +23,7 @@
 #include <unistd.h>
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -145,10 +146,12 @@ absl::StatusOr<size_t> BulkStatRegularFiles(
 
   size_t total = 0;
   // 64KiB holds ~580 entries/call, so even a 15k-file spool is a couple dozen
-  // syscalls rather than one stat() per file.
-  char buf[64 * 1024];
+  // syscalls rather than one stat() per file. Heap-allocated (uninitialized) to
+  // keep it off the stack.
+  constexpr size_t kBufSize = 64 * 1024;
+  auto buf = std::make_unique_for_overwrite<char[]>(kBufSize);
   for (;;) {
-    int count = getattrlistbulk(fd, &attr_list, buf, sizeof(buf), 0);
+    int count = getattrlistbulk(fd, &attr_list, buf.get(), kBufSize, 0);
     if (count < 0) {
       absl::Status status = absl::ErrnoToStatus(
           errno, absl::StrCat("getattrlistbulk failed on ", dir));
@@ -159,7 +162,7 @@ absl::StatusOr<size_t> BulkStatRegularFiles(
       break;  // end of directory
     }
 
-    char* entry = buf;
+    char* entry = buf.get();
     for (int i = 0; i < count; i++) {
       // Fields are packed in attrlist order; copy them out to dodge alignment
       // issues. ATTR_CMN_RETURNED_ATTRS tells us which ones are actually

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_nowindows.cc
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_nowindows.cc
@@ -15,11 +15,16 @@
 
 #include <dirent.h>
 #include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/attr.h>
 #include <sys/stat.h>
+#include <sys/vnode.h>
 #include <unistd.h>
 
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h"
 #include "absl/strings/match.h"
@@ -124,41 +129,95 @@ absl::Status IterateDirectory(
   return absl::OkStatus();
 }
 
-size_t EstimateDiskOccupation(size_t fileSize) {
-  // kDiskClusterSize defines the typical size of a disk cluster (4KiB).
-  static constexpr size_t kDiskClusterSize = 4096;
-  size_t n_clusters = (fileSize + kDiskClusterSize - 1) / kDiskClusterSize;
-  // Empty files still occupy some space.
-  if (n_clusters == 0) {
-    n_clusters = 1;
+absl::StatusOr<size_t> BulkStatRegularFiles(
+    const std::string& dir, std::vector<DirEntryInfo>* entries) {
+  int fd = open(dir.c_str(), O_RDONLY | O_DIRECTORY);
+  if (fd < 0) {
+    return absl::ErrnoToStatus(errno, absl::StrCat("failed to open ", dir));
   }
-  return n_clusters * kDiskClusterSize;
+
+  struct attrlist attr_list;
+  memset(&attr_list, 0, sizeof(attr_list));
+  attr_list.bitmapcount = ATTR_BIT_MAP_COUNT;
+  attr_list.commonattr = ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_NAME |
+                         ATTR_CMN_OBJTYPE | ATTR_CMN_MODTIME;
+  attr_list.fileattr = ATTR_FILE_ALLOCSIZE;
+
+  size_t total = 0;
+  // 64KiB holds ~580 entries/call, so even a 15k-file spool is a couple dozen
+  // syscalls rather than one stat() per file.
+  char buf[64 * 1024];
+  for (;;) {
+    int count = getattrlistbulk(fd, &attr_list, buf, sizeof(buf), 0);
+    if (count < 0) {
+      absl::Status status = absl::ErrnoToStatus(
+          errno, absl::StrCat("getattrlistbulk failed on ", dir));
+      close(fd);
+      return status;
+    }
+    if (count == 0) {
+      break;  // end of directory
+    }
+
+    char* entry = buf;
+    for (int i = 0; i < count; i++) {
+      // Fields are packed in attrlist order; copy them out to dodge alignment
+      // issues. ATTR_CMN_RETURNED_ATTRS tells us which ones are actually
+      // present.
+      char* field = entry;
+      uint32_t length;
+      memcpy(&length, field, sizeof(length));
+      field += sizeof(uint32_t);
+
+      attribute_set_t returned;
+      memcpy(&returned, field, sizeof(returned));
+      field += sizeof(attribute_set_t);
+
+      const char* name = nullptr;
+      if (returned.commonattr & ATTR_CMN_NAME) {
+        attrreference_t name_ref;
+        memcpy(&name_ref, field, sizeof(name_ref));
+        name = field + name_ref.attr_dataoffset;
+        field += sizeof(attrreference_t);
+      }
+
+      fsobj_type_t obj_type = VNON;
+      if (returned.commonattr & ATTR_CMN_OBJTYPE) {
+        memcpy(&obj_type, field, sizeof(obj_type));
+        field += sizeof(fsobj_type_t);
+      }
+
+      time_t mtime = 0;
+      if (returned.commonattr & ATTR_CMN_MODTIME) {
+        struct timespec mod_time;
+        memcpy(&mod_time, field, sizeof(mod_time));
+        field += sizeof(struct timespec);
+        mtime = mod_time.tv_sec;
+      }
+
+      off_t alloc_size = 0;
+      if (returned.fileattr & ATTR_FILE_ALLOCSIZE) {
+        memcpy(&alloc_size, field, sizeof(alloc_size));
+        field += sizeof(off_t);
+      }
+
+      if (obj_type == VREG) {
+        total += static_cast<size_t>(alloc_size);
+        if (entries != nullptr && name != nullptr) {
+          entries->push_back({absl::StrCat(dir, PathSeparator(), name), mtime,
+                              static_cast<size_t>(alloc_size)});
+        }
+      }
+
+      entry += length;
+    }
+  }
+  close(fd);
+  return total;
 }
 
 absl::StatusOr<size_t> EstimateDirSize(const std::string& dir) {
-  size_t estimate = 0;
-  absl::Status status = IterateDirectory(
-      dir, [&dir, &estimate](const std::string& file_name, bool* stop) {
-        /// NOMUTANTS--We could skip this condition altogether, as S_ISREG on
-        /// the directory would be false anyway.
-        if (file_name == std::string(".") || file_name == std::string("..")) {
-          return;
-        }
-        std::string file_path = absl::StrCat(dir, PathSeparator(), file_name);
-        struct stat stats;
-        if (stat(file_path.c_str(), &stats) < 0) {
-          return;
-        }
-        if (!StatIsReg(stats.st_mode)) {
-          return;
-        }
-        // Use st_size, as st_blocks is not available on Windows.
-        estimate += EstimateDiskOccupation(stats.st_size);
-      });
-  if (status.ok()) {
-    return estimate;
-  }
-  return status;
+  return BulkStatRegularFiles(dir, nullptr);
 }
 
 }  // namespace fsspool

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h
@@ -56,6 +56,10 @@ absl::Status IterateDirectory(
 
 absl::StatusOr<size_t> EstimateDirSize(const std::string& dir);
 
+// Estimate of the on-disk space (in bytes, rounded up to whole disk clusters)
+// occupied by a file of the given logical size.
+size_t EstimateDiskOccupation(size_t fileSize);
+
 }  // namespace fsspool
 
 #endif  // SANTA_SANTAD_LOGS_ENDPOINTSECURITY_WRITERS_FSSPOOL_FSSPOOLPLATFORMSPECIFIC_H

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_platform_specific.h
@@ -16,9 +16,11 @@
 #ifndef SANTA_SANTAD_LOGS_ENDPOINTSECURITY_WRITERS_FSSPOOL_FSSPOOLPLATFORMSPECIFIC_H
 #define SANTA_SANTAD_LOGS_ENDPOINTSECURITY_WRITERS_FSSPOOL_FSSPOOLPLATFORMSPECIFIC_H
 
+#include <ctime>
 #include <functional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -54,11 +56,21 @@ absl::Status IterateDirectory(
     const std::string& dir,
     std::function<void(const std::string&, bool*)> callback);
 
-absl::StatusOr<size_t> EstimateDirSize(const std::string& dir);
+// Metadata for a single regular file gathered during a bulk directory scan.
+struct DirEntryInfo {
+  std::string path;
+  time_t mtime;
+  size_t occupancy;  // true on-disk allocated size, in bytes
+};
 
-// Estimate of the on-disk space (in bytes, rounded up to whole disk clusters)
-// occupied by a file of the given logical size.
-size_t EstimateDiskOccupation(size_t fileSize);
+// Lists the regular files in `dir` together with their mtime and on-disk size
+// in a single getattrlistbulk(2) pass - i.e. without a stat() per file. Returns
+// the summed on-disk size of those files. When `entries` is non-null it is also
+// populated with the per-file metadata. Non-regular entries are ignored.
+absl::StatusOr<size_t> BulkStatRegularFiles(
+    const std::string& dir, std::vector<DirEntryInfo>* entries = nullptr);
+
+absl::StatusOr<size_t> EstimateDirSize(const std::string& dir);
 
 }  // namespace fsspool
 

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_test.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_test.mm
@@ -38,9 +38,6 @@ class FsSpoolWriterPeer : public FsSpoolWriter<T> {
   // Private Methods
   using FsSpoolWriter<T>::BuildDirectoryStructureIfNeeded;
   using FsSpoolWriter<T>::EstimateSpoolDirSize;
-
-  // Private member variables
-  using FsSpoolWriter<T>::spool_size_estimate_;
 };
 
 }  // namespace fsspool
@@ -129,11 +126,12 @@ google::protobuf::Any TestAnyTimestamp(int64_t s, int32_t n) {
   XCTAssertTrue([self.fileMgr fileExistsAtPath:fifoFile]);
 }
 
-- (void)testEstimateSpoolDirSizeAnyBatcher {
+- (void)testEstimateSpoolDirSize {
   NSString* testData = @"What a day for some testing!";
   NSString* largeTestData = RepeatedString(@"A", 10240);
   NSString* path = [NSString stringWithFormat:@"%@/%@", self.spoolDir, @"temppy.log"];
-  NSString* emptyPath = [NSString stringWithFormat:@"%@/%@", self.spoolDir, @"empty.log"];
+  NSString* secondPath = [NSString stringWithFormat:@"%@/%@", self.spoolDir, @"second.log"];
+  // EstimateSpoolDirSize is batcher-independent, so one batcher exercises it.
   auto writer = std::make_unique<FsSpoolWriterPeer<fsspool::AnyBatcher>>(
       fsspool::AnyBatcher(), [self.baseDir UTF8String], kSpoolSize);
 
@@ -141,108 +139,41 @@ google::protobuf::Any TestAnyTimestamp(int64_t s, int32_t n) {
   XCTAssertStatusOk(writer->BuildDirectoryStructureIfNeeded());
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 0);
 
-  // Ensure that the initial spool dir estimate is 0
+  // An empty spool dir estimates to 0.
   auto status = writer->EstimateSpoolDirSize();
   XCTAssertStatusOk(status);
   XCTAssertEqual(*status, 0);
 
-  // Force the current estimate to be 0 since we're not recomputing on first write.
-  writer->spool_size_estimate_ = *status;
-
+  // A file shows up in the estimate.
   XCTAssertTrue([testData writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil]);
-
-  // Ensure the test file was created
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 1);
-
-  // Ensure the spool size estimate has grown at least as much as the content length
   status = writer->EstimateSpoolDirSize();
   XCTAssertStatusOk(status);
-  // Update the current estimate
-  writer->spool_size_estimate_ = *status;
-  XCTAssertGreaterThanOrEqual(writer->spool_size_estimate_, testData.length);
+  XCTAssertGreaterThanOrEqual(*status, testData.length);
+  size_t before_growth = *status;
 
-  // Modify file contents without modifying spool directory mtime
+  // Growing a file's contents (without touching the spool dir's mtime) is
+  // reflected immediately: every call does a fresh scan, there is no mtime cache.
   NSFileHandle* fileHandle = [NSFileHandle fileHandleForWritingAtPath:path];
   [fileHandle seekToEndOfFile];
   [fileHandle writeData:[largeTestData dataUsingEncoding:NSUTF8StringEncoding]];
   [fileHandle closeFile];
-
-  // Ensure only one file still exists
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 1);
-
-  // Ensure that the returned estimate is the same as the old since mtime didn't change
   status = writer->EstimateSpoolDirSize();
   XCTAssertStatusOk(status);
-  // Check that the current estimate is the same as the old estimate
-  XCTAssertEqual(*status, writer->spool_size_estimate_);
-
-  // Create a second file in the spool dir to bump mtime
-  XCTAssertTrue([@"" writeToFile:emptyPath atomically:YES encoding:NSUTF8StringEncoding error:nil]);
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 2);
-
-  status = writer->EstimateSpoolDirSize();
-  XCTAssertStatusOk(status);
-
-  // Ensure the newly returned size is appropriate
+  XCTAssertGreaterThan(*status, before_growth);
   XCTAssertGreaterThanOrEqual(*status, testData.length + largeTestData.length);
-}
+  size_t before_second = *status;
 
-- (void)testEstimateSpoolDirSizeStreamBatcher {
-  NSString* testData = @"What a day for some testing!";
-  NSString* largeTestData = RepeatedString(@"A", 10240);
-  NSString* path = [NSString stringWithFormat:@"%@/%@", self.spoolDir, @"temppy.log"];
-  NSString* emptyPath = [NSString stringWithFormat:@"%@/%@", self.spoolDir, @"empty.log"];
-  auto writer = std::make_unique<FsSpoolWriterPeer<fsspool::UncompressedStreamBatcher>>(
-      fsspool::UncompressedStreamBatcher(), [self.baseDir UTF8String], kSpoolSize);
-
-  // Create the spool dir structure and ensure no files exist
-  XCTAssertStatusOk(writer->BuildDirectoryStructureIfNeeded());
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 0);
-
-  // Ensure that the initial spool dir estimate is 0
-  auto status = writer->EstimateSpoolDirSize();
-  XCTAssertStatusOk(status);
-  XCTAssertEqual(*status, 0);
-
-  // Force the current estimate to be 0 since we're not recomputing on first write.
-  writer->spool_size_estimate_ = *status;
-
-  XCTAssertTrue([testData writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil]);
-
-  // Ensure the test file was created
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 1);
-
-  // Ensure the spool size estimate has grown at least as much as the content length
-  status = writer->EstimateSpoolDirSize();
-  XCTAssertStatusOk(status);
-  // Update the current estimate
-  writer->spool_size_estimate_ = *status;
-  XCTAssertGreaterThanOrEqual(writer->spool_size_estimate_, testData.length);
-
-  // Modify file contents without modifying spool directory mtime
-  NSFileHandle* fileHandle = [NSFileHandle fileHandleForWritingAtPath:path];
-  [fileHandle seekToEndOfFile];
-  [fileHandle writeData:[largeTestData dataUsingEncoding:NSUTF8StringEncoding]];
-  [fileHandle closeFile];
-
-  // Ensure only one file still exists
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 1);
-
-  // Ensure that the returned estimate is the same as the old since mtime didn't change
-  status = writer->EstimateSpoolDirSize();
-  XCTAssertStatusOk(status);
-  // Check that the current estimate is the same as the old estimate
-  XCTAssertEqual(*status, writer->spool_size_estimate_);
-
-  // Create a second file in the spool dir to bump mtime
-  XCTAssertTrue([@"" writeToFile:emptyPath atomically:YES encoding:NSUTF8StringEncoding error:nil]);
+  // A second file adds to the total.
+  XCTAssertTrue([largeTestData writeToFile:secondPath
+                                atomically:YES
+                                  encoding:NSUTF8StringEncoding
+                                     error:nil]);
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:nil] count], 2);
-
   status = writer->EstimateSpoolDirSize();
   XCTAssertStatusOk(status);
-
-  // Ensure the newly returned size is appropriate
-  XCTAssertGreaterThanOrEqual(*status, testData.length + largeTestData.length);
+  XCTAssertGreaterThan(*status, before_second);
 }
 
 - (void)testSimpleWriteAnyBatcher {

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_test.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_test.mm
@@ -304,17 +304,24 @@ google::protobuf::Any TestAnyTimestamp(int64_t s, int32_t n) {
   NSError* err = nil;
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.tmpDir error:&err] count], 0);
   XCTAssertNil(err);
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:&err] count], 1);
+  NSArray<NSString*>* afterFirst = [self.fileMgr contentsOfDirectoryAtPath:self.spoolDir
+                                                                     error:&err];
   XCTAssertNil(err);
+  XCTAssertEqual(afterFirst.count, 1);
 
-  // Try to write again, but expect failure. File counts shouldn't change.
+  // Writing again when the spool is full evicts the oldest file to make room and writes the new
+  // one, rather than dropping the write.
   XCTAssertStatusOk(writer->Write(largeMessage));
-  XCTAssertStatusNotOk(writer->Flush());
+  XCTAssertStatusOk(writer->Flush());
 
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.tmpDir error:&err] count], 0);
   XCTAssertNil(err);
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:&err] count], 1);
+  NSArray<NSString*>* afterSecond = [self.fileMgr contentsOfDirectoryAtPath:self.spoolDir
+                                                                      error:&err];
   XCTAssertNil(err);
+  // Still a single file, but it's the newer one: the oldest was evicted.
+  XCTAssertEqual(afterSecond.count, 1);
+  XCTAssertNotEqualObjects(afterFirst.firstObject, afterSecond.firstObject);
 }
 
 - (void)testSpoolFullStreamBatcher {
@@ -338,17 +345,52 @@ google::protobuf::Any TestAnyTimestamp(int64_t s, int32_t n) {
   NSError* err = nil;
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.tmpDir error:&err] count], 0);
   XCTAssertNil(err);
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:&err] count], 1);
+  NSArray<NSString*>* afterFirst = [self.fileMgr contentsOfDirectoryAtPath:self.spoolDir
+                                                                     error:&err];
   XCTAssertNil(err);
+  XCTAssertEqual(afterFirst.count, 1);
 
-  // Try to write again, but expect failure. File counts shouldn't change.
-  XCTAssertStatusNotOk(writer->Write(largeMessage));
+  // Writing again when the spool is full evicts the oldest file to make room and writes the new
+  // one, rather than dropping the write.
+  XCTAssertStatusOk(writer->Write(largeMessage));
   XCTAssertStatusOk(writer->Flush());
 
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.tmpDir error:&err] count], 0);
   XCTAssertNil(err);
-  XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:&err] count], 1);
+  NSArray<NSString*>* afterSecond = [self.fileMgr contentsOfDirectoryAtPath:self.spoolDir
+                                                                      error:&err];
   XCTAssertNil(err);
+  // Still a single file, but it's the newer one: the oldest was evicted.
+  XCTAssertEqual(afterSecond.count, 1);
+  XCTAssertNotEqualObjects(afterFirst.firstObject, afterSecond.firstObject);
+}
+
+- (void)testSpoolEvictionCallback {
+  // Plain locals (not __block): FsSpoolWriter invokes the callback synchronously during
+  // Write/Flush.
+  size_t totalEvicted = 0;
+  int callbackCalls = 0;
+  std::function<void(size_t)> cb = [&totalEvicted, &callbackCalls](size_t erased) {
+    totalEvicted += erased;
+    callbackCalls++;
+  };
+
+  auto writer = std::make_unique<FsSpoolWriterPeer<fsspool::AnyBatcher>>(
+      fsspool::AnyBatcher(), [self.baseDir UTF8String], kSpoolSize, cb);
+  std::vector<uint8_t> largeMessage(kSpoolSize + 1, '\x42');
+
+  // First file: the spool starts empty, so nothing is evicted.
+  XCTAssertStatusOk(writer->Write(largeMessage));
+  XCTAssertStatusOk(writer->Flush());
+  XCTAssertEqual(callbackCalls, 0);
+  XCTAssertEqual(totalEvicted, (size_t)0);
+
+  // Second file: the spool is now over the limit, so the single oldest file is evicted and the
+  // callback is invoked with the number erased.
+  XCTAssertStatusOk(writer->Write(largeMessage));
+  XCTAssertStatusOk(writer->Flush());
+  XCTAssertEqual(callbackCalls, 1);
+  XCTAssertEqual(totalEvicted, (size_t)1);
 }
 
 - (void)testWriteMessageNoFlushAnyBatcher {

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
@@ -19,6 +19,7 @@
 #import <Foundation/Foundation.h>
 #include <dispatch/dispatch.h>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -26,6 +27,7 @@
 #include <vector>
 
 #import "Source/common/SNTLogging.h"
+#import "Source/common/SNTMetricSet.h"
 #include "Source/common/santa.pb.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
@@ -55,8 +57,30 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool<T>> {
     dispatch_source_set_timer(timer_source, dispatch_time(DISPATCH_TIME_NOW, 0),
                               NSEC_PER_MSEC * flush_timeout_ms, 0);
 
+    // Records how many spool files are erased when the spool exceeds its size limit.
+    SNTMetricCounter* eviction_counter = [[SNTMetricSet sharedInstance]
+        counterWithName:@"/santa/spool/eviction_count"
+             fieldNames:@[]
+               helpText:@"Number of spool files erased to stay under the spool size limit"];
+    std::function<void(size_t)> eviction_callback = [eviction_counter](size_t erased) {
+      [eviction_counter incrementBy:static_cast<long long>(erased) forFieldValues:@[]];
+    };
+
+    // Reports the current on-disk size of the spool directory, sampled at metric export time.
+    SNTMetricInt64Gauge* size_gauge = [[SNTMetricSet sharedInstance]
+        int64GaugeWithName:@"/santa/spool/size_bytes"
+                fieldNames:@[]
+                  helpText:@"Current on-disk size of the telemetry spool directory in bytes"];
+    std::string spool_dir =
+        ::fsspool::SpoolNewDirectory(absl::string_view(base_dir.data(), base_dir.length()));
+    [[SNTMetricSet sharedInstance] registerCallback:^{
+      auto size = ::fsspool::EstimateDirSize(spool_dir);
+      [size_gauge set:(size.ok() ? static_cast<long long>(*size) : 0) forFieldValues:@[]];
+    }];
+
     auto spool_writer = std::make_shared<Spool<T>>(q, timer_source, std::move(batcher), base_dir,
-                                                   max_spool_disk_size, max_spool_batch_size);
+                                                   max_spool_disk_size, max_spool_batch_size,
+                                                   nullptr, nullptr, std::move(eviction_callback));
 
     spool_writer->BeginFlushTask();
 
@@ -65,12 +89,13 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool<T>> {
 
   Spool(dispatch_queue_t q, dispatch_source_t timer_source, T batcher, std::string_view base_dir,
         size_t max_spool_disk_size, size_t max_spool_file_size,
-        void (^write_complete_f)(void) = nullptr, void (^flush_task_complete_f)(void) = nullptr)
+        void (^write_complete_f)(void) = nullptr, void (^flush_task_complete_f)(void) = nullptr,
+        std::function<void(size_t)> eviction_callback = nullptr)
       : q_(q),
         timer_source_(timer_source),
         spool_reader_(absl::string_view(base_dir.data(), base_dir.length())),
         spool_writer_(std::move(batcher), absl::string_view(base_dir.data(), base_dir.length()),
-                      max_spool_disk_size),
+                      max_spool_disk_size, std::move(eviction_callback)),
         spool_file_size_threshold_(max_spool_file_size),
         spool_file_size_threshold_leniency_(spool_file_size_threshold_ *
                                             spool_file_size_threshold_leniency_factor_),

--- a/Source/santad/SleighLauncher.mm
+++ b/Source/santad/SleighLauncher.mm
@@ -59,10 +59,23 @@ absl::Status SleighLauncher::LaunchTelemetryExport(const std::vector<std::string
   for (const auto& file : input_files) {
     int fd = open(file.c_str(), O_RDONLY);
     if (fd < 0) {
+      // The file may have been evicted (spool full) or already consumed between
+      // enumeration and now. A vanished file isn't an error: skip it and export
+      // the rest rather than failing the whole batch.
+      if (errno == ENOENT) {
+        LOGD(@"SleighLauncher::LaunchTelemetryExport(): Skipping missing input file: %s",
+             file.c_str());
+        continue;
+      }
       LOGD(@"SleighLauncher::LaunchTelemetryExport(): Failed to open input file: %s", file.c_str());
       return absl::InternalError("Failed to open input file: " + file);
     }
     input_fds.push_back(fd);
+  }
+
+  // Everything vanished before we could open it; nothing to export.
+  if (input_fds.empty()) {
+    return absl::OkStatus();
   }
 
   absl::StatusOr<std::string> serialized = SerializeTelemetryUploadConfig(input_fds);

--- a/docs/docs/features/telemetry.mdx
+++ b/docs/docs/features/telemetry.mdx
@@ -373,7 +373,7 @@ Applies when using the `protobuf` or `json` log types.
 
 - `SpoolDirectory`: Base directory for protobuf format (default: `/var/db/santa/spool`)
 - `SpoolDirectoryFileSizeThresholdKB`: Per-file size limit (default: 250KB)
-- `SpoolDirectorySizeThresholdMB`: Total spool directory size limit (default: 100MB)
+- `SpoolDirectorySizeThresholdMB`: Total spool directory size limit (default: 250MB)
 - `SpoolDirectoryEventMaxFlushTimeSec`: Maximum buffer time before flush (default: 15 sec)
 
 ### File Change Monitoring


### PR DESCRIPTION
When the telemetry spool reaches its size limit, erase the oldest spool files to make room rather than dropping all new writes (which also starved downstream processing). Raise the default spool size limit from 100MB to 250MB.

Also move from directory-walking and calling `stat()` once per-file when calculating the directory size and files to evict into batched calls to `getattrlistbulk()`, which dramatically reduces the number of syscalls when the spool is full (with no negative impact when the spool has few files in).

Add two metrics:
  * `/santa/spool/eviction_count` - spool files erased due to the size limit
  * `/santa/spool/size_bytes`     - current on-disk spool directory size

Part of WS-787