### PR TITLE
build: scope dSYM generation to release builds; drop dead test code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,14 @@
-build --apple_generate_dsym
+# --apple_generate_dsym is intentionally NOT global: it forces -g onto every
+# compile and ~doubles build output, wasted on dev/test builds. Builds that ship
+# dSYMs pass it explicitly (Makefile release targets; santa-codesign's release.yml).
+# For local debugging use `-c dbg` (emits -g without the dSYM bundle).
+#
+# Keep apple.propagate_embedded_extra_outputs global: it is inert unless dSYMs are
+# being generated, but for release builds it is what puts the EMBEDDED binaries'
+# dSYMs (daemon, services, CLIs) into //Source/gui:Santa's default outputs for the
+# //:release genrule to collect. Without it, releases silently ship with only
+# Santa.app's dSYM -- the daemon and services lose their symbols.
 build --define=apple.propagate_embedded_extra_outputs=yes
-
 build --copt=-Werror
 build --copt=-Wall
 build --copt=-Wformat-security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
             bazel build \
               --verbose_failures \
               --sandbox_debug \
-              --apple_generate_dsym \
               --define=SANTA_BUILD_TYPE=adhoc \
               --remote_cache=https://storage.googleapis.com/santa-build-cache \
               --google_default_credentials \
@@ -104,7 +103,6 @@ jobs:
             bazel build \
               --verbose_failures \
               --sandbox_debug \
-              --apple_generate_dsym \
               --define=SANTA_BUILD_TYPE=adhoc \
               //Source/gui:Santa
           fi

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -256,9 +256,11 @@ objc_library(
     ],
 )
 
-# Using :sync_lib breaks the Zlib category hack used in the tests to
-# disable compression, in turn failing the tests. Re-compile here to keep
-# the "override" category behavior.
+# This test drives the individual sync stages directly, so it recompiles the
+# sync sources here instead of depending on :sync_lib, which only exports
+# SNTSyncManager.h (the per-stage headers live in its srcs). De-duping these
+# compiles would mean exporting those headers from :sync_lib (or splitting the
+# stages into their own libraries) and switching the sync tests to deps.
 santa_unit_test(
     name = "SNTSyncTest",
     srcs = [

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -41,16 +41,6 @@
 #import "Source/santasyncservice/SNTSyncStage.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
-// Prevent Zlib compression during testing
-@implementation NSData (Zlib)
-- (NSData*)zlibCompressed {
-  return nil;
-}
-- (NSData*)gzipCompressed {
-  return nil;
-}
-@end
-
 @interface SNTSyncStage (XSSI)
 - (NSData*)stripXssi:(NSData*)data;
 @property double retryBackoffBase;


### PR DESCRIPTION
## What

`--apple_generate_dsym` was a global `.bazelrc` default, so `dsymutil` ran and `-g` debug info was emitted on **every** build — dev, test, and CI — not just releases.

**Measured impact:** ~9% faster cold builds and ~half the build output (3.8 GB → 1.7 GB) on the dev/test path (A/B of a clean `//Source/gui:Santa` build with the flag on vs off, interleaved).

## Changes

- **`.bazelrc`** — remove the global `--apple_generate_dsym`. **Keep `apple.propagate_embedded_extra_outputs` global** — it's inert without dSYM generation, but it's load-bearing for release builds: it's what puts the embedded daemon/service/CLI dSYMs into `//Source/gui:Santa`'s default outputs for the `//:release` genrule to collect. (An in-file comment warns against removing it.)
- **`.github/workflows/ci.yml`** — drop `--apple_generate_dsym` from the PR build; nothing consumes those dSYMs (no artifact upload / release / symbolication step).
- **`Source/santasyncservice/{BUILD,SNTSyncTest.mm}`** — remove a dead `NSData(Zlib)` test override that "disabled compression" (compression never fires in these tests — `syncState.contentEncoding` defaults to `None`), and fix the now-inaccurate comment.

For local source-level debugging, use `-c dbg` (emits `-g` without the dSYM bundle; lldb reads DWARF from the objects).

## Release safety (verified)

Release builds pass `--apple_generate_dsym` explicitly (Makefile targets and `santa-codesign/release.yml`) and inherit the global propagate define, so release behavior is unchanged. Verified via `aquery` that all 7 DWARF binaries (app, daemon, the three services, santactl, sleigh) still reach the `//:release` tarball. `Makefile` is intentionally unchanged.

## Testing

- `bazel test //Source/santasyncservice:SNTSyncTest` passes (66 methods × v1/v2), confirming the removed Zlib override was dead.
- `aquery` confirms default dev/test builds emit **0** `-g` / **0** dSYM actions; `-c opt --apple_generate_dsym` still emits them.

## Not in this PR (investigated, tracked separately)

Disk/remote cache (the biggest remaining cold-build lever), `--reuse_sandbox_directories`, the ThinLTO-under-`-c opt` release gap, and monolith splits (measured ~0 build-perf — code-org only). Dependency-side ideas (cel-cpp API consolidation, protoc generator trimming, prebuilt protoc/upb) all measured to ~0 or proved unavailable.
