### PR TITLE
test: Significantly speed-up some slower tests

### DIFF
--- a/Source/common/es/SNTEndpointSecurityClient.mm
+++ b/Source/common/es/SNTEndpointSecurityClient.mm
@@ -23,6 +23,8 @@
 #include <sys/qos.h>
 
 #include <algorithm>
+#include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -338,15 +340,20 @@ using santa::Processor;
   int64_t processingBudget = [self computeBudgetForDeadline:msg->deadline
                                                 currentTime:mach_absolute_time()];
 
-  // Copy the original message and then move into the auto-responder block
-  __block Message tmpDeadlineMsg = msg;
+  // Copy the original message into a heap holder shared with the auto-responder
+  // block. The holder lets the handler release the copy as soon as it wins the
+  // race (see below) instead of keeping the Message (and its underlying
+  // es_message_t) alive until the budget elapses.
+  auto deadlineMsgHolder = std::make_shared<std::optional<Message>>(msg);
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, processingBudget), self->_authQueue, ^(void) {
     if (dispatch_semaphore_wait(processingSema, DISPATCH_TIME_NOW) != 0) {
-      // Handler has already responded, nothing to do.
+      // Handler has already responded, nothing to do. The handler also released
+      // the message copy, so the holder may already be empty.
       return;
     }
 
-    Message deadlineMsg = std::move(tmpDeadlineMsg);
+    // We won the race, so the handler has not reset the holder.
+    Message deadlineMsg = std::move(**deadlineMsgHolder);
 
     es_auth_result_t authResult;
     if (self.configurator.failClosed) {
@@ -370,6 +377,11 @@ using santa::Processor;
     if (dispatch_semaphore_wait(processingSema, DISPATCH_TIME_NOW) != 0) {
       // Deadline expired, wait for deadline block to finish.
       dispatch_semaphore_wait(deadlineExpiredSema, DISPATCH_TIME_FOREVER);
+    } else {
+      // We won the race against the deadline block, which will now no-op. Release
+      // our copy of the message immediately rather than holding it (and the
+      // underlying es_message_t) alive until the deadline block fires.
+      deadlineMsgHolder->reset();
     }
   });
 }

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -75,6 +75,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 @interface SNTRuleTable () {
   std::unique_ptr<santa::cel::Evaluator<false>> _celEvaluator;
   std::unique_ptr<santa::cel::Evaluator<true>> _celV2Evaluator;
+  dispatch_once_t _criticalSystemBinariesToken;
 }
 @property MOLCodesignChecker* santadCSInfo;
 @property MOLCodesignChecker* launchdCSInfo;
@@ -227,6 +228,16 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   self.criticalSystemBinaries = bins;
 }
 
+- (NSDictionary<NSString*, SNTCachedDecision*>*)criticalSystemBinaries {
+  // Computed lazily and cached: most callers (and tests) never need it, and
+  // hashing/codesigning the critical binaries is expensive. dispatch_once keeps
+  // it thread-safe across concurrent decision lookups.
+  dispatch_once(&_criticalSystemBinariesToken, ^{
+    [self setupSystemCriticalBinaries];
+  });
+  return _criticalSystemBinaries;
+}
+
 - (uint32_t)currentSupportedVersion {
   return kRuleTableCurrentVersion;
 }
@@ -364,8 +375,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     LOGE(@"Failed to create CELv2 evaluator: %s", std::string(celEval.status().message()).c_str());
   }
 
-  // Setup critical system binaries
-  [self setupSystemCriticalBinaries];
+  // Critical system binaries (hashing + codesigning real binaries) are computed
+  // lazily on first access via the criticalSystemBinaries getter, keeping init cheap.
 
   // Prime the cached static rules.
   [self updateStaticRules:[[SNTConfigurator configurator] staticRules]];

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -72,6 +72,9 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator* configurator,
     LOGE(@"Failed to initialize rule table.");
     exit(EXIT_FAILURE);
   }
+  // Prime the lazily-computed critical system binaries now, at startup, so the
+  // expensive hashing/codesigning doesn't block the first AUTH decision.
+  (void)rule_table.criticalSystemBinaries;
 
   SNTEventTable* event_table = [SNTDatabaseController eventTable];
   if (!event_table) {

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -39,6 +39,10 @@ using santa::NSStringToUTF8String;
 @property(readwrite) SNTSyncState* syncState;
 @property(readwrite) MOLXPCConnection* daemonConn;
 
+// Base for the exponential retry backoff (2^attempt seconds). Overridable so tests
+// can set it to 0 and skip the real nanosleep. ponytail: test seam, not a tunable.
+@property double retryBackoffBase;
+
 @end
 
 @implementation SNTSyncStage
@@ -49,6 +53,7 @@ using santa::NSStringToUTF8String;
     _syncState = syncState;
     _urlSession = syncState.session;
     _daemonConn = syncState.daemonConn;
+    _retryBackoffBase = 2;
   }
   return self;
 }
@@ -146,10 +151,9 @@ using santa::NSStringToUTF8String;
   int maxAttempts = 5;
   for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
     if (attempt >= 2) {
-      // Exponentially back off with larger and larger delays.
-      int exponentialBackoffMultiplier = 2;  // E.g. 2^2 = 4, 2^3 = 8, 2^4 = 16...
-      struct timespec ts = {.tv_sec = __darwin_time_t(pow(exponentialBackoffMultiplier, attempt))};
-      nanosleep(&ts, NULL);
+      // Exponentially back off with larger and larger delays. E.g. 2^2 = 4, 2^3 = 8, 2^4 = 16...
+      struct timespec ts = {.tv_sec = __darwin_time_t(pow(self.retryBackoffBase, attempt))};
+      if (ts.tv_sec > 0) nanosleep(&ts, NULL);
     }
 
     SLOGD(@"Performing request, attempt %d (of %d maximum)...", attempt, maxAttempts);

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -53,6 +53,7 @@
 
 @interface SNTSyncStage (XSSI)
 - (NSData*)stripXssi:(NSData*)data;
+@property double retryBackoffBase;
 @end
 
 @interface SNTSyncManager (Testing)
@@ -282,6 +283,7 @@
   NSURL* u1 = [NSURL URLWithString:stageName relativeToURL:self.syncState.syncBaseURL];
 
   SNTSyncStage* sut = [[SNTSyncStage alloc] initWithState:self.syncState];
+  sut.retryBackoffBase = 0;  // Skip the real retry nanosleep.
   NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:u1];
   XCTAssertNil([sut performRequest:req intoMessage:NULL timeout:5]);
   XCTAssertEqualObjects(self.syncState.xsrfToken, @"my-xsrf-token");
@@ -330,6 +332,7 @@
   NSURL* u1 = [NSURL URLWithString:stageName relativeToURL:self.syncState.syncBaseURL];
 
   SNTSyncStage* sut = [[SNTSyncStage alloc] initWithState:self.syncState];
+  sut.retryBackoffBase = 0;  // Skip the real retry nanosleep.
   NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:u1];
   XCTAssertNil([sut performRequest:req intoMessage:NULL timeout:5]);
   XCTAssertEqualObjects(self.syncState.xsrfToken, @"my-xsrf-token");
@@ -1109,6 +1112,8 @@
                                                                  nil])]);
   OCMStub([self.daemonConnRop postRuleSyncNotificationForApplication:[OCMArg any]
                                                                reply:([OCMArg invokeBlock])]);
+  // Invoke the reply immediately; otherwise sync blocks on the 5s reply timeout.
+  OCMStub([self.daemonConnRop updateSyncSettings:[OCMArg any] reply:([OCMArg invokeBlock])]);
   [sut sync];
 
   NSArray* rules = @[
@@ -1168,6 +1173,8 @@
                                                                  nil])]);
   OCMStub([self.daemonConnRop postRuleSyncNotificationForApplication:[OCMArg any]
                                                                reply:([OCMArg invokeBlock])]);
+  // Invoke the reply immediately; otherwise sync blocks on the 5s reply timeout.
+  OCMStub([self.daemonConnRop updateSyncSettings:[OCMArg any] reply:([OCMArg invokeBlock])]);
   [sut sync];
 
   SNTRuleState state = self.syncState.isSyncV2 ? SNTRuleStateCELv2 : SNTRuleStateCEL;
@@ -1220,6 +1227,8 @@
                                                                  nil])]);
   OCMStub([self.daemonConnRop postRuleSyncNotificationForApplication:[OCMArg any]
                                                                reply:([OCMArg invokeBlock])]);
+  // Invoke the reply immediately; otherwise sync blocks on the 5s reply timeout.
+  OCMStub([self.daemonConnRop updateSyncSettings:[OCMArg any] reply:([OCMArg invokeBlock])]);
   [sut sync];
 
   NSArray* rules = @[


### PR DESCRIPTION
* SNTSyncTest: >60s -> 0.2s. Stub `updateSyncSettings:reply:` to bypass the semaphore timeout, allow overriding the XSRF retry backoff
* SantadTest: ~60s -> 1.5s. Wrap the deadline's Message copy in a `std::optional<Message>` shared by both blocks so that the handler can reset it once it wins the `processingSema` race. This speeds up the test (because the message is not kept alive for the full 1.5s after the handler responds) and also releases the message faster in normal execution
* SNTRuleTableTest: ~15s -> 1.2s. Every tests eagerly hashed + codesign-validated all critical system binaries even though most tests never used it. Made `criticalSystemBinaries` lazy using dispatch_once.