### PR TITLE
common: Add SNTStoredNetworkFlowEvent

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -918,6 +918,27 @@ santa_unit_test(
 )
 
 objc_library(
+    name = "SNTStoredNetworkFlowEvent",
+    srcs = ["SNTStoredNetworkFlowEvent.mm"],
+    hdrs = ["SNTStoredNetworkFlowEvent.h"],
+    module_name = "santa_common_SNTStoredNetworkFlowEvent",
+    deps = [
+        ":CoderMacros",
+        ":SNTStoredEvent",
+        ":SNTStoredProcess",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTStoredNetworkFlowEventTest",
+    srcs = ["SNTStoredNetworkFlowEventTest.mm"],
+    deps = [
+        ":SNTStoredNetworkFlowEvent",
+        ":SNTStoredProcess",
+    ],
+)
+
+objc_library(
     name = "SNTStoredNetworkMountEvent",
     srcs = ["SNTStoredNetworkMountEvent.mm"],
     hdrs = ["SNTStoredNetworkMountEvent.h"],
@@ -1218,6 +1239,7 @@ test_suite(
         ":SNTSandboxExecRequestTest",
         ":SNTStoredEventTest",
         ":SNTStoredExecutionEventTest",
+        ":SNTStoredNetworkFlowEventTest",
         ":SNTStoredNetworkMountEventTest",
         ":SNTStoredProcessTest",
         ":SNTStoredTemporaryMonitorModeAuditEventTest",

--- a/Source/common/SNTStoredNetworkFlowEvent.h
+++ b/Source/common/SNTStoredNetworkFlowEvent.h
@@ -44,6 +44,17 @@ typedef NS_ENUM(int32_t, SNTNetworkFlowSocketFamily) {
   SNTNetworkFlowSocketFamilyINET6 = 30,
 };
 
+/// How the matching rule's remote matcher matched the flow, most to least
+/// specific. Values aligned to the v2 proto NetworkFlowTier.
+typedef NS_ENUM(int32_t, SNTNetworkFlowTier) {
+  SNTNetworkFlowTierUnspecified = 0,
+  SNTNetworkFlowTierExactIP = 1,
+  SNTNetworkFlowTierCIDR = 2,
+  SNTNetworkFlowTierHostname = 3,
+  SNTNetworkFlowTierDomain = 4,
+  SNTNetworkFlowTierAnyRemote = 5,
+};
+
 /// A per-flow policy decision event, mirroring the v2 proto NetworkFlowEvent.
 @interface SNTStoredNetworkFlowEvent : SNTStoredEvent <NSSecureCoding>
 
@@ -60,12 +71,19 @@ typedef NS_ENUM(int32_t, SNTNetworkFlowSocketFamily) {
 
 // Outcome.
 @property SNTNetworkFlowDecision decision;
+@property SNTNetworkFlowTier decisionTier;
 @property int64_t ruleId;
+@property(nullable) NSString* ruleName;
 @property(nullable) NSArray<NSNumber*>* competingRuleIds;  // capped at 10, precedence-ordered
 @property uint32_t totalCompetingRuleCount;
 
 // Process (originating; .parent = lightweight parent).
 @property(nullable) SNTStoredProcess* process;
+
+// Opaque dedup keys built by santanetd (process identity + rule + matched-tier
+// discriminator, with cap-driven degradation). santa-internal, never uploaded.
+@property(nullable) NSString* eventDedupeKey;  // backs uniqueID (upload backoff)
+@property(nullable) NSString* uiDedupeKey;     // drives the dialog de-dup
 
 // santad-local, NOT mapped to the proto: drives the loud-deny dialog only.
 @property BOOL silent;

--- a/Source/common/SNTStoredNetworkFlowEvent.h
+++ b/Source/common/SNTStoredNetworkFlowEvent.h
@@ -1,0 +1,73 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTStoredEvent.h"
+#import "Source/common/SNTStoredProcess.h"
+
+/// Outcome of a network flow policy decision. Values are aligned to the v2 proto
+/// NetworkFlowDecision so santasyncservice maps by a plain cast. The 4-way engine
+/// decision collapses here: both deny variants map to Block (the silent bit, set
+/// separately, distinguishes them for dialog routing).
+typedef NS_ENUM(int32_t, SNTNetworkFlowDecision) {
+  SNTNetworkFlowDecisionUnspecified = 0,
+  SNTNetworkFlowDecisionAllow = 1,
+  SNTNetworkFlowDecisionBlock = 2,
+  SNTNetworkFlowDecisionAudit = 3,
+};
+
+/// Flow direction. Values aligned to the v2 proto NetworkFlowDirection.
+typedef NS_ENUM(int32_t, SNTNetworkFlowDirection) {
+  SNTNetworkFlowDirectionUnspecified = 0,
+  SNTNetworkFlowDirectionAny = 1,
+  SNTNetworkFlowDirectionOutgoing = 2,
+  SNTNetworkFlowDirectionIncoming = 3,
+};
+
+/// Socket address family. Values aligned to the v2 proto NetworkFlowSocketFamily
+/// (which match Darwin AF_INET / AF_INET6).
+typedef NS_ENUM(int32_t, SNTNetworkFlowSocketFamily) {
+  SNTNetworkFlowSocketFamilyUnspecified = 0,
+  SNTNetworkFlowSocketFamilyINET = 2,
+  SNTNetworkFlowSocketFamilyINET6 = 30,
+};
+
+/// A per-flow policy decision event, mirroring the v2 proto NetworkFlowEvent.
+@interface SNTStoredNetworkFlowEvent : SNTStoredEvent <NSSecureCoding>
+
+// Flow.
+@property(nullable) NSString* remoteAddress;
+@property uint16_t remotePort;
+@property(nullable) NSString* localAddress;
+@property uint16_t localPort;
+@property int protocol;  // IANA protocol number (6=TCP, 17=UDP, ...)
+@property SNTNetworkFlowSocketFamily socketFamily;
+@property SNTNetworkFlowDirection direction;
+@property(nullable) NSString* hostname;
+@property(nullable) NSDate* flowTime;
+
+// Outcome.
+@property SNTNetworkFlowDecision decision;
+@property int64_t ruleId;
+@property(nullable) NSArray<NSNumber*>* competingRuleIds;  // capped at 10, precedence-ordered
+@property uint32_t totalCompetingRuleCount;
+
+// Process (originating; .parent = lightweight parent).
+@property(nullable) SNTStoredProcess* process;
+
+// santad-local, NOT mapped to the proto: drives the loud-deny dialog only.
+@property BOOL silent;
+
+@end

--- a/Source/common/SNTStoredNetworkFlowEvent.mm
+++ b/Source/common/SNTStoredNetworkFlowEvent.mm
@@ -42,10 +42,14 @@
   ENCODE(coder, hostname);
   ENCODE(coder, flowTime);
   ENCODE_BOXABLE(coder, decision);
+  ENCODE_BOXABLE(coder, decisionTier);
   ENCODE_BOXABLE(coder, ruleId);
+  ENCODE(coder, ruleName);
   ENCODE(coder, competingRuleIds);
   ENCODE_BOXABLE(coder, totalCompetingRuleCount);
   ENCODE(coder, process);
+  ENCODE(coder, eventDedupeKey);
+  ENCODE(coder, uiDedupeKey);
   ENCODE_BOXABLE(coder, silent);
 }
 
@@ -62,10 +66,14 @@
     DECODE(decoder, hostname, NSString);
     DECODE(decoder, flowTime, NSDate);
     DECODE_SELECTOR(decoder, decision, NSNumber, intValue);
+    DECODE_SELECTOR(decoder, decisionTier, NSNumber, intValue);
     DECODE_SELECTOR(decoder, ruleId, NSNumber, longLongValue);
+    DECODE(decoder, ruleName, NSString);
     DECODE_ARRAY(decoder, competingRuleIds, NSNumber);
     DECODE_SELECTOR(decoder, totalCompetingRuleCount, NSNumber, unsignedIntValue);
     DECODE(decoder, process, SNTStoredProcess);
+    DECODE(decoder, eventDedupeKey, NSString);
+    DECODE(decoder, uiDedupeKey, NSString);
     DECODE_SELECTOR(decoder, silent, NSNumber, boolValue);
   }
   return self;
@@ -77,13 +85,11 @@
                                     self.remotePort, self.ruleId];
 }
 
-// Coarse on purpose: rule_id + originating process identity, NOT destination.
-// Keeps the upload backoff and the (deferred) dialog de-dup keyed on the same
-// dimension; per-destination breadth lives in NetworkActivity telemetry. Process
-// identity is signature-derived: cdhash, else signingID.
+// Opaque dedup key built by santanetd (process identity + rule + matched-tier
+// discriminator, with cap-driven degradation). Returned as-is for the upload
+// backoff cache; santa does not compose or parse it.
 - (NSString*)uniqueID {
-  NSString* procIdentity = self.process.cdhash ?: (self.process.signingID ?: @"<unknown>");
-  return [NSString stringWithFormat:@"%lld|%@", self.ruleId, procIdentity];
+  return self.eventDedupeKey;
 }
 
 // Flow dialogs are informational only (no remediation/approval workflow).

--- a/Source/common/SNTStoredNetworkFlowEvent.mm
+++ b/Source/common/SNTStoredNetworkFlowEvent.mm
@@ -1,0 +1,94 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
+
+#import "Source/common/CoderMacros.h"
+
+@implementation SNTStoredNetworkFlowEvent
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _process = [[SNTStoredProcess alloc] init];
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  [super encodeWithCoder:coder];
+  ENCODE(coder, remoteAddress);
+  ENCODE_BOXABLE(coder, remotePort);
+  ENCODE(coder, localAddress);
+  ENCODE_BOXABLE(coder, localPort);
+  ENCODE_BOXABLE(coder, protocol);
+  ENCODE_BOXABLE(coder, socketFamily);
+  ENCODE_BOXABLE(coder, direction);
+  ENCODE(coder, hostname);
+  ENCODE(coder, flowTime);
+  ENCODE_BOXABLE(coder, decision);
+  ENCODE_BOXABLE(coder, ruleId);
+  ENCODE(coder, competingRuleIds);
+  ENCODE_BOXABLE(coder, totalCompetingRuleCount);
+  ENCODE(coder, process);
+  ENCODE_BOXABLE(coder, silent);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) {
+    DECODE(decoder, remoteAddress, NSString);
+    DECODE_SELECTOR(decoder, remotePort, NSNumber, unsignedShortValue);
+    DECODE(decoder, localAddress, NSString);
+    DECODE_SELECTOR(decoder, localPort, NSNumber, unsignedShortValue);
+    DECODE_SELECTOR(decoder, protocol, NSNumber, intValue);
+    DECODE_SELECTOR(decoder, socketFamily, NSNumber, intValue);
+    DECODE_SELECTOR(decoder, direction, NSNumber, intValue);
+    DECODE(decoder, hostname, NSString);
+    DECODE(decoder, flowTime, NSDate);
+    DECODE_SELECTOR(decoder, decision, NSNumber, intValue);
+    DECODE_SELECTOR(decoder, ruleId, NSNumber, longLongValue);
+    DECODE_ARRAY(decoder, competingRuleIds, NSNumber);
+    DECODE_SELECTOR(decoder, totalCompetingRuleCount, NSNumber, unsignedIntValue);
+    DECODE(decoder, process, SNTStoredProcess);
+    DECODE_SELECTOR(decoder, silent, NSNumber, boolValue);
+  }
+  return self;
+}
+
+- (NSString*)description {
+  return [NSString stringWithFormat:@"SNTStoredNetworkFlowEvent[%@]: %@ -> %@:%hu rule:%lld",
+                                    self.idx, self.process.filePath, self.remoteAddress,
+                                    self.remotePort, self.ruleId];
+}
+
+// Coarse on purpose: rule_id + originating process identity, NOT destination.
+// Keeps the upload backoff and the (deferred) dialog de-dup keyed on the same
+// dimension; per-destination breadth lives in NetworkActivity telemetry. Process
+// identity is signature-derived: cdhash, else signingID.
+- (NSString*)uniqueID {
+  NSString* procIdentity = self.process.cdhash ?: (self.process.signingID ?: @"<unknown>");
+  return [NSString stringWithFormat:@"%lld|%@", self.ruleId, procIdentity];
+}
+
+// Flow dialogs are informational only (no remediation/approval workflow).
+- (BOOL)unactionableEvent {
+  return YES;
+}
+
+@end

--- a/Source/common/SNTStoredNetworkFlowEventTest.mm
+++ b/Source/common/SNTStoredNetworkFlowEventTest.mm
@@ -1,0 +1,95 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTStoredProcess.h"
+
+@interface SNTStoredNetworkFlowEventTest : XCTestCase
+@end
+
+@implementation SNTStoredNetworkFlowEventTest
+
+- (void)testUniqueIDCoarseOnRuleAndProcess {
+  SNTStoredNetworkFlowEvent* e = [[SNTStoredNetworkFlowEvent alloc] init];
+  e.ruleId = 42;
+  e.process.cdhash = @"cd00";
+  e.remoteAddress = @"1.2.3.4";  // destination must NOT affect uniqueID
+  XCTAssertEqualObjects([e uniqueID], @"42|cd00");
+
+  e.remoteAddress = @"9.9.9.9";  // different destination, same key
+  XCTAssertEqualObjects([e uniqueID], @"42|cd00");
+
+  e.process.cdhash = nil;  // falls back to signingID
+  e.process.signingID = @"com.example.app";
+  XCTAssertEqualObjects([e uniqueID], @"42|com.example.app");
+}
+
+- (void)testUnactionableAlwaysYes {
+  XCTAssertTrue([[[SNTStoredNetworkFlowEvent alloc] init] unactionableEvent]);
+}
+
+- (void)testEncodeDecodeRoundTrip {
+  SNTStoredNetworkFlowEvent* e = [[SNTStoredNetworkFlowEvent alloc] init];
+  e.remoteAddress = @"93.184.216.34";
+  e.remotePort = 443;
+  e.localAddress = @"10.0.0.2";
+  e.localPort = 51000;
+  e.protocol = 6;
+  e.socketFamily = SNTNetworkFlowSocketFamilyINET;
+  e.direction = SNTNetworkFlowDirectionOutgoing;
+  e.hostname = @"example.com";
+  e.flowTime = [NSDate dateWithTimeIntervalSince1970:1700000000];
+  e.decision = SNTNetworkFlowDecisionBlock;
+  e.ruleId = 7;
+  e.competingRuleIds = @[ @(3), @(5) ];
+  e.totalCompetingRuleCount = 12;
+  e.silent = YES;
+  e.process.filePath = @"/usr/bin/curl";
+  e.process.cdhash = @"deadbeef";
+  e.process.parent = [[SNTStoredProcess alloc] init];
+  e.process.parent.pid = @(1);
+
+  NSData* data = [NSKeyedArchiver archivedDataWithRootObject:e requiringSecureCoding:YES error:nil];
+  XCTAssertNotNil(data);
+
+  NSSet* allowed =
+      [NSSet setWithObjects:[SNTStoredNetworkFlowEvent class], [SNTStoredProcess class], nil];
+  SNTStoredEvent* out = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowed
+                                                            fromData:data
+                                                               error:nil];
+  XCTAssertTrue([out isKindOfClass:[SNTStoredNetworkFlowEvent class]]);
+  SNTStoredNetworkFlowEvent* d = (SNTStoredNetworkFlowEvent*)out;
+  XCTAssertEqualObjects(d.remoteAddress, @"93.184.216.34");
+  XCTAssertEqual(d.remotePort, 443);
+  XCTAssertEqualObjects(d.localAddress, @"10.0.0.2");
+  XCTAssertEqual(d.localPort, 51000);
+  XCTAssertEqual(d.protocol, 6);
+  XCTAssertEqual(d.socketFamily, SNTNetworkFlowSocketFamilyINET);
+  XCTAssertEqual(d.direction, SNTNetworkFlowDirectionOutgoing);
+  XCTAssertEqualObjects(d.hostname, @"example.com");
+  XCTAssertEqualObjects(d.flowTime, [NSDate dateWithTimeIntervalSince1970:1700000000]);
+  XCTAssertEqual(d.decision, SNTNetworkFlowDecisionBlock);
+  XCTAssertEqual(d.ruleId, 7);
+  XCTAssertEqualObjects(d.competingRuleIds, (@[ @(3), @(5) ]));
+  XCTAssertEqual(d.totalCompetingRuleCount, 12u);
+  XCTAssertTrue(d.silent);  // local field survives the round-trip
+  XCTAssertEqualObjects(d.process.filePath, @"/usr/bin/curl");
+  XCTAssertEqualObjects(d.process.parent.pid, @(1));
+}
+
+@end

--- a/Source/common/SNTStoredNetworkFlowEventTest.mm
+++ b/Source/common/SNTStoredNetworkFlowEventTest.mm
@@ -24,19 +24,13 @@
 
 @implementation SNTStoredNetworkFlowEventTest
 
-- (void)testUniqueIDCoarseOnRuleAndProcess {
+- (void)testUniqueIDReturnsEventDedupeKey {
+  // uniqueID is an opaque pass-through of the santanetd-built event key; the
+  // composition/dedup semantics are tested in santanetd, not here.
   SNTStoredNetworkFlowEvent* e = [[SNTStoredNetworkFlowEvent alloc] init];
-  e.ruleId = 42;
-  e.process.cdhash = @"cd00";
-  e.remoteAddress = @"1.2.3.4";  // destination must NOT affect uniqueID
-  XCTAssertEqualObjects([e uniqueID], @"42|cd00");
-
-  e.remoteAddress = @"9.9.9.9";  // different destination, same key
-  XCTAssertEqualObjects([e uniqueID], @"42|cd00");
-
-  e.process.cdhash = nil;  // falls back to signingID
-  e.process.signingID = @"com.example.app";
-  XCTAssertEqualObjects([e uniqueID], @"42|com.example.app");
+  e.eventDedupeKey = @"TEAM:com.example.app|42|foo.com";
+  e.remoteAddress = @"1.2.3.4";  // unrelated to the (opaque) key
+  XCTAssertEqualObjects([e uniqueID], @"TEAM:com.example.app|42|foo.com");
 }
 
 - (void)testUnactionableAlwaysYes {
@@ -55,9 +49,13 @@
   e.hostname = @"example.com";
   e.flowTime = [NSDate dateWithTimeIntervalSince1970:1700000000];
   e.decision = SNTNetworkFlowDecisionBlock;
+  e.decisionTier = SNTNetworkFlowTierDomain;
   e.ruleId = 7;
+  e.ruleName = @"block-example";
   e.competingRuleIds = @[ @(3), @(5) ];
   e.totalCompetingRuleCount = 12;
+  e.eventDedupeKey = @"TEAM:com.apple.curl|7|example.com";
+  e.uiDedupeKey = @"4242:1|7|example.com";
   e.silent = YES;
   e.process.filePath = @"/usr/bin/curl";
   e.process.cdhash = @"deadbeef";
@@ -84,12 +82,18 @@
   XCTAssertEqualObjects(d.hostname, @"example.com");
   XCTAssertEqualObjects(d.flowTime, [NSDate dateWithTimeIntervalSince1970:1700000000]);
   XCTAssertEqual(d.decision, SNTNetworkFlowDecisionBlock);
+  XCTAssertEqual(d.decisionTier, SNTNetworkFlowTierDomain);
   XCTAssertEqual(d.ruleId, 7);
+  XCTAssertEqualObjects(d.ruleName, @"block-example");
   XCTAssertEqualObjects(d.competingRuleIds, (@[ @(3), @(5) ]));
   XCTAssertEqual(d.totalCompetingRuleCount, 12u);
+  XCTAssertEqualObjects(d.eventDedupeKey, @"TEAM:com.apple.curl|7|example.com");
+  XCTAssertEqualObjects(d.uiDedupeKey, @"4242:1|7|example.com");
   XCTAssertTrue(d.silent);  // local field survives the round-trip
   XCTAssertEqualObjects(d.process.filePath, @"/usr/bin/curl");
   XCTAssertEqualObjects(d.process.parent.pid, @(1));
+  XCTAssertEqualObjects([d uniqueID],
+                        @"TEAM:com.apple.curl|7|example.com");  // backed by eventDedupeKey
 }
 
 @end


### PR DESCRIPTION
Adds `SNTStoredNetworkFlowEvent`, a stored-event model mirroring the v2 sync proto `NetworkFlowEvent`, with three proto-value-aligned `NS_ENUM`s (decision, direction, socket family) and a santad-local `silent` bit. NSSecureCoding round-trip plus uniqueID/unactionable coverage; builds standalone.