### PR TITLE
add support for SyncRequest.max_jitter

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "2e30a3ef15ec6fb793838ce3366d89aa7575c238",
+    commit = "33fd2ddefbfdbe9063e5394e8ca82ef52d7bf84c",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/SNTSyncConstants.h
+++ b/Source/common/SNTSyncConstants.h
@@ -165,3 +165,9 @@ extern const NSUInteger kMinimumFullSyncInterval;
 extern const NSUInteger kDefaultFullSyncInterval;
 extern const NSUInteger kDefaultPushNotificationsFullSyncInterval;
 extern const NSUInteger kDefaultPushNotificationsGlobalRuleSyncDeadline;
+
+///
+///  The default maximum random jitter (in seconds) applied before syncing in
+///  response to a tag push notification that does not specify its own jitter.
+///
+extern const NSUInteger kDefaultPushNotificationTagSyncJitterSeconds;

--- a/Source/common/SNTSyncConstants.mm
+++ b/Source/common/SNTSyncConstants.mm
@@ -158,3 +158,4 @@ const NSUInteger kMinimumFullSyncInterval = 60;
 const NSUInteger kDefaultFullSyncInterval = 600;
 const NSUInteger kDefaultPushNotificationsFullSyncInterval = 14400;
 const NSUInteger kDefaultPushNotificationsGlobalRuleSyncDeadline = 600;
+const NSUInteger kDefaultPushNotificationTagSyncJitterSeconds = 180;

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -459,6 +459,7 @@ santa_unit_test(
         "//Source/common:SNTSystemInfo",
         "@OCMock",
         "@boringssl//:crypto",
+        "@northpolesec_protos//commands:v1_cc_proto",
     ],
 )
 

--- a/Source/santasyncservice/SNTPushClientNATS.mm
+++ b/Source/santasyncservice/SNTPushClientNATS.mm
@@ -704,27 +704,45 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
 }
 
 // Handle a push notification for the given subject by dispatching a sync.
-// Tag subjects (santa.tag.*) get a random jitter delay of 0-180 seconds to
-// avoid thundering herd when many hosts share the same tag. Host subjects
-// (santa.host.*) trigger an immediate sync.
-- (void)handlePushNotificationForSubject:(NSString*)subject {
+// Tag subjects (santa.tag.*) sync with a random jitter delay to avoid a
+// thundering herd when many hosts share the same tag. The amount of jitter is
+// controlled by the optional SyncRequest payload:
+//   - If max_jitter is set, the sync is scheduled at a random point in
+//     [0, max_jitter) seconds. A max_jitter of 0 yields an immediate sync.
+//   - If max_jitter is not set (or the payload is absent/undecodable), the
+//     default of [0, kDefaultPushNotificationTagSyncJitterSeconds) is used.
+// Host subjects (santa.host.*) always trigger an immediate sync.
+- (void)handlePushNotificationForSubject:(NSString*)subject withPayload:(NSData*)payload {
   dispatch_async(self.messageQueue, ^{
-    if (!self.isShuttingDown) {
-      uint32_t jitterSeconds = 0;
-      if ([subject hasPrefix:@"santa.tag."]) {
-        jitterSeconds = arc4random_uniform(181);
-        LOGI(@"NATS: Scheduling sync in %u seconds (jitter) due to tag message on %@",
-             jitterSeconds, subject);
-      } else {
-        LOGI(@"NATS: Triggering immediate sync due to message on %@", subject);
+    if (self.isShuttingDown) {
+      return;
+    }
+
+    uint32_t jitterSeconds = 0;
+    if ([subject hasPrefix:@"santa.tag."]) {
+      // Default to the standard jitter window unless the SyncRequest overrides it.
+      uint32_t maxJitter = (uint32_t)kDefaultPushNotificationTagSyncJitterSeconds;
+
+      ::pbv1::SyncRequest syncRequest;
+      if (payload.length > 0 && syncRequest.ParseFromArray(payload.bytes, (int)payload.length) &&
+          syncRequest.has_max_jitter()) {
+        // max_jitter is explicitly set, honor it (including an explicit 0,
+        // which requests an immediate sync).
+        maxJitter = syncRequest.max_jitter();
       }
 
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (!self.isShuttingDown) {
-          [self.syncDelegate syncSecondsFromNow:jitterSeconds];
-        }
-      });
+      jitterSeconds = arc4random_uniform(maxJitter);
+      LOGI(@"NATS: Scheduling sync in %u seconds (max jitter %u) due to tag message on %@",
+           jitterSeconds, maxJitter, subject);
+    } else {
+      LOGI(@"NATS: Triggering immediate sync due to message on %@", subject);
     }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (!self.isShuttingDown) {
+        [self.syncDelegate syncSecondsFromNow:jitterSeconds];
+      }
+    });
   });
 }
 
@@ -746,16 +764,11 @@ static void messageHandler(natsConnection* nc, natsSubscription* sub, natsMsg* m
   int dataLen = natsMsg_GetDataLength(msg);
 
   NSString* msgSubject = subject ? @(subject) : @"<unknown>";
-  NSString* msgData;
-  if (data && dataLen > 0) {
-    // Decode the payload as a UTF-8 string.
-    // TODO in the future handle binary data e.g. protobuf if / when needed.
-    msgData = [[NSString alloc] initWithBytes:data length:dataLen encoding:NSUTF8StringEncoding];
-  } else {
-    msgData = @"";
-  }
+  // Copy the (optionally present) payload out of the NATS-owned message before
+  // it is destroyed. For tag subjects this is an encoded SyncRequest proto.
+  NSData* payload = (data && dataLen > 0) ? [NSData dataWithBytes:data length:dataLen] : nil;
 
-  LOGD(@"NATS: Received message on subject '%@': %@", msgSubject, msgData ?: @"<no data>");
+  LOGD(@"NATS: Received message on subject '%@' (%d byte payload)", msgSubject, dataLen);
 
   // Process on message queue to serialize handling of messages and gurantee we
   // avoid blocking the NATS managed thread. Then call back to the main thread
@@ -764,7 +777,7 @@ static void messageHandler(natsConnection* nc, natsSubscription* sub, natsMsg* m
   //
   // IMPORTANT: Do not touch the nats objects in this block they are owned by
   // the nats library and will be destroyed after this block.
-  [self handlePushNotificationForSubject:msgSubject];
+  [self handlePushNotificationForSubject:msgSubject withPayload:payload];
 
   natsMsg_Destroy(msg);
 }

--- a/Source/santasyncservice/SNTPushClientNATSTest.mm
+++ b/Source/santasyncservice/SNTPushClientNATSTest.mm
@@ -22,10 +22,14 @@
 #import "Source/santasyncservice/SNTPushNotifications.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
+#include "commands/v1.pb.h"
+
 extern "C" {
 #include <openssl/x509v3.h>
 #import "src/nats.h"
 }
+
+namespace pbv1 = ::santa::commands::v1;
 
 // Forward declaration of the extracted domain-check function.
 extern "C" bool NATSLeafCertHasPushDomain(X509* cert);
@@ -84,7 +88,7 @@ static X509* CreateCertWithDNSSANBytes(const char* data, size_t len) {
                             jwt:(NSString*)jwt
                    pushDeviceID:(NSString*)deviceID
                            tags:(NSArray<NSString*>*)tags;
-- (void)handlePushNotificationForSubject:(NSString*)subject;
+- (void)handlePushNotificationForSubject:(NSString*)subject withPayload:(NSData*)payload;
 @end
 
 @interface SNTPushClientNATSTest : XCTestCase
@@ -643,10 +647,64 @@ static X509* CreateCertWithDNSSANBytes(const char* data, size_t len) {
         [expectation fulfill];
       });
 
-  // When: A tag push notification is received
-  [self.client handlePushNotificationForSubject:@"santa.tag.production"];
+  // When: A tag push notification is received with no payload
+  [self.client handlePushNotificationForSubject:@"santa.tag.production" withPayload:nil];
 
-  // Then: syncSecondsFromNow should be called with jitter in [0, 180]
+  // Then: syncSecondsFromNow should be called with the default jitter in [0, 180]
+  [self waitForExpectations:@[ expectation ] timeout:2.0];
+}
+
+- (void)testTagMessageWithSyncRequestJitter {
+  // Given: Client is initialized
+  self.client = [[SNTPushClientNATS alloc] initWithSyncDelegate:self.mockSyncDelegate];
+
+  XCTestExpectation* expectation =
+      [self expectationWithDescription:@"syncSecondsFromNow called with SyncRequest jitter"];
+
+  OCMStub([self.mockSyncDelegate syncSecondsFromNow:0])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        uint64_t seconds;
+        [invocation getArgument:&seconds atIndex:2];
+        XCTAssertLessThanOrEqual(seconds, 30u);
+        [expectation fulfill];
+      });
+
+  // When: A tag push notification is received with a SyncRequest setting max_jitter to 30
+  pbv1::SyncRequest request;
+  request.set_max_jitter(30);
+  std::string serialized = request.SerializeAsString();
+  NSData* payload = [NSData dataWithBytes:serialized.data() length:serialized.size()];
+  [self.client handlePushNotificationForSubject:@"santa.tag.production" withPayload:payload];
+
+  // Then: syncSecondsFromNow should be called with jitter in [0, 30]
+  [self waitForExpectations:@[ expectation ] timeout:2.0];
+}
+
+- (void)testTagMessageWithSyncRequestZeroJitter {
+  // Given: Client is initialized
+  self.client = [[SNTPushClientNATS alloc] initWithSyncDelegate:self.mockSyncDelegate];
+
+  XCTestExpectation* expectation =
+      [self expectationWithDescription:@"syncSecondsFromNow called with 0 for zero jitter"];
+
+  OCMStub([self.mockSyncDelegate syncSecondsFromNow:0])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        uint64_t seconds;
+        [invocation getArgument:&seconds atIndex:2];
+        XCTAssertEqual(seconds, 0u);
+        [expectation fulfill];
+      });
+
+  // When: A tag push notification is received with a SyncRequest explicitly setting max_jitter to 0
+  pbv1::SyncRequest request;
+  request.set_max_jitter(0);
+  std::string serialized = request.SerializeAsString();
+  NSData* payload = [NSData dataWithBytes:serialized.data() length:serialized.size()];
+  [self.client handlePushNotificationForSubject:@"santa.tag.production" withPayload:payload];
+
+  // Then: syncSecondsFromNow should be called with 0 (immediate sync)
   [self waitForExpectations:@[ expectation ] timeout:2.0];
 }
 
@@ -667,7 +725,7 @@ static X509* CreateCertWithDNSSANBytes(const char* data, size_t len) {
       });
 
   // When: A host push notification is received
-  [self.client handlePushNotificationForSubject:@"santa.host.ABC123"];
+  [self.client handlePushNotificationForSubject:@"santa.host.ABC123" withPayload:nil];
 
   // Then: syncSecondsFromNow should be called with 0 (no jitter)
   [self waitForExpectations:@[ expectation ] timeout:2.0];


### PR DESCRIPTION
This change respects the max_jitter argument on tag push notifications, allowing for variable jitter as determined by the server.