### PR TITLE
gui: Add a notification dialog for blocked network flows

### DIFF
--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -54,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSAttributedString*)attributedBlockMessageForNetworkMountEventWithCustomMessage:
     (nullable NSString*)customMsg;
 
++ (NSAttributedString*)attributedBlockMessageForNetworkFlowEventWithCustomMessage:
+    (nullable NSString*)customMsg;
+
 ///
 ///  Return a URL generated from the EventDetailURL configuration key
 ///  after replacing templates in the URL with values from the event.

--- a/Source/common/SNTBlockMessage.mm
+++ b/Source/common/SNTBlockMessage.mm
@@ -151,6 +151,15 @@ static id EncodedValueOrNull(id value) {
   return [SNTBlockMessage formatMessage:customMsg withFallback:defaultBannedMessage];
 }
 
++ (NSAttributedString*)attributedBlockMessageForNetworkFlowEventWithCustomMessage:
+    (NSString*)customMsg {
+  NSString* defaultBlockedMessage = NSLocalizedString(
+      @"The following application has been blocked<br />from reaching a network destination",
+      @"The default message to show the user when a network flow is blocked");
+
+  return [SNTBlockMessage formatMessage:customMsg withFallback:defaultBlockedMessage];
+}
+
 + (NSString*)blockReasonForEvent:(SNTStoredExecutionEvent*)event {
   NSString* reason;
   switch (event.decision) {

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -23,6 +23,7 @@
 @class SNTDeviceEvent;
 @class SNTStoredExecutionEvent;
 @class SNTStoredFileAccessEvent;
+@class SNTStoredNetworkFlowEvent;
 @class SNTStoredNetworkMountEvent;
 
 /// Protocol implemented by SantaGUI and utilized by santad
@@ -40,6 +41,8 @@
                               customURL:(NSString*)url
                              customText:(NSString*)text
                             configState:(SNTConfigState*)configState;
+- (void)postNetworkFlowBlockNotification:(SNTStoredNetworkFlowEvent*)event
+                            configBundle:(SNTConfigBundle*)configBundle;
 - (void)postClientModeNotification:(SNTClientMode)clientmode;
 - (void)postRuleSyncNotificationForApplication:(NSString*)app;
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply;

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -119,6 +119,20 @@ swift_library(
 )
 
 swift_library(
+    name = "SNTNetworkFlowMessageWindowView",
+    srcs = [
+        "SNTNetworkFlowMessageWindowView.swift",
+    ],
+    generates_header = 1,
+    deps = [
+        ":SNTMessageView",
+        "//Source/common:SNTBlockMessage_SantaGUI",
+        "//Source/common:SNTConfigBundle",
+        "//Source/common:SNTStoredNetworkFlowEvent",
+    ],
+)
+
+swift_library(
     name = "SNTNetworkMountMessageWindowView",
     srcs = [
         "SNTNetworkMountMessageWindowView.swift",
@@ -163,6 +177,8 @@ objc_library(
         "SNTFileAccessMessageWindowController.mm",
         "SNTMessageWindowController.h",
         "SNTMessageWindowController.mm",
+        "SNTNetworkFlowMessageWindowController.h",
+        "SNTNetworkFlowMessageWindowController.mm",
         "SNTNetworkMountMessageWindowController.h",
         "SNTNetworkMountMessageWindowController.mm",
         "SNTNotificationManager.h",
@@ -185,6 +201,7 @@ objc_library(
         ":SNTDeviceMessageWindowView",
         ":SNTFileAccessMessageWindowView",
         ":SNTFileInfoView",
+        ":SNTNetworkFlowMessageWindowView",
         ":SNTNetworkMountMessageWindowView",
         ":SNTSystemExtensionDelegate",
         "//Source/common:CertificateHelpers",
@@ -202,12 +219,14 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredExecutionEvent",
         "//Source/common:SNTStoredFileAccessEvent",
+        "//Source/common:SNTStoredNetworkFlowEvent",
         "//Source/common:SNTStoredNetworkMountEvent",
         "//Source/common:SNTStrengthify",
         "//Source/common:SNTSyncConstants",
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCNotifierInterface",
         "//Source/common:SNTXPCSyncServiceInterface",
+        "//Source/common:SigningIDHelpers",
     ],
 )
 
@@ -264,6 +283,7 @@ swift_library(
         ":SNTDeviceMessageWindowView",
         ":SNTFileAccessMessageWindowView",
         ":SNTMessageView",
+        ":SNTNetworkFlowMessageWindowView",
         "//Source/common:SNTConfigBundle",
         "//Source/common:SNTDeviceEvent",
     ],
@@ -294,7 +314,9 @@ santa_unit_test(
     ],
     deps = [
         ":SantaGUI_lib",
+        "//Source/common:SNTConfigBundle",
         "//Source/common:SNTStoredExecutionEvent",
+        "//Source/common:SNTStoredNetworkFlowEvent",
         "@OCMock",
     ],
 )

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -232,6 +232,9 @@
 /* No comment provided by engineer. */
 "Team ID" = "Team-ID";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "Die folgende Applikation wurde daran gehindert,<br />ein Netzwerkziel zu erreichen";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Die folgende Applikation wurde blockiert,<br />da ihre Vertrauenswürdigkeit nicht überprüft werden kann";
 

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "The event upload failed. Please check your network connection and try again.";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "The following application has been blocked<br />from reaching a network destination";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "The following application has been blocked from executing<br />because its trustworthiness cannot be determined";
 

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "Error al cargar el evento. Por favor, verifique su conexión de red e inténtelo de nuevo.";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "La siguiente aplicación ha sido bloqueada<br />para que no acceda a un destino de red";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "La siguiente aplicación ha sido bloqueada<br />porque no se pudo determinar su nivel de confianza";
 

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -220,6 +220,9 @@
 /* No comment provided by engineer. [QC] */
 "The event upload failed. Please check your network connection and try again." = "Le téléversement de l'événement a échoué. Veuillez vérifier votre connexion réseau et réessayer.";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "L'application suivante a été bloquée<br />et ne peut atteindre une destination réseau";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "L'application suivante a été bloquée<br />car son niveau de confiance n'a pas pu être déterminé";
 

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "L'envoi de l'événement a échoué. Veuillez vérifier votre connexion réseau et réessayer.";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "L'application suivante a été bloquée<br />et ne peut atteindre une destination réseau";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "L'application suivante a été bloquée<br />car son niveau de confiance n'a pas pu être déterminé";
 

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -232,6 +232,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "チームIDルール";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "次のアプリケーションによる<br />ネットワーク宛先への接続がブロックされました";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "次のアプリケーションは信頼性を判断できないため、<br />実行がブロックされました";
 

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -232,6 +232,9 @@
 /* No comment provided by engineer. */
 "Too many syncs are in progress. Please try again later." = "Уже выполняется слишком много операций синхронизации. Пожалуйста, попробуйте позже.";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "Следующему приложению заблокирован доступ<br />к сетевому ресурсу";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Запуск следующего приложения был заблокирован,<br />поскольку невозможно определить, можно ли этому приложению доверять";
 

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -232,6 +232,9 @@
 /* No comment provided by engineer. */
 "Too many syncs are in progress. Please try again later." = "Забагато синхронізацій виконується. Будь ласка, спробуйте пізніше.";
 
+/* The default message to show the user when a network flow is blocked */
+"The following application has been blocked<br />from reaching a network destination" = "Наступній програмі заблоковано доступ<br />до мережевого ресурсу";
+
 /* The default message to show the user when an unknown application is blocked */
 "The following application has been blocked from executing<br />because its trustworthiness cannot be determined" = "Наступна програма була заблокована для виконання,<br />оскільки не може бути визначена її достовірність";
 

--- a/Source/gui/SNTDeviceMessageWindowController.mm
+++ b/Source/gui/SNTDeviceMessageWindowController.mm
@@ -19,6 +19,7 @@
 #import "Source/common/SNTBlockMessage.h"
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTDeviceEvent.h"
+#import "Source/common/SNTStrengthify.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,12 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
 
   self.window = [SNTMessageWindowController defaultWindow];
 
+  WEAKIFY(self);
   self.window.contentViewController = [SNTDeviceMessageWindowViewFactory
       createWithWindow:self.window
                  event:self.event
           configBundle:self.configBundle
            silenceable:([self messageHash] != nil)
        uiStateCallback:^(NSTimeInterval preventNotificationsPeriod) {
+         STRONGIFY(self);
          self.silenceFutureNotificationsPeriod = preventNotificationsPeriod;
        }];
   self.window.delegate = self;

--- a/Source/gui/SNTMessageWindowController.h
+++ b/Source/gui/SNTMessageWindowController.h
@@ -27,8 +27,12 @@
 - (IBAction)closeWindow:(id)sender;
 
 /// Generate a distinct key for a given displayed event. This key is used for silencing future
-/// notifications.
+/// notifications, and by default for collapsing notifications already queued.
 - (NSString*)messageHash;
+
+/// Key used to collapse a notification that is already queued or on-screen. Defaults to
+/// -messageHash; override when queue de-dup should be finer-grained than the silence key.
+- (NSString*)queueDedupeHash;
 
 ///  Linked to checkbox in UI to prevent future notifications for the given event for a given period
 @property NSTimeInterval silenceFutureNotificationsPeriod;

--- a/Source/gui/SNTMessageWindowController.mm
+++ b/Source/gui/SNTMessageWindowController.mm
@@ -80,4 +80,8 @@
   return nil;
 }
 
+- (NSString*)queueDedupeHash {
+  return [self messageHash];
+}
+
 @end

--- a/Source/gui/SNTNetworkFlowMessageWindowController.h
+++ b/Source/gui/SNTNetworkFlowMessageWindowController.h
@@ -1,0 +1,34 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Cocoa/Cocoa.h>
+
+#import "Source/gui/SNTMessageWindowController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SNTConfigBundle;
+@class SNTStoredNetworkFlowEvent;
+
+/// Informational dialog shown when a network flow is loudly denied.
+@interface SNTNetworkFlowMessageWindowController : SNTMessageWindowController <NSWindowDelegate>
+
+- (instancetype)initWithEvent:(SNTStoredNetworkFlowEvent*)event
+                 configBundle:(SNTConfigBundle*)configBundle;
+
+@property(readonly) SNTStoredNetworkFlowEvent* event;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/gui/SNTNetworkFlowMessageWindowController.mm
+++ b/Source/gui/SNTNetworkFlowMessageWindowController.mm
@@ -1,0 +1,85 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/gui/SNTNetworkFlowMessageWindowController.h"
+
+#import "Source/gui/SNTNetworkFlowMessageWindowView-Swift.h"
+
+#import "Source/common/SNTConfigBundle.h"
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
+#import "Source/common/SNTStrengthify.h"
+#import "Source/common/SigningIDHelpers.h"
+
+@interface SNTNetworkFlowMessageWindowController ()
+@property SNTConfigBundle* configBundle;
+@property SNTStoredNetworkFlowEvent* event;
+@end
+
+@implementation SNTNetworkFlowMessageWindowController
+
+- (instancetype)initWithEvent:(SNTStoredNetworkFlowEvent*)event
+                 configBundle:(SNTConfigBundle*)configBundle {
+  self = [super init];
+  if (self) {
+    _event = event;
+    _configBundle = configBundle;
+  }
+  return self;
+}
+
+- (void)showWindow:(id)sender {
+  if (self.window) {
+    [self.window orderOut:sender];
+  }
+
+  self.window = [SNTMessageWindowController defaultWindow];
+
+  WEAKIFY(self);
+  self.window.contentViewController = [SNTNetworkFlowMessageWindowViewFactory
+      createWithWindow:self.window
+                 event:self.event
+          configBundle:self.configBundle
+           silenceable:([self messageHash] != nil)
+       uiStateCallback:^(NSTimeInterval preventNotificationsPeriod) {
+         STRONGIFY(self);
+         self.silenceFutureNotificationsPeriod = preventNotificationsPeriod;
+       }];
+  self.window.delegate = self;
+
+  [super showWindow:sender];
+}
+
+- (NSString*)messageHash {
+  // Silence key: app-level and cross-version, so muting an app suppresses its network-block
+  // dialogs regardless of destination, rule, or app version. Prefer the team+signing ID (stable
+  // across updates), then cdhash, then the best-effort file hash. nil when no stable identity is
+  // present so unidentified events don't collapse onto one shared silence key.
+  SNTStoredProcess* process = self.event.process;
+  NSString* signingID = FormatSigningID(process.signingID, process.teamID, NO);
+  if (signingID.length) return [@"netflow:signingid:" stringByAppendingString:signingID];
+  if (process.cdhash.length) return [@"netflow:cdhash:" stringByAppendingString:process.cdhash];
+  if (process.fileSHA256.length)
+    return [@"netflow:sha256:" stringByAppendingString:process.fileSHA256];
+  return nil;
+}
+
+- (NSString*)queueDedupeHash {
+  // Finer-grained than the silence key: the already-queued check should still collapse only exact
+  // repeats of the same (process, rule, destination), so distinct flows from one app each get
+  // their own dialog. uiDedupeKey encodes that tuple; nil when absent.
+  if (!self.event.uiDedupeKey.length) return nil;
+  return [@"netflow:" stringByAppendingString:self.event.uiDedupeKey];
+}
+
+@end

--- a/Source/gui/SNTNetworkFlowMessageWindowView.swift
+++ b/Source/gui/SNTNetworkFlowMessageWindowView.swift
@@ -1,0 +1,291 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+import SwiftUI
+
+import santa_common_SNTBlockMessage
+import santa_common_SNTConfigBundle
+import santa_common_SNTStoredNetworkFlowEvent
+import santa_gui_SNTMessageView
+
+@objc public class SNTNetworkFlowMessageWindowViewFactory: NSObject {
+  @objc public static func createWith(
+    window: NSWindow,
+    event: SNTStoredNetworkFlowEvent,
+    configBundle: SNTConfigBundle,
+    silenceable: Bool,
+    uiStateCallback: ((TimeInterval) -> Void)?
+  ) -> NSViewController {
+    return NSHostingController(
+      rootView: SNTNetworkFlowMessageWindowView(
+        window: window,
+        event: event,
+        configBundle: configBundle,
+        silenceable: silenceable,
+        uiStateCallback: uiStateCallback
+      ).fixedSize()
+    )
+  }
+}
+
+// Human-readable description of the policy decision.
+func networkFlowDecisionDescription(_ decision: SNTNetworkFlowDecision) -> String {
+  switch decision {
+  case .allow: return "Allow"
+  case .block: return "Block"
+  case .audit: return "Audit"
+  default: return "Unspecified"
+  }
+}
+
+// Human-readable description of how the matching rule's remote matcher matched the flow.
+func networkFlowTierDescription(_ tier: SNTNetworkFlowTier) -> String {
+  switch tier {
+  case .exactIP: return "Exact IP"
+  case .CIDR: return "CIDR"
+  case .hostname: return "Hostname"
+  case .domain: return "Domain"
+  case .anyRemote: return "Any remote"
+  default: return "Unspecified"
+  }
+}
+
+// Human-readable flow direction.
+func networkFlowDirectionDescription(_ direction: SNTNetworkFlowDirection) -> String {
+  switch direction {
+  case .outgoing: return "Outgoing"
+  case .incoming: return "Incoming"
+  case .unspecified: return "Unspecified"
+  default: return "Any"
+  }
+}
+
+// Human-readable socket address family (values match Darwin AF_INET / AF_INET6).
+func networkFlowSocketFamilyDescription(_ family: SNTNetworkFlowSocketFamily) -> String {
+  switch family.rawValue {
+  case 2: return "IPv4"
+  case 30: return "IPv6"
+  default: return "Unspecified"
+  }
+}
+
+// Human-readable transport protocol from its IANA number.
+func networkFlowProtocolDescription(_ proto: Int32) -> String {
+  switch proto {
+  case 6: return "TCP"
+  case 17: return "UDP"
+  default: return "\(proto)"
+  }
+}
+
+func networkFlowRemote(_ e: SNTStoredNetworkFlowEvent?) -> String {
+  return "\(e?.remoteAddress ?? "<unknown>"):\(e?.remotePort ?? 0)"
+}
+
+// Build a plain-text dump of the event for an admin to paste alongside other telemetry.
+func copyNetworkFlowDetailsToClipboard(e: SNTStoredNetworkFlowEvent?) {
+  var s =
+    "Santa blocked \((e?.process?.filePath as NSString?)?.lastPathComponent ?? "<unknown>") from reaching a network destination"
+  s += "\nProcess:"
+  s += "\n  Path           : \(e?.process?.filePath ?? "<unknown>")"
+  s += "\n  SHA-256        : \(e?.process?.fileSHA256 ?? "<unknown>")"
+  if let cdhash = e?.process?.cdhash { s += "\n  CDHash         : \(cdhash)" }
+  if let signingID = e?.process?.signingID { s += "\n  Signing ID     : \(signingID)" }
+  if let teamID = e?.process?.teamID { s += "\n  Team ID        : \(teamID)" }
+  if let pid = e?.process?.pid { s += "\n  PID            : \(pid.stringValue)" }
+  s += "\n  User           : \(e?.process?.executingUser ?? "<unknown>")"
+  if let parent = e?.process?.parent {
+    s +=
+      "\n  Parent         : \((parent.filePath as NSString?)?.lastPathComponent ?? "<unknown>") (\(parent.pid?.stringValue ?? "unknown PID"))"
+  }
+  s += "\nConnection:"
+  s += "\n  Direction      : \(networkFlowDirectionDescription(e?.direction ?? .unspecified))"
+  s += "\n  Protocol       : \(networkFlowProtocolDescription(e?.`protocol` ?? 0))"
+  s += "\n  Remote         : \(networkFlowRemote(e))"
+  if let host = e?.hostname, !host.isEmpty { s += "\n  Hostname       : \(host)" }
+  if let local = e?.localAddress, !local.isEmpty {
+    s += "\n  Local          : \(local):\(e?.localPort ?? 0)"
+  }
+  s += "\n  Address Family : \(networkFlowSocketFamilyDescription(e?.socketFamily ?? .unspecified))"
+  if let flowTime = e?.flowTime { s += "\n  Time           : \(flowTime)" }
+  s += "\nRule:"
+  s += "\n  Decision       : \(networkFlowDecisionDescription(e?.decision ?? .unspecified))"
+  s += "\n  Match          : \(networkFlowTierDescription(e?.decisionTier ?? .unspecified))"
+  if let ruleName = e?.ruleName, !ruleName.isEmpty { s += "\n  Rule Name      : \(ruleName)" }
+  s += "\n"
+
+  let pasteboard = NSPasteboard.general
+  pasteboard.clearContents()
+  pasteboard.setString(s, forType: .string)
+}
+
+// Fine-grained detail pane, surfaced via "More Details". Aimed at an admin correlating this
+// block with other telemetry (process identity + the full connection 5-tuple + rule context).
+struct NetworkFlowMoreDetailsView: View {
+  let e: SNTStoredNetworkFlowEvent?
+
+  @Environment(\.presentationMode) var presentationMode
+
+  func row(_ label: String, _ value: String) -> some View {
+    HStack(alignment: .top, spacing: 8.0) {
+      Text(label).bold().font(Font.system(size: 12.0)).frame(width: 110.0, alignment: .leading)
+      Text(value).font(Font.system(size: 12.0).monospaced()).frame(
+        maxWidth: .infinity,
+        alignment: .leading
+      ).textSelection(.enabled)
+    }
+    .padding(.leading, 12.0)
+  }
+
+  func header(_ title: String) -> some View {
+    Text(title).bold().font(Font.system(size: 13.0)).frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.top, 6.0)
+  }
+
+  var body: some View {
+    VStack(spacing: 12.0) {
+      VStack(alignment: .leading, spacing: 6.0) {
+        header("Process")
+        if let path = e?.process?.filePath { row("Binary Path", path) }
+        if let sha256 = e?.process?.fileSHA256 { row("SHA-256", sha256) }
+        if let cdhash = e?.process?.cdhash { row("CDHash", cdhash) }
+        if let signingID = e?.process?.signingID { row("Signing ID", signingID) }
+        if let teamID = e?.process?.teamID { row("Team ID", teamID) }
+        if let pid = e?.process?.pid { row("PID", pid.stringValue) }
+        if let user = e?.process?.executingUser { row("User", user) }
+        if let parent = e?.process?.parent {
+          row(
+            "Parent",
+            "\((parent.filePath as NSString?)?.lastPathComponent ?? "<unknown>") (\(parent.pid?.stringValue ?? "unknown PID"))"
+          )
+        }
+
+        header("Connection")
+        row("Direction", networkFlowDirectionDescription(e?.direction ?? .unspecified))
+        row("Protocol", networkFlowProtocolDescription(e?.`protocol` ?? 0))
+        row("Remote", networkFlowRemote(e))
+        if let host = e?.hostname, !host.isEmpty { row("Hostname", host) }
+        if let localAddress = e?.localAddress, !localAddress.isEmpty {
+          row("Local", "\(localAddress):\(e?.localPort ?? 0)")
+        }
+        row("Address Family", networkFlowSocketFamilyDescription(e?.socketFamily ?? .unspecified))
+        if let flowTime = e?.flowTime { row("Time", "\(flowTime)") }
+
+        header("Rule")
+        row("Decision", networkFlowDecisionDescription(e?.decision ?? .unspecified))
+        row("Match", networkFlowTierDescription(e?.decisionTier ?? .unspecified))
+        if let ruleName = e?.ruleName, !ruleName.isEmpty { row("Rule Name", ruleName) }
+      }
+
+      HStack {
+        CopyDetailsButton(action: { copyNetworkFlowDetailsToClipboard(e: e) })
+
+        Button(action: { presentationMode.wrappedValue.dismiss() }) {
+          HStack(spacing: 2.0) {
+            Text("Dismiss", comment: "Dismiss button in more details dialog").foregroundColor(.blue)
+            Image(systemName: "xmark.circle").foregroundColor(.blue)
+          }
+        }
+        .buttonStyle(ScalingButtonStyle())
+        .keyboardShortcut(.cancelAction)
+        .help("Esc")
+      }
+    }
+    .padding(20.0)
+    .frame(width: MAX_OUTER_VIEW_WIDTH - 20)
+    .fixedSize(horizontal: false, vertical: true)
+    .background(Color.gray.opacity(0.2))
+  }
+}
+
+struct NetworkFlowDetail: View {
+  let e: SNTStoredNetworkFlowEvent?
+
+  @State private var isShowingDetails = false
+
+  var destinationText: String {
+    let host = e?.hostname ?? ""
+    let dest = host.isEmpty ? (e?.remoteAddress ?? "<unknown>") : host
+    return "\(dest):\(e?.remotePort ?? 0)"
+  }
+
+  var body: some View {
+    HStack(spacing: 20.0) {
+      VStack(alignment: .trailing, spacing: 10.0) {
+        Text("Application").bold()
+        Text("Destination").bold()
+      }
+
+      Divider()
+
+      VStack(alignment: .leading, spacing: 10.0) {
+        TextWithLimit((e?.process?.filePath as NSString?)?.lastPathComponent ?? "<unknown>")
+          .textSelection(.enabled)
+        TextWithLimit(destinationText).textSelection(.enabled)
+      }
+    }
+    .sheet(isPresented: $isShowingDetails) {
+      NetworkFlowMoreDetailsView(e: e)
+    }
+
+    VStack(spacing: 2.0) {
+      Spacer()
+
+      HStack {
+        MoreDetailsButton($isShowingDetails)
+        CopyDetailsButton(action: { copyNetworkFlowDetailsToClipboard(e: e) })
+      }
+
+      Spacer()
+    }
+  }
+}
+
+struct SNTNetworkFlowMessageWindowView: View {
+  let window: NSWindow?
+  let event: SNTStoredNetworkFlowEvent?
+  let configBundle: SNTConfigBundle
+  let silenceable: Bool
+  let uiStateCallback: ((TimeInterval) -> Void)?
+
+  @State public var preventFutureNotifications = false
+  @State public var preventFutureNotificationPeriod: TimeInterval = NotificationSilencePeriods[0]
+
+  var body: some View {
+    SNTMessageView(
+      SNTBlockMessage.attributedBlockMessageForNetworkFlowEvent(withCustomMessage: nil)
+    ) {
+      NetworkFlowDetail(e: event)
+
+      if configBundle.notificationSilencesEnabled() && silenceable {
+        SNTNotificationSilenceView(
+          silence: $preventFutureNotifications,
+          period: $preventFutureNotificationPeriod
+        )
+      }
+
+      HStack {
+        DismissButton(silence: preventFutureNotifications, action: dismissButton)
+      }
+    }
+    .fixedSize()
+  }
+
+  func dismissButton() {
+    if let callback = uiStateCallback {
+      callback(preventFutureNotifications ? preventFutureNotificationPeriod : 0)
+    }
+    window?.close()
+  }
+}

--- a/Source/gui/SNTNetworkFlowMessageWindowView.swift
+++ b/Source/gui/SNTNetworkFlowMessageWindowView.swift
@@ -89,8 +89,15 @@ func networkFlowProtocolDescription(_ proto: Int32) -> String {
   }
 }
 
+// Render an address:port endpoint, bracketing IPv6 literals so "[addr]:port" stays unambiguous.
+func formatEndpoint(_ address: String?, _ port: UInt16?) -> String {
+  let host = (address?.isEmpty == false) ? address! : "<unknown>"
+  let isIPv6 = host.contains(":") && !(host.hasPrefix("[") && host.hasSuffix("]"))
+  return "\(isIPv6 ? "[\(host)]" : host):\(port ?? 0)"
+}
+
 func networkFlowRemote(_ e: SNTStoredNetworkFlowEvent?) -> String {
-  return "\(e?.remoteAddress ?? "<unknown>"):\(e?.remotePort ?? 0)"
+  return formatEndpoint(e?.remoteAddress, e?.remotePort)
 }
 
 // Build a plain-text dump of the event for an admin to paste alongside other telemetry.
@@ -115,7 +122,7 @@ func copyNetworkFlowDetailsToClipboard(e: SNTStoredNetworkFlowEvent?) {
   s += "\n  Remote         : \(networkFlowRemote(e))"
   if let host = e?.hostname, !host.isEmpty { s += "\n  Hostname       : \(host)" }
   if let local = e?.localAddress, !local.isEmpty {
-    s += "\n  Local          : \(local):\(e?.localPort ?? 0)"
+    s += "\n  Local          : \(formatEndpoint(local, e?.localPort))"
   }
   s += "\n  Address Family : \(networkFlowSocketFamilyDescription(e?.socketFamily ?? .unspecified))"
   if let flowTime = e?.flowTime { s += "\n  Time           : \(flowTime)" }
@@ -177,7 +184,7 @@ struct NetworkFlowMoreDetailsView: View {
         row("Remote", networkFlowRemote(e))
         if let host = e?.hostname, !host.isEmpty { row("Hostname", host) }
         if let localAddress = e?.localAddress, !localAddress.isEmpty {
-          row("Local", "\(localAddress):\(e?.localPort ?? 0)")
+          row("Local", formatEndpoint(localAddress, e?.localPort))
         }
         row("Address Family", networkFlowSocketFamilyDescription(e?.socketFamily ?? .unspecified))
         if let flowTime = e?.flowTime { row("Time", "\(flowTime)") }
@@ -217,7 +224,7 @@ struct NetworkFlowDetail: View {
   var destinationText: String {
     let host = e?.hostname ?? ""
     let dest = host.isEmpty ? (e?.remoteAddress ?? "<unknown>") : host
-    return "\(dest):\(e?.remotePort ?? 0)"
+    return formatEndpoint(dest, e?.remotePort)
   }
 
   var body: some View {

--- a/Source/gui/SNTNetworkMountMessageWindowController.mm
+++ b/Source/gui/SNTNetworkMountMessageWindowController.mm
@@ -16,6 +16,8 @@
 
 #import "Source/gui/SNTNetworkMountMessageWindowView-Swift.h"
 
+#import "Source/common/SNTStrengthify.h"
+
 @implementation SNTNetworkMountMessageWindowController
 
 - (instancetype)initWithEvent:(SNTStoredNetworkMountEvent*)event
@@ -33,12 +35,14 @@
 
   self.window = [SNTMessageWindowController defaultWindow];
 
+  WEAKIFY(self);
   self.window.contentViewController = [SNTNetworkMountMessageWindowViewFactory
       createWithWindow:self.window
                  event:self.event
           configBundle:self.configBundle
            silenceable:([self messageHash] != nil)
        uiStateCallback:^(NSTimeInterval preventNotificationsPeriod) {
+         STRONGIFY(self);
          self.silenceFutureNotificationsPeriod = preventNotificationsPeriod;
        }];
   self.window.delegate = self;

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -29,6 +29,7 @@
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStoredFileAccessEvent.h"
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
 #import "Source/common/SNTStoredNetworkMountEvent.h"
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSyncConstants.h"
@@ -40,6 +41,7 @@
 #import "Source/gui/SNTDeviceMessageWindowController.h"
 #import "Source/gui/SNTFileAccessMessageWindowController.h"
 #import "Source/gui/SNTMessageWindowController.h"
+#import "Source/gui/SNTNetworkFlowMessageWindowController.h"
 #import "Source/gui/SNTNetworkMountMessageWindowController.h"
 #import "Source/gui/SNTStatusItemManager.h"
 #import "src/santanetd/SNDFilterConfigurationHelper.h"
@@ -101,7 +103,7 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
 
 - (BOOL)notificationAlreadyQueued:(SNTMessageWindowController*)pendingMsg {
   for (SNTMessageWindowController* msg in self.pendingNotifications) {
-    if ([[msg messageHash] isEqual:[pendingMsg messageHash]]) return YES;
+    if ([[msg queueDedupeHash] isEqual:[pendingMsg queueDedupeHash]]) return YES;
   }
   return NO;
 }
@@ -478,6 +480,23 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
                                                       configState:configState];
 
   [self queueMessage:pendingMsg enableSilences:YES];
+}
+
+- (void)postNetworkFlowBlockNotification:(SNTStoredNetworkFlowEvent*)event
+                            configBundle:(SNTConfigBundle*)configBundle {
+  if (!event) {
+    LOGI(@"Error: Missing event object in message received from daemon!");
+    return;
+  }
+
+  SNTNetworkFlowMessageWindowController* pendingMsg =
+      [[SNTNetworkFlowMessageWindowController alloc] initWithEvent:event configBundle:configBundle];
+
+  __block BOOL enableSilences = YES;
+  [configBundle enableNotificationSilences:^(BOOL val) {
+    enableSilences = val;
+  }];
+  [self queueMessage:pendingMsg enableSilences:enableSilences];
 }
 
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply {

--- a/Source/gui/SNTNotificationManagerTest.mm
+++ b/Source/gui/SNTNotificationManagerTest.mm
@@ -16,15 +16,30 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "Source/gui/SNTMessageWindowController.h"
+#import "Source/gui/SNTNetworkFlowMessageWindowController.h"
 #import "Source/gui/SNTNotificationManager.h"
 
+#import "Source/common/SNTConfigBundle.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
 
 @class SNTBinaryMessageWindowController;
 
 @interface SNTNotificationManager (Testing)
 - (void)hashBundleBinariesForEvent:(SNTStoredEvent*)event
                     withController:(SNTBinaryMessageWindowController*)controller;
+- (void)queueMessage:(SNTMessageWindowController*)pendingMsg enableSilences:(BOOL)enableSilences;
+@end
+
+// Overrides only messageHash, to confirm the base queueDedupeHash defaults to it.
+@interface DedupeHashPassthroughController : SNTMessageWindowController
+@end
+
+@implementation DedupeHashPassthroughController
+- (NSString*)messageHash {
+  return @"passthrough-key";
+}
 @end
 
 @interface SNTNotificationManagerTest : XCTestCase
@@ -76,6 +91,101 @@
                                    return YES;
                                  }]
                        deliverImmediately:YES]);
+}
+
+- (void)testPostNetworkFlowBlockNotificationQueuesAWindow {
+  SNTNotificationManager* mgr = [[SNTNotificationManager alloc] init];
+  id mgrMock = OCMPartialMock(mgr);
+  // Silences track the bundle's EnableNotificationSilences (here: disabled).
+  OCMExpect([mgrMock
+        queueMessage:[OCMArg isKindOfClass:[SNTNetworkFlowMessageWindowController class]]
+      enableSilences:NO]);
+
+  SNTConfigBundle* configBundle = [[SNTConfigBundle alloc] init];
+  [configBundle setValue:@NO forKey:@"enableNotificationSilences"];
+
+  SNTStoredNetworkFlowEvent* event = [[SNTStoredNetworkFlowEvent alloc] init];
+  event.decision = SNTNetworkFlowDecisionBlock;
+  [mgr postNetworkFlowBlockNotification:event configBundle:configBundle];
+
+  OCMVerifyAll(mgrMock);
+  [mgrMock stopMocking];
+}
+
+// The silence key (messageHash) is app-level + cross-version; the already-queued key
+// (queueDedupeHash) stays fine-grained on the full uiDedupeKey.
+- (void)testNetworkFlowControllerSilenceAndDedupeHashes {
+  SNTStoredNetworkFlowEvent* event = [[SNTStoredNetworkFlowEvent alloc] init];
+  event.uiDedupeKey = @"4242:1|7|example.com";
+  event.process.signingID = @"com.example.app";
+  event.process.teamID = @"ABCDE12345";
+  event.process.cdhash = @"cd123";
+  event.process.fileSHA256 = @"sha123";
+
+  SNTNetworkFlowMessageWindowController* controller =
+      [[SNTNetworkFlowMessageWindowController alloc] initWithEvent:event
+                                                      configBundle:[[SNTConfigBundle alloc] init]];
+
+  XCTAssertEqualObjects([controller messageHash], @"netflow:signingid:ABCDE12345:com.example.app");
+  XCTAssertEqualObjects([controller queueDedupeHash], @"netflow:4242:1|7|example.com");
+}
+
+// Silence key degrades cdhash -> sha256 when no signing ID is present.
+- (void)testNetworkFlowControllerSilenceHashFallback {
+  SNTStoredNetworkFlowEvent* cdhashEvent = [[SNTStoredNetworkFlowEvent alloc] init];
+  cdhashEvent.process.cdhash = @"cd123";
+  cdhashEvent.process.fileSHA256 = @"sha123";
+  XCTAssertEqualObjects([[[SNTNetworkFlowMessageWindowController alloc]
+                            initWithEvent:cdhashEvent
+                             configBundle:[[SNTConfigBundle alloc] init]] messageHash],
+                        @"netflow:cdhash:cd123");
+
+  SNTStoredNetworkFlowEvent* shaEvent = [[SNTStoredNetworkFlowEvent alloc] init];
+  shaEvent.process.fileSHA256 = @"sha123";
+  XCTAssertEqualObjects([[[SNTNetworkFlowMessageWindowController alloc]
+                            initWithEvent:shaEvent
+                             configBundle:[[SNTConfigBundle alloc] init]] messageHash],
+                        @"netflow:sha256:sha123");
+}
+
+// No stable identity / no uiDedupeKey -> nil, so unidentified events don't collapse onto a
+// shared key.
+- (void)testNetworkFlowControllerHashesNilWhenUnidentified {
+  SNTStoredNetworkFlowEvent* event = [[SNTStoredNetworkFlowEvent alloc] init];
+  SNTNetworkFlowMessageWindowController* controller =
+      [[SNTNetworkFlowMessageWindowController alloc] initWithEvent:event
+                                                      configBundle:[[SNTConfigBundle alloc] init]];
+
+  XCTAssertNil([controller messageHash]);
+  XCTAssertNil([controller queueDedupeHash]);
+}
+
+// The core decoupling invariant: two flows from the same app to different destinations share one
+// silence key (silencing covers both) but keep distinct already-queued keys (each still shown).
+- (void)testNetworkFlowSilenceScopeIsAppWideButDedupeIsPerFlow {
+  SNTStoredNetworkFlowEvent* (^flow)(NSString*) = ^(NSString* uiDedupeKey) {
+    SNTStoredNetworkFlowEvent* event = [[SNTStoredNetworkFlowEvent alloc] init];
+    event.process.signingID = @"com.example.app";
+    event.process.teamID = @"ABCDE12345";
+    event.uiDedupeKey = uiDedupeKey;
+    return event;
+  };
+  SNTNetworkFlowMessageWindowController* a =
+      [[SNTNetworkFlowMessageWindowController alloc] initWithEvent:flow(@"k|1|host-a")
+                                                      configBundle:[[SNTConfigBundle alloc] init]];
+  SNTNetworkFlowMessageWindowController* b =
+      [[SNTNetworkFlowMessageWindowController alloc] initWithEvent:flow(@"k|1|host-b")
+                                                      configBundle:[[SNTConfigBundle alloc] init]];
+
+  XCTAssertEqualObjects([a messageHash], [b messageHash]);             // one silence covers both
+  XCTAssertNotEqualObjects([a queueDedupeHash], [b queueDedupeHash]);  // but each is still shown
+}
+
+// The base queueDedupeHash defaults to messageHash, so non-overriding dialogs (binary/FAA/mount/
+// device) keep collapsing on their silence key exactly as before.
+- (void)testQueueDedupeHashDefaultsToMessageHash {
+  DedupeHashPassthroughController* controller = [[DedupeHashPassthroughController alloc] init];
+  XCTAssertEqualObjects([controller queueDedupeHash], @"passthrough-key");
 }
 
 @end

--- a/Source/gui/SNTTestGUI.swift
+++ b/Source/gui/SNTTestGUI.swift
@@ -20,9 +20,11 @@ import santa_common_SNTConfigurator
 import santa_common_SNTCommonEnums
 import santa_common_SNTDeviceEvent
 import santa_common_SNTStoredExecutionEvent
+import santa_common_SNTStoredNetworkFlowEvent
 import Source_gui_SNTDeviceMessageWindowView
 import Source_gui_SNTBinaryMessageWindowView
 import Source_gui_SNTAboutWindowView
+import Source_gui_SNTNetworkFlowMessageWindowView
 
 func ShowWindow(_ vc: NSViewController, _ window: NSWindow, appearance: AppearanceMode = .system) {
   window.contentRect(forFrameRect: NSMakeRect(0, 0, 0, 0))
@@ -462,12 +464,131 @@ struct AboutView: View {
   }
 }
 
+struct NetworkFlowView: View {
+  @State private var application: String = "/Applications/Malware.app/Contents/MacOS/Malware"
+  @State private var hostname: String = "evil.example.com"
+  @State private var remoteAddress: String = "93.184.216.34"
+  @State private var remotePort: String = "443"
+  @State private var ruleName: String = "block-evil-example"
+  @State private var ruleId: String = "42"
+  @State private var decisionTier: SNTNetworkFlowTier = .domain
+  @State private var sha256: String = "60055b1f6fb276bfacf61f91505a72201987f20ad8b6867cce3058f4c0f0f5e5"
+  @State private var cdhash: String = "e38e71023d09c2e8e78a0e382669d1338ee8876a"
+  @State private var signingID: String = "com.example.malware"
+  @State private var teamID: String = "9X9633G7QW"
+  @State private var pid: String = "12345"
+  @State private var executingUser: String = NSUserName()
+  @State private var allowNotificationSilence: Bool = true
+
+  @State private var brandingCompanyName: String = ""
+  @State private var brandingCompanyLogo: String = ""
+  @State private var brandingCompanyLogoDark: String = ""
+  @State private var appearanceMode: AppearanceMode = .system
+
+  var body: some View {
+    VStack {
+      GroupBox(label: Label("Event Properties", systemImage: "")) {
+        Form {
+          TextField(text: $application, label: { Text(verbatim: "Application") })
+          TextField(text: $sha256, label: { Text(verbatim: "SHA-256") })
+          TextField(text: $cdhash, label: { Text(verbatim: "CDHash") })
+          TextField(text: $signingID, label: { Text(verbatim: "Signing ID") })
+          TextField(text: $teamID, label: { Text(verbatim: "Team ID") })
+          TextField(text: $pid, label: { Text(verbatim: "PID") })
+          TextField(text: $executingUser, label: { Text(verbatim: "Executing User") })
+          TextField(text: $hostname, label: { Text(verbatim: "Hostname") })
+          TextField(text: $remoteAddress, label: { Text(verbatim: "Remote Address") })
+          TextField(text: $remotePort, label: { Text(verbatim: "Remote Port") })
+          TextField(text: $ruleName, label: { Text(verbatim: "Rule Name") })
+          TextField(text: $ruleId, label: { Text(verbatim: "Rule ID") })
+          HStack {
+            Picker(selection: $decisionTier, label: Text(verbatim: "Match (decisionTier)")) {
+              Text(verbatim: "Exact IP").tag(SNTNetworkFlowTier.exactIP)
+              Text(verbatim: "CIDR").tag(SNTNetworkFlowTier.CIDR)
+              Text(verbatim: "Hostname").tag(SNTNetworkFlowTier.hostname)
+              Text(verbatim: "Domain").tag(SNTNetworkFlowTier.domain)
+              Text(verbatim: "Any Remote").tag(SNTNetworkFlowTier.anyRemote)
+            }.pickerStyle(.segmented)
+          }
+        }
+      }
+
+      GroupBox(label: Label("Config Overrides", systemImage: "")) {
+        Form {
+          HStack {
+            Toggle(isOn: $allowNotificationSilence) {
+              Text(verbatim: "Allow notification silences")
+            }
+          }
+          CommonPropertiesView(
+            brandingCompanyName: $brandingCompanyName,
+            brandingCompanyLogo: $brandingCompanyLogo,
+            brandingCompanyLogoDark: $brandingCompanyLogoDark,
+            appearanceMode: $appearanceMode
+          )
+        }
+      }
+
+      Button("Display") {
+        var configMap: [String: Any] = [:]
+        if !brandingCompanyName.isEmpty {
+          configMap["BrandingCompanyName"] = brandingCompanyName
+        }
+        if !brandingCompanyLogo.isEmpty {
+          configMap["BrandingCompanyLogo"] = brandingCompanyLogo
+        }
+        if !brandingCompanyLogoDark.isEmpty {
+          configMap["BrandingCompanyLogoDark"] = brandingCompanyLogoDark
+        }
+        if !configMap.isEmpty {
+          SNTConfigurator.overrideConfig(configMap)
+        }
+
+        let event = SNTStoredNetworkFlowEvent()
+        event.decision = .block
+        event.process?.filePath = application
+        event.process?.fileSHA256 = sha256
+        event.process?.cdhash = cdhash
+        event.process?.signingID = signingID
+        event.process?.teamID = teamID
+        event.process?.pid = NSNumber(value: Int(pid) ?? 0)
+        event.process?.executingUser = executingUser
+        event.hostname = hostname
+        event.remoteAddress = remoteAddress
+        event.remotePort = UInt16(remotePort) ?? 0
+        event.direction = .outgoing
+        event.`protocol` = 6
+        event.ruleName = ruleName
+        event.ruleId = Int64(ruleId) ?? 0
+        event.decisionTier = decisionTier
+
+        let bundle = SNTConfigBundle()
+        bundle.setValue(NSNumber(value: allowNotificationSilence), forKey: "enableNotificationSilences")
+
+        let window = NSWindow()
+        ShowWindow(
+          SNTNetworkFlowMessageWindowViewFactory.createWith(
+            window: window,
+            event: event,
+            configBundle: bundle,
+            silenceable: true,
+            uiStateCallback: { interval in print("Silence interval was set to \(interval)") }
+          ),
+          window,
+          appearance: appearanceMode
+        )
+      }
+    }
+  }
+}
+
 struct ContentView: View {
   var body: some View {
     TabView {
       BinaryView().padding(15.0).tabItem({ Text("Binary") })
       FAAView().padding(15.0).tabItem({ Text("FAA") })
       DeviceView().padding(15.0).tabItem({ Text("Device") })
+      NetworkFlowView().padding(15.0).tabItem({ Text("Network Flow") })
       AboutView().padding(15.0).tabItem({ Text("About") })
     }
   }

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -210,6 +210,7 @@ objc_library(
     srcs = ["SNTNetworkExtensionQueue.mm"],
     hdrs = ["SNTNetworkExtensionQueue.h"],
     deps = [
+        ":DaemonConfigBundle",
         ":EndpointSecurityLogger",
         ":SNTDecisionCache",
         ":SNTNotificationQueue",
@@ -243,6 +244,7 @@ santa_unit_test(
     deps = [
         ":SNTDecisionCache",
         ":SNTNetworkExtensionQueue",
+        ":SNTNotificationQueue",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
         "//Source/common:MOLXPCConnection",
@@ -251,6 +253,7 @@ santa_unit_test(
         "//Source/common:SNTNetworkFlowRule",
         "//Source/common:SNTStoredNetworkFlowEvent",
         "//Source/common:SNTStoredProcess",
+        "//Source/common:SNTXPCNotifierInterface",
         "//Source/common:SantaVnode",
         "//Source/common/ne:SNDXPCNetworkExtensionInterface",
         "//Source/common/ne:SNTNetworkExtensionSettings",

--- a/Source/santad/DaemonConfigBundle.h
+++ b/Source/santad/DaemonConfigBundle.h
@@ -20,6 +20,9 @@
 
 namespace santa {
 
+// Create a config bundle for use by the blocked network flow UI
+SNTConfigBundle* NetworkFlowConfigBundle(SNTConfigurator* configurator);
+
 // Create a config bundle for use by the blocked network share UI
 SNTConfigBundle* NetworkMountConfigBundle(SNTConfigurator* configurator);
 

--- a/Source/santad/DaemonConfigBundle.mm
+++ b/Source/santad/DaemonConfigBundle.mm
@@ -22,6 +22,14 @@
 
 namespace santa {
 
+SNTConfigBundle* NetworkFlowConfigBundle(SNTConfigurator* configurator) {
+  SNTConfigBundle* bundle = [[SNTConfigBundle alloc] init];
+
+  bundle.enableNotificationSilences = @(configurator.enableNotificationSilences);
+
+  return bundle;
+}
+
 SNTConfigBundle* NetworkMountConfigBundle(SNTConfigurator* configurator) {
   SNTConfigBundle* bundle = [[SNTConfigBundle alloc] init];
 

--- a/Source/santad/DaemonConfigBundleTest.mm
+++ b/Source/santad/DaemonConfigBundleTest.mm
@@ -70,4 +70,24 @@
   [self waitForExpectationsWithTimeout:0.1 handler:NULL];
 }
 
+- (void)testNetworkFlowConfigBundle {
+  __block XCTestExpectation* exp = [self expectationWithDescription:@"Result Block"];
+  SNTConfigBundle* bundle;
+
+  SNTConfigurator* configurator = [SNTConfigurator configurator];
+  id mockConfigurator = OCMPartialMock(configurator);
+
+  OCMExpect([mockConfigurator enableNotificationSilences]).andReturn(YES);
+
+  bundle = santa::NetworkFlowConfigBundle(mockConfigurator);
+
+  [bundle enableNotificationSilences:^(BOOL val) {
+    XCTAssertTrue(val);
+    [exp fulfill];
+  }];
+
+  // Low timeout because code above is synchronous
+  [self waitForExpectationsWithTimeout:0.1 handler:NULL];
+}
+
 @end

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -35,6 +35,7 @@
 #import "Source/common/ne/SNTNetworkExtensionSettings.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 #import "Source/common/ne/SNTXPCNetworkExtensionInterface.h"
+#import "Source/santad/DaemonConfigBundle.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTDecisionCache.h"
 #import "Source/santad/SNTNotificationQueue.h"
@@ -45,6 +46,10 @@
 // 1.1 adds reportNetworkFlowDecisions:. santanetd emits flow decisions only when
 // the daemon advertises >= 1.1 (older/downgraded daemons keep the gate closed).
 NSString* const kSantaNetworkExtensionProtocolVersion = @"1.1";
+
+// Suppress repeat loud-deny dialogs for the same uiDedupeKey for this long. Short relative to
+// the event-upload backoff: it only collapses prompt bursts for one (process, rule, destination).
+static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
 
 @interface SNTNetworkExtensionQueue () {
   std::shared_ptr<santa::Logger> _logger;
@@ -61,6 +66,11 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.1";
 // (which persists nothing) is re-seeded with the full config on its next registration.
 @property SNTNetworkExtensionSettings* lastPushedSettings;
 @property NSString* lastPushedNetworkFlowRulesHash;
+// uiDedupeKey -> dialog suppression expiry. Touched only on the serial netFlowQ that runs
+// handleNetworkFlowDecisions:.
+@property NSMutableDictionary<NSString*, NSDate*>* flowDialogDedupeCache;
+// Last full prune of flowDialogDedupeCache; gates how often the cache is swept.
+@property NSDate* lastDedupeSweep;
 @end
 
 @implementation SNTNetworkExtensionQueue
@@ -77,6 +87,7 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.1";
     _ruleTable = ruleTable;
     _decisionCache = decisionCache;
     _logger = std::move(logger);
+    _flowDialogDedupeCache = [NSMutableDictionary dictionary];
 
     WEAKIFY(self);
 
@@ -231,7 +242,51 @@ NSString* const kSantaNetworkExtensionProtocolVersion = @"1.1";
     }
 
     [self.syncdQueue addStoredEvent:event];
+
+    // Loud denies (Block decision, not silent) get an informational dialog; audits and silent
+    // denies do not. The short-TTL uiDedupeKey cache suppresses repeat prompts for the same
+    // (process, rule, destination) within the window.
+    if (event.decision == SNTNetworkFlowDecisionBlock && !event.silent &&
+        [self shouldPostFlowDialogForKey:event.uiDedupeKey]) {
+      [[self.notifierQueue.notifierConnection remoteObjectProxy]
+          postNetworkFlowBlockNotification:event
+                              configBundle:santa::NetworkFlowConfigBundle(
+                                               [SNTConfigurator configurator])];
+    }
   }
+}
+
+// Suppress repeat loud-deny dialogs for the same uiDedupeKey within the window. The per-key check
+// is O(1); expired entries are pruned at most once per window rather than on every decision, so
+// the cache stays bounded even when a deny-broadly ruleset yields many distinct keys. Confined to
+// the serial netFlowQ.
+- (BOOL)shouldPostFlowDialogForKey:(NSString*)key {
+  if (!key.length) return YES;  // no key to de-dup on; don't suppress
+
+  NSDate* now = [NSDate date];
+
+  // Only an unexpired entry for this key suppresses; a stale one is overwritten below.
+  NSDate* expiry = self.flowDialogDedupeCache[key];
+  if (expiry && [expiry compare:now] == NSOrderedDescending) return NO;
+  self.flowDialogDedupeCache[key] = [now dateByAddingTimeInterval:kNetworkFlowDialogDedupeInterval];
+
+  if (!self.lastDedupeSweep ||
+      [now timeIntervalSinceDate:self.lastDedupeSweep] >= kNetworkFlowDialogDedupeInterval) {
+    [self pruneExpiredFlowDialogEntriesAsOf:now];
+    self.lastDedupeSweep = now;
+  }
+  return YES;
+}
+
+// Drop expired suppression entries to bound the cache. Confined to the serial netFlowQ.
+- (void)pruneExpiredFlowDialogEntriesAsOf:(NSDate*)now {
+  NSMutableArray<NSString*>* expired = [NSMutableArray array];
+  for (NSString* cached in self.flowDialogDedupeCache) {
+    if ([self.flowDialogDedupeCache[cached] compare:now] != NSOrderedDescending) {
+      [expired addObject:cached];
+    }
+  }
+  [self.flowDialogDedupeCache removeObjectsForKeys:expired];
 }
 
 - (SNTNetworkExtensionSettings*)handleRegistrationWithProtocolVersion:(NSString*)protocolVersion

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -244,11 +244,14 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
     [self.syncdQueue addStoredEvent:event];
 
     // Loud denies (Block decision, not silent) get an informational dialog; audits and silent
-    // denies do not. The short-TTL uiDedupeKey cache suppresses repeat prompts for the same
-    // (process, rule, destination) within the window.
-    if (event.decision == SNTNetworkFlowDecisionBlock && !event.silent &&
+    // denies do not. Gate on a live GUI connection before the dedupe check: with none (e.g. at the
+    // loginwindow) the post is a no-op, and consuming the dedupe slot would suppress the first real
+    // dialog once a GUI connects within the window. The uiDedupeKey cache then collapses repeats
+    // for the same (process, rule, destination).
+    MOLXPCConnection* notifierConnection = self.notifierQueue.notifierConnection;
+    if (event.decision == SNTNetworkFlowDecisionBlock && !event.silent && notifierConnection &&
         [self shouldPostFlowDialogForKey:event.uiDedupeKey]) {
-      [[self.notifierQueue.notifierConnection remoteObjectProxy]
+      [[notifierConnection remoteObjectProxy]
           postNetworkFlowBlockNotification:event
                               configBundle:santa::NetworkFlowConfigBundle(
                                                [SNTConfigurator configurator])];

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -27,17 +27,20 @@
 #import "Source/common/SNTNetworkFlowRule.h"
 #import "Source/common/SNTStoredNetworkFlowEvent.h"
 #import "Source/common/SNTStoredProcess.h"
+#import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/common/SantaVnode.h"
 #import "Source/common/ne/SNDXPCNetworkExtensionInterface.h"
 #import "Source/common/ne/SNTNetworkExtensionSettings.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTDecisionCache.h"
+#import "Source/santad/SNTNotificationQueue.h"
 #import "Source/santad/SNTSyncdQueue.h"
 #import "src/santanetd/SNDNetworkFlowDecision.h"
 
 @interface SNTNetworkExtensionQueue (Testing)
 @property MOLXPCConnection* netExtConnection;
+@property(weak) SNTNotificationQueue* notifierQueue;
 @property SNTRuleTable* ruleTable;
 @property SNTNetworkExtensionSettings* lastPushedSettings;
 @property NSString* lastPushedNetworkFlowRulesHash;
@@ -55,6 +58,9 @@
 @property id mockConfigurator;
 @property id mockConnection;
 @property id mockProxy;
+@property id mockNotifierQueue;
+@property id mockNotifierConnection;
+@property id mockNotifierProxy;
 @end
 
 @implementation SNTNetworkExtensionQueueTest
@@ -407,6 +413,99 @@
   OCMVerifyAll(self.mockDecisionCache);
   OCMVerifyAll(self.mockSyncdQueue);
   [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+}
+
+// Wire up a notifier connection so the loud-deny post branch reaches a verifiable proxy.
+// Returns the proxy mock for expectations; the strong test refs keep the queue's weak
+// notifierQueue alive for the test's duration.
+- (id)setUpNotifierProxy {
+  self.mockNotifierQueue = OCMClassMock([SNTNotificationQueue class]);
+  self.mockNotifierConnection = OCMClassMock([MOLXPCConnection class]);
+  self.mockNotifierProxy = OCMProtocolMock(@protocol(SNTNotifierXPC));
+  OCMStub([self.mockNotifierQueue notifierConnection]).andReturn(self.mockNotifierConnection);
+  OCMStub([self.mockNotifierConnection remoteObjectProxy]).andReturn(self.mockNotifierProxy);
+  self.sut.notifierQueue = self.mockNotifierQueue;
+  return self.mockNotifierProxy;
+}
+
+- (SNTStoredNetworkFlowEvent*)loudDenyEventWithUIKey:(NSString*)uiDedupeKey {
+  SNTStoredNetworkFlowEvent* event = [[SNTStoredNetworkFlowEvent alloc] init];
+  event.decision = SNTNetworkFlowDecisionBlock;
+  event.silent = NO;
+  event.uiDedupeKey = uiDedupeKey;
+  return event;
+}
+
+- (void)testHandleNetworkFlowDecisionsLoudDenyPostsDialog {
+  [self stubNetworkExtensionEnabled];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"4242:1|7|example.com"];
+  // isNotNil guards the queue -> NetworkFlowConfigBundle -> post wiring (a real bundle is built).
+  OCMExpect([proxy postNetworkFlowBlockNotification:event configBundle:[OCMArg isNotNil]]);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  OCMVerifyAll(proxy);
+}
+
+- (void)testHandleNetworkFlowDecisionsAuditDoesNotPostDialog {
+  [self stubNetworkExtensionEnabled];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.decision = SNTNetworkFlowDecisionAudit;
+  OCMReject([proxy postNetworkFlowBlockNotification:OCMOCK_ANY configBundle:OCMOCK_ANY]);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  OCMVerifyAll(proxy);
+}
+
+- (void)testHandleNetworkFlowDecisionsSilentDenyDoesNotPostDialog {
+  [self stubNetworkExtensionEnabled];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.silent = YES;
+  OCMReject([proxy postNetworkFlowBlockNotification:OCMOCK_ANY configBundle:OCMOCK_ANY]);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  OCMVerifyAll(proxy);
+}
+
+- (void)testHandleNetworkFlowDecisionsDeDupesRepeatDialogByUIKey {
+  [self stubNetworkExtensionEnabled];
+  id proxy = [self setUpNotifierProxy];
+
+  // Same uiDedupeKey within the window: only the first prompts.
+  SNTStoredNetworkFlowEvent* first = [self loudDenyEventWithUIKey:@"same-key"];
+  SNTStoredNetworkFlowEvent* second = [self loudDenyEventWithUIKey:@"same-key"];
+  OCMExpect([proxy postNetworkFlowBlockNotification:first configBundle:OCMOCK_ANY]);
+  OCMReject([proxy postNetworkFlowBlockNotification:second configBundle:OCMOCK_ANY]);
+
+  [self.sut handleNetworkFlowDecisions:@[
+    [self decisionForCacheMissWithEvent:first], [self decisionForCacheMissWithEvent:second]
+  ]];
+
+  OCMVerifyAll(proxy);
+}
+
+- (void)testHandleNetworkFlowDecisionsDistinctUIKeysBothPost {
+  [self stubNetworkExtensionEnabled];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTStoredNetworkFlowEvent* first = [self loudDenyEventWithUIKey:@"key-1"];
+  SNTStoredNetworkFlowEvent* second = [self loudDenyEventWithUIKey:@"key-2"];
+  OCMExpect([proxy postNetworkFlowBlockNotification:first configBundle:OCMOCK_ANY]);
+  OCMExpect([proxy postNetworkFlowBlockNotification:second configBundle:OCMOCK_ANY]);
+
+  [self.sut handleNetworkFlowDecisions:@[
+    [self decisionForCacheMissWithEvent:first], [self decisionForCacheMissWithEvent:second]
+  ]];
+
+  OCMVerifyAll(proxy);
 }
 
 @end

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -492,6 +492,24 @@
   OCMVerifyAll(proxy);
 }
 
+- (void)testHandleNetworkFlowDecisionsNoGUIConnectionDoesNotConsumeDedupeSlot {
+  [self stubNetworkExtensionEnabled];
+
+  // No notifier connection yet (notifierQueue is nil): the post is skipped, and the dedupe slot
+  // must NOT be consumed so the dialog still shows once a GUI connects within the window.
+  SNTStoredNetworkFlowEvent* first = [self loudDenyEventWithUIKey:@"same-key"];
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:first] ]];
+
+  // GUI connects; the same flow must still prompt (the earlier disconnected deny didn't burn it).
+  id proxy = [self setUpNotifierProxy];
+  SNTStoredNetworkFlowEvent* second = [self loudDenyEventWithUIKey:@"same-key"];
+  OCMExpect([proxy postNetworkFlowBlockNotification:second configBundle:[OCMArg isNotNil]]);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:second] ]];
+
+  OCMVerifyAll(proxy);
+}
+
 - (void)testHandleNetworkFlowDecisionsDistinctUIKeysBothPost {
   [self stubNetworkExtensionEnabled];
   id proxy = [self setUpNotifierProxy];


### PR DESCRIPTION
Shows an informational dialog when santanetd reports a loud (non-silent) network-flow block: santad forwards the event to SantaGUI over XPC (repeat prompts suppressed by a short-TTL cache) and the dialog mirrors the existing file-access and network-mount stacks, with a summary and a More Details pane. Notification silences are app-level and cross-version—keyed on signing identity, falling back to cdhash then SHA-256, gated by EnableNotificationSilences—and a new queueDedupeHash decouples the already-queued de-dup key from the silence key so distinct destinations each still surface. Also fixes a retain cycle in the silence callbacks of the network-flow, network-mount, and device notification controllers.

<img width="605" height="498" alt="image" src="https://github.com/user-attachments/assets/f14a0f45-f4f6-42d1-aa37-8e21742260a6" />

<img width="652" height="590" alt="image" src="https://github.com/user-attachments/assets/083110da-dd7e-4e46-8532-f267237c5529" />
