### PR TITLE
common: add Temporary Admin Mode policy, audit events, and config plumbing

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -533,6 +533,7 @@ objc_library(
         ":SNTRule",
         ":SNTStrengthify",
         ":SNTSystemInfo",
+        ":SNTTemporaryAdminPolicy",
         "//Source/common/faa:WatchItems",
         "//Source/common/ne:SNTSyncNetworkExtensionSettings",
     ],
@@ -549,6 +550,7 @@ objc_library(
         ":SNTCommonEnums",
         ":SNTExportConfiguration",
         ":SNTModeTransition",
+        ":SNTTemporaryAdminPolicy",
         "//Source/common/ne:SNTSyncNetworkExtensionSettings",
     ],
 )
@@ -561,6 +563,7 @@ santa_unit_test(
         ":SNTConfigBundle",
         ":SNTExportConfiguration",
         ":SNTModeTransition",
+        ":SNTTemporaryAdminPolicy",
         "//Source/common/ne:SNTSyncNetworkExtensionSettings",
     ],
 )
@@ -599,6 +602,24 @@ santa_unit_test(
     srcs = ["SNTModeTransitionTest.mm"],
     deps = [
         ":SNTModeTransition",
+    ],
+)
+
+objc_library(
+    name = "SNTTemporaryAdminPolicy",
+    srcs = ["SNTTemporaryAdminPolicy.mm"],
+    hdrs = ["SNTTemporaryAdminPolicy.h"],
+    deps = [
+        ":CoderMacros",
+        ":SNTLogging",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTTemporaryAdminPolicyTest",
+    srcs = ["SNTTemporaryAdminPolicyTest.mm"],
+    deps = [
+        ":SNTTemporaryAdminPolicy",
     ],
 )
 
@@ -855,12 +876,32 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTTimedSessionAuditEvent",
+    srcs = ["SNTTimedSessionAuditEvent.mm"],
+    hdrs = ["SNTTimedSessionAuditEvent.h"],
+    deps = [
+        ":CoderMacros",
+        ":SNTStoredEvent",
+    ],
+)
+
+objc_library(
     name = "SNTStoredTemporaryMonitorModeAuditEvent",
     srcs = ["SNTStoredTemporaryMonitorModeAuditEvent.mm"],
     hdrs = ["SNTStoredTemporaryMonitorModeAuditEvent.h"],
     deps = [
         ":CoderMacros",
-        ":SNTStoredEvent",
+        ":SNTTimedSessionAuditEvent",
+    ],
+)
+
+objc_library(
+    name = "SNTStoredTemporaryAdminModeAuditEvent",
+    srcs = ["SNTStoredTemporaryAdminModeAuditEvent.mm"],
+    hdrs = ["SNTStoredTemporaryAdminModeAuditEvent.h"],
+    deps = [
+        ":CoderMacros",
+        ":SNTTimedSessionAuditEvent",
     ],
 )
 
@@ -904,6 +945,15 @@ santa_unit_test(
     deps = [
         ":SNTStoredEvent",
         ":SNTStoredTemporaryMonitorModeAuditEvent",
+        ":SNTTimedSessionAuditEvent",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTStoredTemporaryAdminModeAuditEventTest",
+    srcs = ["SNTStoredTemporaryAdminModeAuditEventTest.mm"],
+    deps = [
+        ":SNTStoredTemporaryAdminModeAuditEvent",
     ],
 )
 
@@ -1256,8 +1306,10 @@ test_suite(
         ":SNTStoredNetworkFlowEventTest",
         ":SNTStoredNetworkMountEventTest",
         ":SNTStoredProcessTest",
+        ":SNTStoredTemporaryAdminModeAuditEventTest",
         ":SNTStoredTemporaryMonitorModeAuditEventTest",
         ":SNTStoredUSBMountEventTest",
+        ":SNTTemporaryAdminPolicyTest",
         ":SNTTimerTest",
         ":SNTXxhashTest",
         ":SantaCacheTest",

--- a/Source/common/SNTConfigBundle.h
+++ b/Source/common/SNTConfigBundle.h
@@ -20,6 +20,7 @@
 @class SNTExportConfiguration;
 @class SNTModeTransition;
 @class SNTSyncNetworkExtensionSettings;
+@class SNTTemporaryAdminPolicy;
 
 @interface SNTConfigBundle : NSObject <NSSecureCoding>
 
@@ -44,6 +45,7 @@
 - (void)fullSyncLastSuccess:(void (^)(NSDate*))block;
 - (void)ruleSyncLastSuccess:(void (^)(NSDate*))block;
 - (void)modeTransition:(void (^)(SNTModeTransition*))block;
+- (void)temporaryAdminPolicy:(void (^)(SNTTemporaryAdminPolicy*))block;
 - (void)eventDetailURL:(void (^)(NSString*))block;
 - (void)eventDetailText:(void (^)(NSString*))block;
 - (void)fileAccessEventDetailURL:(void (^)(NSString*))block;

--- a/Source/common/SNTConfigBundle.mm
+++ b/Source/common/SNTConfigBundle.mm
@@ -18,6 +18,7 @@
 #import "Source/common/SNTCELFallbackRule.h"
 #import "Source/common/SNTExportConfiguration.h"
 #import "Source/common/SNTModeTransition.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 
 @interface SNTConfigBundle ()
@@ -41,6 +42,7 @@
 @property NSDate* fullSyncLastSuccess;
 @property NSDate* ruleSyncLastSuccess;
 @property SNTModeTransition* modeTransition;
+@property SNTTemporaryAdminPolicy* temporaryAdminPolicy;
 @property NSString* eventDetailURL;
 @property NSString* eventDetailText;
 @property NSString* fileAccessEventDetailURL;
@@ -83,6 +85,7 @@
   ENCODE(coder, fullSyncLastSuccess);
   ENCODE(coder, ruleSyncLastSuccess);
   ENCODE(coder, modeTransition);
+  ENCODE(coder, temporaryAdminPolicy);
   ENCODE(coder, eventDetailURL);
   ENCODE(coder, eventDetailText);
   ENCODE(coder, fileAccessEventDetailURL);
@@ -121,6 +124,7 @@
     DECODE(decoder, fullSyncLastSuccess, NSDate);
     DECODE(decoder, ruleSyncLastSuccess, NSDate);
     DECODE(decoder, modeTransition, SNTModeTransition);
+    DECODE(decoder, temporaryAdminPolicy, SNTTemporaryAdminPolicy);
     DECODE(decoder, eventDetailURL, NSString);
     DECODE(decoder, eventDetailText, NSString);
     DECODE(decoder, fileAccessEventDetailURL, NSString);
@@ -254,6 +258,12 @@
 - (void)modeTransition:(void (^)(SNTModeTransition*))block {
   if (self.modeTransition) {
     block(self.modeTransition);
+  }
+}
+
+- (void)temporaryAdminPolicy:(void (^)(SNTTemporaryAdminPolicy*))block {
+  if (self.temporaryAdminPolicy) {
+    block(self.temporaryAdminPolicy);
   }
 }
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -20,6 +20,7 @@
 @class SNTCELFallbackRule;
 @class SNTExportConfiguration;
 @class SNTModeTransition;
+@class SNTTemporaryAdminPolicy;
 @class SNTSyncNetworkExtensionSettings;
 @class SNTRule;
 
@@ -849,6 +850,16 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 ///  Set the mode transition configuration as received from a sync server.
 ///
 - (void)setSyncServerModeTransition:(nonnull SNTModeTransition*)modeTransition;
+
+///
+///  Currently defined Temporary Admin Mode policy. Its value is set by a sync server.
+///
+@property(nullable, readonly) SNTTemporaryAdminPolicy* temporaryAdminPolicy;
+
+///
+///  Set the Temporary Admin Mode policy as received from a sync server.
+///
+- (void)setSyncServerTemporaryAdminPolicy:(nonnull SNTTemporaryAdminPolicy*)temporaryAdminPolicy;
 
 ///
 ///  Return if Santa is temporarily in Monitor Mode and will revert back

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -31,6 +31,7 @@
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTSystemInfo.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
 #import "Source/common/faa/WatchItems.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 
@@ -112,6 +113,7 @@ NSString* const kStateFilePath = @"/var/db/santa/state.plist";
 
 /// Keys associated with the state file.
 static NSString* const kStateTempMonitorModeKey = @"TMM";
+static NSString* const kStateTempAdminModeKey = @"TempAdmin";
 static NSString* const kStateLastBootUUIDKey = @"LastBootUUID";
 
 /// User defaults key for user override of the menu item enabled setting.
@@ -266,6 +268,7 @@ static NSString* const kSyncCleanRequiredDeprecated = @"SyncCleanRequired";
 static NSString* const kSyncTypeRequired = @"SyncTypeRequired";
 static NSString* const kExportConfigurationKey = @"ExportConfiguration";
 static NSString* const kModeTransitionKey = @"ModeTransition";
+static NSString* const kTemporaryAdminPolicyKey = @"TemporaryAdminPolicy";
 static NSString* const kNetworkExtensionSettingsKey = @"NetworkExtensionSettings";
 static NSString* const kDNSUpstreamTimeoutSecondsKey = @"DNSUpstreamTimeoutSeconds";
 static NSString* const kPushTokenChainKey = @"PushTokenChain";
@@ -322,6 +325,7 @@ static NSString* const kPushTokenChainKey = @"PushTokenChain";
       kEnableBundlesKey : number,
       kExportConfigurationKey : data,
       kModeTransitionKey : data,
+      kTemporaryAdminPolicyKey : data,
       kNetworkExtensionSettingsKey : data,
       kPushTokenChainKey : array,
       kTelemetryFilterExpressionsKey : array,
@@ -931,6 +935,10 @@ static SNTConfigurator* sharedConfigurator = nil;
   return [self syncStateSet];
 }
 
++ (NSSet*)keyPathsForValuesAffectingTemporaryAdminPolicy {
+  return [self syncStateSet];
+}
+
 + (NSSet*)keyPathsForValuesAffectingSyncNetworkExtensionSettings {
   return [self syncStateSet];
 }
@@ -1046,6 +1054,19 @@ static SNTConfigurator* sharedConfigurator = nil;
     [self updateSyncStateForKey:kModeTransitionKey value:nil];
   } else {
     [self updateSyncStateForKey:kModeTransitionKey value:[modeTransition serialize]];
+  }
+}
+
+- (SNTTemporaryAdminPolicy*)temporaryAdminPolicy {
+  return [SNTTemporaryAdminPolicy deserialize:self.syncState[kTemporaryAdminPolicyKey]];
+}
+
+- (void)setSyncServerTemporaryAdminPolicy:(SNTTemporaryAdminPolicy*)temporaryAdminPolicy {
+  if (temporaryAdminPolicy.type == SNTTemporaryAdminPolicyTypeRevoke) {
+    // On revoke, set the value to nil to remove the key from the dictionary
+    [self updateSyncStateForKey:kTemporaryAdminPolicyKey value:nil];
+  } else {
+    [self updateSyncStateForKey:kTemporaryAdminPolicyKey value:[temporaryAdminPolicy serialize]];
   }
 }
 
@@ -2188,6 +2209,10 @@ static SNTConfigurator* sharedConfigurator = nil;
 
   if ([state[kStateTempMonitorModeKey] isKindOfClass:[NSDictionary class]]) {
     newState[kStateTempMonitorModeKey] = state[kStateTempMonitorModeKey];
+  }
+
+  if ([state[kStateTempAdminModeKey] isKindOfClass:[NSDictionary class]]) {
+    newState[kStateTempAdminModeKey] = state[kStateTempAdminModeKey];
   }
 
   if ([state[kStateLastBootUUIDKey] isKindOfClass:[NSString class]]) {

--- a/Source/common/SNTError.h
+++ b/Source/common/SNTError.h
@@ -68,6 +68,16 @@ typedef NS_ENUM(NSInteger, SNTErrorCode) {
   SNTErrorCodeSandboxAlreadyPending = 813,
   SNTErrorCodeSandboxInternal = 814,
   SNTErrorCodeSandboxCapacityExceeded = 815,
+
+  // Temporary Admin Mode errors
+  SNTErrorCodeTAMNoPolicy = 910,
+  SNTErrorCodeTAMInvalidSyncServer = 911,
+  SNTErrorCodeTAMAuthFailed = 912,
+  SNTErrorCodeTAMAlreadyAdmin = 913,
+  SNTErrorCodeTAMMembershipChangeFailed = 914,
+  SNTErrorCodeTAMNoConsoleUser = 915,
+  SNTErrorCodeTAMSessionAlreadyActive = 916,
+  SNTErrorCodeTAMJustificationRequired = 917,
 };
 
 @interface SNTError : NSObject

--- a/Source/common/SNTStoredTemporaryAdminModeAuditEvent.h
+++ b/Source/common/SNTStoredTemporaryAdminModeAuditEvent.h
@@ -1,0 +1,130 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTTimedSessionAuditEvent.h"
+
+// Reason for entering Temporary Admin Mode.
+typedef NS_ENUM(NSInteger, SNTTemporaryAdminModeEnterReason) {
+  // On demand request by the user for a new Temporary Admin Mode session.
+  SNTTemporaryAdminModeEnterReasonOnDemand,
+
+  // On demand request by the user, changing the timing parameters
+  // of an existing Temporary Admin Mode session.
+  SNTTemporaryAdminModeEnterReasonOnDemandRefresh,
+
+  // The Santa daemon was restarted but a previously existing Temporary
+  // Admin Mode session was still active.
+  SNTTemporaryAdminModeEnterReasonRestart,
+};
+
+// Reason for leaving Temporary Admin Mode.
+typedef NS_ENUM(NSInteger, SNTTemporaryAdminModeLeaveReason) {
+  // The requested duration expired.
+  SNTTemporaryAdminModeLeaveReasonSessionExpired,
+
+  // The user manually ended the session.
+  SNTTemporaryAdminModeLeaveReasonCancelled,
+
+  // The server revoked the machine's eligibility for Temporary Admin Mode
+  // and an existing session was terminated.
+  SNTTemporaryAdminModeLeaveReasonRevoked,
+
+  // The machine's SyncBaseURL configuration changed which cancelled
+  // an active session.
+  SNTTemporaryAdminModeLeaveReasonSyncServerChanged,
+
+  // The machine rebooted and the previous session is no longer applicable.
+  SNTTemporaryAdminModeLeaveReasonReboot,
+
+  // The user's screen was locked.
+  SNTTemporaryAdminModeLeaveReasonScreenLocked,
+
+  // The user's login session ended.
+  SNTTemporaryAdminModeLeaveReasonSessionEnded,
+};
+
+// Reason a Temporary Admin Mode request was denied.
+typedef NS_ENUM(NSInteger, SNTTemporaryAdminModeDeniedReason) {
+  // No on-demand admin policy is configured.
+  SNTTemporaryAdminModeDeniedReasonNoPolicy,
+
+  // The requesting user is not eligible (e.g. not in Lockdown mode).
+  SNTTemporaryAdminModeDeniedReasonNotEligible,
+
+  // Authentication was required but failed.
+  SNTTemporaryAdminModeDeniedReasonAuthFailed,
+
+  // A justification was required but not provided.
+  SNTTemporaryAdminModeDeniedReasonJustificationRequired,
+
+  // The requesting user is already an administrator.
+  SNTTemporaryAdminModeDeniedReasonAlreadyAdmin,
+
+  // A Temporary Admin Mode session is already active for a different user.
+  SNTTemporaryAdminModeDeniedReasonSessionAlreadyActive,
+
+  // The group membership change could not be applied.
+  SNTTemporaryAdminModeDeniedReasonMembershipChangeFailed,
+};
+
+// Base class for Temporary Admin Mode audit events. Not instantiated directly;
+// use the Enter / Leave / Denied subclasses. Inherits uuid / uniqueID /
+// unactionableEvent from SNTTimedSessionAuditEvent.
+@interface SNTStoredTemporaryAdminModeAuditEvent : SNTTimedSessionAuditEvent <NSSecureCoding>
+@property(readonly) NSString* username;
+- (instancetype)initWithUUID:(NSString*)uuid username:(NSString*)username;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+//
+// Enter audit event
+//
+@interface SNTStoredTemporaryAdminModeEnterAuditEvent
+    : SNTStoredTemporaryAdminModeAuditEvent <NSSecureCoding>
+@property(readonly) uint32_t seconds;
+@property(readonly) SNTTemporaryAdminModeEnterReason reason;
+@property(readonly) NSString* userJustification;
+- (instancetype)initWithUUID:(NSString*)uuid
+                    username:(NSString*)username
+                     seconds:(uint32_t)seconds
+                      reason:(SNTTemporaryAdminModeEnterReason)reason
+           userJustification:(NSString*)userJustification;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+//
+// Leave audit event
+//
+@interface SNTStoredTemporaryAdminModeLeaveAuditEvent
+    : SNTStoredTemporaryAdminModeAuditEvent <NSSecureCoding>
+@property(readonly) SNTTemporaryAdminModeLeaveReason reason;
+- (instancetype)initWithUUID:(NSString*)uuid
+                    username:(NSString*)username
+                      reason:(SNTTemporaryAdminModeLeaveReason)reason;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+//
+// Denied audit event
+//
+@interface SNTStoredTemporaryAdminModeDeniedAuditEvent
+    : SNTStoredTemporaryAdminModeAuditEvent <NSSecureCoding>
+@property(readonly) SNTTemporaryAdminModeDeniedReason reason;
+- (instancetype)initWithUUID:(NSString*)uuid
+                    username:(NSString*)username
+                      reason:(SNTTemporaryAdminModeDeniedReason)reason;
+- (instancetype)init NS_UNAVAILABLE;
+@end

--- a/Source/common/SNTStoredTemporaryAdminModeAuditEvent.mm
+++ b/Source/common/SNTStoredTemporaryAdminModeAuditEvent.mm
@@ -1,0 +1,144 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
+
+#import "Source/common/CoderMacros.h"
+
+@implementation SNTStoredTemporaryAdminModeEnterAuditEvent
+
+- (instancetype)initWithUUID:(NSString*)uuid
+                    username:(NSString*)username
+                     seconds:(uint32_t)seconds
+                      reason:(SNTTemporaryAdminModeEnterReason)reason
+           userJustification:(NSString*)userJustification {
+  self = [super initWithUUID:uuid username:username];
+  if (self) {
+    _seconds = seconds;
+    _reason = reason;
+    _userJustification = userJustification;
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  [super encodeWithCoder:coder];
+  ENCODE_BOXABLE(coder, reason);
+  ENCODE_BOXABLE(coder, seconds);
+  ENCODE(coder, userJustification);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) {
+    DECODE_SELECTOR(decoder, reason, NSNumber, integerValue);
+    DECODE_SELECTOR(decoder, seconds, NSNumber, unsignedIntValue);
+    DECODE(decoder, userJustification, NSString);
+  }
+  return self;
+}
+
+@end
+
+@implementation SNTStoredTemporaryAdminModeLeaveAuditEvent
+
+- (instancetype)initWithUUID:(NSString*)uuid
+                    username:(NSString*)username
+                      reason:(SNTTemporaryAdminModeLeaveReason)reason {
+  self = [super initWithUUID:uuid username:username];
+  if (self) _reason = reason;
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  [super encodeWithCoder:coder];
+  ENCODE_BOXABLE(coder, reason);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) DECODE_SELECTOR(decoder, reason, NSNumber, integerValue);
+  return self;
+}
+
+@end
+
+@implementation SNTStoredTemporaryAdminModeDeniedAuditEvent
+
+- (instancetype)initWithUUID:(NSString*)uuid
+                    username:(NSString*)username
+                      reason:(SNTTemporaryAdminModeDeniedReason)reason {
+  self = [super initWithUUID:uuid username:username];
+  if (self) {
+    _reason = reason;
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  [super encodeWithCoder:coder];
+  ENCODE_BOXABLE(coder, reason);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) {
+    DECODE_SELECTOR(decoder, reason, NSNumber, integerValue);
+  }
+  return self;
+}
+
+@end
+
+// NB: Intentionally not implementing SNTStoredEvent base class methods:
+//   - (NSString *)uniqueID
+//   - (BOOL)unactionableEvent
+// This class should not be directly instantiated. These methods are provided by
+// SNTTimedSessionAuditEvent and are inherited by the concrete subclasses above.
+@implementation SNTStoredTemporaryAdminModeAuditEvent
+
+- (instancetype)initWithUUID:(NSString*)uuid username:(NSString*)username {
+  self = [super initWithUUID:uuid];
+  if (self) _username = username;
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  [super encodeWithCoder:coder];
+  ENCODE(coder, username);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) DECODE(decoder, username, NSString);
+  return self;
+}
+
+@end

--- a/Source/common/SNTStoredTemporaryAdminModeAuditEventTest.mm
+++ b/Source/common/SNTStoredTemporaryAdminModeAuditEventTest.mm
@@ -1,0 +1,239 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTStoredEvent.h"
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
+
+// Helper: archive an object using NSKeyedArchiver with secure coding.
+static NSData* Archive(id<NSSecureCoding> obj) {
+  NSError* err = nil;
+  NSData* data = [NSKeyedArchiver archivedDataWithRootObject:obj
+                                       requiringSecureCoding:YES
+                                                       error:&err];
+  return err ? nil : data;
+}
+
+// Helper: unarchive from data, allowing the full TAM class hierarchy.
+static id Unarchive(NSData* data) {
+  NSSet* allowed = [NSSet setWithObjects:[SNTStoredTemporaryAdminModeAuditEvent class],
+                                         [SNTStoredTemporaryAdminModeEnterAuditEvent class],
+                                         [SNTStoredTemporaryAdminModeLeaveAuditEvent class],
+                                         [SNTStoredTemporaryAdminModeDeniedAuditEvent class], nil];
+  NSError* err = nil;
+  return [NSKeyedUnarchiver unarchivedObjectOfClasses:allowed fromData:data error:&err];
+}
+
+@interface SNTStoredTemporaryAdminModeAuditEventTest : XCTestCase
+@end
+
+@implementation SNTStoredTemporaryAdminModeAuditEventTest
+
+#pragma mark - Enter event
+
+- (void)testEnterRoundTrip {
+  SNTStoredTemporaryAdminModeEnterAuditEvent* orig =
+      [[SNTStoredTemporaryAdminModeEnterAuditEvent alloc]
+               initWithUUID:@"session-uuid-1"
+                   username:@"alice"
+                    seconds:300
+                     reason:SNTTemporaryAdminModeEnterReasonOnDemand
+          userJustification:@"need to install software"];
+
+  NSData* data = Archive(orig);
+  XCTAssertNotNil(data, @"archiving Enter event should succeed");
+
+  SNTStoredTemporaryAdminModeEnterAuditEvent* decoded =
+      (SNTStoredTemporaryAdminModeEnterAuditEvent*)Unarchive(data);
+  XCTAssertNotNil(decoded);
+  XCTAssertTrue([decoded isKindOfClass:[SNTStoredTemporaryAdminModeEnterAuditEvent class]]);
+
+  XCTAssertEqualObjects(decoded.uuid, @"session-uuid-1");
+  XCTAssertEqualObjects(decoded.username, @"alice");
+  XCTAssertEqual(decoded.seconds, 300u);
+  XCTAssertEqual(decoded.reason, SNTTemporaryAdminModeEnterReasonOnDemand);
+  XCTAssertEqualObjects(decoded.userJustification, @"need to install software");
+
+  // Inherited from SNTStoredEvent via SNTTimedSessionAuditEvent.
+  XCTAssertNotNil(decoded.occurrenceDate);
+
+  // uniqueID is based on a per-instance UUID and must be a UUID-length string.
+  XCTAssertNotNil([decoded uniqueID]);
+  XCTAssertEqual([[decoded uniqueID] length], [[NSUUID UUID] UUIDString].length);
+
+  // The uniqueID is stable across the same instance (the encoded uniqueUuid round-trips).
+  XCTAssertEqualObjects([decoded uniqueID], [orig uniqueID]);
+
+  // Must never be dropped from the event database.
+  XCTAssertFalse([decoded unactionableEvent]);
+}
+
+- (void)testEnterRefreshReasonRoundTrip {
+  SNTStoredTemporaryAdminModeEnterAuditEvent* orig =
+      [[SNTStoredTemporaryAdminModeEnterAuditEvent alloc]
+               initWithUUID:@"session-uuid-refresh"
+                   username:@"bob"
+                    seconds:600
+                     reason:SNTTemporaryAdminModeEnterReasonOnDemandRefresh
+          userJustification:@""];
+
+  SNTStoredTemporaryAdminModeEnterAuditEvent* decoded =
+      (SNTStoredTemporaryAdminModeEnterAuditEvent*)Unarchive(Archive(orig));
+  XCTAssertEqual(decoded.reason, SNTTemporaryAdminModeEnterReasonOnDemandRefresh);
+  XCTAssertEqual(decoded.seconds, 600u);
+  XCTAssertEqualObjects(decoded.username, @"bob");
+}
+
+- (void)testEnterRestartReasonRoundTrip {
+  SNTStoredTemporaryAdminModeEnterAuditEvent* orig =
+      [[SNTStoredTemporaryAdminModeEnterAuditEvent alloc]
+               initWithUUID:@"session-uuid-restart"
+                   username:@"carol"
+                    seconds:120
+                     reason:SNTTemporaryAdminModeEnterReasonRestart
+          userJustification:@""];
+
+  SNTStoredTemporaryAdminModeEnterAuditEvent* decoded =
+      (SNTStoredTemporaryAdminModeEnterAuditEvent*)Unarchive(Archive(orig));
+  XCTAssertEqual(decoded.reason, SNTTemporaryAdminModeEnterReasonRestart);
+  XCTAssertEqualObjects(decoded.uuid, @"session-uuid-restart");
+  XCTAssertFalse([decoded unactionableEvent]);
+  XCTAssertNotNil([decoded uniqueID]);
+}
+
+#pragma mark - Leave event
+
+- (void)testLeaveRoundTrip {
+  SNTStoredTemporaryAdminModeLeaveAuditEvent* orig =
+      [[SNTStoredTemporaryAdminModeLeaveAuditEvent alloc]
+          initWithUUID:@"session-uuid-2"
+              username:@"alice"
+                reason:SNTTemporaryAdminModeLeaveReasonCancelled];
+
+  NSData* data = Archive(orig);
+  XCTAssertNotNil(data, @"archiving Leave event should succeed");
+
+  SNTStoredTemporaryAdminModeLeaveAuditEvent* decoded =
+      (SNTStoredTemporaryAdminModeLeaveAuditEvent*)Unarchive(data);
+  XCTAssertNotNil(decoded);
+  XCTAssertTrue([decoded isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+
+  XCTAssertEqualObjects(decoded.uuid, @"session-uuid-2");
+  XCTAssertEqualObjects(decoded.username, @"alice");
+  XCTAssertEqual(decoded.reason, SNTTemporaryAdminModeLeaveReasonCancelled);
+
+  XCTAssertNotNil(decoded.occurrenceDate);
+  XCTAssertNotNil([decoded uniqueID]);
+  XCTAssertEqual([[decoded uniqueID] length], [[NSUUID UUID] UUIDString].length);
+  XCTAssertEqualObjects([decoded uniqueID], [orig uniqueID]);
+  XCTAssertFalse([decoded unactionableEvent]);
+}
+
+- (void)testLeaveAllReasonsRoundTrip {
+  SNTTemporaryAdminModeLeaveReason reasons[] = {
+      SNTTemporaryAdminModeLeaveReasonSessionExpired,
+      SNTTemporaryAdminModeLeaveReasonCancelled,
+      SNTTemporaryAdminModeLeaveReasonRevoked,
+      SNTTemporaryAdminModeLeaveReasonSyncServerChanged,
+      SNTTemporaryAdminModeLeaveReasonReboot,
+      SNTTemporaryAdminModeLeaveReasonScreenLocked,
+      SNTTemporaryAdminModeLeaveReasonSessionEnded,
+  };
+  for (size_t i = 0; i < sizeof(reasons) / sizeof(reasons[0]); i++) {
+    SNTStoredTemporaryAdminModeLeaveAuditEvent* orig =
+        [[SNTStoredTemporaryAdminModeLeaveAuditEvent alloc] initWithUUID:@"uuid"
+                                                                username:@"dave"
+                                                                  reason:reasons[i]];
+    SNTStoredTemporaryAdminModeLeaveAuditEvent* decoded =
+        (SNTStoredTemporaryAdminModeLeaveAuditEvent*)Unarchive(Archive(orig));
+    XCTAssertEqual(decoded.reason, reasons[i], @"leave reason %zu should round-trip", i);
+  }
+}
+
+#pragma mark - Denied event
+
+- (void)testDeniedRoundTrip {
+  SNTStoredTemporaryAdminModeDeniedAuditEvent* orig =
+      [[SNTStoredTemporaryAdminModeDeniedAuditEvent alloc]
+          initWithUUID:@"session-uuid-3"
+              username:@"eve"
+                reason:SNTTemporaryAdminModeDeniedReasonAuthFailed];
+
+  NSData* data = Archive(orig);
+  XCTAssertNotNil(data, @"archiving Denied event should succeed");
+
+  SNTStoredTemporaryAdminModeDeniedAuditEvent* decoded =
+      (SNTStoredTemporaryAdminModeDeniedAuditEvent*)Unarchive(data);
+  XCTAssertNotNil(decoded);
+  XCTAssertTrue([decoded isKindOfClass:[SNTStoredTemporaryAdminModeDeniedAuditEvent class]]);
+
+  XCTAssertEqualObjects(decoded.uuid, @"session-uuid-3");
+  XCTAssertEqualObjects(decoded.username, @"eve");
+  XCTAssertEqual(decoded.reason, SNTTemporaryAdminModeDeniedReasonAuthFailed);
+
+  XCTAssertNotNil(decoded.occurrenceDate);
+  XCTAssertNotNil([decoded uniqueID]);
+  XCTAssertEqual([[decoded uniqueID] length], [[NSUUID UUID] UUIDString].length);
+  XCTAssertEqualObjects([decoded uniqueID], [orig uniqueID]);
+  XCTAssertFalse([decoded unactionableEvent]);
+}
+
+- (void)testDeniedAllReasonsRoundTrip {
+  SNTTemporaryAdminModeDeniedReason reasons[] = {
+      SNTTemporaryAdminModeDeniedReasonNoPolicy,
+      SNTTemporaryAdminModeDeniedReasonNotEligible,
+      SNTTemporaryAdminModeDeniedReasonAuthFailed,
+      SNTTemporaryAdminModeDeniedReasonJustificationRequired,
+      SNTTemporaryAdminModeDeniedReasonAlreadyAdmin,
+      SNTTemporaryAdminModeDeniedReasonSessionAlreadyActive,
+      SNTTemporaryAdminModeDeniedReasonMembershipChangeFailed,
+  };
+  for (size_t i = 0; i < sizeof(reasons) / sizeof(reasons[0]); i++) {
+    SNTStoredTemporaryAdminModeDeniedAuditEvent* orig =
+        [[SNTStoredTemporaryAdminModeDeniedAuditEvent alloc] initWithUUID:@"uuid"
+                                                                 username:@"frank"
+                                                                   reason:reasons[i]];
+    SNTStoredTemporaryAdminModeDeniedAuditEvent* decoded =
+        (SNTStoredTemporaryAdminModeDeniedAuditEvent*)Unarchive(Archive(orig));
+    XCTAssertEqual(decoded.reason, reasons[i], @"denied reason %zu should round-trip", i);
+  }
+}
+
+#pragma mark - uniqueID distinctness
+
+- (void)testUniqueIDsAreDistinctAcrossInstances {
+  // Two independently created events must have different uniqueIDs even with the
+  // same session UUID — this prevents de-duplication of refresh events.
+  SNTStoredTemporaryAdminModeEnterAuditEvent* e1 =
+      [[SNTStoredTemporaryAdminModeEnterAuditEvent alloc]
+               initWithUUID:@"same-uuid"
+                   username:@"gina"
+                    seconds:60
+                     reason:SNTTemporaryAdminModeEnterReasonOnDemand
+          userJustification:@""];
+  SNTStoredTemporaryAdminModeEnterAuditEvent* e2 =
+      [[SNTStoredTemporaryAdminModeEnterAuditEvent alloc]
+               initWithUUID:@"same-uuid"
+                   username:@"gina"
+                    seconds:60
+                     reason:SNTTemporaryAdminModeEnterReasonOnDemandRefresh
+          userJustification:@""];
+
+  XCTAssertNotEqualObjects([e1 uniqueID], [e2 uniqueID],
+                           @"distinct instances must produce distinct uniqueIDs");
+}
+
+@end

--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Source/common/SNTStoredEvent.h"
+#import "Source/common/SNTTimedSessionAuditEvent.h"
 
 // Reason for entering temporary Monitor Mode.
 typedef NS_ENUM(NSInteger, SNTTemporaryMonitorModeEnterReason) {
@@ -52,13 +52,7 @@ typedef NS_ENUM(NSInteger, SNTTemporaryMonitorModeLeaveReason) {
 
 // Represents a temporary Monitor Mode audit event stored in the events database.
 // This class is not meant to be directly instantiated. Use derived classes instead.
-@interface SNTStoredTemporaryMonitorModeAuditEvent : SNTStoredEvent <NSSecureCoding>
-
-@property(readonly) NSString* uuid;
-
-- (instancetype)initWithUUID:(NSString*)uuid;
-- (instancetype)init NS_UNAVAILABLE;
-
+@interface SNTStoredTemporaryMonitorModeAuditEvent : SNTTimedSessionAuditEvent <NSSecureCoding>
 @end
 
 //

--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.mm
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.mm
@@ -17,11 +17,17 @@
 
 #import "Source/common/CoderMacros.h"
 
-@interface SNTStoredTemporaryMonitorModeAuditEvent ()
-// These events should never get dropped due to a conflict. E.g., if a session is refreshed
-// multiple times, each refresh should be reported. This property will be used to compute a
-// random UUID on each instatiation to prevent caching.
-@property(readonly) NSUUID* uniqueUuid;
+// NB: Intentionally not overriding SNTTimedSessionAuditEvent / SNTStoredEvent base class methods:
+//   - (NSString *)uniqueID
+//   - (BOOL)unactionableEvent
+// This class should not be directly instantiated. The base class provides these implementations
+// using the per-instance uniqueUuid so subclasses inherit correct behavior automatically.
+@implementation SNTStoredTemporaryMonitorModeAuditEvent
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
 @end
 
 @implementation SNTStoredTemporaryMonitorModeEnterAuditEvent
@@ -56,15 +62,6 @@
   return self;
 }
 
-- (NSString*)uniqueID {
-  return [self.uniqueUuid UUIDString];
-}
-
-- (BOOL)unactionableEvent {
-  // These events should always be stored
-  return NO;
-}
-
 @end
 
 @implementation SNTStoredTemporaryMonitorModeLeaveAuditEvent
@@ -90,52 +87,6 @@
   self = [super initWithCoder:decoder];
   if (self) {
     DECODE_SELECTOR(decoder, reason, NSNumber, integerValue);
-  }
-  return self;
-}
-
-- (NSString*)uniqueID {
-  return [self.uniqueUuid UUIDString];
-}
-
-- (BOOL)unactionableEvent {
-  // These events should always be stored
-  return NO;
-}
-
-@end
-
-// NB: Intentionally not implementing SNTStoredEvent base class methods:
-//   - (NSString *)uniqueID
-//   - (BOOL)unactionableEvent
-// This class should not be directly instantiated. The default base class implementation
-// for these methods will throw, making it so attempting to instantiate this is not very useful.
-@implementation SNTStoredTemporaryMonitorModeAuditEvent
-
-- (instancetype)initWithUUID:(NSString*)uuid {
-  self = [super init];
-  if (self) {
-    _uuid = uuid;
-    _uniqueUuid = [NSUUID UUID];
-  }
-  return self;
-}
-
-+ (BOOL)supportsSecureCoding {
-  return YES;
-}
-
-- (void)encodeWithCoder:(NSCoder*)coder {
-  [super encodeWithCoder:coder];
-  ENCODE(coder, uuid);
-  ENCODE(coder, uniqueUuid);
-}
-
-- (instancetype)initWithCoder:(NSCoder*)decoder {
-  self = [super initWithCoder:decoder];
-  if (self) {
-    DECODE(decoder, uuid, NSString);
-    DECODE(decoder, uniqueUuid, NSUUID);
   }
   return self;
 }

--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEventTest.mm
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEventTest.mm
@@ -14,6 +14,7 @@
 
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h"
+#import "Source/common/SNTTimedSessionAuditEvent.h"
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
@@ -24,7 +25,7 @@
 @implementation StoredEventTest
 
 - (void)testUniqueID {
-  // Ensure some UUID-length string is returned.It should be random and not match
+  // Ensure some UUID-length string is returned. It should be random and not match
   // what the object was initialized with.
   SNTStoredTemporaryMonitorModeEnterAuditEvent* tmmAuditEnter =
       [[SNTStoredTemporaryMonitorModeEnterAuditEvent alloc]
@@ -79,8 +80,11 @@
   XCTAssertNotNil(archivedTmmEnterEvent);
   XCTAssertNotNil(archivedTmmLeaveEvent);
 
+  // SNTTimedSessionAuditEvent must be included so NSKeyedUnarchiver can decode the
+  // intermediate class in the hierarchy.
   NSSet* allowedClasses =
-      [NSSet setWithObjects:[SNTStoredTemporaryMonitorModeAuditEvent class],
+      [NSSet setWithObjects:[SNTTimedSessionAuditEvent class],
+                            [SNTStoredTemporaryMonitorModeAuditEvent class],
                             [SNTStoredTemporaryMonitorModeEnterAuditEvent class],
                             [SNTStoredTemporaryMonitorModeLeaveAuditEvent class], nil];
 
@@ -93,9 +97,14 @@
       [unarchivedTmmEnterEvent isKindOfClass:[SNTStoredTemporaryMonitorModeEnterAuditEvent class]]);
   SNTStoredTemporaryMonitorModeEnterAuditEvent* tmmEnterAuditEvent =
       (SNTStoredTemporaryMonitorModeEnterAuditEvent*)unarchivedTmmEnterEvent;
-  XCTAssertEqualObjects([tmmEnterAuditEvent uniqueID], [tmmAuditEnter uniqueID]);
-  XCTAssertEqual(tmmEnterAuditEvent.seconds, 123);
+  // uuid, seconds, and reason must survive a coding round-trip.
+  XCTAssertEqualObjects(tmmEnterAuditEvent.uuid, @"abc");
+  XCTAssertEqual(tmmEnterAuditEvent.seconds, 123u);
   XCTAssertEqual(tmmEnterAuditEvent.reason, SNTTemporaryMonitorModeEnterReasonOnDemandRefresh);
+  // uniqueID is keyed on the per-instance uniqueUuid — must be non-nil and survive encoding.
+  XCTAssertEqualObjects([tmmEnterAuditEvent uniqueID], [tmmAuditEnter uniqueID]);
+  XCTAssertNotNil([tmmEnterAuditEvent uniqueID]);
+  XCTAssertFalse([tmmEnterAuditEvent unactionableEvent]);
 
   SNTStoredEvent* unarchivedTmmLeaveEvent =
       [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedClasses
@@ -106,8 +115,12 @@
       [unarchivedTmmLeaveEvent isKindOfClass:[SNTStoredTemporaryMonitorModeLeaveAuditEvent class]]);
   SNTStoredTemporaryMonitorModeLeaveAuditEvent* tmmLeaveAuditEvent =
       (SNTStoredTemporaryMonitorModeLeaveAuditEvent*)unarchivedTmmLeaveEvent;
-  XCTAssertEqualObjects([tmmLeaveAuditEvent uniqueID], [tmmAuditLeave uniqueID]);
+  // uuid and reason must survive a coding round-trip.
+  XCTAssertEqualObjects(tmmLeaveAuditEvent.uuid, @"xyz");
   XCTAssertEqual(tmmLeaveAuditEvent.reason, SNTTemporaryMonitorModeLeaveReasonSyncServerChanged);
+  XCTAssertEqualObjects([tmmLeaveAuditEvent uniqueID], [tmmAuditLeave uniqueID]);
+  XCTAssertNotNil([tmmLeaveAuditEvent uniqueID]);
+  XCTAssertFalse([tmmLeaveAuditEvent unactionableEvent]);
 }
 
 @end

--- a/Source/common/SNTTemporaryAdminPolicy.h
+++ b/Source/common/SNTTemporaryAdminPolicy.h
@@ -1,0 +1,41 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+static constexpr uint32_t kMinTemporaryAdminMinutes = 1;
+static constexpr uint32_t kMaxTemporaryAdminMinutes = 1 * 60 * 24 * 30;
+
+typedef NS_ENUM(NSInteger, SNTTemporaryAdminPolicyType) {
+  SNTTemporaryAdminPolicyTypeUnspecified = 0,
+  SNTTemporaryAdminPolicyTypeRevoke,
+  SNTTemporaryAdminPolicyTypeOnDemand,
+};
+
+@interface SNTTemporaryAdminPolicy : NSObject <NSSecureCoding>
+@property(readonly) SNTTemporaryAdminPolicyType type;
+@property(readonly) NSNumber* maxMinutes;
+@property(readonly) NSNumber* defaultDurationMinutes;
+@property(readonly) BOOL requireJustification;
+
+- (instancetype)initRevocation;
+- (instancetype)initOnDemandMinutes:(uint32_t)minutes
+                    defaultDuration:(uint32_t)defaultDuration
+               requireJustification:(BOOL)requireJustification;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (NSData*)serialize;
++ (instancetype)deserialize:(NSData*)data;
+- (uint32_t)getDurationMinutes:(NSNumber*)requestedDuration;
+@end

--- a/Source/common/SNTTemporaryAdminPolicy.mm
+++ b/Source/common/SNTTemporaryAdminPolicy.mm
@@ -1,0 +1,121 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+
+#import "Source/common/CoderMacros.h"
+#import "Source/common/SNTLogging.h"
+
+@interface SNTTemporaryAdminPolicy ()
+@property(readwrite) NSNumber* maxMinutes;
+@property(readwrite) NSNumber* defaultDurationMinutes;
+@property(readwrite) BOOL requireJustification;
+@end
+
+@implementation SNTTemporaryAdminPolicy
+
+- (instancetype)initRevocation {
+  self = [super init];
+  if (self) _type = SNTTemporaryAdminPolicyTypeRevoke;
+  return self;
+}
+
+- (instancetype)initOnDemandMinutes:(uint32_t)minutes
+                    defaultDuration:(uint32_t)defaultDuration
+               requireJustification:(BOOL)requireJustification {
+  if (minutes == 0) return nil;
+  self = [super init];
+  if (self) {
+    _type = SNTTemporaryAdminPolicyTypeOnDemand;
+    _maxMinutes = [self clampMinutes:minutes];
+    _defaultDurationMinutes = [self clampDefaultDuration:defaultDuration];
+    _requireJustification = requireJustification;
+  }
+  return self;
+}
+
+- (NSNumber*)clampMinutes:(uint64_t)v {
+  if (v < kMinTemporaryAdminMinutes) return @(kMinTemporaryAdminMinutes);
+  if (v > kMaxTemporaryAdminMinutes) return @(kMaxTemporaryAdminMinutes);
+  return @(v);
+}
+
+- (NSNumber*)clampDefaultDuration:(uint64_t)v {
+  if (v == 0 || v > [self.maxMinutes unsignedLongLongValue]) return self.maxMinutes;
+  return @(v);
+}
+
+- (uint32_t)getDurationMinutes:(NSNumber*)requestedDuration {
+  uint64_t v = [requestedDuration unsignedLongLongValue];
+  if (v == 0) return [self.defaultDurationMinutes unsignedIntValue];
+  if (v > [self.maxMinutes unsignedLongLongValue]) return [self.maxMinutes unsignedIntValue];
+  return [requestedDuration unsignedIntValue];
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  ENCODE_BOXABLE(coder, type);
+  ENCODE(coder, maxMinutes);
+  ENCODE(coder, defaultDurationMinutes);
+  ENCODE_BOXABLE(coder, requireJustification);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super init];
+  if (self) {
+    DECODE_SELECTOR(decoder, type, NSNumber, intValue);
+    DECODE(decoder, maxMinutes, NSNumber);
+    DECODE(decoder, defaultDurationMinutes, NSNumber);
+    DECODE_SELECTOR(decoder, requireJustification, NSNumber, boolValue);
+    // Revoke policies carry no duration fields; preserve their nil values so the
+    // decoded object stays symmetric with -initRevocation. Only on-demand policies
+    // have minutes to clamp.
+    if (_type != SNTTemporaryAdminPolicyTypeRevoke) {
+      self.maxMinutes = [self clampMinutes:[_maxMinutes unsignedLongLongValue]];
+      self.defaultDurationMinutes =
+          [self clampDefaultDuration:[_defaultDurationMinutes unsignedLongLongValue]];
+    }
+  }
+  return self;
+}
+
+- (NSData*)serialize {
+  NSError* error;
+  NSData* data = [NSKeyedArchiver archivedDataWithRootObject:self
+                                       requiringSecureCoding:YES
+                                                       error:&error];
+  if (error) {
+    LOGE(@"Temporary Admin Policy serialization failed: %@", error.localizedDescription);
+    return nil;
+  }
+  return data;
+}
+
++ (instancetype)deserialize:(NSData*)data {
+  if (!data) return nil;
+  NSError* error;
+  id object = [NSKeyedUnarchiver unarchivedObjectOfClass:[SNTTemporaryAdminPolicy class]
+                                                fromData:data
+                                                   error:&error];
+  if (error) {
+    LOGE(@"Temporary Admin Policy deserialization failed: %@", error.localizedDescription);
+    return nil;
+  }
+  return object;
+}
+
+@end

--- a/Source/common/SNTTemporaryAdminPolicyTest.mm
+++ b/Source/common/SNTTemporaryAdminPolicyTest.mm
@@ -1,0 +1,78 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+
+@interface SNTTemporaryAdminPolicyTest : XCTestCase
+@end
+
+@implementation SNTTemporaryAdminPolicyTest
+
+- (void)testOnDemandClampsAndDefaults {
+  SNTTemporaryAdminPolicy* p = [[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:60
+                                                                    defaultDuration:30
+                                                               requireJustification:YES];
+  XCTAssertEqual(p.type, SNTTemporaryAdminPolicyTypeOnDemand);
+  XCTAssertEqualObjects(p.maxMinutes, @60);
+  XCTAssertEqualObjects(p.defaultDurationMinutes, @30);
+  XCTAssertTrue(p.requireJustification);
+  XCTAssertEqual([p getDurationMinutes:@0], 30u);
+  XCTAssertEqual([p getDurationMinutes:@1000], 60u);
+  XCTAssertEqual([p getDurationMinutes:@45], 45u);
+}
+
+- (void)testDefaultDurationClampedToMax {
+  SNTTemporaryAdminPolicy* p = [[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:10
+                                                                    defaultDuration:9999
+                                                               requireJustification:NO];
+  XCTAssertEqualObjects(p.defaultDurationMinutes, @10);
+}
+
+- (void)testZeroMinutesIsNil {
+  XCTAssertNil([[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:0
+                                                    defaultDuration:0
+                                               requireJustification:YES]);
+}
+
+- (void)testRevocation {
+  XCTAssertEqual([[SNTTemporaryAdminPolicy alloc] initRevocation].type,
+                 SNTTemporaryAdminPolicyTypeRevoke);
+}
+
+- (void)testRevocationRoundTripPreservesNilFields {
+  SNTTemporaryAdminPolicy* p = [[SNTTemporaryAdminPolicy alloc] initRevocation];
+  SNTTemporaryAdminPolicy* r = [SNTTemporaryAdminPolicy deserialize:[p serialize]];
+  XCTAssertEqual(r.type, SNTTemporaryAdminPolicyTypeRevoke);
+  // Revoke policies have no duration fields; clamping must not synthesize defaults.
+  XCTAssertNil(r.maxMinutes);
+  XCTAssertNil(r.defaultDurationMinutes);
+}
+
+- (void)testSecureCodingRoundTripPreservesFlags {
+  SNTTemporaryAdminPolicy* p = [[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:120
+                                                                    defaultDuration:15
+                                                               requireJustification:NO];
+  SNTTemporaryAdminPolicy* r = [SNTTemporaryAdminPolicy deserialize:[p serialize]];
+  XCTAssertEqual(r.type, SNTTemporaryAdminPolicyTypeOnDemand);
+  XCTAssertEqualObjects(r.maxMinutes, @120);
+  XCTAssertEqualObjects(r.defaultDurationMinutes, @15);
+  XCTAssertFalse(r.requireJustification);
+}
+
+- (void)testDeserializeNilReturnsNil {
+  XCTAssertNil([SNTTemporaryAdminPolicy deserialize:nil]);
+}
+
+@end

--- a/Source/common/SNTTimedSessionAuditEvent.h
+++ b/Source/common/SNTTimedSessionAuditEvent.h
@@ -1,0 +1,27 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTStoredEvent.h"
+
+// Shared base for timer-bounded-session audit events (Temporary Monitor Mode,
+// Temporary Admin Mode). Not instantiated directly. Carries the session UUID and
+// a per-instance unique UUID so repeated events (e.g. refreshes) are never
+// de-duplicated. Provides uniqueID/unactionableEvent for all subclasses.
+@interface SNTTimedSessionAuditEvent : SNTStoredEvent <NSSecureCoding>
+@property(readonly) NSString* uuid;
+- (instancetype)initWithUUID:(NSString*)uuid;
+- (instancetype)init NS_UNAVAILABLE;
+@end

--- a/Source/common/SNTTimedSessionAuditEvent.mm
+++ b/Source/common/SNTTimedSessionAuditEvent.mm
@@ -1,0 +1,63 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTTimedSessionAuditEvent.h"
+
+#import "Source/common/CoderMacros.h"
+
+@interface SNTTimedSessionAuditEvent ()
+@property(readonly) NSUUID* uniqueUuid;
+@end
+
+@implementation SNTTimedSessionAuditEvent
+
+- (instancetype)initWithUUID:(NSString*)uuid {
+  self = [super init];
+  if (self) {
+    _uuid = uuid;
+    _uniqueUuid = [NSUUID UUID];
+  }
+  return self;
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder*)coder {
+  [super encodeWithCoder:coder];
+  ENCODE(coder, uuid);
+  ENCODE(coder, uniqueUuid);
+}
+
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) {
+    DECODE(decoder, uuid, NSString);
+    DECODE(decoder, uniqueUuid, NSUUID);
+  }
+  return self;
+}
+
+// Hoisted from the per-feature events (identical in TMM and TAM): never drop a
+// timed-session audit event, and key its DB identity on the per-instance UUID.
+- (NSString*)uniqueID {
+  return [self.uniqueUuid UUIDString];
+}
+
+- (BOOL)unactionableEvent {
+  return NO;
+}
+
+@end


### PR DESCRIPTION
Part of WS-1128. PR 1 of 5 in the Temporary Admin Mode (TAM) stack.

Source/common foundation only; inert until later PRs wire it up.

- `SNTTemporaryAdminPolicy`: sync-server policy value type (type, durations, requireJustification)
- `SNTTimedSessionAuditEvent`: shared audit-event base; TMM refactored onto it, TAM audit event added
- `SNTConfigurator/SNTConfigBundle`: TAM policy plumbing
- XPC: TAM ops on control + notifier interfaces
- Error codes `SNTErrorCodeTAM*` (910-917)
