### PR TITLE
santad: add Temporary Admin Mode

### DIFF
--- a/Source/common/SNTStoredTemporaryAdminModeAuditEvent.h
+++ b/Source/common/SNTStoredTemporaryAdminModeAuditEvent.h
@@ -54,6 +54,13 @@ typedef NS_ENUM(NSInteger, SNTTemporaryAdminModeLeaveReason) {
 
   // The user's login session ended.
   SNTTemporaryAdminModeLeaveReasonSessionEnded,
+
+  // A still-valid session's elevation could not be re-applied at daemon
+  // restart because the user was no longer a member of the admin group --
+  // membership was removed out of band (an administrator, MDM, or another
+  // tool). Santa cannot attribute the cause and it is not a sync-server
+  // revocation, so it is reported as REASON_UNSPECIFIED upstream.
+  SNTTemporaryAdminModeLeaveReasonUnspecified,
 };
 
 // Reason a Temporary Admin Mode request was denied.

--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
@@ -48,6 +48,12 @@ typedef NS_ENUM(NSInteger, SNTTemporaryMonitorModeLeaveReason) {
 
   // The machine rebooted and the previous session is no longer applicable
   SNTTemporaryMonitorModeLeaveReasonReboot,
+
+  // A still-valid session's effect could not be re-applied at daemon restart.
+  // Not reachable for temporary Monitor Mode (its effect is always re-applied
+  // on restart); defined for symmetry with the shared TimedSyncSession restart
+  // path. Reported as REASON_UNSPECIFIED upstream.
+  SNTTemporaryMonitorModeLeaveReasonUnspecified,
 };
 
 // Represents a temporary Monitor Mode audit event stored in the events database.

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -49,6 +49,12 @@
 - (void)enterTemporaryMonitorMode:(NSDate*)expiration;
 - (void)leaveTemporaryMonitorMode;
 - (void)temporaryMonitorModePolicyAvailable:(BOOL)available;
+- (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
+                                                    reply:(void (^)(BOOL authenticated,
+                                                                    NSString* reason))reply;
+- (void)enterTemporaryAdminMode:(NSDate*)expiration;
+- (void)leaveTemporaryAdminMode;
+- (void)temporaryAdminModeAvailable:(BOOL)available;
 - (void)setNetworkExtensionFilterEnabled:(BOOL)enabled reply:(void (^)(BOOL success))reply;
 @end
 

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -129,6 +129,16 @@ struct RuleCounts {
 - (void)checkTemporaryMonitorModePolicyAvailable:(void (^)(BOOL))reply;
 
 ///
+/// Temporary Admin Mode Ops
+///
+- (void)requestTemporaryAdminModeWithDurationMinutes:(NSNumber*)requestedDuration
+                                               reply:(void (^)(uint32_t, NSError*))reply;
+- (void)cancelTemporaryAdminMode:(void (^)(NSError*))reply;
+- (void)temporaryAdminModeSecondsRemaining:(void (^)(NSNumber*))reply;
+- (void)checkTemporaryAdminModeAvailable:(void (^)(BOOL available, BOOL alreadyAdmin))reply;
+- (void)temporaryAdminModeSessionResignedActive:(void (^)(NSError*))reply;
+
+///
 /// Network Extension Ops
 ///
 /// Returns whether the network extension should be installed.

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ kann nun ausgeführt werden";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "Eine Begründung ist erforderlich";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "Für einen anderen Benutzer ist bereits eine Sitzung aktiv";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "Der Zugriff auf eine Datei wurde verweigert";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Aufgerufener Pfad";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "Ein unbekannter Fehler ist aufgetreten";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "Ein unbekannter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "Möchten Sie wirklich alle Benachrichtigungsstummschaltungen zurücksetzen? Sie werden wieder Benachrichtigungen für zuvor stummgeschaltete Ereignisse erhalten.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "Autorisierung fehlgeschlagen";
 
 /* Authorize execution fallback */
 "authorize execution" = "Ausführung genehmigen";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Zum Anzeigen der App-Informationen ablegen";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Geben Sie eine Begründung für die Anforderung von Administratorrechten ein:";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "Verbindung zum Synchronisierungsdienst fehlgeschlagen. Bitte versuchen Sie es später erneut.";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Wechsel in den temporären Monitor-Modus fehlgeschlagen: Auf diesem Gerät ist keine Richtlinie vorhanden, die den temporären Monitor-Modus erlaubt";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Anforderung von Administratorrechten fehlgeschlagen: %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Dateiname";
 
 /* No comment provided by engineer. */
 "FS Type" = "FS-Typ";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Begründung";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "Keine passende Regel";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Öffnen...";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Remount-Modus";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Administratorrechte anfordern";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "Administratorrechte anfordern";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "Angefordert kann jetzt ausgeführt werden";
@@ -198,6 +228,9 @@
 
 /* Notification message shown when a sync fails */
 "Sync failed" = "Synchronisierung fehlgeschlagen";
+
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "Die Änderung der Administratorgruppen-Mitgliedschaft ist fehlgeschlagen";
 
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "Der Upload des Ereignisses ist fehlgeschlagen. Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.";
@@ -253,6 +286,9 @@
 /* The default message to show the user when a network share mount is blocked */
 "The following network share has been blocked from mounting" = "Das Mounten der folgenden Netzwerkfreigabe wurde blockiert";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "Dieses Gerät erlaubt derzeit keine temporären Administratorrechte";
+
 /* Block reason when decision state is unrecognized */
 "Unknown" = "Unbekannt";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Administratorrechte anfordern";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Geben Sie eine Begründung für die Anforderung von Administratorrechten ein:";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Begründung";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "Administratorrechte anfordern";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Anforderung von Administratorrechten fehlgeschlagen: Dieses Gerät erlaubt derzeit keine temporären Administratorrechte";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Anforderung von Administratorrechten fehlgeschlagen: Sie sind bereits Administrator";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Anforderung von Administratorrechten fehlgeschlagen: Für einen anderen Benutzer ist bereits eine Sitzung aktiv";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Anforderung von Administratorrechten fehlgeschlagen: Eine Begründung ist erforderlich";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Anforderung von Administratorrechten fehlgeschlagen: Autorisierung fehlgeschlagen";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Anforderung von Administratorrechten fehlgeschlagen: Die Änderung der Administratorgruppen-Mitgliedschaft ist fehlgeschlagen";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Anforderung von Administratorrechten fehlgeschlagen: Ein unbekannter Fehler ist aufgetreten";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "Sie sind bereits Administrator";

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Administratorrechte anfordern";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Geben Sie eine Begründung für die Anforderung von Administratorrechten ein:";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Begründung";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "Administratorrechte anfordern";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Anforderung von Administratorrechten fehlgeschlagen: Dieses Gerät erlaubt derzeit keine temporären Administratorrechte";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Anforderung von Administratorrechten fehlgeschlagen: Sie sind bereits Administrator";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Anforderung von Administratorrechten fehlgeschlagen: Für einen anderen Benutzer ist bereits eine Sitzung aktiv";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Anforderung von Administratorrechten fehlgeschlagen: Eine Begründung ist erforderlich";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Anforderung von Administratorrechten fehlgeschlagen: Autorisierung fehlgeschlagen";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Anforderung von Administratorrechten fehlgeschlagen: Die Änderung der Administratorgruppen-Mitgliedschaft ist fehlgeschlagen";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Anforderung von Administratorrechten fehlgeschlagen: Ein unbekannter Fehler ist aufgetreten";

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ can now be run";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "a justification is required";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "a session is already active for another user";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "Access to a file has been denied";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Accessed Path";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "an unknown error occurred";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "An unknown error occurred. Please try again.";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "authorization failed";
 
 /* Authorize execution */
 "authorize execution" = "authorize execution";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Drop for application info";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Enter a justification for requesting admin privileges:";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "Failed to connect to the sync service. Please try again later.";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Failed to request admin privileges: %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Filename";
 
 /* No comment provided by engineer. */
 "FS Type" = "FS Type";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justification";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "No matching rule";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Open...";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Remount Mode";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Request Admin Privileges";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "request admin privileges";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "Requested application can now be run";
@@ -214,6 +244,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "Team ID rule";
 
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "the admin group membership change failed";
+
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "The event upload failed. Please check your network connection and try again.";
 
@@ -250,6 +283,9 @@
 /* No comment provided by engineer. */
 "The sync operation failed. Please try again." = "The sync operation failed. Please try again.";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "this machine does not currently allow temporary admin elevation";
+
 /* No comment provided by engineer. */
 "Too many syncs are in progress. Please try again later." = "Too many syncs are in progress. Please try again later.";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Request Admin Privileges";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Enter a justification for requesting admin privileges:";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Justification";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "request admin privileges";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Failed to request admin privileges: this machine does not currently allow temporary admin elevation";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Failed to request admin privileges: you are already an administrator";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Failed to request admin privileges: a session is already active for another user";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Failed to request admin privileges: a justification is required";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Failed to request admin privileges: authorization failed";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Failed to request admin privileges: the admin group membership change failed";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Failed to request admin privileges: an unknown error occurred";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "you are already an administrator";

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Request Admin Privileges";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Enter a justification for requesting admin privileges:";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justification";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "request admin privileges";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Failed to request admin privileges: this machine does not currently allow temporary admin elevation";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Failed to request admin privileges: you are already an administrator";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Failed to request admin privileges: a session is already active for another user";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Failed to request admin privileges: a justification is required";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Failed to request admin privileges: authorization failed";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Failed to request admin privileges: the admin group membership change failed";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Failed to request admin privileges: an unknown error occurred";

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ ahora se puede ejecutar";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "se requiere una justificación";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "ya hay una sesión activa para otro usuario";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "El acceso a un archivo ha sido denegado";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Ruta accedida";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "se produjo un error desconocido";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "Se produjo un error desconocido. Por favor, inténtelo de nuevo.";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "¿Está seguro de que desea restablecer todas las notificaciones silenciadas? Comenzará a recibir notificaciones de eventos previamente silenciados.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "la autorización falló";
 
 /* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "autorizar la ejecución de %@";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Soltar para información de la aplicación";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Introduzca una justificación para solicitar privilegios de administrador:";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "Error al conectar con el servicio de sincronización. Por favor, inténtelo más tarde.";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Error al entrar en modo monitor temporal: este equipo no tiene actualmente una política que permita el modo monitor temporal";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Error al solicitar privilegios de administrador: %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Nombre del archivo";
 
 /* No comment provided by engineer. */
 "FS Type" = "Tipo FS";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justificación";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "Sin regla coincidente";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Abrir...";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Modo de remontaje";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Solicitar privilegios de administrador";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "solicitar privilegios de administrador";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "La aplicación solicitada ahora se puede ejecutar";
@@ -214,6 +244,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "Regla de Team ID";
 
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "no se pudo cambiar la pertenencia al grupo de administradores";
+
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "Error al cargar el evento. Por favor, verifique su conexión de red e inténtelo de nuevo.";
 
@@ -250,6 +283,9 @@
 /* No comment provided by engineer. */
 "The sync operation failed. Please try again." = "La operación de sincronización falló. Por favor, inténtelo de nuevo.";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "este equipo no permite actualmente la elevación temporal de administrador";
+
 /* No comment provided by engineer. */
 "Too many syncs are in progress. Please try again later." = "Hay demasiadas sincronizaciones en curso. Por favor, inténtelo más tarde.";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Versión **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Solicitar privilegios de administrador";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Introduzca una justificación para solicitar privilegios de administrador:";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Justificación";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "solicitar privilegios de administrador";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Error al solicitar privilegios de administrador: este equipo no permite actualmente la elevación temporal de administrador";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Error al solicitar privilegios de administrador: ya es administrador";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Error al solicitar privilegios de administrador: ya hay una sesión activa para otro usuario";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Error al solicitar privilegios de administrador: se requiere una justificación";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Error al solicitar privilegios de administrador: la autorización falló";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Error al solicitar privilegios de administrador: no se pudo cambiar la pertenencia al grupo de administradores";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Error al solicitar privilegios de administrador: se produjo un error desconocido";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "ya es administrador";

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Versión **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Solicitar privilegios de administrador";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Introduzca una justificación para solicitar privilegios de administrador:";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justificación";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "solicitar privilegios de administrador";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Error al solicitar privilegios de administrador: este equipo no permite actualmente la elevación temporal de administrador";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Error al solicitar privilegios de administrador: ya es administrador";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Error al solicitar privilegios de administrador: ya hay una sesión activa para otro usuario";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Error al solicitar privilegios de administrador: se requiere una justificación";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Error al solicitar privilegios de administrador: la autorización falló";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Error al solicitar privilegios de administrador: no se pudo cambiar la pertenencia al grupo de administradores";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Error al solicitar privilegios de administrador: se produjo un error desconocido";

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -7,11 +7,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ peut maintenant être exécuté";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "une justification est requise";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "une session est déjà active pour un autre utilisateur";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "L'accès à un fichier a été refusé";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Chemin d'accès";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "une erreur inconnue s'est produite";
 
 /* No comment provided by engineer. [QC] */
 "An unknown error occurred. Please try again." = "Une erreur inconnue s'est produite. Veuillez réessayer s.v.p.";
@@ -24,6 +33,9 @@
 
 /* Message for reset silences confirmation dialog [QC] */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "Êtes-vous certain de vouloir réinitialiser toutes les notifications en sourdine ? Vous allez recommencer à recevoir des notifications pour les événements précédemment mis en sourdine.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "l'autorisation a échoué";
 
 /* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "autoriser l'exécution de %@";
@@ -85,6 +97,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Déposer pour les informations de l'application";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Saisissez une justification pour demander des privilèges d'administrateur :";
+
 /* No comment provided by engineer. [QC] */
 "Failed to connect to the sync service. Please try again later." = "Échec de la connexion au service de synchronisation. Veuillez réessayer plus tard s.v.p.";
 
@@ -103,11 +118,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy [QC] */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Échec du passage en mode moniteur temporaire : cet ordinateur ne dispose pas présentement d'une politique autorisant le mode moniteur temporaire";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Échec de la demande de privilèges d'administrateur : %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Nom du fichier";
 
 /* No comment provided by engineer. */
 "FS Type" = "Type FS";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justification";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -136,6 +157,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "Aucune règle correspondante";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Ouvrir...";
 
@@ -156,6 +180,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Mode de remontage";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Demander des privilèges d'administrateur";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "demander des privilèges d'administrateur";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "L'application demandée peut maintenant être exécutée";
@@ -217,6 +247,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "Règle de Team ID";
 
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "la modification de l'appartenance au groupe d'administrateurs a échoué";
+
 /* No comment provided by engineer. [QC] */
 "The event upload failed. Please check your network connection and try again." = "Le téléversement de l'événement a échoué. Veuillez vérifier votre connexion réseau et réessayer.";
 
@@ -253,6 +286,9 @@
 /* No comment provided by engineer. */
 "The sync operation failed. Please try again." = "L'opération de synchronisation a échoué. Veuillez réessayer.";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "cet ordinateur ne permet pas présentement l'élévation temporaire des privilèges d'administrateur";
+
 /* No comment provided by engineer. [QC] */
 "Too many syncs are in progress. Please try again later." = "Trop de synchronisations sont en cours. Veuillez réessayer plus tard s.v.p.";
 
@@ -271,38 +307,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Demander des privilèges d'administrateur";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Saisissez une justification pour demander des privilèges d'administrateur :";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Justification";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "demander des privilèges d'administrateur";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Échec de la demande de privilèges d'administrateur : cet ordinateur ne permet pas présentement l'élévation temporaire des privilèges d'administrateur";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Échec de la demande de privilèges d'administrateur : vous êtes déjà administrateur";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Échec de la demande de privilèges d'administrateur : une session est déjà active pour un autre utilisateur";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Échec de la demande de privilèges d'administrateur : une justification est requise";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Échec de la demande de privilèges d'administrateur : l'autorisation a échoué";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Échec de la demande de privilèges d'administrateur : la modification de l'appartenance au groupe d'administrateurs a échoué";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Échec de la demande de privilèges d'administrateur : une erreur inconnue s'est produite";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "vous êtes déjà administrateur";

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -270,3 +270,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Demander des privilèges d'administrateur";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Saisissez une justification pour demander des privilèges d'administrateur :";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justification";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "demander des privilèges d'administrateur";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Échec de la demande de privilèges d'administrateur : cet ordinateur ne permet pas présentement l'élévation temporaire des privilèges d'administrateur";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Échec de la demande de privilèges d'administrateur : vous êtes déjà administrateur";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Échec de la demande de privilèges d'administrateur : une session est déjà active pour un autre utilisateur";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Échec de la demande de privilèges d'administrateur : une justification est requise";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Échec de la demande de privilèges d'administrateur : l'autorisation a échoué";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Échec de la demande de privilèges d'administrateur : la modification de l'appartenance au groupe d'administrateurs a échoué";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Échec de la demande de privilèges d'administrateur : une erreur inconnue s'est produite";

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Demander des privilèges d'administrateur";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Saisissez une justification pour demander des privilèges d'administrateur :";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justification";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "demander des privilèges d'administrateur";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Échec de la demande de privilèges d'administrateur : cette machine ne permet pas actuellement l'élévation temporaire des privilèges d'administrateur";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Échec de la demande de privilèges d'administrateur : vous êtes déjà administrateur";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Échec de la demande de privilèges d'administrateur : une session est déjà active pour un autre utilisateur";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Échec de la demande de privilèges d'administrateur : une justification est requise";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Échec de la demande de privilèges d'administrateur : l'autorisation a échoué";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Échec de la demande de privilèges d'administrateur : la modification de l'appartenance au groupe d'administrateurs a échoué";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Échec de la demande de privilèges d'administrateur : une erreur inconnue s'est produite";

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ peut maintenant être exécuté";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "une justification est requise";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "une session est déjà active pour un autre utilisateur";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "L'accès à un fichier a été refusé";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Chemin d'accès";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "une erreur inconnue s'est produite";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "Une erreur inconnue s'est produite. Veuillez réessayer.";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "Voulez-vous vraiment réinitialiser toutes les notifications en sourdine ? Vous recevrez à nouveau des notifications pour les événements précédemment mis en sourdine.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "l'autorisation a échoué";
 
 /* Authorize execution of an application with Signing ID or Path */
 "authorize execution of %@" = "autoriser l'exécution de %@";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Déposer pour les informations de l'application";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Saisissez une justification pour demander des privilèges d'administrateur :";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "Échec de la connexion au service de synchronisation. Veuillez réessayer ultérieurement.";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Échec du passage en mode moniteur temporaire : cette machine ne dispose pas actuellement d'une politique autorisant le mode moniteur temporaire";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Échec de la demande de privilèges d'administrateur : %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Nom du fichier";
 
 /* No comment provided by engineer. */
 "FS Type" = "Type FS";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Justification";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "Aucune règle correspondante";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Ouvrir...";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Mode de remontage";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Demander des privilèges d'administrateur";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "demander des privilèges d'administrateur";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "L'application demandée peut maintenant être exécutée";
@@ -214,6 +244,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "Règle de Team ID";
 
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "la modification de l'appartenance au groupe d'administrateurs a échoué";
+
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "L'envoi de l'événement a échoué. Veuillez vérifier votre connexion réseau et réessayer.";
 
@@ -250,6 +283,9 @@
 /* No comment provided by engineer. */
 "The sync operation failed. Please try again." = "L'opération de synchronisation a échoué. Veuillez réessayer.";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "cette machine ne permet pas actuellement l'élévation temporaire des privilèges d'administrateur";
+
 /* No comment provided by engineer. */
 "Too many syncs are in progress. Please try again later." = "Trop de synchronisations sont en cours. Veuillez réessayer ultérieurement.";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Version **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Demander des privilèges d'administrateur";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Saisissez une justification pour demander des privilèges d'administrateur :";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Justification";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "demander des privilèges d'administrateur";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Échec de la demande de privilèges d'administrateur : cette machine ne permet pas actuellement l'élévation temporaire des privilèges d'administrateur";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Échec de la demande de privilèges d'administrateur : vous êtes déjà administrateur";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Échec de la demande de privilèges d'administrateur : une session est déjà active pour un autre utilisateur";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Échec de la demande de privilèges d'administrateur : une justification est requise";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Échec de la demande de privilèges d'administrateur : l'autorisation a échoué";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Échec de la demande de privilèges d'administrateur : la modification de l'appartenance au groupe d'administrateurs a échoué";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Échec de la demande de privilèges d'administrateur : une erreur inconnue s'est produite";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "vous êtes déjà administrateur";

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "バージョン **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "管理者権限のリクエスト";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "管理者権限をリクエストする理由を入力してください:";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "理由";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "管理者権限をリクエストする";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "管理者権限のリクエストに失敗しました: このマシンは現在、一時的な管理者権限の昇格を許可していません";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "管理者権限のリクエストに失敗しました: すでに管理者です";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "管理者権限のリクエストに失敗しました: 別のユーザーのセッションがすでにアクティブです";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "管理者権限のリクエストに失敗しました: 理由の入力が必要です";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "管理者権限のリクエストに失敗しました: 認証に失敗しました";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "管理者権限のリクエストに失敗しました: 管理者グループのメンバーシップの変更に失敗しました";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "管理者権限のリクエストに失敗しました: 不明なエラーが発生しました";

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@が実行できるようになった";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "理由の入力が必要です";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "別のユーザーのセッションがすでにアクティブです";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "ファイルへのアクセスが拒否されました";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "アクセスパス";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "不明なエラーが発生しました";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "不明なエラーが発生しました。もう一度お試しください。";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "すべての通知の停止設定をリセットしてもよろしいですか？以前停止した通知が再び届くようになります。";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "認証に失敗しました";
 
 /* Authorize execution fallback */
 "authorize execution" = "実行を許可する";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "アプリ情報のためにドロップ";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "管理者権限をリクエストする理由を入力してください:";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "同期サービスへの接続に失敗しました。後ほどもう一度お試しください。";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "一時的なモニターモードへの切り替えに失敗しました: このマシンには現在、一時的なモニターモードを許可するポリシーがありません";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "管理者権限のリクエストに失敗しました: %@";
+
 /* No comment provided by engineer. */
 "Filename" = "ファイル名";
 
 /* No comment provided by engineer. */
 "FS Type" = "ファイルシステム種別";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "理由";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "停止します";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "一致するルールなし";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "開く…";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "再マウントモード";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "管理者権限のリクエスト";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "管理者権限をリクエストする";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "リクエストされたアプリケーションが実行できるようになりました。";
@@ -198,6 +228,9 @@
 
 /* Notification message shown when a sync fails */
 "Sync failed" = "同期に失敗しました";
+
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "管理者グループのメンバーシップの変更に失敗しました";
 
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "イベントのアップロードに失敗しました。ネットワーク接続を確認して、もう一度お試しください。";
@@ -253,6 +286,9 @@
 /* The default message to show the user when a network share mount is blocked */
 "The following network share has been blocked from mounting" = "次のネットワーク共有のマウントがブロックされました";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "このマシンは現在、一時的な管理者権限の昇格を許可していません";
+
 /* No comment provided by engineer. */
 "unknown" = "不明";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "バージョン **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "管理者権限のリクエスト";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "管理者権限をリクエストする理由を入力してください:";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "理由";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "管理者権限をリクエストする";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "管理者権限のリクエストに失敗しました: このマシンは現在、一時的な管理者権限の昇格を許可していません";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "管理者権限のリクエストに失敗しました: すでに管理者です";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "管理者権限のリクエストに失敗しました: 別のユーザーのセッションがすでにアクティブです";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "管理者権限のリクエストに失敗しました: 理由の入力が必要です";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "管理者権限のリクエストに失敗しました: 認証に失敗しました";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "管理者権限のリクエストに失敗しました: 管理者グループのメンバーシップの変更に失敗しました";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "管理者権限のリクエストに失敗しました: 不明なエラーが発生しました";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "すでに管理者です";

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "Теперь можно запустить %@";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "требуется обоснование";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "для другого пользователя уже активна сессия";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "Доступ к файлу запрещён";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Путь, к которому был получен доступ";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "произошла неизвестная ошибка";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "Произошла неизвестная ошибка. Пожалуйста, попробуйте снова.";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "Вы уверены, что хотите сбросить все отключения уведомлений? Вы снова начнёте получать уведомления о событиях, для которых уведомления были ранее отключены.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "ошибка авторизации";
 
 /* Authorize execution fallback */
 "authorize execution" = "разрешить запуск";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Перетащите сюда приложение, чтобы увидеть сведения о нём";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Введите обоснование для запроса прав администратора:";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "Не удалось подключиться к службе синхронизации. Пожалуйста, попробуйте позже.";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Не удалось перейти во временный режим мониторинга: на этом компьютере сейчас нет политики, разрешающей временный режим мониторинга";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Не удалось запросить права администратора: %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Имя файла";
 
 /* No comment provided by engineer. */
 "FS Type" = "Тип файловой системы";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Обоснование";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "Совпадающее правило не найдено";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Открыть...";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Режим перемонтирования";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Запрос прав администратора";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "запросить права администратора";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "Запрошенное приложение теперь можно запустить";
@@ -214,6 +244,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "Правило идентификатора команды";
 
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "не удалось изменить членство в группе администраторов";
+
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "Не удалось отправить событие. Пожалуйста, проверьте подключение к сети и попробуйте снова.";
 
@@ -253,6 +286,9 @@
 /* The default message to show the user when a network share mount is blocked */
 "The following network share has been blocked from mounting" = "Монтирование следующего сетевого ресурса было заблокировано";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "на этом компьютере сейчас не разрешено временное повышение прав администратора";
+
 /* No comment provided by engineer. */
 "unknown" = "неизвестно";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Версия **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Запрос прав администратора";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Введите обоснование для запроса прав администратора:";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Обоснование";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "запросить права администратора";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Не удалось запросить права администратора: на этом компьютере сейчас не разрешено временное повышение прав администратора";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Не удалось запросить права администратора: вы уже являетесь администратором";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Не удалось запросить права администратора: для другого пользователя уже активна сессия";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Не удалось запросить права администратора: требуется обоснование";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Не удалось запросить права администратора: ошибка авторизации";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Не удалось запросить права администратора: не удалось изменить членство в группе администраторов";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Не удалось запросить права администратора: произошла неизвестная ошибка";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "вы уже являетесь администратором";

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Версия **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Запрос прав администратора";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Введите обоснование для запроса прав администратора:";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Обоснование";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "запросить права администратора";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Не удалось запросить права администратора: на этом компьютере сейчас не разрешено временное повышение прав администратора";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Не удалось запросить права администратора: вы уже являетесь администратором";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Не удалось запросить права администратора: для другого пользователя уже активна сессия";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Не удалось запросить права администратора: требуется обоснование";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Не удалось запросить права администратора: ошибка авторизации";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Не удалось запросить права администратора: не удалось изменить членство в группе администраторов";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Не удалось запросить права администратора: произошла неизвестная ошибка";

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -4,11 +4,20 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ тепер можна запускати";
 
+/* Reason shown when a justification is required but not given */
+"a justification is required" = "потрібне обґрунтування";
+
+/* Reason shown when another user already has an active session */
+"a session is already active for another user" = "для іншого користувача вже активна сесія";
+
 /* The default message to show the user when access to a file is blocked */
 "Access to a file has been denied" = "Відмовлено у доступі до файлу";
 
 /* No comment provided by engineer. */
 "Accessed Path" = "Шлях доступу";
+
+/* Reason shown when admin elevation fails with an unknown error */
+"an unknown error occurred" = "сталася невідома помилка";
 
 /* No comment provided by engineer. */
 "An unknown error occurred. Please try again." = "Сталася невідома помилка. Будь ласка, спробуйте ще раз.";
@@ -21,6 +30,9 @@
 
 /* Message for reset silences confirmation dialog */
 "Are you sure you want to reset all notification silences? You will start receiving notifications for previously silenced events." = "Ви впевнені, що хочете скинути всі вимкнення сповіщень? Ви знову почнете отримувати сповіщення для раніше вимкнених подій.";
+
+/* Reason shown when admin elevation authorization fails */
+"authorization failed" = "помилка авторизації";
 
 /* Authorize execution fallback */
 "authorize execution" = "дозволити виконання";
@@ -82,6 +94,9 @@
 /* No comment provided by engineer. */
 "Drop for application info" = "Перетягніть для інформації про додаток";
 
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Введіть обґрунтування для запиту прав адміністратора:";
+
 /* No comment provided by engineer. */
 "Failed to connect to the sync service. Please try again later." = "Не вдалося підключитися до служби синхронізації. Будь ласка, спробуйте пізніше.";
 
@@ -100,11 +115,17 @@
 /* Error message shown when user tries to enter TMM mode without a policy */
 "Failed to enter temporary monitor mode: this machine does not currently have a policy allowing temporary monitor mode" = "Не вдалося перейти в тимчасовий режим монітора: на цьому комп'ютері наразі немає політики, яка дозволяє тимчасовий режим монітора";
 
+/* Admin elevation failure; %@ is the specific reason */
+"Failed to request admin privileges: %@" = "Не вдалося запросити права адміністратора: %@";
+
 /* No comment provided by engineer. */
 "Filename" = "Ім'я файлу";
 
 /* No comment provided by engineer. */
 "FS Type" = "Тип ФС";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Обґрунтування";
 
 /* No comment provided by engineer. */
 "Label after time period picker (application)" = "\U2800";
@@ -133,6 +154,9 @@
 /* Block reason when no rule matched in lockdown mode */
 "No matching rule" = "Немає відповідного правила";
 
+/* OK button */
+"OK" = "OK";
+
 /* Default text for Open button */
 "Open..." = "Відкрито...";
 
@@ -153,6 +177,12 @@
 
 /* No comment provided by engineer. */
 "Remount Mode" = "Режим перевстановлення";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Запит прав адміністратора";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "запросити права адміністратора";
 
 /* Notification message shown when an unknown app has been unblocked */
 "Requested application can now be run" = "Запит тепер можна виконати";
@@ -214,6 +244,9 @@
 /* Block reason for Team ID rule match */
 "Team ID rule" = "Правило Team ID";
 
+/* Reason shown when the group membership change fails */
+"the admin group membership change failed" = "не вдалося змінити членство в групі адміністраторів";
+
 /* No comment provided by engineer. */
 "The event upload failed. Please check your network connection and try again." = "Не вдалося завантажити подію. Будь ласка, перевірте підключення до мережі та спробуйте ще раз.";
 
@@ -253,6 +286,9 @@
 /* The default message to show the user when a network share mount is blocked */
 "The following network share has been blocked from mounting" = "Монтування наступного мережевого ресурсу було заблоковано";
 
+/* Reason shown when requesting admin without a policy */
+"this machine does not currently allow temporary admin elevation" = "цей комп'ютер наразі не дозволяє тимчасове підвищення прав адміністратора";
+
 /* No comment provided by engineer. */
 "unknown" = "невідомо";
 
@@ -268,38 +304,5 @@
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Версія **%@** (Lite)";
 
-/* Temporary admin mode alert title */
-"Request Admin Privileges" = "Запит прав адміністратора";
-
-/* Temporary admin mode alert body */
-"Enter a justification for requesting admin privileges:" = "Введіть обґрунтування для запиту прав адміністратора:";
-
-/* Temporary admin mode justification placeholder */
-"Justification" = "Обґрунтування";
-
-/* OK button */
-"OK" = "OK";
-
-/* Authorize temporary Admin Mode exception */
-"request admin privileges" = "запросити права адміністратора";
-
-/* Error shown when requesting admin without a policy */
-"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Не вдалося запросити права адміністратора: цей комп'ютер наразі не дозволяє тимчасове підвищення прав адміністратора";
-
-/* Error shown when a natural admin requests elevation */
-"Failed to request admin privileges: you are already an administrator" = "Не вдалося запросити права адміністратора: ви вже є адміністратором";
-
-/* Error shown when another user already has an active session */
-"Failed to request admin privileges: a session is already active for another user" = "Не вдалося запросити права адміністратора: для іншого користувача вже активна сесія";
-
-/* Error shown when a justification is required but not given */
-"Failed to request admin privileges: a justification is required" = "Не вдалося запросити права адміністратора: потрібне обґрунтування";
-
-/* Error shown when admin elevation authorization fails */
-"Failed to request admin privileges: authorization failed" = "Не вдалося запросити права адміністратора: помилка авторизації";
-
-/* Error shown when the group membership change fails */
-"Failed to request admin privileges: the admin group membership change failed" = "Не вдалося запросити права адміністратора: не вдалося змінити членство в групі адміністраторів";
-
-/* Error shown when admin elevation fails with an unknown error */
-"Failed to request admin privileges: an unknown error occurred" = "Не вдалося запросити права адміністратора: сталася невідома помилка";
+/* Reason shown when a natural admin requests elevation */
+"you are already an administrator" = "ви вже є адміністратором";

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -267,3 +267,39 @@
 
 /* Version in About view for Lite edition */
 "Version **%@** (Lite)" = "Версія **%@** (Lite)";
+
+/* Temporary admin mode alert title */
+"Request Admin Privileges" = "Запит прав адміністратора";
+
+/* Temporary admin mode alert body */
+"Enter a justification for requesting admin privileges:" = "Введіть обґрунтування для запиту прав адміністратора:";
+
+/* Temporary admin mode justification placeholder */
+"Justification" = "Обґрунтування";
+
+/* OK button */
+"OK" = "OK";
+
+/* Authorize temporary Admin Mode exception */
+"request admin privileges" = "запросити права адміністратора";
+
+/* Error shown when requesting admin without a policy */
+"Failed to request admin privileges: this machine does not currently allow temporary admin elevation" = "Не вдалося запросити права адміністратора: цей комп'ютер наразі не дозволяє тимчасове підвищення прав адміністратора";
+
+/* Error shown when a natural admin requests elevation */
+"Failed to request admin privileges: you are already an administrator" = "Не вдалося запросити права адміністратора: ви вже є адміністратором";
+
+/* Error shown when another user already has an active session */
+"Failed to request admin privileges: a session is already active for another user" = "Не вдалося запросити права адміністратора: для іншого користувача вже активна сесія";
+
+/* Error shown when a justification is required but not given */
+"Failed to request admin privileges: a justification is required" = "Не вдалося запросити права адміністратора: потрібне обґрунтування";
+
+/* Error shown when admin elevation authorization fails */
+"Failed to request admin privileges: authorization failed" = "Не вдалося запросити права адміністратора: помилка авторизації";
+
+/* Error shown when the group membership change fails */
+"Failed to request admin privileges: the admin group membership change failed" = "Не вдалося запросити права адміністратора: не вдалося змінити членство в групі адміністраторів";
+
+/* Error shown when admin elevation fails with an unknown error */
+"Failed to request admin privileges: an unknown error occurred" = "Не вдалося запросити права адміністратора: сталася невідома помилка";

--- a/Source/gui/SNTAuthorizationHelper.h
+++ b/Source/gui/SNTAuthorizationHelper.h
@@ -22,6 +22,15 @@
 /// Authorize temporary monitor mode via TouchID.
 + (void)authorizeTemporaryMonitorModeWithReplyBlock:(void (^)(BOOL success))replyBlock;
 
+/// Authorize temporary admin mode via TouchID, optionally collecting a justification string first.
+/// If requireJustification is YES, an alert with a text field is presented before the Touch ID
+/// prompt; if the user cancels that alert replyBlock is called with (NO, @"") and no LA prompt is
+/// shown. replyBlock is always called exactly once with (authenticated, justification).
++ (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
+                                               replyBlock:
+                                                   (void (^)(BOOL authenticated,
+                                                             NSString* justification))replyBlock;
+
 /// Authorize execution of a binary via TouchID.
 + (void)authorizeExecutionForEvent:(SNTStoredExecutionEvent*)event
                         replyBlock:(void (^)(BOOL success))replyBlock;

--- a/Source/gui/SNTAuthorizationHelper.mm
+++ b/Source/gui/SNTAuthorizationHelper.mm
@@ -20,6 +20,13 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 
+// Upper bound on how long the interactive Temporary Admin Mode justification
+// prompt may stay open. santad reaches this prompt over a synchronous XPC proxy
+// and holds grant_mutex_ plus a request-handler thread until the reply runs, so
+// an abandoned dialog must not wait on the user indefinitely. On timeout the
+// prompt is dismissed and authorization fails closed.
+static const NSTimeInterval kAdminJustificationPromptTimeoutSeconds = 120;
+
 @implementation SNTAuthorizationHelper
 
 + (LAPolicy)authorizationPolicy {
@@ -66,7 +73,21 @@
           NSLocalizedString(@"Justification", @"Temporary admin mode justification placeholder");
       alert.accessoryView = justificationField;
 
+      // Fail closed if the user never responds: dismiss the modal after a bounded
+      // interval so santad's synchronous auth call (which holds grant_mutex_ and a
+      // handler thread until this replies) cannot be pinned by an abandoned dialog.
+      // The timer must run in the modal-panel run-loop mode; runModal does not
+      // service the default mode.
+      NSTimer* timeoutTimer =
+          [NSTimer timerWithTimeInterval:kAdminJustificationPromptTimeoutSeconds
+                                 repeats:NO
+                                   block:^(NSTimer* _Nonnull timer) {
+                                     [NSApp stopModalWithCode:NSModalResponseCancel];
+                                   }];
+      [[NSRunLoop currentRunLoop] addTimer:timeoutTimer forMode:NSModalPanelRunLoopMode];
+
       NSModalResponse response = [alert runModal];
+      [timeoutTimer invalidate];
       if (response != NSAlertFirstButtonReturn) {
         replyBlock(NO, @"");
         return;

--- a/Source/gui/SNTAuthorizationHelper.mm
+++ b/Source/gui/SNTAuthorizationHelper.mm
@@ -14,6 +14,7 @@
 
 #import "Source/gui/SNTAuthorizationHelper.h"
 
+#import <Cocoa/Cocoa.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 
 #import "Source/common/SNTConfigurator.h"
@@ -40,6 +41,48 @@
   NSString* reason = NSLocalizedString(@"authorize temporary Monitor Mode",
                                        @"Authorize temporary Monitor Mode exception");
   [self authorizeWithReason:reason replyBlock:replyBlock];
+}
+
++ (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
+                                               replyBlock:
+                                                   (void (^)(BOOL authenticated,
+                                                             NSString* justification))replyBlock {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSString* capturedJustification = @"";
+
+    if (requireJustification) {
+      NSAlert* alert = [[NSAlert alloc] init];
+      alert.messageText =
+          NSLocalizedString(@"Request Admin Privileges", @"Temporary admin mode alert title");
+      alert.informativeText =
+          NSLocalizedString(@"Enter a justification for requesting admin privileges:",
+                            @"Temporary admin mode alert body");
+      [alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
+      [alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")];
+
+      NSTextField* justificationField =
+          [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 300, 22)];
+      justificationField.placeholderString =
+          NSLocalizedString(@"Justification", @"Temporary admin mode justification placeholder");
+      alert.accessoryView = justificationField;
+
+      NSModalResponse response = [alert runModal];
+      if (response != NSAlertFirstButtonReturn) {
+        replyBlock(NO, @"");
+        return;
+      }
+      capturedJustification = [justificationField.stringValue copy] ?: @"";
+    }
+
+    NSString* authReason =
+        NSLocalizedString(@"request admin privileges", @"Authorize temporary Admin Mode exception");
+    // Capture capturedJustification so it is available in the LA reply block.
+    NSString* justificationForReply = capturedJustification;
+    [self authorizeWithReason:authReason
+                   replyBlock:^(BOOL success) {
+                     replyBlock(success, justificationForReply);
+                   }];
+  });
 }
 
 + (void)authorizeExecutionForEvent:(SNTStoredExecutionEvent*)event

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -500,9 +500,7 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
 }
 
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply {
-  [SNTAuthorizationHelper authorizeTemporaryMonitorModeWithReplyBlock:^(BOOL success) {
-    reply(success);
-  }];
+  [SNTAuthorizationHelper authorizeTemporaryMonitorModeWithReplyBlock:reply];
 }
 
 - (void)enterTemporaryMonitorMode:(NSDate*)expiration {
@@ -515,6 +513,28 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
 
 - (void)temporaryMonitorModePolicyAvailable:(BOOL)available {
   [self.statusItemManager setTemporaryMonitorModePolicyAvailable:available];
+}
+
+- (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
+                                                    reply:(void (^)(BOOL authenticated,
+                                                                    NSString* reason))reply {
+  // The daemon passes through the policy's requireJustification flag; only prompt for a
+  // reason when the policy calls for one. The daemon still enforces the requirement
+  // (an empty reason is rejected with TAMJustificationRequired).
+  [SNTAuthorizationHelper authorizeTemporaryAdminModeRequiringJustification:requireJustification
+                                                                 replyBlock:reply];
+}
+
+- (void)enterTemporaryAdminMode:(NSDate*)expiration {
+  [self.statusItemManager enterAdminModeWithExpiration:expiration];
+}
+
+- (void)leaveTemporaryAdminMode {
+  [self.statusItemManager leaveAdminMode];
+}
+
+- (void)temporaryAdminModeAvailable:(BOOL)available {
+  [self.statusItemManager setTemporaryAdminModeAvailable:available];
 }
 
 - (void)setNetworkExtensionFilterEnabled:(BOOL)enabled reply:(void (^)(BOOL success))reply {

--- a/Source/gui/SNTStatusItemManager.h
+++ b/Source/gui/SNTStatusItemManager.h
@@ -33,4 +33,20 @@
 /// @param available YES if a TMM policy is available, NO otherwise
 - (void)setTemporaryMonitorModePolicyAvailable:(BOOL)available;
 
+- (void)enterAdminModeWithExpiration:(NSDate*)expiration;
+- (void)leaveAdminMode;
+
+/// Sets whether the temporary admin mode menu items should be visible
+/// @param available YES if a TAM policy is available and the user is not already an admin
+- (void)setTemporaryAdminModeAvailable:(BOOL)available;
+
+/// Notifies the daemon that the current user's session has resigned active (fast user switch).
+/// If an admin session is active for this user, asks the daemon to end it with SessionEnded.
+- (void)temporaryAdminModeSessionResignedActive;
+
+/// Re-queries the daemon for live Monitor/Admin session and availability state. Called when the
+/// user's session becomes active again (e.g. returning from fast user switching) to reconcile any
+/// daemon notifications missed while the session was inactive.
+- (void)reconcileTimedModeState;
+
 @end

--- a/Source/gui/SNTStatusItemManager.mm
+++ b/Source/gui/SNTStatusItemManager.mm
@@ -319,45 +319,55 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
 }
 
 - (void)retrieveMonitorModeState {
+  // The synchronous control proxy runs these reply blocks on this background queue, so every
+  // helper that mutates AppKit state (menu items, the countdown timer, the status title) must be
+  // marshaled to the main thread. Each block is enqueued in call order, so main-queue FIFO
+  // preserves the ordering the UI depends on.
   [self withControlProxy:^(id proxy) {
     [proxy checkTemporaryMonitorModePolicyAvailable:^(BOOL available) {
-      [self setAvailable:available forState:self.tmmState];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self setAvailable:available forState:self.tmmState];
+      });
     }];
     [proxy temporaryMonitorModeSecondsRemaining:^(NSNumber* seconds) {
-      if (seconds) {
-        [self enterModeWithExpiration:[NSDate dateWithTimeIntervalSinceNow:[seconds intValue]]
-                             forState:self.tmmState];
-      } else if (self.tmmState.expiration) {
-        // The daemon reports no active session but the GUI still shows one (a leave
-        // notification can be missed while this session is inactive, e.g. fast user
-        // switching). Clear the stale countdown on the main thread (the timer lives there).
-        dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (seconds) {
+          [self enterModeWithExpiration:[NSDate dateWithTimeIntervalSinceNow:[seconds intValue]]
+                               forState:self.tmmState];
+        } else if (self.tmmState.expiration) {
+          // The daemon reports no active session but the GUI still shows one (a leave
+          // notification can be missed while this session is inactive, e.g. fast user
+          // switching). Clear the stale countdown.
           [self leaveModeForState:self.tmmState];
-        });
-      }
+        }
+      });
     }];
   }];
 }
 
 - (void)retrieveAdminModeState {
+  // See retrieveMonitorModeState: reply blocks run on a background queue, so AppKit mutations are
+  // marshaled to the main queue. Determine the active session first (sets the expiration / "Leave"
+  // title), then compute visibility (which depends on whether a session is active) -- main-queue
+  // FIFO keeps that ordering.
   [self withControlProxy:^(id proxy) {
-    // Determine the active session first (sets the expiration / "Leave" title), then
-    // compute visibility (which depends on whether a session is active).
     [proxy temporaryAdminModeSecondsRemaining:^(NSNumber* seconds) {
-      if (seconds) {
-        [self enterModeWithExpiration:[NSDate dateWithTimeIntervalSinceNow:[seconds intValue]]
-                             forState:self.tamState];
-      } else if (self.tamState.expiration) {
-        // The daemon reports no active session but the GUI still shows one (a leave
-        // notification can be missed while this session is inactive, e.g. fast user
-        // switching). Clear the stale countdown on the main thread (the timer lives there).
-        dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (seconds) {
+          [self enterModeWithExpiration:[NSDate dateWithTimeIntervalSinceNow:[seconds intValue]]
+                               forState:self.tamState];
+        } else if (self.tamState.expiration) {
+          // The daemon reports no active session but the GUI still shows one (a leave
+          // notification can be missed while this session is inactive, e.g. fast user
+          // switching). Clear the stale countdown.
           [self leaveModeForState:self.tamState];
-        });
-      }
+        }
+      });
     }];
     [proxy checkTemporaryAdminModeAvailable:^(BOOL available, BOOL alreadyAdmin) {
-      [self setAdminItemVisibleWhenAvailable:available alreadyAdmin:alreadyAdmin];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self setAdminItemVisibleWhenAvailable:available alreadyAdmin:alreadyAdmin];
+      });
     }];
   }];
 }
@@ -674,11 +684,10 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
 }
 
 - (void)temporaryAdminModeSessionResignedActive {
-  // Only message the daemon if an admin session is currently shown for this user. The daemon's
-  // audit-token uid match is authoritative; this is just an optimization to avoid waking it.
-  if (!self.tamState.expiration || [self.tamState.expiration timeIntervalSinceNow] <= 0) {
-    return;
-  }
+  // Always signal the daemon: the GUI's local view of the session (expiration) can be missing or
+  // stale (a leave/enter notification can be dropped while this session is inactive), so it must
+  // not gate the resign. The daemon's audit-token uid match against its own active session is
+  // authoritative and no-ops if there is nothing to end.
   // Fire-and-forget on a background queue (must not block the main thread, especially during
   // session teardown). The reply is ignored.
   dispatch_async(dispatch_get_global_queue(0, 0), ^{

--- a/Source/gui/SNTStatusItemManager.mm
+++ b/Source/gui/SNTStatusItemManager.mm
@@ -193,34 +193,44 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
     [proxy cancelTemporaryAdminMode:reply];
   };
   d.messageForError = ^NSString*(NSInteger code) {
+    NSString* reason;
     switch (code) {
       case SNTErrorCodeTAMNoPolicy:
-        return NSLocalizedString(
-            @"Failed to request admin privileges: this machine does not currently allow "
-            @"temporary admin elevation",
-            @"Error shown when requesting admin without a policy");
+        reason =
+            NSLocalizedString(@"this machine does not currently allow temporary admin elevation",
+                              @"Reason shown when requesting admin without a policy");
+        break;
       case SNTErrorCodeTAMAlreadyAdmin:
-        return NSLocalizedString(
-            @"Failed to request admin privileges: you are already an administrator",
-            @"Error shown when a natural admin requests elevation");
+        reason = NSLocalizedString(@"you are already an administrator",
+                                   @"Reason shown when a natural admin requests elevation");
+        break;
       case SNTErrorCodeTAMAuthFailed:
-        return NSLocalizedString(@"Failed to request admin privileges: authorization failed",
-                                 @"Error shown when admin elevation authorization fails");
+        reason = NSLocalizedString(@"authorization failed",
+                                   @"Reason shown when admin elevation authorization fails");
+        break;
       case SNTErrorCodeTAMJustificationRequired:
-        return NSLocalizedString(@"Failed to request admin privileges: a justification is required",
-                                 @"Error shown when a justification is required but not given");
+        reason = NSLocalizedString(@"a justification is required",
+                                   @"Reason shown when a justification is required but not given");
+        break;
       case SNTErrorCodeTAMSessionAlreadyActive:
-        return NSLocalizedString(
-            @"Failed to request admin privileges: a session is already active for another user",
-            @"Error shown when another user already has an active session");
+        reason = NSLocalizedString(@"a session is already active for another user",
+                                   @"Reason shown when another user already has an active session");
+        break;
       case SNTErrorCodeTAMMembershipChangeFailed:
-        return NSLocalizedString(
-            @"Failed to request admin privileges: the admin group membership change failed",
-            @"Error shown when the group membership change fails");
+        reason = NSLocalizedString(@"the admin group membership change failed",
+                                   @"Reason shown when the group membership change fails");
+        break;
       default:
-        return NSLocalizedString(@"Failed to request admin privileges: an unknown error occurred",
-                                 @"Error shown when admin elevation fails with an unknown error");
+        reason =
+            NSLocalizedString(@"an unknown error occurred",
+                              @"Reason shown when admin elevation fails with an unknown error");
+        break;
     }
+    return [NSString
+        localizedStringWithFormat:NSLocalizedString(
+                                      @"Failed to request admin privileges: %@",
+                                      @"Admin elevation failure; %@ is the specific reason"),
+                                  reason];
   };
   return d;
 }

--- a/Source/gui/SNTStatusItemManager.mm
+++ b/Source/gui/SNTStatusItemManager.mm
@@ -654,8 +654,15 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
 }
 
 - (void)setAvailable:(BOOL)available forState:(SNTTimedModeState*)state {
-  state.menuItem.hidden = !available;
-  state.refreshItem.hidden = !available;
+  // Keep the item visible while a session is active so the user always retains an
+  // in-menu way to leave, even if a policy update pushes availability=false without
+  // cancelling the session (e.g. the policy type drops to Unspecified). The poll path
+  // (setAdminItemVisibleWhenAvailable:) already folds `active` into `available`; doing
+  // it here too covers the daemon-pushed availability updates, which carry no session
+  // state of their own.
+  BOOL active = (state.expiration != nil);
+  state.menuItem.hidden = !(available || active);
+  state.refreshItem.hidden = !(available || active);
 }
 
 // Public wrappers used by SNTNotificationManager (daemon-pushed enter/leave/availability).

--- a/Source/gui/SNTStatusItemManager.mm
+++ b/Source/gui/SNTStatusItemManager.mm
@@ -28,7 +28,39 @@
 #import "Source/gui/SNTAboutWindowController.h"
 #import "Source/gui/SNTNotificationManager.h"
 
-@interface SNTStatusItemManager ()
+// Per-mode descriptor: the titles, the request/cancel XPC calls, and the
+// error-message map that differ between Temporary Monitor Mode and Temporary
+// Admin Mode. The shared menu/countdown code is driven by this.
+@interface SNTTimedModeDescriptor : NSObject
+@property(copy) NSString* enterTitle;
+@property(copy) NSString* leaveTitle;
+@property(copy) NSString* refreshTitle;
+// Short label used to disambiguate this mode's countdown in the status-bar title
+// when more than one timed mode is active simultaneously.
+@property(copy) NSString* statusLabel;
+@property(copy) void (^request)(id proxy, void (^reply)(uint32_t minutes, NSError* err));
+@property(copy) void (^cancel)(id proxy, void (^reply)(NSError* err));
+@property(copy) NSString* (^messageForError)(NSInteger code);
+@end
+
+@implementation SNTTimedModeDescriptor
+@end
+
+// Per-mode mutable state: the menu items, the countdown timer, and the current
+// expiration. One instance per mode; the shared code operates on whichever state
+// corresponds to the menu item that was clicked.
+@interface SNTTimedModeState : NSObject
+@property(strong) SNTTimedModeDescriptor* descriptor;
+@property NSMenuItem* menuItem;
+@property NSMenuItem* refreshItem;
+@property(atomic, strong) NSTimer* timer;
+@property(atomic, strong) NSDate* expiration;
+@end
+
+@implementation SNTTimedModeState
+@end
+
+@interface SNTStatusItemManager () <NSMenuDelegate>
 @property SNTAboutWindowController* aboutWindowController;
 @property(strong, nonatomic, readwrite) NSStatusItem* statusItem;
 @property SNTKVOManager* kvoEnableMenuItem;
@@ -36,18 +68,21 @@
 // Sync items
 @property NSMenuItem* syncMenuItem;
 
-// Temporary monitor mode items
-@property(atomic, strong) NSTimer* temporaryMonitorModeTimer;
-@property(atomic, strong) NSDate* temporaryMonitorModeExpiration;
+// Temporary mode (Monitor / Admin) state. One descriptor-backed state per mode;
+// the shared menu/countdown code operates on whichever the user interacts with.
+@property(strong) SNTTimedModeState* tmmState;
+@property(strong) SNTTimedModeState* tamState;
 @property(atomic, strong) NSTimer* iconTintTimer;
-@property NSMenuItem* temporaryMonitorModeMenuItem;
-@property NSMenuItem* temporaryMonitorModeRefreshItem;
 
 // Reset silences item
 @property NSMenuItem* resetSilencesMenuItem;
 
 // Countdown formatter
 @property(nonatomic, strong) NSDateComponentsFormatter* countdownFormatter;
+
+// Last status-bar title pushed via refreshStatusTitle, used to suppress redundant
+// updates (the per-mode timers fire every 5s but the displayed units change slowly).
+@property(copy) NSString* lastStatusTitle;
 @end
 
 static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
@@ -61,6 +96,11 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
     self.countdownFormatter.allowedUnits =
         NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute;
     self.countdownFormatter.unitsStyle = NSDateComponentsFormatterUnitsStyleAbbreviated;
+
+    self.tmmState = [[SNTTimedModeState alloc] init];
+    self.tmmState.descriptor = [self monitorModeDescriptor];
+    self.tamState = [[SNTTimedModeState alloc] init];
+    self.tamState.descriptor = [self adminModeDescriptor];
 
     [self setupStatusBarItem];
 
@@ -98,6 +138,91 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
                                                object:nil];
   }
   return self;
+}
+
+- (SNTTimedModeDescriptor*)monitorModeDescriptor {
+  SNTTimedModeDescriptor* d = [[SNTTimedModeDescriptor alloc] init];
+  d.enterTitle = @"Enter Temporary Monitor Mode";
+  d.leaveTitle = @"Leave Temporary Monitor Mode";
+  d.refreshTitle = @"Refresh Temporary Monitor Mode";
+  d.statusLabel = @"Monitor";
+  d.request = ^(id proxy, void (^reply)(uint32_t, NSError*)) {
+    [proxy requestTemporaryMonitorModeWithDurationMinutes:0 reply:reply];
+  };
+  d.cancel = ^(id proxy, void (^reply)(NSError*)) {
+    [proxy cancelTemporaryMonitorMode:reply];
+  };
+  d.messageForError = ^NSString*(NSInteger code) {
+    switch (code) {
+      case SNTErrorCodeTMMNoPolicy:
+        return NSLocalizedString(
+            @"Failed to enter temporary monitor mode: this machine does not currently have a "
+            @"policy allowing temporary monitor mode",
+            @"Error message shown when user tries to enter TMM mode without a policy");
+      case SNTErrorCodeTMMNotInLockdown:
+        return NSLocalizedString(
+            @"Failed to enter temporary monitor mode: not currently in lockdown",
+            @"Error message shown when user tries to enter TMM while not in lockdown");
+      case SNTErrorCodeTMMAuthFailed:
+        return NSLocalizedString(
+            @"Failed to enter temporary monitor mode: authorization failed",
+            @"Error message shown when user tries to enter TMM but authorization failed");
+      case SNTErrorCodeTMMInvalidSyncServer:
+        return NSLocalizedString(
+            @"Failed to enter temporary monitor mode: not using a supported sync server",
+            @"Error message shown when user tries to enter TMM while not using Workshop");
+      default:
+        return NSLocalizedString(
+            @"Failed to enter temporary monitor mode: an unknown error occurred",
+            @"Error shown when user tries to enter TMM and an unknown error occurred.");
+    }
+  };
+  return d;
+}
+
+- (SNTTimedModeDescriptor*)adminModeDescriptor {
+  SNTTimedModeDescriptor* d = [[SNTTimedModeDescriptor alloc] init];
+  d.enterTitle = @"Request Admin Privileges";
+  d.leaveTitle = @"Leave Admin Privileges";
+  d.refreshTitle = @"Refresh Admin Privileges";
+  d.statusLabel = @"Admin";
+  d.request = ^(id proxy, void (^reply)(uint32_t, NSError*)) {
+    [proxy requestTemporaryAdminModeWithDurationMinutes:0 reply:reply];
+  };
+  d.cancel = ^(id proxy, void (^reply)(NSError*)) {
+    [proxy cancelTemporaryAdminMode:reply];
+  };
+  d.messageForError = ^NSString*(NSInteger code) {
+    switch (code) {
+      case SNTErrorCodeTAMNoPolicy:
+        return NSLocalizedString(
+            @"Failed to request admin privileges: this machine does not currently allow "
+            @"temporary admin elevation",
+            @"Error shown when requesting admin without a policy");
+      case SNTErrorCodeTAMAlreadyAdmin:
+        return NSLocalizedString(
+            @"Failed to request admin privileges: you are already an administrator",
+            @"Error shown when a natural admin requests elevation");
+      case SNTErrorCodeTAMAuthFailed:
+        return NSLocalizedString(@"Failed to request admin privileges: authorization failed",
+                                 @"Error shown when admin elevation authorization fails");
+      case SNTErrorCodeTAMJustificationRequired:
+        return NSLocalizedString(@"Failed to request admin privileges: a justification is required",
+                                 @"Error shown when a justification is required but not given");
+      case SNTErrorCodeTAMSessionAlreadyActive:
+        return NSLocalizedString(
+            @"Failed to request admin privileges: a session is already active for another user",
+            @"Error shown when another user already has an active session");
+      case SNTErrorCodeTAMMembershipChangeFailed:
+        return NSLocalizedString(
+            @"Failed to request admin privileges: the admin group membership change failed",
+            @"Error shown when the group membership change fails");
+      default:
+        return NSLocalizedString(@"Failed to request admin privileges: an unknown error occurred",
+                                 @"Error shown when admin elevation fails with an unknown error");
+    }
+  };
+  return d;
 }
 
 - (void)setupStatusBarItem {
@@ -143,41 +268,131 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
   // Add separator
   [menu addItem:[NSMenuItem separatorItem]];
 
-  // Add temporary monitor mode items (hidden by default until policy is verified)
-  self.temporaryMonitorModeMenuItem = [self menuItemWithTitle:@"Enter Temporary Monitor Mode"
-                                                    andAction:@selector(tmmMenuItemClicked:)];
-  self.temporaryMonitorModeMenuItem.hidden = YES;
-  [menu addItem:self.temporaryMonitorModeMenuItem];
+  // Add temporary-mode (Monitor / Admin) items, hidden by default until
+  // availability is verified.
+  [self addMenuItemsForState:self.tmmState toMenu:menu];
+  [self addMenuItemsForState:self.tamState toMenu:menu];
 
-  self.temporaryMonitorModeRefreshItem = [self menuItemWithTitle:@"Refresh Temporary Monitor Mode"
-                                                       andAction:@selector(tmmRefreshItemClicked:)];
-  self.temporaryMonitorModeRefreshItem.target = nil;
-  self.temporaryMonitorModeRefreshItem.hidden = YES;
-  [menu addItem:self.temporaryMonitorModeRefreshItem];
-
+  menu.delegate = self;
   self.statusItem.menu = menu;
 
+  [self refreshAllTimedModeStateAsync];
+}
+
+- (void)addMenuItemsForState:(SNTTimedModeState*)state toMenu:(NSMenu*)menu {
+  state.menuItem = [self menuItemWithTitle:state.descriptor.enterTitle
+                                 andAction:@selector(timedModeMenuItemClicked:)];
+  state.menuItem.hidden = YES;
+  [menu addItem:state.menuItem];
+
+  state.refreshItem = [self menuItemWithTitle:state.descriptor.refreshTitle
+                                    andAction:@selector(timedModeRefreshItemClicked:)];
+  state.refreshItem.target = nil;
+  state.refreshItem.hidden = YES;
+  [menu addItem:state.refreshItem];
+}
+
+// Resolve which mode's state a clicked menu item belongs to.
+- (SNTTimedModeState*)stateForSender:(id)sender {
+  if (sender == self.tamState.menuItem || sender == self.tamState.refreshItem) {
+    return self.tamState;
+  }
+  return self.tmmState;
+}
+
+// Vend a resumed synchronous control proxy to `block`, then invalidate the connection.
+// The synchronous proxy blocks until each reply runs, so the connection stays valid for
+// the duration of `block`; this centralizes the connect/resume/invalidate lifecycle.
+- (void)withControlProxy:(void (^)(id proxy))block {
+  MOLXPCConnection* daemonConn = [SNTXPCControlInterface configuredConnection];
+  [daemonConn resume];
+  block([daemonConn synchronousRemoteObjectProxy]);
+  [daemonConn invalidate];
+}
+
+// Re-query the daemon for live Monitor + Admin session/availability state off the main thread.
+- (void)refreshAllTimedModeStateAsync {
   dispatch_async(dispatch_get_global_queue(0, 0), ^{
-    [self retrieveTMMState];
+    [self retrieveMonitorModeState];
+    [self retrieveAdminModeState];
   });
 }
 
-- (void)retrieveTMMState {
-  // Check whether temporary monitor mode is available and if we're currently in it.
-  MOLXPCConnection* daemonConn = [SNTXPCControlInterface configuredConnection];
-  [daemonConn resume];
-  [[daemonConn synchronousRemoteObjectProxy]
-      checkTemporaryMonitorModePolicyAvailable:^(BOOL available) {
-        [self setTemporaryMonitorModePolicyAvailable:available];
-      }];
-  [[daemonConn synchronousRemoteObjectProxy]
-      temporaryMonitorModeSecondsRemaining:^(NSNumber* seconds) {
-        if (seconds) {
-          NSDate* expiry = [NSDate dateWithTimeIntervalSinceNow:[seconds intValue]];
-          [self enterMonitorModeWithExpiration:expiry];
-        }
-      }];
-  [daemonConn invalidate];
+- (void)retrieveMonitorModeState {
+  [self withControlProxy:^(id proxy) {
+    [proxy checkTemporaryMonitorModePolicyAvailable:^(BOOL available) {
+      [self setAvailable:available forState:self.tmmState];
+    }];
+    [proxy temporaryMonitorModeSecondsRemaining:^(NSNumber* seconds) {
+      if (seconds) {
+        [self enterModeWithExpiration:[NSDate dateWithTimeIntervalSinceNow:[seconds intValue]]
+                             forState:self.tmmState];
+      } else if (self.tmmState.expiration) {
+        // The daemon reports no active session but the GUI still shows one (a leave
+        // notification can be missed while this session is inactive, e.g. fast user
+        // switching). Clear the stale countdown on the main thread (the timer lives there).
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [self leaveModeForState:self.tmmState];
+        });
+      }
+    }];
+  }];
+}
+
+- (void)retrieveAdminModeState {
+  [self withControlProxy:^(id proxy) {
+    // Determine the active session first (sets the expiration / "Leave" title), then
+    // compute visibility (which depends on whether a session is active).
+    [proxy temporaryAdminModeSecondsRemaining:^(NSNumber* seconds) {
+      if (seconds) {
+        [self enterModeWithExpiration:[NSDate dateWithTimeIntervalSinceNow:[seconds intValue]]
+                             forState:self.tamState];
+      } else if (self.tamState.expiration) {
+        // The daemon reports no active session but the GUI still shows one (a leave
+        // notification can be missed while this session is inactive, e.g. fast user
+        // switching). Clear the stale countdown on the main thread (the timer lives there).
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [self leaveModeForState:self.tamState];
+        });
+      }
+    }];
+    [proxy checkTemporaryAdminModeAvailable:^(BOOL available, BOOL alreadyAdmin) {
+      [self setAdminItemVisibleWhenAvailable:available alreadyAdmin:alreadyAdmin];
+    }];
+  }];
+}
+
+// The admin item is visible while a session is active (so it can be left — note an
+// active session makes the user a group-80 member, so `alreadyAdmin` is true) or
+// when elevation is available and the user is not already an admin.
+- (void)setAdminItemVisibleWhenAvailable:(BOOL)available alreadyAdmin:(BOOL)alreadyAdmin {
+  BOOL active = (self.tamState.expiration != nil);
+  [self setAvailable:(active || (available && !alreadyAdmin)) forState:self.tamState];
+}
+
+// Re-query Temporary Admin Mode availability against live state each time the menu
+// opens. The user's admin status and policy availability can change after launch
+// (e.g. dropping admin) between sync pushes. checkTemporaryAdminModeAvailable: does not
+// re-enter the GUI, so a synchronous call here is safe (unlike the request path, which is
+// dispatched off the main thread).
+- (void)menuNeedsUpdate:(NSMenu*)menu {
+  [self withControlProxy:^(id proxy) {
+    [proxy checkTemporaryAdminModeAvailable:^(BOOL available, BOOL alreadyAdmin) {
+      [self setAdminItemVisibleWhenAvailable:available alreadyAdmin:alreadyAdmin];
+    }];
+  }];
+}
+
+// Re-query the daemon for live Monitor/Admin session + availability state. Called when this
+// user's session becomes active again (e.g. returning from fast user switching), where daemon
+// push notifications (enter/leave/availability) sent while the session was inactive were missed.
+// Uses retrieve*ModeState's own short-lived control connection, so it does not depend on the
+// daemon->GUI notifier listener (which is torn down while the session is inactive).
+- (void)reconcileTimedModeState {
+  if (!self.statusItem) {
+    return;
+  }
+  [self refreshAllTimedModeStateAsync];
 }
 
 - (void)removeStatusBarItem {
@@ -186,8 +401,10 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
     self.statusItem = nil;
     self.syncMenuItem = nil;
     self.resetSilencesMenuItem = nil;
-    self.temporaryMonitorModeMenuItem = nil;
-    self.temporaryMonitorModeRefreshItem = nil;
+    self.tmmState.menuItem = nil;
+    self.tmmState.refreshItem = nil;
+    self.tamState.menuItem = nil;
+    self.tamState.refreshItem = nil;
   }
 }
 
@@ -207,92 +424,49 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
   [self showAboutWindow];
 }
 
-- (void)tmmRefreshItemClicked:(id)sender {
-  MOLXPCConnection* daemonConn = [SNTXPCControlInterface configuredConnection];
-  [daemonConn resume];
-  [[daemonConn synchronousRemoteObjectProxy]
-      requestTemporaryMonitorModeWithDurationMinutes:0
-                                               reply:^(uint32 minutes, NSError* err) {
-                                                 if (err) {
-                                                   // TODO: Handle this properly
-                                                   NSLog(@"Failed to refresh TMM");
-                                                 }
-                                               }];
-  [daemonConn invalidate];
+- (void)timedModeRefreshItemClicked:(id)sender {
+  SNTTimedModeState* state = [self stateForSender:sender];
+  SNTTimedModeDescriptor* descriptor = state.descriptor;
+  // Run off the main thread: the request re-enters the GUI synchronously (the daemon
+  // calls back to authorize, which must present UI on the main thread). Blocking the
+  // main thread here would deadlock against that callback.
+  dispatch_async(dispatch_get_global_queue(0, 0), ^{
+    [self withControlProxy:^(id proxy) {
+      descriptor.request(proxy, ^(uint32_t minutes, NSError* err) {
+        if (err) {
+          NSLog(@"Failed to refresh timed mode: %@", err.localizedDescription);
+        }
+      });
+    }];
+  });
 }
 
-- (void)tmmMenuItemClicked:(id)sender {
-  MOLXPCConnection* daemonConn = [SNTXPCControlInterface configuredConnection];
-  [daemonConn resume];
-
-  if (self.temporaryMonitorModeExpiration) {
-    [[daemonConn synchronousRemoteObjectProxy] cancelTemporaryMonitorMode:^(NSError* err) {
-      if (err) {
-        [self notificationWithIdentifier:@"tmm_cancel_failed_notification"
-                                 andBody:err.localizedDescription];
+- (void)timedModeMenuItemClicked:(id)sender {
+  SNTTimedModeState* state = [self stateForSender:sender];
+  SNTTimedModeDescriptor* descriptor = state.descriptor;
+  // Run off the main thread: the request re-enters the GUI synchronously (the daemon
+  // calls back to authorize, which must present UI on the main thread). Blocking the
+  // main thread here would deadlock against that callback.
+  dispatch_async(dispatch_get_global_queue(0, 0), ^{
+    [self withControlProxy:^(id proxy) {
+      if (state.expiration) {
+        descriptor.cancel(proxy, ^(NSError* err) {
+          if (err) {
+            [self notificationWithIdentifier:@"timed_mode_cancel_failed_notification"
+                                     andBody:err.localizedDescription];
+          }
+        });
+      } else {
+        descriptor.request(proxy, ^(uint32_t minutes, NSError* err) {
+          if (err) {
+            [self temporarilyTintIconWithColor:[NSColor colorNamed:@"SyncFailureColor"]];
+            [self notificationWithIdentifier:@"timed_mode_enter_failed_notification"
+                                     andBody:descriptor.messageForError(err.code)];
+          }
+        });
       }
     }];
-  } else {
-    [[daemonConn synchronousRemoteObjectProxy]
-        requestTemporaryMonitorModeWithDurationMinutes:0
-                                                 reply:^(uint32 minutes, NSError* err) {
-                                                   if (err) {
-                                                     [self temporarilyTintIconWithColor:
-                                                               [NSColor
-                                                                   colorNamed:@"SyncFailureColor"]];
-                                                     NSString* failureDescription;
-                                                     switch (err.code) {
-                                                       case SNTErrorCodeTMMNoPolicy:
-                                                         failureDescription = NSLocalizedString(
-                                                             @"Failed to enter temporary monitor "
-                                                             @"mode: this machine does not "
-                                                             @"currently have a policy allowing "
-                                                             @"temporary monitor mode",
-                                                             @"Error message shown when user tries "
-                                                             @"to enter TMM mode without a policy");
-                                                         break;
-                                                       case SNTErrorCodeTMMNotInLockdown:
-                                                         failureDescription = NSLocalizedString(
-                                                             @"Failed to enter temporary monitor "
-                                                             @"mode: not currently in lockdown",
-                                                             @"Error message shown when user tries "
-                                                             @"to enter TMM while not in lockdown");
-                                                         break;
-                                                       case SNTErrorCodeTMMAuthFailed:
-                                                         failureDescription = NSLocalizedString(
-                                                             @"Failed to enter temporary monitor "
-                                                             @"mode: authorization failed",
-                                                             @"Error message shown when user tries "
-                                                             @"to enter TMM but authorization "
-                                                             @"failed");
-                                                         break;
-                                                       case SNTErrorCodeTMMInvalidSyncServer:
-                                                         failureDescription = NSLocalizedString(
-                                                             @"Failed to enter temporary monitor "
-                                                             @"mode: not using a supported sync "
-                                                             @"server",
-                                                             @"Error message shown when user tries "
-                                                             @"to enter TMM while not using "
-                                                             @"Workshop");
-                                                         break;
-                                                       default:
-                                                         failureDescription = NSLocalizedString(
-                                                             @"Failed to enter temporary monitor "
-                                                             @"mode: an unknown error occurred",
-                                                             @"Error shown when user tries to "
-                                                             @"enter TMM and an unknown error "
-                                                             @"occurred.");
-                                                         break;
-                                                     }
-                                                     [self
-                                                         notificationWithIdentifier:
-                                                             @"tmm_enter_failed_notification"
-                                                                            andBody:
-                                                                                failureDescription];
-                                                   }
-                                                 }];
-  }
-  [daemonConn invalidate];
+  });
 }
 
 - (void)resetSilencesMenuItemClicked:(id)sender {
@@ -390,65 +564,129 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
   });
 }
 
-- (void)enterMonitorModeWithExpiration:(NSDate*)expiration {
-  self.temporaryMonitorModeExpiration = expiration;
+- (void)enterModeWithExpiration:(NSDate*)expiration forState:(SNTTimedModeState*)state {
+  state.expiration = expiration;
 
   // Invalidate any existing timer
-  [self.temporaryMonitorModeTimer invalidate];
+  [state.timer invalidate];
 
   // Update menu options
-  self.temporaryMonitorModeMenuItem.title = @"Leave Temporary Monitor Mode";
-  self.temporaryMonitorModeRefreshItem.target = self;
+  state.menuItem.title = state.descriptor.leaveTitle;
+  state.refreshItem.target = self;
 
   // Create a timer that updates the countdown display. Using a 5 second interval is sufficient
-  // since the displayed units are days/hours/minutes which change infrequently.
+  // since the displayed units are days/hours/minutes which change infrequently. The timer only
+  // detects this mode's expiry; the title itself is composed from all active modes by
+  // refreshStatusTitle so concurrent TMM/TAM sessions are both shown.
   dispatch_async(dispatch_get_main_queue(), ^{
-    __block NSString* previousTitle = nil;
-
     // Fire immediately to set the initial title, then repeat every 5 seconds.
-    self.temporaryMonitorModeTimer = [NSTimer
-        scheduledTimerWithTimeInterval:5.0
-                               repeats:YES
-                                 block:^(NSTimer* timer) {
-                                   if (!self.temporaryMonitorModeExpiration) {
-                                     [self leaveMonitorMode];
-                                     return;
-                                   }
-
-                                   NSTimeInterval remainingSeconds =
-                                       [self.temporaryMonitorModeExpiration timeIntervalSinceNow];
-
-                                   // If time has expired, stop the timer
-                                   if (remainingSeconds <= 0) {
-                                     [self leaveMonitorMode];
-                                     return;
-                                   }
-
-                                   NSString* title = [self.countdownFormatter
-                                       stringFromDate:[NSDate now]
-                                               toDate:self.temporaryMonitorModeExpiration];
-                                   if (![title isEqualToString:previousTitle]) {
-                                     previousTitle = title;
-                                     [self updateTitle:title];
-                                   }
-                                 }];
-    [self.temporaryMonitorModeTimer fire];
+    state.timer =
+        [NSTimer scheduledTimerWithTimeInterval:5.0
+                                        repeats:YES
+                                          block:^(NSTimer* timer) {
+                                            if (!state.expiration ||
+                                                [state.expiration timeIntervalSinceNow] <= 0) {
+                                              [self leaveModeForState:state];
+                                              return;
+                                            }
+                                            [self refreshStatusTitle];
+                                          }];
+    [state.timer fire];
   });
 }
 
-- (void)leaveMonitorMode {
-  [self.temporaryMonitorModeTimer invalidate];
-  self.temporaryMonitorModeTimer = nil;
-  self.temporaryMonitorModeExpiration = nil;
+// Compose the status-bar title from every currently-active timed mode. With a single
+// active mode the bare countdown is shown (preserving the original single-mode display);
+// with more than one, each countdown is labeled (e.g. "Monitor 4m  ·  Admin 2m") so they
+// are distinguishable. This is the single writer of the status-bar title, so concurrent
+// modes no longer clobber each other and leaving one mode does not blank the survivor.
+- (void)refreshStatusTitle {
+  NSMutableArray<SNTTimedModeState*>* active = [NSMutableArray array];
+  for (SNTTimedModeState* state in @[ self.tmmState, self.tamState ]) {
+    if (state.expiration && [state.expiration timeIntervalSinceNow] > 0) {
+      [active addObject:state];
+    }
+  }
 
-  [self updateTitle:@""];
-  self.temporaryMonitorModeMenuItem.title = @"Enter Temporary Monitor Mode";
-  self.temporaryMonitorModeRefreshItem.target = nil;
+  NSString* title;
+  if (active.count == 0) {
+    title = @"";
+  } else if (active.count == 1) {
+    title = [self.countdownFormatter stringFromDate:[NSDate now]
+                                             toDate:active.firstObject.expiration];
+  } else {
+    NSMutableArray<NSString*>* parts = [NSMutableArray array];
+    for (SNTTimedModeState* state in active) {
+      NSString* countdown = [self.countdownFormatter stringFromDate:[NSDate now]
+                                                             toDate:state.expiration];
+      [parts
+          addObject:[NSString stringWithFormat:@"%@ %@", state.descriptor.statusLabel, countdown]];
+    }
+    title = [parts componentsJoinedByString:@"  ·  "];
+  }
+
+  if (![title isEqualToString:self.lastStatusTitle]) {
+    self.lastStatusTitle = title;
+    [self updateTitle:title];
+  }
+}
+
+- (void)leaveModeForState:(SNTTimedModeState*)state {
+  [state.timer invalidate];
+  state.timer = nil;
+  state.expiration = nil;
+
+  // Recompose rather than blanking: another mode may still be active and must keep
+  // showing its countdown.
+  [self refreshStatusTitle];
+  state.menuItem.title = state.descriptor.enterTitle;
+  state.refreshItem.target = nil;
+}
+
+- (void)setAvailable:(BOOL)available forState:(SNTTimedModeState*)state {
+  state.menuItem.hidden = !available;
+  state.refreshItem.hidden = !available;
+}
+
+// Public wrappers used by SNTNotificationManager (daemon-pushed enter/leave/availability).
+- (void)enterMonitorModeWithExpiration:(NSDate*)expiration {
+  [self enterModeWithExpiration:expiration forState:self.tmmState];
+}
+
+- (void)leaveMonitorMode {
+  [self leaveModeForState:self.tmmState];
 }
 
 - (void)setTemporaryMonitorModePolicyAvailable:(BOOL)available {
-  self.temporaryMonitorModeMenuItem.hidden = !available;
-  self.temporaryMonitorModeRefreshItem.hidden = !available;
+  [self setAvailable:available forState:self.tmmState];
+}
+
+- (void)enterAdminModeWithExpiration:(NSDate*)expiration {
+  [self enterModeWithExpiration:expiration forState:self.tamState];
+}
+
+- (void)leaveAdminMode {
+  [self leaveModeForState:self.tamState];
+}
+
+- (void)setTemporaryAdminModeAvailable:(BOOL)available {
+  [self setAvailable:available forState:self.tamState];
+}
+
+- (void)temporaryAdminModeSessionResignedActive {
+  // Only message the daemon if an admin session is currently shown for this user. The daemon's
+  // audit-token uid match is authoritative; this is just an optimization to avoid waking it.
+  if (!self.tamState.expiration || [self.tamState.expiration timeIntervalSinceNow] <= 0) {
+    return;
+  }
+  // Fire-and-forget on a background queue (must not block the main thread, especially during
+  // session teardown). The reply is ignored.
+  dispatch_async(dispatch_get_global_queue(0, 0), ^{
+    [self withControlProxy:^(id proxy) {
+      [proxy temporaryAdminModeSessionResignedActive:^(NSError*){
+      }];
+    }];
+  });
 }
 
 - (NSMenuItem*)menuItemWithTitle:(NSString*)title andAction:(SEL)action {

--- a/Source/santactl/Commands/SNTCommandStatus.mm
+++ b/Source/santactl/Commands/SNTCommandStatus.mm
@@ -290,6 +290,21 @@ REGISTER_COMMAND_NAME(@"status")
     }];
   }
 
+  // Temporary Admin Mode status for the invoking user. The daemon resolves the
+  // target uid from the XPC peer audit token; `secondsRemaining` is nil when no
+  // session is active.
+  __block BOOL temporaryAdminModeAvailable = NO;
+  __block BOOL currentUserIsAdmin = NO;
+  [rop checkTemporaryAdminModeAvailable:^(BOOL available, BOOL alreadyAdmin) {
+    temporaryAdminModeAvailable = available;
+    currentUserIsAdmin = alreadyAdmin;
+  }];
+
+  __block NSNumber* temporaryAdminModeSecondsRemaining = nil;
+  [rop temporaryAdminModeSecondsRemaining:^(NSNumber* secs) {
+    temporaryAdminModeSecondsRemaining = secs;
+  }];
+
   // Format dates
   NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
   dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
@@ -465,6 +480,15 @@ REGISTER_COMMAND_NAME(@"status")
       stats[@"telemetry"][@"export_interval_seconds"] = @(telemetryExportInterval);
     }
 
+    NSMutableDictionary* temporaryAdminMode = [@{
+      @"available" : @(temporaryAdminModeAvailable),
+      @"current_user_is_admin" : @(currentUserIsAdmin),
+    } mutableCopy];
+    if (temporaryAdminModeSecondsRemaining != nil) {
+      temporaryAdminMode[@"session_seconds_remaining"] = temporaryAdminModeSecondsRemaining;
+    }
+    stats[@"temporary_admin_mode"] = temporaryAdminMode;
+
     NSData* statsData = [NSJSONSerialization dataWithJSONObject:stats
                                                         options:NSJSONWritingPrettyPrinted
                                                           error:nil];
@@ -504,6 +528,15 @@ REGISTER_COMMAND_NAME(@"status")
     printf("  %-40s | %lld\n", "Static Rules", staticRuleCount);
     printf("  %-40s | %lld  (Peak: %.2f%%)\n", "Watchdog CPU Events", cpuEvents, cpuPeak);
     printf("  %-40s | %lld  (Peak: %.2fMB)\n", "Watchdog RAM Events", ramEvents, ramPeak);
+
+    printf(">>> Temporary Admin Mode\n");
+    printf("  %-40s | %s\n", "Available", (temporaryAdminModeAvailable ? "Yes" : "No"));
+    printf("  %-40s | %s\n", "Current User Is Admin", (currentUserIsAdmin ? "Yes" : "No"));
+    if (temporaryAdminModeSecondsRemaining != nil) {
+      printf("  %-40s | %s\n", "Session Time Remaining",
+             [FormatTimeRemaining([temporaryAdminModeSecondsRemaining unsignedLongLongValue])
+                 UTF8String]);
+    }
 
     printf(">>> Cache Info\n");
     printf("  %-40s | %lld\n", "Root cache count", rootCacheCount);

--- a/Source/santad/AdminGroupMembership.h
+++ b/Source/santad/AdminGroupMembership.h
@@ -1,0 +1,56 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_SANTAD_ADMINGROUPMEMBERSHIP_H
+#define SANTA_SANTAD_ADMINGROUPMEMBERSHIP_H
+
+#import <Foundation/Foundation.h>
+
+#include <sys/types.h>
+#include <memory>
+
+namespace santa {
+
+// Abstracts mutation of admin-group (GID 80) membership. The orchestrator depends
+// only on this interface so it can be unit-tested with a fake, and so the
+// privileged backing can be either an in-process CoreServices call or an XPC call
+// to a root helper without changing any consumer.
+class AdminGroupMembership {
+ public:
+  static constexpr gid_t kAdminGroupID = 80;
+
+  virtual ~AdminGroupMembership() = default;
+
+  // Returns true if `uid` is currently a member of the admin group.
+  virtual bool IsMember(uid_t uid) = 0;
+
+  // Adds `uid` to the admin group and commits. A committed add is authoritative;
+  // a post-commit verification mismatch (opendirectoryd cache latency) is logged,
+  // not failed. Returns true on a committed change; populates `error` on failure.
+  virtual bool AddMember(uid_t uid, NSError** error) = 0;
+
+  // Removes `uid` from the admin group and commits. Fails closed: a committed
+  // remove that the verification re-read still shows as a member (after one bounded
+  // retry) returns false and populates `error`, so callers never record a clean
+  // revocation for a user who is still elevated. Returns true only on a verified
+  // removal; populates `error` on failure.
+  virtual bool RemoveMember(uid_t uid, NSError** error) = 0;
+};
+
+// Returns the in-process CoreServices-backed implementation.
+std::unique_ptr<AdminGroupMembership> CreateAdminGroupMembership();
+
+}  // namespace santa
+
+#endif  // SANTA_SANTAD_ADMINGROUPMEMBERSHIP_H

--- a/Source/santad/AdminGroupMembership.mm
+++ b/Source/santad/AdminGroupMembership.mm
@@ -1,0 +1,165 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/AdminGroupMembership.h"
+
+#import <Collaboration/Collaboration.h>
+#import <CoreServices/CoreServices.h>
+
+#include <pwd.h>
+#include <unistd.h>
+
+#import "Source/common/SNTError.h"
+#import "Source/common/SNTLogging.h"
+
+namespace santa {
+
+namespace {
+
+NSString* UsernameForUID(uid_t uid) {
+  struct passwd* pw = getpwuid(uid);
+  if (!pw || !pw->pw_name) {
+    return nil;
+  }
+  return @(pw->pw_name);
+}
+
+// The admin group is always a local group, so it is resolved with the local
+// identity authority. The user, however, may be a network/directory (e.g. AD)
+// account, so it is resolved with the default authority (local plus managed).
+// This asymmetry is deliberate — a network user must still be addable to the
+// local admin group — and matches the approach used by SAP Privileges. Do not
+// "simplify" both to the same authority.
+CBGroupIdentity* AdminGroupIdentity() {
+  return [CBGroupIdentity groupIdentityWithPosixGID:AdminGroupMembership::kAdminGroupID
+                                          authority:[CBIdentityAuthority localIdentityAuthority]];
+}
+
+CBIdentity* UserIdentityForUID(uid_t uid) {
+  NSString* username = UsernameForUID(uid);
+  if (!username) {
+    return nil;
+  }
+  return [CBIdentity identityWithName:username
+                            authority:[CBIdentityAuthority defaultIdentityAuthority]];
+}
+
+// Delay between the two post-commit verification reads on the remove path, to
+// absorb opendirectoryd membership-cache latency before failing closed.
+static constexpr useconds_t kVerifyRetryDelayUSec = 200 * 1000;  // 200ms
+
+// Re-reads live membership and returns whether it matches `expected`. A failed
+// identity resolution counts as not matching.
+bool VerifyMembership(uid_t uid, bool expected) {
+  CBIdentity* fresh = UserIdentityForUID(uid);
+  return fresh && ([fresh isMemberOfGroup:AdminGroupIdentity()] == expected);
+}
+
+class AdminGroupMembershipImpl : public AdminGroupMembership {
+ public:
+  bool IsMember(uid_t uid) override {
+    CBIdentity* user = UserIdentityForUID(uid);
+    CBGroupIdentity* group = AdminGroupIdentity();
+    if (!user || !group) {
+      return false;
+    }
+    return [user isMemberOfGroup:group];
+  }
+
+  bool AddMember(uid_t uid, NSError** error) override {
+    return ChangeMembership(uid, /*add=*/true, error);
+  }
+
+  bool RemoveMember(uid_t uid, NSError** error) override {
+    return ChangeMembership(uid, /*add=*/false, error);
+  }
+
+ private:
+  bool ChangeMembership(uid_t uid, bool add, NSError** error) {
+    CBIdentity* user = UserIdentityForUID(uid);
+    CBGroupIdentity* group = AdminGroupIdentity();
+    if (!user || !group) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMNoConsoleUser
+                       format:@"Unable to resolve identity for uid %u", uid];
+      return false;
+    }
+
+    CSIdentityRef cs_user = [user CSIdentity];
+    CSIdentityRef cs_group = [group CSIdentity];
+    if (!cs_user || !cs_group) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"Unable to obtain CSIdentity for uid %u", uid];
+      return false;
+    }
+
+    if (add) {
+      CSIdentityAddMember(cs_group, cs_user);
+    } else {
+      CSIdentityRemoveMember(cs_group, cs_user);
+    }
+
+    CFErrorRef commit_error = NULL;
+    if (!CSIdentityCommit(cs_group, NULL, &commit_error)) {
+      NSError* bridged = (NSError*)CFBridgingRelease(commit_error);
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"CSIdentityCommit failed: %@", bridged.localizedDescription];
+      return false;
+    }
+
+    // Re-read membership to verify the commit took effect. opendirectoryd caches
+    // membership with a short TTL, so a single fresh read can lag the commit.
+    //
+    // Add and remove are deliberately asymmetric. For add, optimism favors the
+    // user: a committed add is treated as authoritative and a verify mismatch is
+    // logged, because the next live lookup (sudo, Authorization Services) re-reads
+    // through opendirectoryd anyway. For remove, optimism would favor NOT revoking,
+    // which defeats the feature: a committed remove whose verification still shows
+    // membership is retried once, and if it still shows membership it is reported as
+    // a failure so the caller does not record a clean revocation.
+    if (add) {
+      if (!VerifyMembership(uid, /*expected=*/true)) {
+        LOGW(@"Admin group add committed but verification read still shows "
+             @"non-member (uid=%u) — treating commit as authoritative",
+             uid);
+      }
+      return true;
+    }
+
+    if (VerifyMembership(uid, /*expected=*/false)) {
+      return true;
+    }
+    // One bounded retry to absorb opendirectoryd cache latency.
+    usleep(kVerifyRetryDelayUSec);
+    if (VerifyMembership(uid, /*expected=*/false)) {
+      return true;
+    }
+    [SNTError populateError:error
+                   withCode:SNTErrorCodeTAMMembershipChangeFailed
+                     format:@"Admin group remove committed but uid %u is still a "
+                            @"member after verification",
+                            uid];
+    return false;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<AdminGroupMembership> CreateAdminGroupMembership() {
+  return std::make_unique<AdminGroupMembershipImpl>();
+}
+
+}  // namespace santa

--- a/Source/santad/AdminGroupMembership.mm
+++ b/Source/santad/AdminGroupMembership.mm
@@ -17,7 +17,6 @@
 #import <Collaboration/Collaboration.h>
 #import <CoreServices/CoreServices.h>
 
-#include <pwd.h>
 #include <unistd.h>
 
 #import "Source/common/SNTError.h"
@@ -26,14 +25,6 @@
 namespace santa {
 
 namespace {
-
-NSString* UsernameForUID(uid_t uid) {
-  struct passwd* pw = getpwuid(uid);
-  if (!pw || !pw->pw_name) {
-    return nil;
-  }
-  return @(pw->pw_name);
-}
 
 // The admin group is always a local group, so it is resolved with the local
 // identity authority. The user, however, may be a network/directory (e.g. AD)
@@ -46,13 +37,17 @@ CBGroupIdentity* AdminGroupIdentity() {
                                           authority:[CBIdentityAuthority localIdentityAuthority]];
 }
 
+// Resolve the user by numeric POSIX UID rather than by name. The UID is the
+// stable, unambiguous directory key we already hold; resolving by name would put
+// a non-reentrant getpwuid on this privileged mutation path — where a clobbered
+// pw_name would change which account is added to or removed from the admin group
+// — and could disagree across the separate IsMember / ChangeMembership /
+// VerifyMembership lookups if the account were renamed between them. The default
+// authority is retained so network/directory users still resolve (see
+// AdminGroupIdentity for the group/user authority asymmetry).
 CBIdentity* UserIdentityForUID(uid_t uid) {
-  NSString* username = UsernameForUID(uid);
-  if (!username) {
-    return nil;
-  }
-  return [CBIdentity identityWithName:username
-                            authority:[CBIdentityAuthority defaultIdentityAuthority]];
+  return [CBUserIdentity userIdentityWithPosixUID:uid
+                                        authority:[CBIdentityAuthority defaultIdentityAuthority]];
 }
 
 // Delay between the two post-commit verification reads on the remove path, to

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -385,6 +385,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
         "//Source/common:SNTTemporaryAdminPolicy",
+        "//Source/common:SNTXPCNotifierInterface",
         "@abseil-cpp//absl/synchronization",
     ],
 )

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -60,6 +60,7 @@ objc_library(
         "//Source/common:SNTStoredExecutionEvent",
         "//Source/common:SNTStoredFileAccessEvent",
         "//Source/common:SNTStoredSignalReport",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
         "//Source/common:SNTStoredTemporaryMonitorModeAuditEvent",
         "//Source/common:SantaCache",
         "//Source/common:String",
@@ -362,6 +363,45 @@ santa_unit_test(
         ":TemporaryMonitorMode",
         ":TimedSyncSession",
         "//Source/common:SNTModeTransition",
+        "//Source/common:SystemResources",
+        "@OCMock",
+    ],
+)
+
+objc_library(
+    name = "TemporaryAdminMode",
+    srcs = ["TemporaryAdminMode.mm"],
+    hdrs = ["TemporaryAdminMode.h"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
+    deps = [
+        ":AdminGroupMembership",
+        ":SNTNotificationQueue",
+        ":TimedSyncSession",
+        "//Source/common:PassKey",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTError",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
+        "//Source/common:SNTTemporaryAdminPolicy",
+        "@abseil-cpp//absl/synchronization",
+    ],
+)
+
+santa_unit_test(
+    name = "TemporaryAdminModeTest",
+    srcs = ["TemporaryAdminModeTest.mm"],
+    deps = [
+        ":AdminGroupMembership",
+        ":SNTNotificationQueue",
+        ":TemporaryAdminMode",
+        ":TimedSyncSession",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTError",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
+        "//Source/common:SNTSystemInfo",
+        "//Source/common:SNTTemporaryAdminPolicy",
         "//Source/common:SystemResources",
         "@OCMock",
     ],
@@ -1083,10 +1123,25 @@ santa_unit_test(
 )
 
 objc_library(
+    name = "AdminGroupMembership",
+    srcs = ["AdminGroupMembership.mm"],
+    hdrs = ["AdminGroupMembership.h"],
+    sdk_frameworks = [
+        "Collaboration",
+        "CoreServices",
+    ],
+    deps = [
+        "//Source/common:SNTError",
+        "//Source/common:SNTLogging",
+    ],
+)
+
+objc_library(
     name = "SNTDaemonControlController",
     srcs = ["SNTDaemonControlController.mm"],
     hdrs = ["SNTDaemonControlController.h"],
     deps = [
+        ":AdminGroupMembership",
         ":AuthResultCache",
         ":EndpointSecurityLogger",
         ":KillingMachine",
@@ -1098,6 +1153,7 @@ objc_library(
         ":SNTRuleTable",
         ":SNTSyncdQueue",
         ":SandboxExpectations",
+        ":TemporaryAdminMode",
         ":TemporaryMonitorMode",
         "//Source/common:MOLCodesignChecker",
         "//Source/common:MOLXPCConnection",
@@ -1117,7 +1173,9 @@ objc_library(
         "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SNTSandboxExecRequest",
         "//Source/common:SNTStoredExecutionEvent",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
         "//Source/common:SNTStrengthify",
+        "//Source/common:SNTTemporaryAdminPolicy",
         "//Source/common:SNTTimer",
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCNotifierInterface",
@@ -1362,6 +1420,7 @@ santa_unit_test(
         "//Source/common:SNTStoredFileAccessEvent",
         "//Source/common:SNTStoredProcess",
         "//Source/common:SNTStoredSignalReport",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
         "//Source/common:SNTStoredTemporaryMonitorModeAuditEvent",
         "//Source/common:SantaCache",
         "//Source/common:String",
@@ -1912,6 +1971,7 @@ test_suite(
         ":SandboxExpectationsTest",
         ":SantadTest",
         ":SleighLauncherTest",
+        ":TemporaryAdminModeTest",
         ":TemporaryMonitorModeTest",
         "//Source/common/es:EndpointSecurityClientTest",
         "//Source/common/es:EndpointSecurityEnricherTest",

--- a/Source/santad/DataLayer/SNTEventTable.mm
+++ b/Source/santad/DataLayer/SNTEventTable.mm
@@ -23,6 +23,7 @@
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStoredFileAccessEvent.h"
 #import "Source/common/SNTStoredSignalReport.h"
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
 #import "Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h"
 #include "Source/common/SantaCache.h"
 #include "Source/common/String.h"
@@ -135,6 +136,9 @@ static const NSTimeInterval kSignalReportDedupWindowSeconds = (60 * 10);
   } else if ([event isKindOfClass:[SNTStoredTemporaryMonitorModeAuditEvent class]]) {
     SNTStoredTemporaryMonitorModeAuditEvent* se = (SNTStoredTemporaryMonitorModeAuditEvent*)event;
     return se.uuid != nil;
+  } else if ([event isKindOfClass:[SNTStoredTemporaryAdminModeAuditEvent class]]) {
+    SNTStoredTemporaryAdminModeAuditEvent* se = (SNTStoredTemporaryAdminModeAuditEvent*)event;
+    return se.uuid != nil;
   } else {
     return NO;
   }
@@ -225,7 +229,11 @@ static const NSTimeInterval kSignalReportDedupWindowSeconds = (60 * 10);
       [NSSet setWithObjects:[SNTStoredExecutionEvent class], [SNTStoredFileAccessEvent class],
                             [SNTStoredTemporaryMonitorModeAuditEvent class],
                             [SNTStoredTemporaryMonitorModeEnterAuditEvent class],
-                            [SNTStoredTemporaryMonitorModeLeaveAuditEvent class], nil];
+                            [SNTStoredTemporaryMonitorModeLeaveAuditEvent class],
+                            [SNTStoredTemporaryAdminModeAuditEvent class],
+                            [SNTStoredTemporaryAdminModeEnterAuditEvent class],
+                            [SNTStoredTemporaryAdminModeLeaveAuditEvent class],
+                            [SNTStoredTemporaryAdminModeDeniedAuditEvent class], nil];
   NSError* err;
   SNTStoredEvent* event = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedClasses
                                                               fromData:eventData

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -15,6 +15,7 @@
 
 #import "Source/santad/SNTDaemonControlController.h"
 #include <limits.h>
+#include <pwd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -43,14 +44,17 @@
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTSandboxExecRequest.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
 #import "Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h"
 #import "Source/common/SNTStrengthify.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
 #import "Source/common/SNTTimer.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/common/SNTXPCSyncServiceInterface.h"
 #include "Source/common/String.h"
 #include "Source/common/faa/WatchItems.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
+#include "Source/santad/AdminGroupMembership.h"
 #import "Source/santad/DataLayer/SNTEventTable.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #include "Source/santad/KillingMachine.h"
@@ -58,6 +62,7 @@
 #import "Source/santad/SNTNetworkExtensionQueue.h"
 #import "Source/santad/SNTNotificationQueue.h"
 #import "Source/santad/SNTSyncdQueue.h"
+#include "Source/santad/TemporaryAdminMode.h"
 #include "Source/santad/TemporaryMonitorMode.h"
 #include "commands/v1.pb.h"
 #import "src/santanetd/SNDNetworkFlowDecision.h"
@@ -104,10 +109,18 @@ double watchdogRAMPeak = 0;
 
 @end
 
+// Resolve a username from a uid for the Temporary Admin Mode audit trail. Returns
+// an empty string when the uid does not resolve.
+static NSString* TAMUsernameForUID(uid_t uid) {
+  struct passwd* pw = getpwuid(uid);
+  return (pw && pw->pw_name) ? @(pw->pw_name) : @"";
+}
+
 @implementation SNTDaemonControlController {
   std::shared_ptr<Logger> _logger;
   std::shared_ptr<WatchItems> _watchItems;
   std::shared_ptr<santa::TemporaryMonitorMode> _temporaryMonitorMode;
+  std::shared_ptr<santa::TemporaryAdminMode> _temporaryAdminMode;
   std::shared_ptr<santa::SandboxExpectations> _sandboxExpectations;
   std::shared_ptr<santa::SNTBinaryUploadController> _binaryUploadController;
 }
@@ -159,6 +172,13 @@ double watchdogRAMPeak = 0;
     _temporaryMonitorMode = santa::TemporaryMonitorMode::Create(
         [SNTConfigurator configurator], _notQueue,
         ^(SNTStoredTemporaryMonitorModeAuditEvent* auditEvent) {
+          [[SNTDatabaseController eventTable] addStoredEvent:auditEvent];
+          [syncdQueue addStoredEvent:auditEvent];
+        });
+
+    _temporaryAdminMode = santa::TemporaryAdminMode::Create(
+        [SNTConfigurator configurator], _notQueue, santa::CreateAdminGroupMembership(),
+        ^(SNTStoredTemporaryAdminModeAuditEvent* auditEvent) {
           [[SNTDatabaseController eventTable] addStoredEvent:auditEvent];
           [syncdQueue addStoredEvent:auditEvent];
         });
@@ -558,6 +578,13 @@ double watchdogRAMPeak = 0;
       [configurator setSyncServerModeTransition:val];
     }];
 
+    // Persist the temporary admin policy in the same batch, for the same reason as
+    // modeTransition above. Its enforcement side effects (Revoke + GUI notify) run
+    // after the batch via NewPolicyReceived.
+    [result temporaryAdminPolicy:^(SNTTemporaryAdminPolicy* val) {
+      [configurator setSyncServerTemporaryAdminPolicy:val];
+    }];
+
     [result clientMode:^(SNTClientMode m) {
       [configurator setSyncServerClientMode:m];
     }];
@@ -689,6 +716,12 @@ double watchdogRAMPeak = 0;
   // modeTransition.
   [result modeTransition:^(SNTModeTransition* val) {
     _temporaryMonitorMode->NewModeTransitionReceived(val);
+  }];
+
+  // Same post-batch ordering as modeTransition: enforce revoke and re-notify GUI
+  // availability against just-committed state.
+  [result temporaryAdminPolicy:^(SNTTemporaryAdminPolicy* val) {
+    _temporaryAdminMode->NewPolicyReceived(val);
   }];
 
   if (committed) {
@@ -1157,6 +1190,56 @@ static const char* const kAllowedCanonicalBundlePaths[] = {
 
 - (void)checkTemporaryMonitorModePolicyAvailable:(void (^)(BOOL))reply {
   reply(_temporaryMonitorMode->Available());
+}
+
+#pragma mark Temporary Admin Mode Ops
+
+- (void)requestTemporaryAdminModeWithDurationMinutes:(NSNumber*)requestedDuration
+                                               reply:(void (^)(uint32_t, NSError*))reply {
+  // The target is the connecting peer (the console user's GUI), resolved from the
+  // XPC audit token — never trusted from the GUI payload.
+  audit_token_t peer = [MOLXPCConnection currentPeerAuditToken];
+  uid_t uid = audit_token_to_euid(peer);
+  NSError* err = nil;
+  uint32_t duration =
+      _temporaryAdminMode->RequestMinutes(requestedDuration, uid, TAMUsernameForUID(uid), &err);
+  reply(duration, err);
+}
+
+- (void)cancelTemporaryAdminMode:(void (^)(NSError*))reply {
+  NSError* err = nil;
+  if (!_temporaryAdminMode->Cancel()) {
+    err = [SNTError createErrorWithFormat:@"Machine is not currently in temporary Admin Mode"];
+  }
+  reply(err);
+}
+
+- (void)temporaryAdminModeSecondsRemaining:(void (^)(NSNumber*))reply {
+  std::optional<uint64_t> secsRemaining = _temporaryAdminMode->SecondsRemaining();
+  reply(secsRemaining.has_value() ? @(*secsRemaining) : nil);
+}
+
+- (void)checkTemporaryAdminModeAvailable:(void (^)(BOOL available, BOOL alreadyAdmin))reply {
+  // Resolve alreadyAdmin from the SAME peer euid the grant path uses so
+  // fast-user-switching cannot show/hide the menu item for the wrong user.
+  audit_token_t peer = [MOLXPCConnection currentPeerAuditToken];
+  uid_t uid = audit_token_to_euid(peer);
+  reply(_temporaryAdminMode->Available(), _temporaryAdminMode->IsCurrentlyAdmin(uid));
+}
+
+- (void)temporaryAdminModeSessionResignedActive:(void (^)(NSError*))reply {
+  // The GUI reports only that its own session resigned active (fast user switch). Resolve the
+  // target from the XPC peer's audit token — never trusted from the GUI payload — and set the
+  // leave reason here, so the GUI cannot author an audit reason. Silent no-op if it is not this
+  // user's active session.
+  audit_token_t peer = [MOLXPCConnection currentPeerAuditToken];
+  uid_t uid = audit_token_to_euid(peer);
+  _temporaryAdminMode->EndForUserEvent(uid, SNTTemporaryAdminModeLeaveReasonSessionEnded);
+  reply(nil);
+}
+
+- (std::shared_ptr<santa::TemporaryAdminMode>)temporaryAdminMode {
+  return _temporaryAdminMode;
 }
 
 #pragma mark Network Extension Ops

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -14,16 +14,19 @@
 /// limitations under the License.
 
 #import "Source/santad/SNTDaemonControlController.h"
+#include <errno.h>
 #include <limits.h>
 #include <pwd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #import <Foundation/Foundation.h>
 #include <sys/qos.h>
 
 #include <memory>
+#include <vector>
 
 #import "Source/common/MOLCodesignChecker.h"
 #import "Source/common/MOLXPCConnection.h"
@@ -110,10 +113,30 @@ double watchdogRAMPeak = 0;
 @end
 
 // Resolve a username from a uid for the Temporary Admin Mode audit trail. Returns
-// an empty string when the uid does not resolve.
+// an empty string when the uid does not resolve. getpwuid_r is used because this
+// runs on concurrent XPC handler threads, where the process-wide static buffer
+// behind getpwuid could be clobbered by another lookup in flight.
 static NSString* TAMUsernameForUID(uid_t uid) {
-  struct passwd* pw = getpwuid(uid);
-  return (pw && pw->pw_name) ? @(pw->pw_name) : @"";
+  struct passwd pwd;
+  struct passwd* result = NULL;
+  long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+  if (bufsize <= 0) {
+    bufsize = 1024;
+  }
+  std::vector<char> buf(bufsize);
+  // getpwuid_r returns ERANGE when the entry doesn't fit; grow and retry so
+  // directory-backed (LDAP/AD) entries larger than the initial buffer still
+  // resolve. Cap the growth so a pathological entry can't drive unbounded
+  // allocation.
+  int rc;
+  while ((rc = getpwuid_r(uid, &pwd, buf.data(), buf.size(), &result)) == ERANGE &&
+         buf.size() < (1 << 20)) {
+    buf.resize(buf.size() * 2);
+  }
+  if (rc != 0 || result == NULL || !pwd.pw_name) {
+    return @"";
+  }
+  return @(pwd.pw_name);
 }
 
 @implementation SNTDaemonControlController {

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -43,4 +43,8 @@ using NotificationReplyBlock = void (^)(BOOL);
 
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply;
 
+- (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
+                                                    reply:(void (^)(BOOL authenticated,
+                                                                    NSString* reason))reply;
+
 @end

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -203,9 +203,25 @@
 - (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
                                                     reply:(void (^)(BOOL authenticated,
                                                                     NSString* reason))reply {
-  [[self.notifierConnection synchronousRemoteObjectProxy]
-      authorizeTemporaryAdminModeRequiringJustification:requireJustification
-                                                  reply:reply];
+  id rop = [self.notifierConnection synchronousRemoteObjectProxy];
+  if (!rop) {
+    // No GUI connection. Fail immediately rather than leaving the caller's reply
+    // uninvoked, which would stall its fail-closed timeout for the full duration.
+    reply(NO, @"");
+    return;
+  }
+  // The proxy is synchronous: if the reply block hasn't run by the time the call
+  // returns, the XPC transport failed (e.g. the GUI died mid-auth) and it never
+  // will. Convert that into an immediate NO so the caller fails fast.
+  __block BOOL replied = NO;
+  [rop authorizeTemporaryAdminModeRequiringJustification:requireJustification
+                                                   reply:^(BOOL authenticated, NSString* reason) {
+                                                     replied = YES;
+                                                     reply(authenticated, reason);
+                                                   }];
+  if (!replied) {
+    reply(NO, @"");
+  }
 }
 
 @end

--- a/Source/santad/SNTNotificationQueue.mm
+++ b/Source/santad/SNTNotificationQueue.mm
@@ -200,4 +200,12 @@
   }
 }
 
+- (void)authorizeTemporaryAdminModeRequiringJustification:(BOOL)requireJustification
+                                                    reply:(void (^)(BOOL authenticated,
+                                                                    NSString* reason))reply {
+  [[self.notifierConnection synchronousRemoteObjectProxy]
+      authorizeTemporaryAdminModeRequiringJustification:requireJustification
+                                                  reply:reply];
+}
+
 @end

--- a/Source/santad/SNTNotificationQueueTest.mm
+++ b/Source/santad/SNTNotificationQueueTest.mm
@@ -325,7 +325,7 @@
   OCMStub([self.mockConnection synchronousRemoteObjectProxy]).andReturn(self.mockProxy);
   // Proxy accepts the call but never runs the reply block.
   OCMStub([self.mockProxy authorizeTemporaryAdminModeRequiringJustification:YES
-                                                                     reply:[OCMArg any]]);
+                                                                      reply:[OCMArg any]]);
 
   __block BOOL replied = NO;
   __block BOOL gotAuthed = YES;

--- a/Source/santad/SNTNotificationQueueTest.mm
+++ b/Source/santad/SNTNotificationQueueTest.mm
@@ -298,4 +298,45 @@
   XCTAssertTrue(self.ringbuf->Empty());
 }
 
+// Patch 1: with no GUI connection, the TAM auth request must invoke its reply
+// synchronously with (NO, @"") rather than leaving it uninvoked — otherwise the
+// daemon-side grant stalls its full fail-closed timeout.
+- (void)testAuthorizeTemporaryAdminModeNoConnectionFailsClosed {
+  self.sut.notifierConnection = nil;
+
+  __block BOOL replied = NO;
+  __block BOOL gotAuthed = YES;
+  __block NSString* gotReason = nil;
+  [self.sut authorizeTemporaryAdminModeRequiringJustification:YES
+                                                        reply:^(BOOL authed, NSString* reason) {
+                                                          replied = YES;
+                                                          gotAuthed = authed;
+                                                          gotReason = reason;
+                                                        }];
+
+  XCTAssertTrue(replied);  // invoked synchronously, no stall
+  XCTAssertFalse(gotAuthed);
+  XCTAssertEqualObjects(gotReason, @"");
+}
+
+// Patch 1: if the synchronous proxy returns without ever invoking the reply block
+// (e.g. the GUI died mid-auth), the queue must still fail closed synchronously.
+- (void)testAuthorizeTemporaryAdminModeProxyNeverRepliesFailsClosed {
+  OCMStub([self.mockConnection synchronousRemoteObjectProxy]).andReturn(self.mockProxy);
+  // Proxy accepts the call but never runs the reply block.
+  OCMStub([self.mockProxy authorizeTemporaryAdminModeRequiringJustification:YES
+                                                                     reply:[OCMArg any]]);
+
+  __block BOOL replied = NO;
+  __block BOOL gotAuthed = YES;
+  [self.sut authorizeTemporaryAdminModeRequiringJustification:YES
+                                                        reply:^(BOOL authed, NSString* reason) {
+                                                          replied = YES;
+                                                          gotAuthed = authed;
+                                                        }];
+
+  XCTAssertTrue(replied);  // fail-fast via the replied guard
+  XCTAssertFalse(gotAuthed);
+}
+
 @end

--- a/Source/santad/TemporaryAdminMode.h
+++ b/Source/santad/TemporaryAdminMode.h
@@ -1,0 +1,114 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_SANTAD_TEMPORARYADMINMODE_H
+#define SANTA_SANTAD_TEMPORARYADMINMODE_H
+
+#include <sys/types.h>
+
+#include <memory>
+
+#include "Source/common/PassKey.h"
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+#include "Source/santad/AdminGroupMembership.h"
+#import "Source/santad/SNTNotificationQueue.h"
+#include "Source/santad/TimedSyncSession.h"
+
+namespace santa {
+
+// Temporary Admin Mode: a sync-blessed, timer-bounded grant of admin-group
+// (GID 80) membership to a single user. A thin subclass of TimedSyncSession; the
+// effect is real OS state (group membership) mutated through AdminGroupMembership.
+//
+// target_uid_ / target_username_ identify the elevated user. They are accessed
+// only under the base's lock_ (set in RequestMinutes / RestoreAndValidateExtraState,
+// read by the effect/audit/persist hooks, all of which the base invokes under
+// lock_), so they are not separately annotated.
+class TemporaryAdminMode : public TimedSyncSession, public PassKey<TemporaryAdminMode> {
+ public:
+  using HandleAuditEventBlock = void (^)(SNTStoredTemporaryAdminModeAuditEvent*);
+
+  static std::shared_ptr<TemporaryAdminMode> Create(
+      SNTConfigurator* configurator, SNTNotificationQueue* notification_queue,
+      std::unique_ptr<AdminGroupMembership> membership,
+      HandleAuditEventBlock handle_audit_event_block);
+
+  TemporaryAdminMode(PassKey, SNTConfigurator* configurator,
+                     SNTNotificationQueue* notification_queue,
+                     std::unique_ptr<AdminGroupMembership> membership,
+                     HandleAuditEventBlock handle_audit_event_block);
+
+  // Public entry. The target uid/username are resolved by the daemon controller
+  // from the XPC peer's audit token; they are never trusted from the GUI. Returns
+  // the granted minutes, or 0 on error (with `err` populated and a Denied audit
+  // event emitted).
+  uint32_t RequestMinutes(NSNumber* requested_duration, uid_t uid, NSString* username,
+                          NSError** err);
+
+  // Whether `uid` is currently a member of the admin group.
+  bool IsCurrentlyAdmin(uid_t uid);
+
+  // On a Revoke policy, cancel any active session; always re-notify GUI availability.
+  void NewPolicyReceived(SNTTemporaryAdminPolicy* policy);
+
+  // End the active session iff it belongs to `uid`, with the given leave reason and no revoke
+  // policy. No-op (returns false) if no session is active or the uid does not match. Used by
+  // the session-presence triggers (screen lock / logout / fast-user-switch).
+  bool EndForUserEvent(uid_t uid, SNTTemporaryAdminModeLeaveReason reason);
+
+  friend class TemporaryAdminModePeer;
+
+ protected:
+  bool ApplyEffect(NSError** err) override;
+  void RevertEffect() override;
+  bool ReapplyEffectOnRestart() override;
+  bool ExtraPreconditions() override;
+  NSString* StateKey() override;
+  bool HasOnDemandPolicy() override;
+  uint32_t ClampDuration(NSNumber* requested) override;
+  bool PolicyRequiresAuth() override;
+  bool PolicyRequiresJustification() override;
+  void WriteRevokePolicy() override;
+  void RequestAuthorization(void (^reply)(BOOL authenticated, NSString* reason)) override;
+  NSDictionary* ExtraStateToPersist() override;
+  bool RestoreAndValidateExtraState(NSDictionary* state) override;
+  void ClearExtraState() override;
+  id BuildEnterAuditEvent(NSString* session_uuid, uint32_t seconds, NSInteger enter_reason,
+                          NSString* user_justification) override;
+  id BuildLeaveAuditEvent(NSString* session_uuid, NSInteger leave_reason) override;
+  NSInteger EnterReasonOnDemand() override;
+  NSInteger EnterReasonRefresh() override;
+  NSInteger EnterReasonRestart() override;
+  NSInteger LeaveReasonCancelled() override;
+  NSInteger LeaveReasonSessionExpired() override;
+  NSInteger LeaveReasonReboot() override;
+  NSInteger LeaveReasonSyncServerChanged() override;
+  void EmitAudit(id audit_event) override;
+  void NotifyEnter(NSDate* expiration) override;
+  void NotifyLeave() override;
+
+ private:
+  void EmitDenied(NSString* username, SNTTemporaryAdminModeDeniedReason reason);
+
+  std::unique_ptr<AdminGroupMembership> membership_;
+  HandleAuditEventBlock handle_audit_event_block_;
+  uid_t target_uid_;
+  NSString* target_username_;
+};
+
+}  // namespace santa
+
+#endif  // SANTA_SANTAD_TEMPORARYADMINMODE_H

--- a/Source/santad/TemporaryAdminMode.h
+++ b/Source/santad/TemporaryAdminMode.h
@@ -96,6 +96,7 @@ class TemporaryAdminMode : public TimedSyncSession, public PassKey<TemporaryAdmi
   NSInteger LeaveReasonSessionExpired() override;
   NSInteger LeaveReasonReboot() override;
   NSInteger LeaveReasonSyncServerChanged() override;
+  NSInteger LeaveReasonUnspecified() override;
   void EmitAudit(id audit_event) override;
   void NotifyEnter(NSDate* expiration) override;
   void NotifyLeave() override;

--- a/Source/santad/TemporaryAdminMode.h
+++ b/Source/santad/TemporaryAdminMode.h
@@ -73,7 +73,7 @@ class TemporaryAdminMode : public TimedSyncSession, public PassKey<TemporaryAdmi
 
  protected:
   bool ApplyEffect(NSError** err) override;
-  void RevertEffect() override;
+  bool RevertEffect() override;
   bool ReapplyEffectOnRestart() override;
   bool ExtraPreconditions() override;
   NSString* StateKey() override;

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -313,6 +313,9 @@ NSInteger TemporaryAdminMode::LeaveReasonReboot() {
 NSInteger TemporaryAdminMode::LeaveReasonSyncServerChanged() {
   return SNTTemporaryAdminModeLeaveReasonSyncServerChanged;
 }
+NSInteger TemporaryAdminMode::LeaveReasonUnspecified() {
+  return SNTTemporaryAdminModeLeaveReasonUnspecified;
+}
 
 void TemporaryAdminMode::EmitAudit(id audit_event) {
   handle_audit_event_block_((SNTStoredTemporaryAdminModeAuditEvent*)audit_event);

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -1,0 +1,319 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/TemporaryAdminMode.h"
+
+#include <pwd.h>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTError.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTXPCNotifierInterface.h"
+
+namespace santa {
+
+static NSString* const kTAMTargetUIDKey = @"TargetUID";
+static NSString* const kTAMTargetUsernameKey = @"TargetUsername";
+
+std::shared_ptr<TemporaryAdminMode> TemporaryAdminMode::Create(
+    SNTConfigurator* configurator, SNTNotificationQueue* notification_queue,
+    std::unique_ptr<AdminGroupMembership> membership,
+    HandleAuditEventBlock handle_audit_event_block) {
+  auto tam = std::make_shared<TemporaryAdminMode>(PassKey(), configurator, notification_queue,
+                                                  std::move(membership), handle_audit_event_block);
+  // NB: SetupFromState is split out of the constructor since it could start the
+  // timer, which takes a weak reference that must not be taken before construction
+  // is complete.
+  tam->SetupFromState();
+  return tam;
+}
+
+TemporaryAdminMode::TemporaryAdminMode(PassKey, SNTConfigurator* configurator,
+                                       SNTNotificationQueue* notification_queue,
+                                       std::unique_ptr<AdminGroupMembership> membership,
+                                       HandleAuditEventBlock handle_audit_event_block)
+    : TimedSyncSession(kMinTemporaryAdminMinutes, kMaxTemporaryAdminMinutes, "Temporary Admin Mode",
+                       configurator, notification_queue),
+      membership_(std::move(membership)),
+      handle_audit_event_block_([handle_audit_event_block copy]),
+      target_uid_(0) {}
+
+bool TemporaryAdminMode::IsCurrentlyAdmin(uid_t uid) {
+  return membership_->IsMember(uid);
+}
+
+uint32_t TemporaryAdminMode::RequestMinutes(NSNumber* requested_duration, uid_t uid,
+                                            NSString* username, NSError** err) {
+  // Serialize the whole grant (pre-checks + auth + apply) against other grants so
+  // two concurrent requests cannot both pass the single-session / already-admin
+  // checks and leave an untracked, never-reverting elevation. grant_mutex_ does not
+  // block the fast readers (SecondsRemaining / Available use lock_ only).
+  absl::MutexLock grant_lock(grant_mutex_);
+
+  if (!Available()) {
+    [SNTError populateError:err
+                   withCode:SNTErrorCodeTAMNoPolicy
+                     format:@"This machine does not currently allow admin elevation."];
+    EmitDenied(username, SNTTemporaryAdminModeDeniedReasonNoPolicy);
+    return 0;
+  }
+
+  // TAM-specific pre-checks (single session / natural admin). Atomic with the grant
+  // below because grant_mutex_ is held across the whole method.
+  bool is_refresh = false;
+  {
+    absl::MutexLock lock(lock_);
+    if (IsStartedLocked()) {
+      if (target_uid_ != uid) {
+        [SNTError populateError:err
+                       withCode:SNTErrorCodeTAMSessionAlreadyActive
+                         format:@"A temporary admin session is already active for another user."];
+        EmitDenied(username, SNTTemporaryAdminModeDeniedReasonSessionAlreadyActive);
+        return 0;
+      }
+      // Same uid with an active session -> refresh (target already set).
+      is_refresh = true;
+    } else if (membership_->IsMember(uid)) {
+      // Natural admin with no active session -> never record a session for them.
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTAMAlreadyAdmin
+                       format:@"This user is already an administrator."];
+      EmitDenied(username, SNTTemporaryAdminModeDeniedReasonAlreadyAdmin);
+      return 0;
+    } else {
+      target_uid_ = uid;
+      target_username_ = username;
+    }
+  }
+
+  uint32_t minutes = 0;
+  GrantOutcome outcome = BeginGrant(requested_duration, &minutes);
+  if (outcome == GrantOutcome::kGranted) {
+    return minutes;
+  }
+
+  // Failure. Defense-in-depth (review H4): clear the freshly-stashed target so no
+  // leave path can later act on it. A refresh leaves the original active session's
+  // target intact (it is still elevated).
+  if (!is_refresh) {
+    absl::MutexLock lock(lock_);
+    ClearExtraState();
+  }
+
+  switch (outcome) {
+    case GrantOutcome::kAuthFailed:
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTAMAuthFailed
+                       format:@"Authorization failed."];
+      EmitDenied(username, SNTTemporaryAdminModeDeniedReasonAuthFailed);
+      return 0;
+    case GrantOutcome::kJustificationRequired:
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTAMJustificationRequired
+                       format:@"A justification is required to elevate."];
+      EmitDenied(username, SNTTemporaryAdminModeDeniedReasonJustificationRequired);
+      return 0;
+    case GrantOutcome::kApplyFailed:
+      [SNTError populateError:err
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"Failed to change admin group membership."];
+      EmitDenied(username, SNTTemporaryAdminModeDeniedReasonMembershipChangeFailed);
+      return 0;
+    default:  // kNoPolicy / kInvalidSyncServer / kNotEligible (raced with Available)
+      [SNTError populateError:err withCode:SNTErrorCodeTAMNoPolicy format:@"Not eligible."];
+      EmitDenied(username, SNTTemporaryAdminModeDeniedReasonNotEligible);
+      return 0;
+  }
+}
+
+bool TemporaryAdminMode::EndForUserEvent(uid_t uid, SNTTemporaryAdminModeLeaveReason reason) {
+  absl::MutexLock lock(lock_);
+  if (!IsStartedLocked() || target_uid_ != uid) {
+    return false;
+  }
+  return EndForReasonLocked((NSInteger)reason);
+}
+
+void TemporaryAdminMode::NewPolicyReceived(SNTTemporaryAdminPolicy* policy) {
+  if (policy.type == SNTTemporaryAdminPolicyTypeRevoke) {
+    if (Revoke(SNTTemporaryAdminModeLeaveReasonRevoked)) {
+      LOGI(@"Temporary Admin Mode session revoked due to policy change.");
+    }
+  }
+  [[notification_queue_.notifierConnection remoteObjectProxy]
+      temporaryAdminModeAvailable:Available()];
+}
+
+#pragma mark Hooks
+
+// Effect hooks run UNDER lock_ (the base invokes them while holding lock_).
+bool TemporaryAdminMode::ApplyEffect(NSError** err) {
+  return membership_->AddMember(target_uid_, err);
+}
+
+void TemporaryAdminMode::RevertEffect() {
+  if (target_uid_ == 0) {
+    return;
+  }
+  NSError* err = nil;
+  if (!membership_->RemoveMember(target_uid_, &err)) {
+    LOGE(@"Temporary Admin Mode failed to demote uid %u: %@", target_uid_,
+         err.localizedDescription);
+  }
+}
+
+bool TemporaryAdminMode::ReapplyEffectOnRestart() {
+  // If the user is no longer a member, the elevation was revoked out of band
+  // (admin/MDM/another tool). Do not re-add — end the session instead.
+  if (!membership_->IsMember(target_uid_)) {
+    LOGI(@"Temporary Admin Mode: persisted session for uid %u is no longer a group member; "
+         @"treating as revoked out of band and ending the session.",
+         target_uid_);
+    return false;
+  }
+  // Still a member: AddMember is idempotent. A failure here is logged and ignored —
+  // membership persists and the timer still resumes.
+  NSError* err = nil;
+  if (!membership_->AddMember(target_uid_, &err)) {
+    LOGW(@"Temporary Admin Mode: restart re-apply for uid %u failed: %@", target_uid_,
+         err.localizedDescription);
+  }
+  return true;
+}
+
+bool TemporaryAdminMode::ExtraPreconditions() {
+  return true;
+}
+
+NSString* TemporaryAdminMode::StateKey() {
+  return @"TempAdmin";
+}
+
+bool TemporaryAdminMode::HasOnDemandPolicy() {
+  return [configurator_ temporaryAdminPolicy].type == SNTTemporaryAdminPolicyTypeOnDemand;
+}
+
+uint32_t TemporaryAdminMode::ClampDuration(NSNumber* requested) {
+  return [[configurator_ temporaryAdminPolicy] getDurationMinutes:requested];
+}
+
+bool TemporaryAdminMode::PolicyRequiresAuth() {
+  // Authentication is always required to elevate; it is not server-configurable.
+  return true;
+}
+
+bool TemporaryAdminMode::PolicyRequiresJustification() {
+  SNTTemporaryAdminPolicy* p = [configurator_ temporaryAdminPolicy];
+  return p ? p.requireJustification : YES;
+}
+
+void TemporaryAdminMode::WriteRevokePolicy() {
+  [configurator_
+      setSyncServerTemporaryAdminPolicy:[[SNTTemporaryAdminPolicy alloc] initRevocation]];
+}
+
+void TemporaryAdminMode::RequestAuthorization(void (^reply)(BOOL, NSString*)) {
+  // Tell the GUI whether the policy requires a free-text reason so it only prompts
+  // when configured to. The daemon still enforces the requirement (an empty reason
+  // is rejected with kJustificationRequired when PolicyRequiresJustification() is true).
+  [notification_queue_
+      authorizeTemporaryAdminModeRequiringJustification:PolicyRequiresJustification()
+                                                  reply:^(BOOL ok, NSString* reason) {
+                                                    reply(ok, reason);
+                                                  }];
+}
+
+NSDictionary* TemporaryAdminMode::ExtraStateToPersist() {
+  return @{kTAMTargetUIDKey : @(target_uid_), kTAMTargetUsernameKey : target_username_ ?: @""};
+}
+
+bool TemporaryAdminMode::RestoreAndValidateExtraState(NSDictionary* state) {
+  if (![state[kTAMTargetUIDKey] isKindOfClass:[NSNumber class]] ||
+      ![state[kTAMTargetUsernameKey] isKindOfClass:[NSString class]]) {
+    return false;
+  }
+  uid_t uid = [state[kTAMTargetUIDKey] unsignedIntValue];
+  // Reject uid 0 and any uid that no longer resolves to a user (deleted account).
+  if (uid == 0 || getpwuid(uid) == NULL) {
+    return false;
+  }
+  target_uid_ = uid;
+  target_username_ = state[kTAMTargetUsernameKey];
+  return true;
+}
+
+void TemporaryAdminMode::ClearExtraState() {
+  target_uid_ = 0;
+  target_username_ = nil;
+}
+
+id TemporaryAdminMode::BuildEnterAuditEvent(NSString* session_uuid, uint32_t seconds,
+                                            NSInteger enter_reason, NSString* user_justification) {
+  return [[SNTStoredTemporaryAdminModeEnterAuditEvent alloc]
+           initWithUUID:session_uuid
+               username:target_username_ ?: @""
+                seconds:seconds
+                 reason:(SNTTemporaryAdminModeEnterReason)enter_reason
+      userJustification:user_justification ?: @""];
+}
+
+id TemporaryAdminMode::BuildLeaveAuditEvent(NSString* session_uuid, NSInteger leave_reason) {
+  return [[SNTStoredTemporaryAdminModeLeaveAuditEvent alloc]
+      initWithUUID:session_uuid
+          username:target_username_ ?: @""
+            reason:(SNTTemporaryAdminModeLeaveReason)leave_reason];
+}
+
+NSInteger TemporaryAdminMode::EnterReasonOnDemand() {
+  return SNTTemporaryAdminModeEnterReasonOnDemand;
+}
+NSInteger TemporaryAdminMode::EnterReasonRefresh() {
+  return SNTTemporaryAdminModeEnterReasonOnDemandRefresh;
+}
+NSInteger TemporaryAdminMode::EnterReasonRestart() {
+  return SNTTemporaryAdminModeEnterReasonRestart;
+}
+NSInteger TemporaryAdminMode::LeaveReasonCancelled() {
+  return SNTTemporaryAdminModeLeaveReasonCancelled;
+}
+NSInteger TemporaryAdminMode::LeaveReasonSessionExpired() {
+  return SNTTemporaryAdminModeLeaveReasonSessionExpired;
+}
+NSInteger TemporaryAdminMode::LeaveReasonReboot() {
+  return SNTTemporaryAdminModeLeaveReasonReboot;
+}
+NSInteger TemporaryAdminMode::LeaveReasonSyncServerChanged() {
+  return SNTTemporaryAdminModeLeaveReasonSyncServerChanged;
+}
+
+void TemporaryAdminMode::EmitAudit(id audit_event) {
+  handle_audit_event_block_((SNTStoredTemporaryAdminModeAuditEvent*)audit_event);
+}
+
+void TemporaryAdminMode::NotifyEnter(NSDate* expiration) {
+  [[notification_queue_.notifierConnection remoteObjectProxy] enterTemporaryAdminMode:expiration];
+}
+
+void TemporaryAdminMode::NotifyLeave() {
+  [[notification_queue_.notifierConnection remoteObjectProxy] leaveTemporaryAdminMode];
+}
+
+void TemporaryAdminMode::EmitDenied(NSString* username, SNTTemporaryAdminModeDeniedReason reason) {
+  handle_audit_event_block_([[SNTStoredTemporaryAdminModeDeniedAuditEvent alloc]
+      initWithUUID:[[NSUUID UUID] UUIDString]
+          username:username ?: @""
+            reason:reason]);
+}
+
+}  // namespace santa

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -61,6 +61,17 @@ uint32_t TemporaryAdminMode::RequestMinutes(NSNumber* requested_duration, uid_t 
   // block the fast readers (SecondsRemaining / Available use lock_ only).
   absl::MutexLock grant_lock(grant_mutex_);
 
+  // uid 0 is already fully privileged, and RevertEffect / RestoreAndValidateExtraState
+  // treat a target_uid_ of 0 as "no session" -- so a session must never be stored for it
+  // (it could never be reverted). Reject before any state is touched.
+  if (uid == 0) {
+    [SNTError populateError:err
+                   withCode:SNTErrorCodeTAMAlreadyAdmin
+                     format:@"This user is already an administrator."];
+    EmitDenied(username, SNTTemporaryAdminModeDeniedReasonAlreadyAdmin);
+    return 0;
+  }
+
   if (!Available()) {
     [SNTError populateError:err
                    withCode:SNTErrorCodeTAMNoPolicy

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -173,15 +173,21 @@ bool TemporaryAdminMode::ApplyEffect(NSError** err) {
   return membership_->AddMember(target_uid_, err);
 }
 
-void TemporaryAdminMode::RevertEffect() {
+bool TemporaryAdminMode::RevertEffect() {
   if (target_uid_ == 0) {
-    return;
+    // No session target -> nothing to revert.
+    return true;
   }
   NSError* err = nil;
   if (!membership_->RemoveMember(target_uid_, &err)) {
+    // Report the failure so the base keeps an expired session record and retries the
+    // demotion on the next daemon start, rather than clearing state and leaving the
+    // user elevated past the intended window.
     LOGE(@"Temporary Admin Mode failed to demote uid %u: %@", target_uid_,
          err.localizedDescription);
+    return false;
   }
+  return true;
 }
 
 bool TemporaryAdminMode::ReapplyEffectOnRestart() {

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -317,6 +317,46 @@ static uint64_t MakeDeadline(uint64_t want) {
       [events.lastObject isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
 }
 
+// If the demotion fails during reconciliation of an expired session, the session state
+// must NOT be cleared: the base keeps an already-expired record (deadline 0) so the next
+// daemon start retries the revert, rather than leaving the user elevated with nothing
+// tracking it. (The success case is covered by testReconcileExpiredRemovesMember; together
+// they exercise the retry loop.)
+- (void)testReconcileRevertFailureRetainsExpiredStateForRetry {
+  [self stubPolicyAvailable];
+  uid_t uid = getuid();
+  OCMStub([self.mockConfigurator savedTimedSessionStateForKey:@"TempAdmin"])
+      .andReturn([self stateWithBootUUID:[SNTSystemInfo bootSessionUUID]
+                                deadline:1  // already in the past
+                                syncHost:@"foo.workshop.cloud"
+                                     uid:uid]);
+  __block NSDictionary* lastPersisted = nil;
+  OCMStub([self.mockConfigurator persistTimedSessionState:[OCMArg any] forKey:@"TempAdmin"])
+      .andDo(^(NSInvocation* inv) {
+        __unsafe_unretained NSDictionary* s = nil;
+        [inv getArgument:&s atIndex:2];
+        lastPersisted = s;
+      });
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  fake->members_.insert(uid);
+  fake->fail_remove_ = true;  // the demotion cannot be committed
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  // Still elevated (removal failed) ...
+  XCTAssertTrue(fake->IsMember(uid));
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+  // ... and the state was NOT cleared: an already-expired record was persisted for retry.
+  XCTAssertNotNil(lastPersisted);
+  XCTAssertEqualObjects(lastPersisted[kTimedSessionDeadlineKey], @0);
+  XCTAssertEqualObjects(lastPersisted[@"TargetUID"], @(uid));
+}
+
 #pragma mark EndForUserEvent tests
 
 // After a successful grant, EndForUserEvent for the granted uid returns true, removes the uid

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -1,0 +1,478 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/TemporaryAdminMode.h"
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#include <mach/mach_time.h>
+#include <unistd.h>
+
+#include <set>
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTError.h"
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
+#import "Source/common/SNTSystemInfo.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+#include "Source/common/SystemResources.h"
+#include "Source/santad/AdminGroupMembership.h"
+#import "Source/santad/SNTNotificationQueue.h"
+#include "Source/santad/TimedSyncSession.h"
+
+namespace santa {
+
+// In-memory fake admin-group membership for tests. Never touches the real group 80.
+class FakeAdminGroupMembership : public AdminGroupMembership {
+ public:
+  bool IsMember(uid_t uid) override { return members_.count(uid) > 0; }
+
+  bool AddMember(uid_t uid, NSError** error) override {
+    if (fail_add_) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"fake add"];
+      return false;
+    }
+    members_.insert(uid);
+    return true;
+  }
+
+  bool RemoveMember(uid_t uid, NSError** error) override {
+    if (fail_remove_) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"fake remove"];
+      return false;
+    }
+    members_.erase(uid);
+    return true;
+  }
+
+  std::set<uid_t> members_;
+  bool fail_add_ = false;
+  bool fail_remove_ = false;
+};
+
+}  // namespace santa
+
+using santa::FakeAdminGroupMembership;
+
+// A mach continuous time at least the given seconds in the future.
+static uint64_t MakeDeadline(uint64_t want) {
+  return MachTimeToNanos(
+      AddNanosecondsToMachTime((want + 5) * NSEC_PER_SEC, mach_continuous_time()));
+}
+
+@interface TemporaryAdminModeTest : XCTestCase
+@property id mockConfigurator;
+@property id mockNotQueue;
+@end
+
+@implementation TemporaryAdminModeTest
+
+- (void)setUp {
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  self.mockNotQueue = OCMClassMock([SNTNotificationQueue class]);
+}
+
+// Stub an available on-demand policy that requires a justification.
+- (void)stubPolicyAvailable {
+  OCMStub([self.mockConfigurator temporaryAdminPolicy])
+      .andReturn([[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:60
+                                                      defaultDuration:5
+                                                 requireJustification:YES]);
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
+  OCMStub([self.mockConfigurator syncBaseURL])
+      .andReturn([NSURL URLWithString:@"https://foo.workshop.cloud"]);
+}
+
+- (void)stubAuthReply:(BOOL)authed reason:(NSString*)reason {
+  // setUp configures a policy with requireJustification:YES, so RequestAuthorization passes YES.
+  OCMStub([self.mockNotQueue
+      authorizeTemporaryAdminModeRequiringJustification:YES
+                                                  reply:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(
+                                                                                         authed),
+                                                                                     reason,
+                                                                                     nil])]);
+}
+
+// Builds a persisted TAM session-state dict for reconciliation tests.
+- (NSDictionary*)stateWithBootUUID:(NSString*)bootUUID
+                          deadline:(uint64_t)deadline
+                          syncHost:(NSString*)syncHost
+                               uid:(uid_t)uid {
+  return @{
+    kTimedSessionBootUUIDKey : bootUUID,
+    kTimedSessionDeadlineKey : @(deadline),
+    kTimedSessionSyncURLKey : syncHost,
+    kTimedSessionSessionUUIDKey : [[NSUUID UUID] UUIDString],
+    @"TargetUID" : @(uid),
+    @"TargetUsername" : @"reconcile-user",
+  };
+}
+
+#pragma mark Grant-path tests
+
+- (void)testGrantAddsMemberAndEmitsEnter {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need to install"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(events.count, 1u);
+  XCTAssertTrue([events[0] isKindOfClass:[SNTStoredTemporaryAdminModeEnterAuditEvent class]]);
+  SNTStoredTemporaryAdminModeEnterAuditEvent* enter =
+      (SNTStoredTemporaryAdminModeEnterAuditEvent*)events[0];
+  XCTAssertEqual(enter.reason, SNTTemporaryAdminModeEnterReasonOnDemand);
+  XCTAssertEqualObjects(enter.username, @"alice");
+}
+
+- (void)testNaturalAdminRefused {
+  [self stubPolicyAvailable];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  fake->members_.insert(501);  // already an admin
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 0u);
+  XCTAssertEqual(err.code, SNTErrorCodeTAMAlreadyAdmin);
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+  XCTAssertTrue(fake->IsMember(501));  // unchanged: never stripped
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryAdminModeDeniedAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryAdminModeDeniedAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryAdminModeDeniedReasonAlreadyAdmin);
+}
+
+- (void)testSecondUserRefused {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);  // first user grants
+
+  err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 502, @"bob", &err), 0u);  // second user refused
+  XCTAssertEqual(err.code, SNTErrorCodeTAMSessionAlreadyActive);
+  XCTAssertEqual(((SNTStoredTemporaryAdminModeDeniedAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryAdminModeDeniedReasonSessionAlreadyActive);
+}
+
+- (void)testAuthFailEmitsDenied {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:NO reason:@""];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 0u);
+  XCTAssertEqual(err.code, SNTErrorCodeTAMAuthFailed);
+  XCTAssertFalse(fake->IsMember(501));  // never elevated
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(((SNTStoredTemporaryAdminModeDeniedAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryAdminModeDeniedReasonAuthFailed);
+}
+
+// Review M3: an unresolvable / AD account fails cleanly via AddMember -> kApplyFailed.
+- (void)testApplyFailedFailsClean {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  fake->fail_add_ = true;  // simulate a directory user that cannot be committed locally
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 0u);
+  XCTAssertEqual(err.code, SNTErrorCodeTAMMembershipChangeFailed);
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(((SNTStoredTemporaryAdminModeDeniedAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryAdminModeDeniedReasonMembershipChangeFailed);
+}
+
+#pragma mark Reconciliation tests
+
+- (void)testReconcileRebootRemovesMember {
+  [self stubPolicyAvailable];
+  uid_t uid = getuid();  // a uid getpwuid resolves
+  OCMStub([self.mockConfigurator savedTimedSessionStateForKey:@"TempAdmin"])
+      .andReturn([self stateWithBootUUID:@"a-previous-boot"
+                                deadline:MakeDeadline(100)
+                                syncHost:@"foo.workshop.cloud"
+                                     uid:uid]);
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  fake->members_.insert(uid);  // membership persisted across the (simulated) reboot
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  XCTAssertFalse(fake->IsMember(uid));  // actively demoted
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryAdminModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryAdminModeLeaveReasonReboot);
+}
+
+- (void)testReconcileExpiredRemovesMember {
+  [self stubPolicyAvailable];
+  uid_t uid = getuid();
+  OCMStub([self.mockConfigurator savedTimedSessionStateForKey:@"TempAdmin"])
+      .andReturn([self stateWithBootUUID:[SNTSystemInfo bootSessionUUID]
+                                deadline:1  // already in the past
+                                syncHost:@"foo.workshop.cloud"
+                                     uid:uid]);
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  fake->members_.insert(uid);
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  XCTAssertFalse(fake->IsMember(uid));
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(((SNTStoredTemporaryAdminModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryAdminModeLeaveReasonSessionExpired);
+}
+
+// Review M1: a still-valid session whose user is no longer a member must NOT be
+// re-added — the elevation was revoked out of band. End the session instead.
+- (void)testReconcileValidButNotMemberEndsSession {
+  [self stubPolicyAvailable];
+  uid_t uid = getuid();
+  OCMStub([self.mockConfigurator savedTimedSessionStateForKey:@"TempAdmin"])
+      .andReturn([self stateWithBootUUID:[SNTSystemInfo bootSessionUUID]
+                                deadline:MakeDeadline(100)
+                                syncHost:@"foo.workshop.cloud"
+                                     uid:uid]);
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  // NOT a member: removed out of band while the session was still within its deadline.
+  NSMutableArray* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  XCTAssertFalse(fake->IsMember(uid));                  // not re-added
+  XCTAssertFalse(tam->SecondsRemaining().has_value());  // session ended, not resumed
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+}
+
+#pragma mark EndForUserEvent tests
+
+// After a successful grant, EndForUserEvent for the granted uid returns true, removes the uid
+// from the admin group, and emits a Leave audit with the specified reason.
+- (void)testEndForUserEventEndsMatchingSession {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"install something"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+  XCTAssertTrue(fake->IsMember(501));
+
+  // EndForUserEvent with the matching uid must return true.
+  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+
+  // The user must be removed from the admin group.
+  XCTAssertFalse(fake->IsMember(501));
+
+  // A Leave audit must have been emitted with the correct reason.
+  XCTAssertEqual(events.count, 2u);
+  XCTAssertTrue([events[1] isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+  SNTStoredTemporaryAdminModeLeaveAuditEvent* leave =
+      (SNTStoredTemporaryAdminModeLeaveAuditEvent*)events[1];
+  XCTAssertEqual(leave.reason, SNTTemporaryAdminModeLeaveReasonScreenLocked);
+}
+
+// After EndForUserEvent the feature must remain available (no revoke policy written).
+- (void)testEndForUserEventDoesNotWriteRevokePolicy {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"install something"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+  // Available() must be true before and after; EndForUserEvent must not call WriteRevokePolicy.
+  XCTAssertTrue(tam->Available());
+
+  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+
+  // The feature must still be available — no revoke policy was written.
+  XCTAssertTrue(tam->Available());
+}
+
+// With an active session for uid 501, EndForUserEvent for a different uid is a no-op.
+- (void)testEndForUserEventWrongUidIsNoOp {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+  XCTAssertTrue(fake->IsMember(501));
+
+  // A different uid must be rejected.
+  XCTAssertFalse(tam->EndForUserEvent(502, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+
+  // Session for 501 must remain intact.
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(tam->SecondsRemaining().has_value());
+
+  // No additional audit event should have been emitted (only the Enter from the grant).
+  XCTAssertEqual(events.count, 1u);
+}
+
+// With no active session, EndForUserEvent is a no-op.
+- (void)testEndForUserEventNoActiveSession {
+  [self stubPolicyAvailable];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  // No session was started.
+  XCTAssertFalse(tam->SecondsRemaining().has_value());
+
+  XCTAssertFalse(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+
+  // No audit events must have been emitted.
+  XCTAssertEqual(events.count, 0u);
+}
+
+// A second EndForUserEvent after the first returns false and does not emit a second Leave audit.
+- (void)testEndForUserEventIdempotent {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+
+  // First call succeeds.
+  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  NSUInteger countAfterFirst = events.count;
+
+  // Second call must return false and must not emit another audit event.
+  XCTAssertFalse(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertEqual(events.count, countAfterFirst);
+}
+
+// EndForUserEvent with SNTTemporaryAdminModeLeaveReasonSessionEnded flows the reason through.
+- (void)testEndForUserEventSessionEndedReason {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"logout test"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+
+  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonSessionEnded));
+
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+  SNTStoredTemporaryAdminModeLeaveAuditEvent* leave =
+      (SNTStoredTemporaryAdminModeLeaveAuditEvent*)events.lastObject;
+  XCTAssertEqual(leave.reason, SNTTemporaryAdminModeLeaveReasonSessionEnded);
+}
+
+@end

--- a/Source/santad/TemporaryMonitorMode.h
+++ b/Source/santad/TemporaryMonitorMode.h
@@ -79,6 +79,7 @@ class TemporaryMonitorMode : public TimedSyncSession, public PassKey<TemporaryMo
   NSInteger LeaveReasonSessionExpired() override;
   NSInteger LeaveReasonReboot() override;
   NSInteger LeaveReasonSyncServerChanged() override;
+  NSInteger LeaveReasonUnspecified() override;
   void EmitAudit(id audit_event) override;
   void NotifyEnter(NSDate* expiration) override;
   void NotifyLeave() override;

--- a/Source/santad/TemporaryMonitorMode.mm
+++ b/Source/santad/TemporaryMonitorMode.mm
@@ -203,6 +203,9 @@ NSInteger TemporaryMonitorMode::LeaveReasonReboot() {
 NSInteger TemporaryMonitorMode::LeaveReasonSyncServerChanged() {
   return SNTTemporaryMonitorModeLeaveReasonSyncServerChanged;
 }
+NSInteger TemporaryMonitorMode::LeaveReasonUnspecified() {
+  return SNTTemporaryMonitorModeLeaveReasonUnspecified;
+}
 
 void TemporaryMonitorMode::EmitAudit(id audit_event) {
   handle_audit_event_block_((SNTStoredTemporaryMonitorModeAuditEvent*)audit_event);

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -177,6 +177,10 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   virtual NSInteger LeaveReasonSessionExpired() = 0;
   virtual NSInteger LeaveReasonReboot() = 0;
   virtual NSInteger LeaveReasonSyncServerChanged() = 0;
+  // Reason for a still-valid session whose effect the subclass declined to
+  // re-apply at daemon restart (not a reboot; the reboot case is handled by the
+  // boot-UUID check). Reported upstream as REASON_UNSPECIFIED.
+  virtual NSInteger LeaveReasonUnspecified() = 0;
 
   // Deliver the audit event + GUI notifications.
   virtual void EmitAudit(id audit_event) = 0;

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -239,8 +239,14 @@ TimedSyncSession::GrantOutcome TimedSyncSession::BeginGrant(NSNumber* requested_
     return GrantOutcome::kNotEligible;
   }
 
-  // Authorization runs OFF lock_ (Touch ID + typing a reason). Wrap it with a
-  // fail-closed timeout so a hung GUI cannot hold grant_mutex_ indefinitely.
+  // Authorization runs OFF lock_ (Touch ID + typing a reason) and reaches the GUI
+  // over a synchronous XPC proxy, so this call blocks until the GUI replies. The
+  // GUI bounds the interactive prompt with its own timeout (see
+  // SNTAuthorizationHelper), which is what keeps grant_mutex_ from being held
+  // indefinitely. The semaphore wait below is a secondary backstop: for a live GUI
+  // it is already signaled by the time it is reached, and it only bounds a wedged
+  // transport that returns without invoking the reply (a dead connection is
+  // already converted to an immediate NO in SNTNotificationQueue).
   __block BOOL authenticated = NO;
   __block NSString* reason = nil;
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -145,7 +145,12 @@ void TimedSyncSession::SetupFromState() {
     EmitAudit(BuildEnterAuditEvent([current_uuid_ UUIDString], secs_remaining, EnterReasonRestart(),
                                    @""));
   } else {
-    EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonReboot()));
+    // Still time-valid, but the subclass declined to re-apply its effect on
+    // restart (TAM: the user is no longer an admin-group member, i.e. the
+    // elevation was removed out of band). This is provably not a reboot -- a
+    // reboot mismatches the boot-session UUID and is handled above -- so it is
+    // recorded with an unattributed reason rather than Reboot.
+    EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], LeaveReasonUnspecified()));
     [configurator_ persistTimedSessionState:nil forKey:StateKey()];
     NotifyLeave();
     ClearExtraState();


### PR DESCRIPTION
Part of WS-1128, stacked on #1035

Adds Temporary Admin Mode (TAM): a console user can self-elevate to admin for a bounded, auto-reverting window, modeled on Temporary Monitor Mode and built on the shared TimedSyncSession base from the prior PR #1035.

- daemon: (TemporaryAdminMode, AdminGroupMembership): add/revert with auto-expiry, audit-event emission, and the unprivileged-control XPC surface. The elevation target is resolved from the XPC peer's audit token, never trusted from the GUI payload.

- gui: status-bar menu entry to request/observe TAM, with justification prompting driven by policy, plus the notifier-XPC methods the daemon calls to drive the UI.
 
- santactl: santactl status reports TAM availability and seconds remaining.