### PR TITLE
santad: extract shared TimedSyncSession base and refactor TMM onto it

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -868,19 +868,24 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 @property(readonly) BOOL inTemporaryMonitorMode;
 
 ///
-///  Set Santa to be in Monitor Mode temporarily
+///  Set / clear the in-memory temporary Monitor Mode effect (the flag the
+///  clientMode getter reads). The persisted session state is managed separately
+///  via the generic timed-session accessors below.
 ///
-- (void)enterTemporaryMonitorMode:(nullable NSDictionary*)temporaryMonitorModeState;
+- (void)setInTemporaryMonitorMode:(BOOL)enabled;
+
+#pragma mark - Timed Session State
 
 ///
-///  Set Santa as having left temporary Monitor Mode
+///  Persist (or clear, when `state` is nil) the session state for a timed-session
+///  feature (e.g. Temporary Monitor Mode, Temporary Admin Mode) under `key`.
 ///
-- (void)leaveTemporaryMonitorMode;
+- (void)persistTimedSessionState:(nullable NSDictionary*)state forKey:(nonnull NSString*)key;
 
 ///
-/// Returns the Temporary Monitor Mode state if it exists
+///  Returns the persisted timed-session state for `key`, if any.
 ///
-- (nullable NSDictionary*)savedTemporaryMonitorModeState;
+- (nullable NSDictionary*)savedTimedSessionStateForKey:(nonnull NSString*)key;
 
 #pragma mark - USB Settings
 

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -978,24 +978,14 @@ static SNTConfigurator* sharedConfigurator = nil;
   }
 }
 
-- (void)enterTemporaryMonitorMode:(NSDictionary*)temporaryMonitorModeState {
+- (void)persistTimedSessionState:(NSDictionary*)state forKey:(NSString*)key {
   @synchronized(self) {
-    [self updateStateSynchronizedKey:kStateTempMonitorModeKey value:temporaryMonitorModeState];
-    self.inTemporaryMonitorMode = YES;
+    [self updateStateSynchronizedKey:key value:state];
   }
 }
 
-- (void)leaveTemporaryMonitorMode {
-  @synchronized(self) {
-    self.inTemporaryMonitorMode = NO;
-
-    // Clear the temporary Monitor Mode state now that it has ended
-    [self updateStateSynchronizedKey:kStateTempMonitorModeKey value:nil];
-  }
-}
-
-- (nullable NSDictionary*)savedTemporaryMonitorModeState {
-  return self.state[kStateTempMonitorModeKey];
+- (nullable NSDictionary*)savedTimedSessionStateForKey:(NSString*)key {
+  return self.state[key];
 }
 
 - (void)updateLastBootUUID:(NSString*)bootUUID {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -316,6 +316,25 @@ santa_unit_test(
 )
 
 objc_library(
+    name = "TimedSyncSession",
+    srcs = ["TimedSyncSession.mm"],
+    hdrs = ["TimedSyncSession.h"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
+    deps = [
+        ":SNTNotificationQueue",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTKVOManager",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTSystemInfo",
+        "//Source/common:SystemResources",
+        "//Source/common:Timer",
+        "@abseil-cpp//absl/synchronization",
+    ],
+)
+
+objc_library(
     name = "TemporaryMonitorMode",
     srcs = ["TemporaryMonitorMode.mm"],
     hdrs = ["TemporaryMonitorMode.h"],
@@ -324,16 +343,12 @@ objc_library(
     ],
     deps = [
         ":SNTNotificationQueue",
+        ":TimedSyncSession",
         "//Source/common:PassKey",
-        "//Source/common:Pinning",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTError",
-        "//Source/common:SNTKVOManager",
         "//Source/common:SNTModeTransition",
         "//Source/common:SNTStoredTemporaryMonitorModeAuditEvent",
-        "//Source/common:SNTSystemInfo",
-        "//Source/common:SystemResources",
-        "//Source/common:Timer",
         "@abseil-cpp//absl/synchronization",
     ],
 )
@@ -344,6 +359,7 @@ santa_unit_test(
     deps = [
         ":SNTNotificationQueue",
         ":TemporaryMonitorMode",
+        ":TimedSyncSession",
         "//Source/common:SNTModeTransition",
         "//Source/common:SystemResources",
         "@OCMock",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -347,6 +347,7 @@ objc_library(
         "//Source/common:PassKey",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTError",
+        "//Source/common:SNTLogging",
         "//Source/common:SNTModeTransition",
         "//Source/common:SNTStoredTemporaryMonitorModeAuditEvent",
         "@abseil-cpp//absl/synchronization",

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -1156,7 +1156,7 @@ static const char* const kAllowedCanonicalBundlePaths[] = {
 }
 
 - (void)checkTemporaryMonitorModePolicyAvailable:(void (^)(BOOL))reply {
-  reply(_temporaryMonitorMode->Available(nil));
+  reply(_temporaryMonitorMode->Available());
 }
 
 #pragma mark Network Extension Ops

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -180,7 +180,24 @@
 }
 
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply {
-  [[self.notifierConnection synchronousRemoteObjectProxy] authorizeTemporaryMonitorMode:reply];
+  id rop = [self.notifierConnection synchronousRemoteObjectProxy];
+  if (!rop) {
+    // No GUI connection. Fail immediately rather than leaving the caller's reply
+    // uninvoked, which would stall its fail-closed timeout for the full duration.
+    reply(NO);
+    return;
+  }
+  // The proxy is synchronous: if the reply block hasn't run by the time the call
+  // returns, the XPC transport failed (e.g. the GUI died mid-auth) and it never
+  // will. Convert that into an immediate NO so the caller fails fast.
+  __block BOOL replied = NO;
+  [rop authorizeTemporaryMonitorMode:^(BOOL authenticated) {
+    replied = YES;
+    reply(authenticated);
+  }];
+  if (!replied) {
+    reply(NO);
+  }
 }
 
 @end

--- a/Source/santad/TemporaryMonitorMode.h
+++ b/Source/santad/TemporaryMonitorMode.h
@@ -16,26 +16,21 @@
 #define SANTA_SANTAD_TEMPORARYMONITORMODE_H
 
 #include <memory>
-#include <optional>
 
 #include "Source/common/PassKey.h"
 #import "Source/common/SNTConfigurator.h"
-#import "Source/common/SNTKVOManager.h"
 #import "Source/common/SNTModeTransition.h"
 #import "Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h"
-#include "Source/common/Timer.h"
 #import "Source/santad/SNTNotificationQueue.h"
-#include "absl/synchronization/mutex.h"
-
-extern NSString* const kStateTempMonitorModeBootUUIDKey;
-extern NSString* const kStateTempMonitorModeDeadlineKey;
-extern NSString* const kStateTempMonitorModeSavedSyncURLKey;
-extern NSString* const kStateTempMonitorModeSessionUUIDKey;
+#include "Source/santad/TimedSyncSession.h"
 
 namespace santa {
 
-class TemporaryMonitorMode : public Timer<TemporaryMonitorMode>,
-                             public PassKey<TemporaryMonitorMode> {
+// Temporary Monitor Mode: a sync-blessed, timer-bounded override that puts the
+// client into Monitor mode for a requested duration. A thin subclass of
+// TimedSyncSession; the effect is an in-memory flag that the clientMode getter
+// reads.
+class TemporaryMonitorMode : public TimedSyncSession, public PassKey<TemporaryMonitorMode> {
  public:
   using HandleAuditEventBlock = void (^)(SNTStoredTemporaryMonitorModeAuditEvent*);
 
@@ -44,77 +39,52 @@ class TemporaryMonitorMode : public Timer<TemporaryMonitorMode>,
       SNTConfigurator* configurator, SNTNotificationQueue* notification_queue,
       HandleAuditEventBlock handle_audit_event_block);
 
-  // Construction and setup require a PassKey, can only be used internally.
+  // Construction requires a PassKey, can only be used internally / by tests.
   TemporaryMonitorMode(PassKey, SNTConfigurator* configurator,
                        SNTNotificationQueue* notification_queue,
                        HandleAuditEventBlock handle_audit_event_block);
-  void SetupFromState(PassKey, NSDictionary* tmm);
 
-  // No moves, no copies
-  TemporaryMonitorMode(TemporaryMonitorMode&& other) = delete;
-  TemporaryMonitorMode& operator=(TemporaryMonitorMode&& rhs) = delete;
-  TemporaryMonitorMode(const TemporaryMonitorMode& other) = delete;
-  TemporaryMonitorMode& operator=(const TemporaryMonitorMode& other) = delete;
-
-  // Enter Monitor Mode temporarily for the requested duration.
-  // Returns the actual number of minutes allowed, or 0 if error.
+  // Enter Monitor Mode temporarily for the requested duration. Returns the actual
+  // number of minutes allowed, or 0 on error (with `err` populated).
   uint32_t RequestMinutes(NSNumber* requested_duration, NSError** err);
 
-  // Cancel an existing temporary Monitor Mode session.
-  // Return true if a session was active, otherwise false.
-  bool Cancel();
-
-  // Cancel an existing temporary Monitor Mode session and revoke any
-  // stored mode transition sync setting to prevent future sessions.
-  // Return true if a session was active, otherwise false.
-  bool Revoke(SNTTemporaryMonitorModeLeaveReason reason);
-
-  // Requried method of Timer mixin derived classes. Will be called when
-  // a previously started timer expires.
-  bool OnTimer();
-
-  // Return whether temporary monitor mode is available: a policy is set,
-  // the sync domain is pinned and the current client mode can transition.
-  // When returning false, the optional err parameter may be populated.
-  bool Available(NSError** err);
-
-  // If a temporary Monitor Mode session is active, return the number of
-  // of seconds remaining. Otherwise nullopt.
-  std::optional<uint64_t> SecondsRemaining() const;
-  static std::optional<uint64_t> SecondsRemaining(uint64_t deadline_mach_time);
-
-  // If the mode transition was authorization was revoked, immediate cancel
-  // any existing session. The configurator sync settings are also updated.
+  // If the mode transition authorization was revoked, immediately cancel any
+  // existing session; always re-notify the GUI of availability.
   void NewModeTransitionReceived(SNTModeTransition* mode_transition);
 
   friend class TemporaryMonitorModePeer;
 
+ protected:
+  bool ApplyEffect(NSError** err) override;
+  void RevertEffect() override;
+  bool ReapplyEffectOnRestart() override;
+  bool ExtraPreconditions() override;
+  NSString* StateKey() override;
+  bool HasOnDemandPolicy() override;
+  uint32_t ClampDuration(NSNumber* requested) override;
+  bool PolicyRequiresAuth() override;
+  bool PolicyRequiresJustification() override;
+  void WriteRevokePolicy() override;
+  void RequestAuthorization(void (^reply)(BOOL authenticated, NSString* reason)) override;
+  NSDictionary* ExtraStateToPersist() override;
+  bool RestoreAndValidateExtraState(NSDictionary* state) override;
+  void ClearExtraState() override;
+  id BuildEnterAuditEvent(NSString* session_uuid, uint32_t seconds, NSInteger enter_reason,
+                          NSString* user_justification) override;
+  id BuildLeaveAuditEvent(NSString* session_uuid, NSInteger leave_reason) override;
+  NSInteger EnterReasonOnDemand() override;
+  NSInteger EnterReasonRefresh() override;
+  NSInteger EnterReasonRestart() override;
+  NSInteger LeaveReasonCancelled() override;
+  NSInteger LeaveReasonSessionExpired() override;
+  NSInteger LeaveReasonReboot() override;
+  NSInteger LeaveReasonSyncServerChanged() override;
+  void EmitAudit(id audit_event) override;
+  void NotifyEnter(NSDate* expiration) override;
+  void NotifyLeave() override;
+
  private:
-  // Require at least 5 seconds left of Monitor Mode a previously authorized
-  // Temporary Monitor Mode session in order to re-enter. Otherwise don't bother.
-  static constexpr uint64_t kMinAllowedStateRemainingSeconds = 5;
-
-  bool BeginLocked(uint32_t seconds, bool gen_uuid_on_start) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-  bool EndLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-  uint64_t GetSecondsRemainingFromInitialStateLocked(NSDictionary* tmm,
-                                                     NSString* currentBootSessionUUID,
-                                                     NSURL* syncURL)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-  bool RevokeLocked(SNTTemporaryMonitorModeLeaveReason reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-
-  // hide the base class Start/Stop methods
-  bool StartTimer();
-  bool StopTimer();
-  bool StartTimerWithInterval(uint32_t interval_seconds);
-
-  mutable absl::Mutex lock_;
-
-  SNTConfigurator* configurator_;
-  SNTNotificationQueue* notification_queue_;
   HandleAuditEventBlock handle_audit_event_block_;
-  uint64_t deadline_ ABSL_GUARDED_BY(lock_);
-  NSUUID* current_uuid_ ABSL_GUARDED_BY(lock_);
-  NSArray<SNTKVOManager*>* kvo_;
 };
 
 }  // namespace santa

--- a/Source/santad/TemporaryMonitorMode.h
+++ b/Source/santad/TemporaryMonitorMode.h
@@ -56,7 +56,7 @@ class TemporaryMonitorMode : public TimedSyncSession, public PassKey<TemporaryMo
 
  protected:
   bool ApplyEffect(NSError** err) override;
-  void RevertEffect() override;
+  bool RevertEffect() override;
   bool ReapplyEffectOnRestart() override;
   bool ExtraPreconditions() override;
   NSString* StateKey() override;

--- a/Source/santad/TemporaryMonitorMode.mm
+++ b/Source/santad/TemporaryMonitorMode.mm
@@ -102,8 +102,10 @@ bool TemporaryMonitorMode::ApplyEffect(NSError** err) {
   return true;
 }
 
-void TemporaryMonitorMode::RevertEffect() {
+bool TemporaryMonitorMode::RevertEffect() {
+  // Clearing an in-memory flag cannot fail, so the revert always succeeds.
   [configurator_ setInTemporaryMonitorMode:NO];
+  return true;
 }
 
 bool TemporaryMonitorMode::ReapplyEffectOnRestart() {

--- a/Source/santad/TemporaryMonitorMode.mm
+++ b/Source/santad/TemporaryMonitorMode.mm
@@ -14,21 +14,13 @@
 
 #include "Source/santad/TemporaryMonitorMode.h"
 
-#include <mach/mach_time.h>
-
 #import "Source/common/MOLXPCConnection.h"
-#include "Source/common/Pinning.h"
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTError.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTModeTransition.h"
 #import "Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h"
-#import "Source/common/SNTSystemInfo.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
-#include "Source/common/SystemResources.h"
-
-NSString* const kStateTempMonitorModeBootUUIDKey = @"BootUUID";
-NSString* const kStateTempMonitorModeDeadlineKey = @"Deadline";
-NSString* const kStateTempMonitorModeSavedSyncURLKey = @"SyncURL";
-NSString* const kStateTempMonitorModeSessionUUIDKey = @"SessionUUID";
 
 namespace santa {
 
@@ -38,10 +30,10 @@ std::shared_ptr<TemporaryMonitorMode> TemporaryMonitorMode::Create(
   auto tmm = std::make_shared<TemporaryMonitorMode>(PassKey(), configurator, notification_queue,
                                                     handle_audit_event_block);
 
-  // NB: SetupFromState Is split out of the constructor since it could
-  // potentially start the timer, which would take a weak reference before
-  // construction was complete.
-  tmm->SetupFromState(PassKey(), [configurator savedTemporaryMonitorModeState]);
+  // NB: SetupFromState is split out of the constructor since it could start the
+  // timer, which takes a weak reference that must not be taken before construction
+  // is complete.
+  tmm->SetupFromState();
 
   return tmm;
 }
@@ -49,111 +41,50 @@ std::shared_ptr<TemporaryMonitorMode> TemporaryMonitorMode::Create(
 TemporaryMonitorMode::TemporaryMonitorMode(PassKey, SNTConfigurator* configurator,
                                            SNTNotificationQueue* notification_queue,
                                            HandleAuditEventBlock handle_audit_event_block)
-    : Timer(kMinTemporaryMonitorModeMinutes, kMaxTemporaryMonitorModeMinutes,
-            Timer::OnStart::kWaitOneCycle, "Temporary Monitor Mode",
-            Timer::RescheduleMode::kTrailingEdge, QOS_CLASS_USER_INITIATED),
-      configurator_(configurator),
-      notification_queue_(notification_queue),
-      handle_audit_event_block_([handle_audit_event_block copy]),
-      deadline_(0) {}
+    : TimedSyncSession(kMinTemporaryMonitorModeMinutes, kMaxTemporaryMonitorModeMinutes,
+                       "Temporary Monitor Mode", configurator, notification_queue),
+      handle_audit_event_block_([handle_audit_event_block copy]) {}
 
-void TemporaryMonitorMode::SetupFromState(PassKey, NSDictionary* tmm) {
-  std::weak_ptr<TemporaryMonitorMode> weak_self = weak_from_base<TemporaryMonitorMode>();
-  kvo_ = @[ [[SNTKVOManager alloc]
-      initWithObject:configurator_
-            selector:@selector(syncBaseURL)
-                type:[NSURL class]
-            callback:^(NSURL* oldValue, NSURL* newValue) {
-              if ((!newValue && !oldValue) ||
-                  ([newValue.absoluteString isEqualToString:oldValue.absoluteString])) {
-                return;
-              }
+uint32_t TemporaryMonitorMode::RequestMinutes(NSNumber* requested_duration, NSError** err) {
+  // Serialize the whole grant (pre-checks + auth + apply) against other grants.
+  absl::MutexLock grant_lock(grant_mutex_);
 
-              if (auto strong_self = weak_self.lock()) {
-                if (strong_self->Revoke(SNTTemporaryMonitorModeLeaveReasonSyncServerChanged)) {
-                  LOGI(@"Temporary Monitor Mode session revoked due to SyncBaseURL changing.");
-                }
-              }
-            }] ];
-
-  absl::MutexLock lock(lock_);
-  uint32_t secs_remaining = static_cast<uint32_t>(
-      std::min(GetSecondsRemainingFromInitialStateLocked(tmm, [SNTSystemInfo bootSessionUUID],
-                                                         configurator_.syncBaseURL),
-               static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
-  if (secs_remaining < kMinAllowedStateRemainingSeconds) {
-    [configurator_ leaveTemporaryMonitorMode];
-    [[notification_queue_.notifierConnection remoteObjectProxy] leaveTemporaryMonitorMode];
-  } else {
-    BeginLocked(secs_remaining, false);
-    handle_audit_event_block_([[SNTStoredTemporaryMonitorModeEnterAuditEvent alloc]
-        initWithUUID:[current_uuid_ UUIDString]
-             seconds:secs_remaining
-              reason:SNTTemporaryMonitorModeEnterReasonRestart]);
-  }
-}
-
-// When reading Temporary Monitor Mode state, all of the following
-// conditions must be true, otherwise the state is discarded:
-//   0. All types must meet expectations
-//   1. The saved boot session UUID must match the current boot session UUID
-//   2. The saved sync URL must match the current SyncBaseURL
-//   3. The current SyncBaseURL must be pinned
-//   4. The saved session UUID must be a valid UUID
-uint64_t TemporaryMonitorMode::GetSecondsRemainingFromInitialStateLocked(
-    NSDictionary* tmm, NSString* currentBootSessionUUID, NSURL* syncURL) {
-  if (![tmm[kStateTempMonitorModeBootUUIDKey] isKindOfClass:[NSString class]] ||
-      ![tmm[kStateTempMonitorModeDeadlineKey] isKindOfClass:[NSNumber class]] ||
-      ![tmm[kStateTempMonitorModeSavedSyncURLKey] isKindOfClass:[NSString class]] ||
-      ![tmm[kStateTempMonitorModeSessionUUIDKey] isKindOfClass:[NSString class]]) {
-    return 0;
-  }
-
-  NSUUID* saved_uuid = [[NSUUID alloc] initWithUUIDString:tmm[kStateTempMonitorModeSessionUUIDKey]];
-  if (!saved_uuid) {
-    // Invalid config value for saved UUID
-    return 0;
-  }
-  current_uuid_ = saved_uuid;
-
-  if (![tmm[kStateTempMonitorModeBootUUIDKey] isEqualToString:currentBootSessionUUID]) {
-    // Reboot detected, do not attempt to re-enter Monitor Mode
-    handle_audit_event_block_([[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
-        initWithUUID:[current_uuid_ UUIDString]
-              reason:SNTTemporaryMonitorModeLeaveReasonReboot]);
-    return 0;
-  }
-
-  if (![tmm[kStateTempMonitorModeSavedSyncURLKey] isEqualToString:syncURL.host] ||
-      !configurator_.isSyncV2Enabled) {
-    // SyncBaseURL changed or is not pinned, do not attempt to re-enter Monitor Mode automatically.
-    // Revoke the mode transition authorization as well so the machine is no longer eligible.
-    RevokeLocked(SNTTemporaryMonitorModeLeaveReasonSyncServerChanged);
-    return 0;
-  }
-
-  NSNumber* deadline = tmm[kStateTempMonitorModeDeadlineKey];
-  if (!deadline) {
-    return 0;
-  }
-
-  std::optional<uint64_t> secs_remaining = SecondsRemaining([deadline unsignedLongLongValue]);
-  if (secs_remaining.has_value()) {
-    return *secs_remaining;
-  } else {
-    handle_audit_event_block_([[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
-        initWithUUID:[current_uuid_ UUIDString]
-              reason:SNTTemporaryMonitorModeLeaveReasonSessionExpired]);
-    return 0;
+  uint32_t minutes = 0;
+  switch (BeginGrant(requested_duration, &minutes)) {
+    case GrantOutcome::kGranted: return minutes;
+    case GrantOutcome::kNoPolicy:
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTMMNoPolicy
+                       format:@"This machine does not currently have a "
+                              @"policy allowing temporary Monitor Mode."];
+      return 0;
+    case GrantOutcome::kNotEligible:
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTMMNotInLockdown
+                       format:@"Machine must be in Lockdown Mode in order to "
+                              @"transition to temporary Monitor Mode."];
+      return 0;
+    case GrantOutcome::kInvalidSyncServer:
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTMMInvalidSyncServer
+                       format:@"This machine is not configured with a sync "
+                              @"server that supports temporary Monitor Mode."];
+      return 0;
+    case GrantOutcome::kAuthFailed:
+    case GrantOutcome::kJustificationRequired:  // TMM never requires a reason
+    case GrantOutcome::kApplyFailed:            // TMM's effect (the in-memory flag) cannot fail
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTMMAuthFailed
+                       format:@"User authorization failed."];
+      return 0;
   }
 }
 
 void TemporaryMonitorMode::NewModeTransitionReceived(SNTModeTransition* mode_transition) {
   // Persistence of the received mode_transition is the caller's responsibility
   // (the daemon controller writes it inside a sync-state batch so that all
-  // sync-derived state lands in a single commit). This method handles
-  // enforcement side effects for Revoke and the GUI availability notification,
-  // both of which must run regardless of how persistence was sequenced.
+  // sync-derived state lands in a single commit). This method handles enforcement
+  // side effects for Revoke and the GUI availability notification.
   if (mode_transition.type == SNTModeTransitionTypeRevoke) {
     if (Revoke(SNTTemporaryMonitorModeLeaveReasonRevoked)) {
       LOGI(@"Temporary Monitor Mode session revoked due to policy change.");
@@ -161,187 +92,126 @@ void TemporaryMonitorMode::NewModeTransitionReceived(SNTModeTransition* mode_tra
   }
 
   [[notification_queue_.notifierConnection remoteObjectProxy]
-      temporaryMonitorModePolicyAvailable:Available(nil)];
+      temporaryMonitorModePolicyAvailable:Available()];
 }
 
-bool TemporaryMonitorMode::Available(NSError** err) {
-  SNTModeTransition* mode_transition = [configurator_ modeTransition];
-  if (mode_transition.type != SNTModeTransitionTypeOnDemand) {
-    [SNTError populateError:err
-                   withCode:SNTErrorCodeTMMNoPolicy
-                     format:@"This machine does not currently have a "
-                            @"policy allowing temporary Monitor Mode."];
-    return false;
-  }
+#pragma mark Hooks
 
-  SNTClientMode clientMode = [configurator_ clientMode];
-  if (!(clientMode == SNTClientModeLockdown ||
-        (clientMode == SNTClientModeMonitor && [configurator_ inTemporaryMonitorMode]))) {
-    [SNTError populateError:err
-                   withCode:SNTErrorCodeTMMNotInLockdown
-                     format:@"Machine must be in Lockdown Mode in order to "
-                            @"transition to temporary Monitor Mode."];
-    return false;
-  }
-
-  if (!configurator_.isSyncV2Enabled) {
-    [SNTError populateError:err
-                   withCode:SNTErrorCodeTMMInvalidSyncServer
-                     format:@"This machine is not configured with a sync "
-                            @"server that supports temporary Monitor Mode."];
-    return false;
-  }
+bool TemporaryMonitorMode::ApplyEffect(NSError** err) {
+  [configurator_ setInTemporaryMonitorMode:YES];
   return true;
-};
-
-uint32_t TemporaryMonitorMode::RequestMinutes(NSNumber* requested_duration, NSError** err) {
-  if (!Available(err)) {
-    return 0;
-  }
-
-  __block BOOL auth_success = NO;
-  [notification_queue_ authorizeTemporaryMonitorMode:^(BOOL authenticated) {
-    auth_success = authenticated;
-  }];
-
-  if (!auth_success) {
-    [SNTError populateError:err
-                   withCode:SNTErrorCodeTMMAuthFailed
-                     format:@"User authorization failed."];
-    return 0;
-  }
-
-  SNTModeTransition* mode_transition = [configurator_ modeTransition];
-  uint32_t duration_min = [mode_transition getDurationMinutes:requested_duration];
-
-  absl::MutexLock lock(lock_);
-  SNTTemporaryMonitorModeEnterReason reason;
-  if (BeginLocked(duration_min * 60, true)) {
-    reason = SNTTemporaryMonitorModeEnterReasonOnDemand;
-  } else {
-    reason = SNTTemporaryMonitorModeEnterReasonOnDemandRefresh;
-  }
-  handle_audit_event_block_([[SNTStoredTemporaryMonitorModeEnterAuditEvent alloc]
-      initWithUUID:[current_uuid_ UUIDString]
-           seconds:static_cast<uint32_t>(SecondsRemaining(deadline_).value_or(0))
-            reason:reason]);
-
-  return duration_min;
 }
 
-std::optional<uint64_t> TemporaryMonitorMode::SecondsRemaining() const {
-  absl::ReaderMutexLock lock(lock_);
-  if (IsStarted()) {
-    return SecondsRemaining(deadline_);
-  } else {
-    return std::nullopt;
-  }
+void TemporaryMonitorMode::RevertEffect() {
+  [configurator_ setInTemporaryMonitorMode:NO];
 }
 
-std::optional<uint64_t> TemporaryMonitorMode::SecondsRemaining(uint64_t deadline_mach_time) {
-  uint64_t current_mach_time = mach_continuous_time();
-  if (deadline_mach_time <= current_mach_time) {
-    return std::nullopt;
-  } else {
-    return MachTimeToNanos(deadline_mach_time - current_mach_time) / NSEC_PER_SEC;
-  }
+bool TemporaryMonitorMode::ReapplyEffectOnRestart() {
+  // The in-memory flag is lost across a daemon restart; re-applying is required so
+  // Monitor mode keeps being enforced. Santa is the sole authority for this flag,
+  // so re-applying is always correct.
+  [configurator_ setInTemporaryMonitorMode:YES];
+  return true;
 }
 
-bool TemporaryMonitorMode::BeginLocked(uint32_t seconds, bool gen_uuid_on_start) {
-  bool did_start_new_timer = StartTimerWithInterval(seconds);
-  if (did_start_new_timer && gen_uuid_on_start) {
-    current_uuid_ = [NSUUID UUID];
-  }
-
-  uint64_t deadline = AddNanosecondsToMachTime(seconds * NSEC_PER_SEC, mach_continuous_time());
-
-  [configurator_ enterTemporaryMonitorMode:@{
-    kStateTempMonitorModeBootUUIDKey : [SNTSystemInfo bootSessionUUID],
-    kStateTempMonitorModeDeadlineKey : @(deadline),
-    kStateTempMonitorModeSavedSyncURLKey : configurator_.syncBaseURL.host,
-    kStateTempMonitorModeSessionUUIDKey : [current_uuid_ UUIDString],
-  }];
-
-  deadline_ = deadline;
-
-  id<SNTNotifierXPC> rop = [notification_queue_.notifierConnection remoteObjectProxy];
-  [rop enterTemporaryMonitorMode:[NSDate dateWithTimeIntervalSinceNow:seconds]];
-
-  return did_start_new_timer;
+bool TemporaryMonitorMode::ExtraPreconditions() {
+  SNTClientMode clientMode = [configurator_ clientMode];
+  return clientMode == SNTClientModeLockdown ||
+         (clientMode == SNTClientModeMonitor && [configurator_ inTemporaryMonitorMode]);
 }
 
-bool TemporaryMonitorMode::Cancel() {
-  absl::MutexLock lock(lock_);
-  if (EndLocked()) {
-    handle_audit_event_block_([[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
-        initWithUUID:[current_uuid_ UUIDString]
-              reason:SNTTemporaryMonitorModeLeaveReasonCancelled]);
-    current_uuid_ = nil;
-    return true;
-  } else {
-    return false;
-  }
+NSString* TemporaryMonitorMode::StateKey() {
+  return @"TMM";
 }
 
-bool TemporaryMonitorMode::Revoke(SNTTemporaryMonitorModeLeaveReason reason) {
-  absl::MutexLock lock(lock_);
-  return RevokeLocked(reason);
+bool TemporaryMonitorMode::HasOnDemandPolicy() {
+  return [configurator_ modeTransition].type == SNTModeTransitionTypeOnDemand;
 }
 
-bool TemporaryMonitorMode::RevokeLocked(SNTTemporaryMonitorModeLeaveReason reason) {
-  // Skip the persistence write if the current effective transition is already
-  // a revoke. On the sync-update path the daemon controller writes the revoke
-  // inside its batch, so this would otherwise produce a second `syncState`
-  // KVO fire. On all other Revoke entry points (sync URL change, etc.) the
-  // current transition will not be a revoke and this writes as before.
+uint32_t TemporaryMonitorMode::ClampDuration(NSNumber* requested) {
+  return [[configurator_ modeTransition] getDurationMinutes:requested];
+}
+
+bool TemporaryMonitorMode::PolicyRequiresAuth() {
+  return YES;
+}
+
+bool TemporaryMonitorMode::PolicyRequiresJustification() {
+  return NO;
+}
+
+void TemporaryMonitorMode::WriteRevokePolicy() {
+  // Skip the write if the current effective transition is already a revoke, to
+  // avoid a second syncState KVO fire on the sync-update path (where the daemon
+  // controller writes the revoke inside its batch).
   if ([configurator_ modeTransition].type != SNTModeTransitionTypeRevoke) {
     [configurator_ setSyncServerModeTransition:[[SNTModeTransition alloc] initRevocation]];
   }
-  if (EndLocked()) {
-    handle_audit_event_block_([[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
-        initWithUUID:[current_uuid_ UUIDString]
-              reason:reason]);
-    current_uuid_ = nil;
-    return true;
-  } else {
-    return false;
-  }
 }
 
-bool TemporaryMonitorMode::EndLocked() {
-  if (StopTimer()) {
-    [configurator_ leaveTemporaryMonitorMode];
-    [[notification_queue_.notifierConnection remoteObjectProxy] leaveTemporaryMonitorMode];
-    return true;
-  } else {
-    return false;
-  }
+void TemporaryMonitorMode::RequestAuthorization(void (^reply)(BOOL, NSString*)) {
+  [notification_queue_ authorizeTemporaryMonitorMode:^(BOOL authenticated) {
+    reply(authenticated, nil);
+  }];
 }
 
-bool TemporaryMonitorMode::OnTimer() {
-  absl::MutexLock lock(lock_);
-  [configurator_ leaveTemporaryMonitorMode];
+NSDictionary* TemporaryMonitorMode::ExtraStateToPersist() {
+  return @{};
+}
+
+bool TemporaryMonitorMode::RestoreAndValidateExtraState(NSDictionary* state) {
+  return true;
+}
+
+void TemporaryMonitorMode::ClearExtraState() {}
+
+id TemporaryMonitorMode::BuildEnterAuditEvent(NSString* session_uuid, uint32_t seconds,
+                                              NSInteger enter_reason,
+                                              NSString* user_justification) {
+  return [[SNTStoredTemporaryMonitorModeEnterAuditEvent alloc]
+      initWithUUID:session_uuid
+           seconds:seconds
+            reason:(SNTTemporaryMonitorModeEnterReason)enter_reason];
+}
+
+id TemporaryMonitorMode::BuildLeaveAuditEvent(NSString* session_uuid, NSInteger leave_reason) {
+  return [[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
+      initWithUUID:session_uuid
+            reason:(SNTTemporaryMonitorModeLeaveReason)leave_reason];
+}
+
+NSInteger TemporaryMonitorMode::EnterReasonOnDemand() {
+  return SNTTemporaryMonitorModeEnterReasonOnDemand;
+}
+NSInteger TemporaryMonitorMode::EnterReasonRefresh() {
+  return SNTTemporaryMonitorModeEnterReasonOnDemandRefresh;
+}
+NSInteger TemporaryMonitorMode::EnterReasonRestart() {
+  return SNTTemporaryMonitorModeEnterReasonRestart;
+}
+NSInteger TemporaryMonitorMode::LeaveReasonCancelled() {
+  return SNTTemporaryMonitorModeLeaveReasonCancelled;
+}
+NSInteger TemporaryMonitorMode::LeaveReasonSessionExpired() {
+  return SNTTemporaryMonitorModeLeaveReasonSessionExpired;
+}
+NSInteger TemporaryMonitorMode::LeaveReasonReboot() {
+  return SNTTemporaryMonitorModeLeaveReasonReboot;
+}
+NSInteger TemporaryMonitorMode::LeaveReasonSyncServerChanged() {
+  return SNTTemporaryMonitorModeLeaveReasonSyncServerChanged;
+}
+
+void TemporaryMonitorMode::EmitAudit(id audit_event) {
+  handle_audit_event_block_((SNTStoredTemporaryMonitorModeAuditEvent*)audit_event);
+}
+
+void TemporaryMonitorMode::NotifyEnter(NSDate* expiration) {
+  [[notification_queue_.notifierConnection remoteObjectProxy] enterTemporaryMonitorMode:expiration];
+}
+
+void TemporaryMonitorMode::NotifyLeave() {
   [[notification_queue_.notifierConnection remoteObjectProxy] leaveTemporaryMonitorMode];
-
-  handle_audit_event_block_([[SNTStoredTemporaryMonitorModeLeaveAuditEvent alloc]
-      initWithUUID:[current_uuid_ UUIDString]
-            reason:SNTTemporaryMonitorModeLeaveReasonSessionExpired]);
-  current_uuid_ = nil;
-
-  // Don't restart the timer
-  return false;
-}
-
-bool TemporaryMonitorMode::StartTimer() {
-  return Timer<TemporaryMonitorMode>::StartTimer();
-}
-
-bool TemporaryMonitorMode::StartTimerWithInterval(uint32_t interval_seconds) {
-  return Timer<TemporaryMonitorMode>::StartTimerWithInterval(interval_seconds);
-}
-
-bool TemporaryMonitorMode::StopTimer() {
-  return Timer<TemporaryMonitorMode>::StopTimer();
 }
 
 }  // namespace santa

--- a/Source/santad/TemporaryMonitorModeTest.mm
+++ b/Source/santad/TemporaryMonitorModeTest.mm
@@ -132,7 +132,10 @@ uint64_t MakeDeadline(uint64_t want) {
       }]]);
   XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, unpinnedURL), 0);
 
-  // Mismatched sync URL
+  // Mismatched sync URL. Re-enable Sync V2 so this case validates the URL-mismatch
+  // path specifically, rather than passing because Sync V2 is still disabled from the
+  // prior case.
+  syncV2Enabled = YES;
   testState = [goodTestState mutableCopy];
   testState[kTimedSessionSyncURLKey] = pinnedURL2.host;
   OCMExpect([self.mockConfigurator

--- a/Source/santad/TemporaryMonitorModeTest.mm
+++ b/Source/santad/TemporaryMonitorModeTest.mm
@@ -23,6 +23,7 @@
 #import "Source/common/SNTModeTransition.h"
 #include "Source/common/SystemResources.h"
 #import "Source/santad/SNTNotificationQueue.h"
+#include "Source/santad/TimedSyncSession.h"
 
 namespace santa {
 class TemporaryMonitorModePeer : public TemporaryMonitorMode {
@@ -31,7 +32,7 @@ class TemporaryMonitorModePeer : public TemporaryMonitorMode {
                            HandleAuditEventBlock block)
       : santa::TemporaryMonitorMode(MakeKey(), configurator, notQueue, block) {}
 
-  using TemporaryMonitorMode::GetSecondsRemainingFromInitialStateLocked;
+  using santa::TimedSyncSession::GetSecondsRemainingFromStateLocked;
 };
 }  // namespace santa
 
@@ -55,11 +56,12 @@ uint64_t MakeDeadline(uint64_t want) {
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
 
+  // Use the class mock directly as the notification-queue instance. (The previous
+  // alloc / initWithRingBuffer: dance did not reliably yield a usable mock: the
+  // designated initializer takes a C++ std::unique_ptr that OCMock cannot match, so
+  // instance-method stubs such as authorizeTemporaryMonitorMode: could not be
+  // recorded. The peer never calls the initializer, so a class mock stands in fine.)
   self.mockNotQueue = OCMClassMock([SNTNotificationQueue class]);
-  OCMStub([self.mockNotQueue alloc]).andReturn(self.mockNotQueue);
-
-  OCMStub([self.mockNotQueue initWithRingBuffer:nullptr]).andReturn(self.mockNotQueue);
-  self.mockNotQueue = [[SNTNotificationQueue alloc] initWithRingBuffer:nil];
 }
 
 - (void)testGetSecondsRemainingFromInitialState {
@@ -76,10 +78,10 @@ uint64_t MakeDeadline(uint64_t want) {
                                });
 
   NSDictionary* goodTestState = @{
-    kStateTempMonitorModeBootUUIDKey : testBootUUID,
-    kStateTempMonitorModeDeadlineKey : @(MakeDeadline(wantAtLeastSeconds)),
-    kStateTempMonitorModeSavedSyncURLKey : pinnedURL.host,
-    kStateTempMonitorModeSessionUUIDKey : testSessionUUID,
+    kTimedSessionBootUUIDKey : testBootUUID,
+    kTimedSessionDeadlineKey : @(MakeDeadline(wantAtLeastSeconds)),
+    kTimedSessionSyncURLKey : pinnedURL.host,
+    kTimedSessionSessionUUIDKey : testSessionUUID,
   };
 
   __block BOOL syncV2Enabled = YES;
@@ -88,66 +90,196 @@ uint64_t MakeDeadline(uint64_t want) {
   });
 
   NSMutableDictionary* testState = [goodTestState copy];
-  XCTAssertGreaterThan(
-      tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-      wantAtLeastSeconds);
+  XCTAssertGreaterThan(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL),
+                       wantAtLeastSeconds);
 
   // Bad Boot Session UUID type
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeBootUUIDKey] = @(123);
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-                 0);
+  testState[kTimedSessionBootUUIDKey] = @(123);
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL), 0);
 
   // Bad Deadline type
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeDeadlineKey] = @"123";
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-                 0);
+  testState[kTimedSessionDeadlineKey] = @"123";
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL), 0);
 
   // Bad Session UUID type
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeSessionUUIDKey] = @(123);
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-                 0);
+  testState[kTimedSessionSessionUUIDKey] = @(123);
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL), 0);
 
   // Invalid Session UUID
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeSessionUUIDKey] = @"ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ";
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-                 0);
+  testState[kTimedSessionSessionUUIDKey] = @"ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ";
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL), 0);
 
   // Bad Sync URL type type
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeSavedSyncURLKey] = @(123);
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-                 0);
+  testState[kTimedSessionSyncURLKey] = @(123);
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL), 0);
 
   // Mismatched boot session UUID
   testState = [goodTestState mutableCopy];
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, @"xyz", pinnedURL), 0);
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, @"xyz", pinnedURL), 0);
 
   // Sync V2 not enabled
   syncV2Enabled = NO;
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeSavedSyncURLKey] = unpinnedURL.host;
+  testState[kTimedSessionSyncURLKey] = unpinnedURL.host;
   OCMExpect([self.mockConfigurator
       setSyncServerModeTransition:[OCMArg checkWithBlock:^BOOL(SNTModeTransition* mt) {
         return mt.type == SNTModeTransitionTypeRevoke;
       }]]);
-  XCTAssertEqual(
-      tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, unpinnedURL), 0);
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, unpinnedURL), 0);
 
   // Mismatched sync URL
   testState = [goodTestState mutableCopy];
-  testState[kStateTempMonitorModeSavedSyncURLKey] = pinnedURL2.host;
+  testState[kTimedSessionSyncURLKey] = pinnedURL2.host;
   OCMExpect([self.mockConfigurator
       setSyncServerModeTransition:[OCMArg checkWithBlock:^BOOL(SNTModeTransition* mt) {
         return mt.type == SNTModeTransitionTypeRevoke;
       }]]);
-  XCTAssertEqual(tmm.GetSecondsRemainingFromInitialStateLocked(testState, testBootUUID, pinnedURL),
-                 0);
+  XCTAssertEqual(tmm.GetSecondsRemainingFromStateLocked(testState, testBootUUID, pinnedURL), 0);
 
   XCTAssertTrue(OCMVerifyAll(self.mockConfigurator));
+}
+
+// Characterization tests: lock in the grant / refresh / cancel / revoke / OnTimer
+// behavior of the CURRENT TemporaryMonitorMode before it is refactored onto the
+// shared TimedSyncSession base. They must pass against today's TMM unchanged.
+//
+// These construct the peer via std::make_shared so the Timer mixin's
+// shared_from_this() works when the timer starts (a stack-allocated peer would
+// throw bad_weak_ptr the moment RequestMinutes starts the timer). make_shared on
+// the peer also skips SetupFromState, so no KVO is registered on the mock.
+
+// Stub the configurator/notification-queue so Available() passes and the GUI auth
+// callback returns YES. Durations are minutes; the live timer (>= 1 minute) never
+// fires during a unit test, so expiry is driven explicitly via OnTimer().
+- (void)stubOnDemandAvailableMaxMinutes:(uint32_t)maxMinutes defaultDuration:(uint32_t)def {
+  OCMStub([self.mockConfigurator modeTransition])
+      .andReturn([[SNTModeTransition alloc] initOnDemandMinutes:maxMinutes defaultDuration:def]);
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
+  OCMStub([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
+  OCMStub([self.mockConfigurator syncBaseURL])
+      .andReturn([NSURL URLWithString:@"https://foo.workshop.cloud"]);
+  OCMStub([self.mockNotQueue
+      authorizeTemporaryMonitorMode:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(YES), nil])]);
+}
+
+- (void)testGrantEntersAndEmitsOnDemandEnter {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+  XCTAssertNil(err);
+
+  OCMVerify([self.mockConfigurator setInTemporaryMonitorMode:YES]);
+
+  std::optional<uint64_t> remaining = tmm->SecondsRemaining();
+  XCTAssertTrue(remaining.has_value());
+  XCTAssertGreaterThan(*remaining, 0u);
+
+  XCTAssertEqual(events.count, 1u);
+  XCTAssertTrue([events[0] isKindOfClass:[SNTStoredTemporaryMonitorModeEnterAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeEnterAuditEvent*)events[0]).reason,
+                 SNTTemporaryMonitorModeEnterReasonOnDemand);
+}
+
+- (void)testSecondRequestIsRefresh {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  XCTAssertTrue(tmm->SecondsRemaining().has_value());
+  XCTAssertEqual(events.count, 2u);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeEnterAuditEvent*)events[0]).reason,
+                 SNTTemporaryMonitorModeEnterReasonOnDemand);
+  XCTAssertTrue([events[1] isKindOfClass:[SNTStoredTemporaryMonitorModeEnterAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeEnterAuditEvent*)events[1]).reason,
+                 SNTTemporaryMonitorModeEnterReasonOnDemandRefresh);
+}
+
+- (void)testCancelEmitsCancelledLeave {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+  XCTAssertTrue(tmm->Cancel());
+
+  OCMVerify([self.mockConfigurator setInTemporaryMonitorMode:NO]);
+  XCTAssertFalse(tmm->SecondsRemaining().has_value());
+
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryMonitorModeLeaveAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryMonitorModeLeaveReasonCancelled);
+}
+
+- (void)testRevokeWritesRevocationAndEmitsRevokedLeave {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+  XCTAssertTrue(tmm->Revoke(SNTTemporaryMonitorModeLeaveReasonRevoked));
+
+  OCMVerify([self.mockConfigurator
+      setSyncServerModeTransition:[OCMArg checkWithBlock:^BOOL(SNTModeTransition* mt) {
+        return mt.type == SNTModeTransitionTypeRevoke;
+      }]]);
+  OCMVerify([self.mockConfigurator setInTemporaryMonitorMode:NO]);
+  XCTAssertFalse(tmm->SecondsRemaining().has_value());
+
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryMonitorModeLeaveReasonRevoked);
+}
+
+- (void)testOnTimerEmitsSessionExpiredLeave {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  // OnTimer returns false: the session expired, do not reschedule.
+  XCTAssertFalse(tmm->OnTimer());
+
+  OCMVerify([self.mockConfigurator setInTemporaryMonitorMode:NO]);
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryMonitorModeLeaveAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryMonitorModeLeaveReasonSessionExpired);
 }
 
 @end

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -125,8 +125,14 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   // for a still-valid session at daemon start: it returns true to keep the session
   // (the effect is re-established) or false to end it (e.g. TAM: the user is no
   // longer a group member, so the elevation was revoked out of band).
+  //
+  // RevertEffect returns true on success (or when there is nothing to revert) and
+  // false if the revert failed and the effect may still be in place. On false the
+  // base keeps an already-expired persisted session record instead of clearing it,
+  // so the next daemon start reconciles and retries the revert rather than leaving
+  // the effect stuck on with nothing tracking it.
   virtual bool ApplyEffect(NSError** err) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
-  virtual void RevertEffect() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+  virtual bool RevertEffect() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
   virtual bool ReapplyEffectOnRestart() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
 
   // Extra availability preconditions (TMM: client mode can transition; TAM: none).
@@ -200,6 +206,9 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   // subclass extra state (the leave audit/RevertEffect read it).
   bool EndSessionLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   bool RevokeLocked(NSInteger leave_reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  // Persist an already-expired session record (used when RevertEffect fails) so the
+  // next daemon start reconciles the persisted state and retries the revert.
+  void PersistExpiredForRetryLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   // Whether the sync-server gate is satisfied (`configurator_.isSyncV2Enabled`).
   bool SyncServerGateSatisfied();

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -1,0 +1,212 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_SANTAD_TIMEDSYNCSESSION_H
+#define SANTA_SANTAD_TIMEDSYNCSESSION_H
+
+#include <memory>
+#include <optional>
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTKVOManager.h"
+#include "Source/common/Timer.h"
+#import "Source/santad/SNTNotificationQueue.h"
+#include "absl/synchronization/mutex.h"
+
+// Common persisted session-state keys, shared by every TimedSyncSession feature.
+// The top-level state-dict key is provided per-feature via the StateKey() hook.
+extern NSString* const kTimedSessionBootUUIDKey;
+extern NSString* const kTimedSessionDeadlineKey;
+extern NSString* const kTimedSessionSyncURLKey;
+extern NSString* const kTimedSessionSessionUUIDKey;
+
+namespace santa {
+
+// Base for a timer-bounded, sync-blessed, self-reverting session (Temporary
+// Monitor Mode, Temporary Admin Mode). Owns the timer, the persisted common
+// state, reconciliation (including the load-bearing boot-UUID-before-deadline
+// ordering and the sync-pin gate), and the grant/cancel/revoke/expiry skeleton.
+// All per-feature behavior is provided through the virtual hooks below.
+//
+// Threading: `grant_mutex_` serializes a whole grant (pre-checks + auth + apply)
+// against other grants; `lock_` guards the session fields. Ordering is always
+// `grant_mutex_` then `lock_`; nothing takes `grant_mutex_` while holding `lock_`,
+// so there is no inversion. Fast readers (SecondsRemaining/Available) take only
+// `lock_` and read the `active_` flag rather than Timer::IsStarted(), which
+// dispatch_syncs to the timer queue and would deadlock against a firing OnTimer.
+class TimedSyncSession : public Timer<TimedSyncSession> {
+ public:
+  ~TimedSyncSession() override;
+
+  TimedSyncSession(TimedSyncSession&&) = delete;
+  TimedSyncSession& operator=(TimedSyncSession&&) = delete;
+  TimedSyncSession(const TimedSyncSession&) = delete;
+  TimedSyncSession& operator=(const TimedSyncSession&) = delete;
+
+  // Cancel an active session (user-initiated "leave"). Returns true if a session
+  // was active.
+  bool Cancel();
+
+  // Revoke an active session and write the revoke policy. `leave_reason` is the
+  // subclass's leave-reason enum value used for the audit event. Returns true if
+  // a session was active.
+  bool Revoke(NSInteger leave_reason);
+
+  // Timer<> expiry callback (base implements; subclasses do not override).
+  bool OnTimer();
+
+  // Whether the feature is currently available: an on-demand policy is set, the
+  // sync server is enabled, and any extra preconditions hold. Granular failure
+  // reasons for a denied request are produced by BeginGrant's GrantOutcome.
+  bool Available();
+
+  // Seconds remaining in the active session, or nullopt if none.
+  std::optional<uint64_t> SecondsRemaining() const;
+  static std::optional<uint64_t> SecondsRemaining(uint64_t deadline_mach_time);
+
+  // Outcome of a grant attempt. The base produces these; the subclass maps them
+  // to its own NSError codes (and, for TAM, a Denied audit event), so the base
+  // stays feature-agnostic.
+  enum class GrantOutcome {
+    kGranted,
+    kNoPolicy,
+    kInvalidSyncServer,
+    kNotEligible,
+    kAuthFailed,
+    kJustificationRequired,
+    kApplyFailed,
+  };
+
+ protected:
+  TimedSyncSession(uint32_t min_minutes, uint32_t max_minutes, const char* label,
+                   SNTConfigurator* configurator, SNTNotificationQueue* notification_queue);
+
+  // Run reconciliation against the persisted state (call once, post-construction,
+  // from the subclass factory). Installs the syncBaseURL KVO watcher.
+  void SetupFromState();
+
+  // Shared grant flow. MUST be called with `grant_mutex_` held by the subclass's
+  // public request method (held across the whole flow, including the off-lock auth
+  // callback, so two grants cannot interleave). On kGranted, *out_minutes is the
+  // granted duration.
+  GrantOutcome BeginGrant(NSNumber* requested_duration, uint32_t* out_minutes)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(grant_mutex_) ABSL_LOCKS_EXCLUDED(lock_);
+
+  // Reads the lock_-guarded `active_` flag (NOT Timer::IsStarted()).
+  bool IsStartedLocked() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) { return active_; }
+
+  // Validate + reconcile the persisted state, returning seconds remaining (0 if the
+  // session is not resumable). Emits the reboot/expiry leave audit and writes the
+  // revoke policy on a sync-server change. Protected so a test peer can exercise it.
+  uint64_t GetSecondsRemainingFromStateLocked(NSDictionary* state, NSString* current_boot_uuid,
+                                              NSURL* sync_url) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+
+  // End an active session with the given leave reason WITHOUT writing a revoke policy (the
+  // feature stays available for immediate re-entry). Returns whether a session was active.
+  bool EndForReasonLocked(NSInteger leave_reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+
+  // ---- Hooks (subclass provides) ----
+
+  // Apply / revert / re-apply the effect. All run UNDER lock_. Apply may fail
+  // (TAM); Revert must be best-effort idempotent. ReapplyEffectOnRestart is called
+  // for a still-valid session at daemon start: it returns true to keep the session
+  // (the effect is re-established) or false to end it (e.g. TAM: the user is no
+  // longer a group member, so the elevation was revoked out of band).
+  virtual bool ApplyEffect(NSError** err) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+  virtual void RevertEffect() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+  virtual bool ReapplyEffectOnRestart() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+
+  // Extra availability preconditions (TMM: client mode can transition; TAM: none).
+  virtual bool ExtraPreconditions() = 0;
+
+  // The top-level SNTConfigurator state-dict key for this feature (TMM: @"TMM";
+  // TAM: @"TempAdmin").
+  virtual NSString* StateKey() = 0;
+
+  // Policy questions (answered by the subclass using its own policy object).
+  virtual bool HasOnDemandPolicy() = 0;
+  virtual uint32_t ClampDuration(NSNumber* requested) = 0;
+  virtual bool PolicyRequiresAuth() = 0;
+  virtual bool PolicyRequiresJustification() = 0;
+  virtual void WriteRevokePolicy() = 0;
+
+  // Authenticate the user; reply with success + (TAM) a reason string. The base
+  // wraps this with a fail-closed timeout.
+  virtual void RequestAuthorization(void (^reply)(BOOL authenticated, NSString* reason)) = 0;
+
+  // Persisted extra state (TAM: TargetUID/Username). Restore returns false if
+  // invalid. Restore runs BEFORE any RevertEffect/audit. Clear runs AFTER the
+  // leave audit is built (the audit and RevertEffect read the extra state).
+  virtual NSDictionary* ExtraStateToPersist() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+  virtual bool RestoreAndValidateExtraState(NSDictionary* state)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+  virtual void ClearExtraState() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) = 0;
+
+  // Audit-event builders (return an object the subclass's audit sink accepts).
+  virtual id BuildEnterAuditEvent(NSString* session_uuid, uint32_t seconds, NSInteger enter_reason,
+                                  NSString* user_justification) = 0;
+  virtual id BuildLeaveAuditEvent(NSString* session_uuid, NSInteger leave_reason) = 0;
+
+  // Enter-reason / leave-reason values, as the subclass's enum.
+  virtual NSInteger EnterReasonOnDemand() = 0;
+  virtual NSInteger EnterReasonRefresh() = 0;
+  virtual NSInteger EnterReasonRestart() = 0;
+  virtual NSInteger LeaveReasonCancelled() = 0;
+  virtual NSInteger LeaveReasonSessionExpired() = 0;
+  virtual NSInteger LeaveReasonReboot() = 0;
+  virtual NSInteger LeaveReasonSyncServerChanged() = 0;
+
+  // Deliver the audit event + GUI notifications.
+  virtual void EmitAudit(id audit_event) = 0;
+  virtual void NotifyEnter(NSDate* expiration) = 0;
+  virtual void NotifyLeave() = 0;
+
+  // Require at least this many seconds remaining to resume a session on restart.
+  static constexpr uint64_t kMinAllowedStateRemainingSeconds = 5;
+
+  mutable absl::Mutex grant_mutex_;
+  mutable absl::Mutex lock_;
+  SNTConfigurator* configurator_;
+  SNTNotificationQueue* notification_queue_;
+  uint64_t deadline_ ABSL_GUARDED_BY(lock_);
+  NSUUID* current_uuid_ ABSL_GUARDED_BY(lock_);
+  bool active_ ABSL_GUARDED_BY(lock_);
+  NSArray<SNTKVOManager*>* kvo_;
+
+ private:
+  // Persist the common session state (merged with ExtraStateToPersist), start the
+  // timer, notify the GUI, set `active_`. Returns whether a NEW timer was started
+  // (false on a refresh of an already-running session).
+  bool BeginSessionLocked(uint32_t seconds, bool gen_uuid_on_start)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  // Stop the timer, clear the persisted state, notify the GUI, clear `active_`.
+  // Returns whether a genuinely-active session was ended. Does NOT clear the
+  // subclass extra state (the leave audit/RevertEffect read it).
+  bool EndSessionLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  bool RevokeLocked(NSInteger leave_reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+
+  // Whether the sync-server gate is satisfied (`configurator_.isSyncV2Enabled`).
+  bool SyncServerGateSatisfied();
+
+  // hide the base class Start/Stop methods
+  bool StartTimer();
+  bool StopTimer();
+  bool StartTimerWithInterval(uint32_t interval_seconds);
+};
+
+}  // namespace santa
+
+#endif  // SANTA_SANTAD_TIMEDSYNCSESSION_H

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -144,7 +144,10 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   virtual void WriteRevokePolicy() = 0;
 
   // Authenticate the user; reply with success + (TAM) a reason string. The base
-  // wraps this with a fail-closed timeout.
+  // wraps this with a fail-closed timeout, but implementations MUST invoke `reply`
+  // exactly once, including on transport failure (e.g. an absent or dead GUI XPC
+  // connection). Otherwise the timeout becomes the only exit and the grant stalls
+  // for its full duration instead of failing fast.
   virtual void RequestAuthorization(void (^reply)(BOOL authenticated, NSString* reason)) = 0;
 
   // Persisted extra state (TAM: TargetUID/Username). Restore returns false if

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -43,7 +43,10 @@ static constexpr NSUInteger kMaxReasonLength = 512;
 TimedSyncSession::TimedSyncSession(uint32_t min_minutes, uint32_t max_minutes, const char* label,
                                    SNTConfigurator* configurator,
                                    SNTNotificationQueue* notification_queue)
-    : Timer(min_minutes, max_minutes, Timer::OnStart::kWaitOneCycle, label,
+    // Session bounds are expressed in minutes; the Timer base clamps its interval
+    // in seconds. Convert here so the min/max clamp reflects the real bounds
+    // instead of treating a minute count as a second count.
+    : Timer(min_minutes * 60, max_minutes * 60, Timer::OnStart::kWaitOneCycle, label,
             Timer::RescheduleMode::kTrailingEdge, QOS_CLASS_USER_INITIATED),
       configurator_(configurator),
       notification_queue_(notification_queue),
@@ -80,6 +83,17 @@ void TimedSyncSession::SetupFromState() {
               selector:@selector(pushTokenChain)
                   type:[NSArray class]
               callback:^(NSArray* oldValue, NSArray* newValue) {
+                // Ignore no-op fires. pushTokenChain is a KVO dependent key on the
+                // whole syncState, so every syncState write fires this callback even
+                // when the chain itself is unchanged. Without this guard the Revoke()
+                // below -> WriteRevokePolicy() -> setSyncServerModeTransition: would
+                // rewrite syncState and synchronously re-enter this callback, re-taking
+                // lock_ and deadlocking. The re-entrant fire always carries an unchanged
+                // chain (old == new), so the equality check breaks the cycle while still
+                // acting on a genuine chain change.
+                if ((!newValue && !oldValue) || [newValue isEqualToArray:oldValue]) {
+                  return;
+                }
                 if (auto strong_self = weak_self.lock()) {
                   if (!strong_self->SyncServerGateSatisfied() &&
                       strong_self->Revoke(strong_self->LeaveReasonSyncServerChanged())) {

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -1,0 +1,349 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/TimedSyncSession.h"
+
+#include <dispatch/dispatch.h>
+#include <mach/mach_time.h>
+
+#include <algorithm>
+#include <limits>
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTSystemInfo.h"
+#include "Source/common/SystemResources.h"
+
+NSString* const kTimedSessionBootUUIDKey = @"BootUUID";
+NSString* const kTimedSessionDeadlineKey = @"Deadline";
+NSString* const kTimedSessionSyncURLKey = @"SyncURL";
+NSString* const kTimedSessionSessionUUIDKey = @"SessionUUID";
+
+namespace santa {
+
+// Fail-closed timeout for the synchronous GUI authorization callback (Touch ID +
+// typing a reason). Generous, but bounded so a hung/stalled GUI cannot hold
+// grant_mutex_ and the request handler thread indefinitely.
+static constexpr int64_t kAuthTimeoutNSec = 90 * NSEC_PER_SEC;
+
+// Free-text reason is capped before it is logged, audited, or synced.
+static constexpr NSUInteger kMaxReasonLength = 512;
+
+TimedSyncSession::TimedSyncSession(uint32_t min_minutes, uint32_t max_minutes, const char* label,
+                                   SNTConfigurator* configurator,
+                                   SNTNotificationQueue* notification_queue)
+    : Timer(min_minutes, max_minutes, Timer::OnStart::kWaitOneCycle, label,
+            Timer::RescheduleMode::kTrailingEdge, QOS_CLASS_USER_INITIATED),
+      configurator_(configurator),
+      notification_queue_(notification_queue),
+      deadline_(0),
+      active_(false) {}
+
+TimedSyncSession::~TimedSyncSession() = default;
+
+void TimedSyncSession::SetupFromState() {
+  std::weak_ptr<TimedSyncSession> weak_self = weak_from_base<TimedSyncSession>();
+  kvo_ = @[ [[SNTKVOManager alloc]
+      initWithObject:configurator_
+            selector:@selector(syncBaseURL)
+                type:[NSURL class]
+            callback:^(NSURL* oldValue, NSURL* newValue) {
+              if ((!newValue && !oldValue) ||
+                  ([newValue.absoluteString isEqualToString:oldValue.absoluteString])) {
+                return;
+              }
+              if (auto strong_self = weak_self.lock()) {
+                if (strong_self->Revoke(strong_self->LeaveReasonSyncServerChanged())) {
+                  LOGI(@"Timed sync session revoked due to SyncBaseURL changing.");
+                }
+              }
+            }] ];
+
+  absl::MutexLock lock(lock_);
+  NSDictionary* state = [configurator_ savedTimedSessionStateForKey:StateKey()];
+  uint32_t secs_remaining = static_cast<uint32_t>(
+      std::min(GetSecondsRemainingFromStateLocked(state, [SNTSystemInfo bootSessionUUID],
+                                                  configurator_.syncBaseURL),
+               static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
+
+  if (secs_remaining < kMinAllowedStateRemainingSeconds) {
+    // Not resumable. The reboot/expiry leave audit (and sync-change revoke policy)
+    // were already produced by GetSecondsRemainingFromStateLocked. Actively revert
+    // the effect (TMM: clear the flag, a no-op on a fresh boot; TAM: remove the
+    // user from the admin group), clear persisted + extra state, notify the GUI.
+    RevertEffect();
+    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    NotifyLeave();
+    ClearExtraState();
+    return;
+  }
+
+  // Still valid. Re-establish the effect. The subclass decides whether to resume:
+  // TMM always re-applies its in-memory flag; TAM verifies the user is still a
+  // group member and ends the session instead of re-adding if it was revoked out
+  // of band.
+  if (ReapplyEffectOnRestart()) {
+    BeginSessionLocked(secs_remaining, /*gen_uuid_on_start=*/false);
+    EmitAudit(BuildEnterAuditEvent([current_uuid_ UUIDString], secs_remaining, EnterReasonRestart(),
+                                   @""));
+  } else {
+    EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonReboot()));
+    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    NotifyLeave();
+    ClearExtraState();
+  }
+}
+
+// When reading persisted session state, all of the following must hold, otherwise
+// the state is discarded (return 0):
+//   0. All types must meet expectations.
+//   1. The saved boot session UUID must match the current boot session UUID.
+//   2. The saved sync URL must match the current SyncBaseURL.
+//   3. The current SyncBaseURL must be pinned (sync v2 enabled).
+//   4. The saved session UUID must be a valid UUID.
+//
+// The boot-UUID check is evaluated BEFORE the deadline: `Deadline` is a
+// mach_continuous_time value whose time base resets on reboot, so comparing a
+// previous boot's deadline against the current clock is meaningless. For TMM a
+// mis-ordering is benign; for TAM it would mean failing to demote. This ordering
+// is load-bearing.
+uint64_t TimedSyncSession::GetSecondsRemainingFromStateLocked(NSDictionary* state,
+                                                              NSString* current_boot_uuid,
+                                                              NSURL* sync_url) {
+  if (![state[kTimedSessionBootUUIDKey] isKindOfClass:[NSString class]] ||
+      ![state[kTimedSessionDeadlineKey] isKindOfClass:[NSNumber class]] ||
+      ![state[kTimedSessionSyncURLKey] isKindOfClass:[NSString class]] ||
+      ![state[kTimedSessionSessionUUIDKey] isKindOfClass:[NSString class]]) {
+    return 0;
+  }
+
+  NSUUID* saved_uuid = [[NSUUID alloc] initWithUUIDString:state[kTimedSessionSessionUUIDKey]];
+  if (!saved_uuid) {
+    return 0;
+  }
+  current_uuid_ = saved_uuid;
+
+  // Restore + validate subclass extra state BEFORE any RevertEffect/audit, so the
+  // leave paths target the right user / never audit a blank one. Load-bearing.
+  if (!RestoreAndValidateExtraState(state)) {
+    return 0;
+  }
+
+  if (![state[kTimedSessionBootUUIDKey] isEqualToString:current_boot_uuid]) {
+    // Reboot detected.
+    EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonReboot()));
+    return 0;
+  }
+
+  if (![state[kTimedSessionSyncURLKey] isEqualToString:sync_url.host] ||
+      !configurator_.isSyncV2Enabled) {
+    // SyncBaseURL changed or is no longer pinned. Revoke eligibility. (No leave
+    // audit here: as in the prior TMM behavior, no session was active in memory
+    // yet at reconciliation time.)
+    WriteRevokePolicy();
+    return 0;
+  }
+
+  NSNumber* deadline = state[kTimedSessionDeadlineKey];
+  std::optional<uint64_t> secs_remaining = SecondsRemaining([deadline unsignedLongLongValue]);
+  if (secs_remaining.has_value()) {
+    deadline_ = [deadline unsignedLongLongValue];
+    return *secs_remaining;
+  }
+
+  EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonSessionExpired()));
+  return 0;
+}
+
+bool TimedSyncSession::SyncServerGateSatisfied() {
+  return configurator_.isSyncV2Enabled;
+}
+
+bool TimedSyncSession::Available() {
+  return HasOnDemandPolicy() && SyncServerGateSatisfied() && ExtraPreconditions();
+}
+
+TimedSyncSession::GrantOutcome TimedSyncSession::BeginGrant(NSNumber* requested_duration,
+                                                            uint32_t* out_minutes) {
+  // Granular availability sub-checks (before the off-lock auth).
+  if (!HasOnDemandPolicy()) {
+    return GrantOutcome::kNoPolicy;
+  }
+  if (!SyncServerGateSatisfied()) {
+    return GrantOutcome::kInvalidSyncServer;
+  }
+  if (!ExtraPreconditions()) {
+    return GrantOutcome::kNotEligible;
+  }
+
+  // Authorization runs OFF lock_ (Touch ID + typing a reason). Wrap it with a
+  // fail-closed timeout so a hung GUI cannot hold grant_mutex_ indefinitely.
+  __block BOOL authenticated = NO;
+  __block NSString* reason = nil;
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  RequestAuthorization(^(BOOL ok, NSString* r) {
+    authenticated = ok;
+    reason = r;
+    dispatch_semaphore_signal(sema);
+  });
+  if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, kAuthTimeoutNSec)) != 0) {
+    LOGW(@"Timed sync session authorization timed out; failing closed.");
+    return GrantOutcome::kAuthFailed;
+  }
+
+  if (reason.length > kMaxReasonLength) {
+    reason = [reason substringToIndex:kMaxReasonLength];
+  }
+
+  if (PolicyRequiresAuth() && !authenticated) {
+    return GrantOutcome::kAuthFailed;
+  }
+  if (PolicyRequiresJustification() && reason.length == 0) {
+    return GrantOutcome::kJustificationRequired;
+  }
+
+  // Re-check availability after the auth window: a sync Revoke that arrived while
+  // the user was authenticating must not be elevated against.
+  if (!Available()) {
+    return GrantOutcome::kNotEligible;
+  }
+
+  uint32_t minutes = ClampDuration(requested_duration);
+
+  absl::MutexLock lock(lock_);
+  NSError* err = nil;
+  if (!ApplyEffect(&err)) {
+    LOGE(@"Timed sync session failed to apply effect: %@", err.localizedDescription);
+    return GrantOutcome::kApplyFailed;
+  }
+  bool new_session = BeginSessionLocked(minutes * 60, /*gen_uuid_on_start=*/true);
+  EmitAudit(BuildEnterAuditEvent(
+      [current_uuid_ UUIDString], static_cast<uint32_t>(SecondsRemaining(deadline_).value_or(0)),
+      new_session ? EnterReasonOnDemand() : EnterReasonRefresh(), reason ?: @""));
+  *out_minutes = minutes;
+  return GrantOutcome::kGranted;
+}
+
+std::optional<uint64_t> TimedSyncSession::SecondsRemaining() const {
+  absl::ReaderMutexLock lock(lock_);
+  if (active_) {
+    return SecondsRemaining(deadline_);
+  }
+  return std::nullopt;
+}
+
+std::optional<uint64_t> TimedSyncSession::SecondsRemaining(uint64_t deadline_mach_time) {
+  uint64_t current_mach_time = mach_continuous_time();
+  if (deadline_mach_time <= current_mach_time) {
+    return std::nullopt;
+  }
+  return MachTimeToNanos(deadline_mach_time - current_mach_time) / NSEC_PER_SEC;
+}
+
+bool TimedSyncSession::BeginSessionLocked(uint32_t seconds, bool gen_uuid_on_start) {
+  bool did_start_new_timer = StartTimerWithInterval(seconds);
+  if (did_start_new_timer && gen_uuid_on_start) {
+    current_uuid_ = [NSUUID UUID];
+  }
+
+  uint64_t deadline = AddNanosecondsToMachTime(seconds * NSEC_PER_SEC, mach_continuous_time());
+
+  NSMutableDictionary* state = [@{
+    kTimedSessionBootUUIDKey : [SNTSystemInfo bootSessionUUID],
+    kTimedSessionDeadlineKey : @(deadline),
+    // syncBaseURL.host is nil when sync v2 is satisfied via the push token chain
+    // rather than a pinned URL. Store "" so the literal never receives nil; on
+    // restart it won't match a real host, so the session fails closed.
+    kTimedSessionSyncURLKey : configurator_.syncBaseURL.host ?: @"",
+    kTimedSessionSessionUUIDKey : [current_uuid_ UUIDString],
+  } mutableCopy];
+  [state addEntriesFromDictionary:ExtraStateToPersist()];
+  [configurator_ persistTimedSessionState:state forKey:StateKey()];
+
+  deadline_ = deadline;
+  active_ = true;
+
+  NotifyEnter([NSDate dateWithTimeIntervalSinceNow:seconds]);
+
+  return did_start_new_timer;
+}
+
+bool TimedSyncSession::EndSessionLocked() {
+  if (StopTimer()) {
+    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    active_ = false;
+    NotifyLeave();
+    return true;
+  }
+  return false;
+}
+
+bool TimedSyncSession::EndForReasonLocked(NSInteger leave_reason) {
+  if (EndSessionLocked()) {
+    RevertEffect();
+    EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], leave_reason));
+    ClearExtraState();
+    current_uuid_ = nil;
+    return true;
+  }
+  return false;
+}
+
+bool TimedSyncSession::Cancel() {
+  absl::MutexLock lock(lock_);
+  return EndForReasonLocked(LeaveReasonCancelled());
+}
+
+bool TimedSyncSession::Revoke(NSInteger leave_reason) {
+  absl::MutexLock lock(lock_);
+  return RevokeLocked(leave_reason);
+}
+
+bool TimedSyncSession::RevokeLocked(NSInteger leave_reason) {
+  // A revoke is a teardown that additionally records the revoke policy; the
+  // teardown itself is shared with EndForReasonLocked so the two cannot diverge.
+  WriteRevokePolicy();
+  return EndForReasonLocked(leave_reason);
+}
+
+bool TimedSyncSession::OnTimer() {
+  absl::MutexLock lock(lock_);
+  // OnTimer fires only for a running timer, so a session is active. The Timer
+  // mixin (trailing edge) has already stopped the timer; just tear down the
+  // session state here.
+  RevertEffect();
+  [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+  active_ = false;
+  NotifyLeave();
+  EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonSessionExpired()));
+  ClearExtraState();
+  current_uuid_ = nil;
+
+  // Don't restart the timer.
+  return false;
+}
+
+bool TimedSyncSession::StartTimer() {
+  return Timer<TimedSyncSession>::StartTimer();
+}
+
+bool TimedSyncSession::StartTimerWithInterval(uint32_t interval_seconds) {
+  return Timer<TimedSyncSession>::StartTimerWithInterval(interval_seconds);
+}
+
+bool TimedSyncSession::StopTimer() {
+  return Timer<TimedSyncSession>::StopTimer();
+}
+
+}  // namespace santa

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -126,8 +126,11 @@ void TimedSyncSession::SetupFromState() {
     // were already produced by GetSecondsRemainingFromStateLocked. Actively revert
     // the effect (TMM: clear the flag, a no-op on a fresh boot; TAM: remove the
     // user from the admin group), clear persisted + extra state, notify the GUI.
-    RevertEffect();
-    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    if (RevertEffect()) {
+      [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    } else {
+      PersistExpiredForRetryLocked();
+    }
     NotifyLeave();
     ClearExtraState();
     return;
@@ -333,9 +336,33 @@ bool TimedSyncSession::EndSessionLocked() {
   return false;
 }
 
+void TimedSyncSession::PersistExpiredForRetryLocked() {
+  // The effect revert failed, so the effect (e.g. TAM admin-group membership) may
+  // still be in place. Rather than clearing the persisted state — which would leave
+  // the effect stuck on with nothing tracking it — persist an already-expired session
+  // record. On the next daemon start, reconciliation reads it, finds it non-resumable
+  // (deadline in the past, or a reboot/sync change), and calls RevertEffect again,
+  // retrying until the revert succeeds.
+  LOGE(@"Timed sync session revert failed; persisting an expired session record so the "
+       @"next daemon start retries the revert.");
+  NSMutableDictionary* state = [@{
+    kTimedSessionBootUUIDKey : [SNTSystemInfo bootSessionUUID],
+    kTimedSessionDeadlineKey : @0,  // already in the past -> non-resumable -> retry revert
+    kTimedSessionSyncURLKey : configurator_.syncBaseURL.host ?: @"",
+    kTimedSessionSessionUUIDKey : current_uuid_ ? [current_uuid_ UUIDString]
+                                                : [[NSUUID UUID] UUIDString],
+  } mutableCopy];
+  [state addEntriesFromDictionary:ExtraStateToPersist()];
+  [configurator_ persistTimedSessionState:state forKey:StateKey()];
+}
+
 bool TimedSyncSession::EndForReasonLocked(NSInteger leave_reason) {
   if (EndSessionLocked()) {
-    RevertEffect();
+    // EndSessionLocked already cleared the persisted state; if the revert fails,
+    // re-persist an expired record so the next daemon start retries the revert.
+    if (!RevertEffect()) {
+      PersistExpiredForRetryLocked();
+    }
     EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], leave_reason));
     ClearExtraState();
     current_uuid_ = nil;
@@ -366,8 +393,11 @@ bool TimedSyncSession::OnTimer() {
   // OnTimer fires only for a running timer, so a session is active. The Timer
   // mixin (trailing edge) has already stopped the timer; just tear down the
   // session state here.
-  RevertEffect();
-  [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+  if (RevertEffect()) {
+    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+  } else {
+    PersistExpiredForRetryLocked();
+  }
   active_ = false;
   NotifyLeave();
   EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonSessionExpired()));

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -54,24 +54,54 @@ TimedSyncSession::~TimedSyncSession() = default;
 
 void TimedSyncSession::SetupFromState() {
   std::weak_ptr<TimedSyncSession> weak_self = weak_from_base<TimedSyncSession>();
-  kvo_ = @[ [[SNTKVOManager alloc]
-      initWithObject:configurator_
-            selector:@selector(syncBaseURL)
-                type:[NSURL class]
-            callback:^(NSURL* oldValue, NSURL* newValue) {
-              if ((!newValue && !oldValue) ||
-                  ([newValue.absoluteString isEqualToString:oldValue.absoluteString])) {
-                return;
-              }
-              if (auto strong_self = weak_self.lock()) {
-                if (strong_self->Revoke(strong_self->LeaveReasonSyncServerChanged())) {
-                  LOGI(@"Timed sync session revoked due to SyncBaseURL changing.");
+  kvo_ = @[
+    [[SNTKVOManager alloc]
+        initWithObject:configurator_
+              selector:@selector(syncBaseURL)
+                  type:[NSURL class]
+              callback:^(NSURL* oldValue, NSURL* newValue) {
+                if ((!newValue && !oldValue) ||
+                    ([newValue.absoluteString isEqualToString:oldValue.absoluteString])) {
+                  return;
                 }
-              }
-            }] ];
+                if (auto strong_self = weak_self.lock()) {
+                  if (strong_self->Revoke(strong_self->LeaveReasonSyncServerChanged())) {
+                    LOGI(@"Timed sync session revoked due to SyncBaseURL changing.");
+                  }
+                }
+              }],
+    // The sync-v2 gate (SyncServerGateSatisfied) is also satisfied by a valid push
+    // token chain, so a push-token-only deployment can hold a session with a nil
+    // syncBaseURL. Watching syncBaseURL alone would never revoke such a session when
+    // its token chain is lost. Watch the chain too and revoke as soon as the gate is
+    // no longer satisfied.
+    [[SNTKVOManager alloc]
+        initWithObject:configurator_
+              selector:@selector(pushTokenChain)
+                  type:[NSArray class]
+              callback:^(NSArray* oldValue, NSArray* newValue) {
+                if (auto strong_self = weak_self.lock()) {
+                  if (!strong_self->SyncServerGateSatisfied() &&
+                      strong_self->Revoke(strong_self->LeaveReasonSyncServerChanged())) {
+                    LOGI(@"Timed sync session revoked due to sync-v2 gate no longer being "
+                         @"satisfied.");
+                  }
+                }
+              }],
+  ];
 
   absl::MutexLock lock(lock_);
   NSDictionary* state = [configurator_ savedTimedSessionStateForKey:StateKey()];
+  if (!state) {
+    // Clean startup: no session was ever persisted. GetSecondsRemainingFromStateLocked
+    // would return 0 here just as it does for an expired/reboot session, so guard on
+    // the raw state to keep the no-state case a genuine no-op instead of emitting a
+    // spurious leave notification. There is nothing to revert (the in-memory effect is
+    // already clear on a fresh daemon start; a subclass whose effect outlives the
+    // daemon must reconcile that in ReapplyEffectOnRestart / its own startup path
+    // rather than rely on an incidental revert here).
+    return;
+  }
   uint32_t secs_remaining = static_cast<uint32_t>(
       std::min(GetSecondsRemainingFromStateLocked(state, [SNTSystemInfo bootSessionUUID],
                                                   configurator_.syncBaseURL),


### PR DESCRIPTION
Part of WS-1128. Stacked on #1034, ~review/merge that first~ which has been merged, so the base branch for this is `main`

- Extract a shared TimedSyncSession base class: timer, on-disk state
  persistence, and KVO lifecycle common to timed sync sessions.
- Refactor Temporary Monitor Mode onto it; drop its bespoke timer/state code.
- Replace TMM-specific SNTConfigurator accessors with generic timed-session
  accessors (persistTimedSessionState:forKey: / savedTimedSessionStateForKey:).
- No behavior change.