### PR TITLE
ci: make labeler job non-blocking

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,9 @@ jobs:
   labels:
     name: Labelers
     runs-on: ubuntu-latest
+    # Labeling is best-effort. Fork PRs get a read-only GITHUB_TOKEN, so the
+    # labeler can't apply labels there — don't let that fail the PR.
+    continue-on-error: true
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Fork PRs receive a read-only `GITHUB_TOKEN`, so `actions/labeler` can't apply labels and fails with `Resource not accessible by integration`. This marks the Labelers job `continue-on-error` so best-effort labeling never blocks a PR.