### PR TITLE
santad: revoke Temporary Admin Mode on console-session leave

### DIFF
--- a/Source/gui/SNTAppDelegate.mm
+++ b/Source/gui/SNTAppDelegate.mm
@@ -50,19 +50,25 @@
 
   NSNotificationCenter* workspaceNotifications = [[NSWorkspace sharedWorkspace] notificationCenter];
 
-  [workspaceNotifications addObserverForName:NSWorkspaceSessionDidResignActiveNotification
-                                      object:nil
-                                       queue:[NSOperationQueue currentQueue]
-                                  usingBlock:^(NSNotification* note) {
-                                    self.daemonListener.invalidationHandler = nil;
-                                    [self.daemonListener invalidate];
-                                    self.daemonListener = nil;
-                                  }];
+  [workspaceNotifications
+      addObserverForName:NSWorkspaceSessionDidResignActiveNotification
+                  object:nil
+                   queue:[NSOperationQueue currentQueue]
+              usingBlock:^(NSNotification* note) {
+                [self.statusItemManager temporaryAdminModeSessionResignedActive];
+                self.daemonListener.invalidationHandler = nil;
+                [self.daemonListener invalidate];
+                self.daemonListener = nil;
+              }];
   [workspaceNotifications addObserverForName:NSWorkspaceSessionDidBecomeActiveNotification
                                       object:nil
                                        queue:[NSOperationQueue currentQueue]
                                   usingBlock:^(NSNotification* note) {
                                     [self attemptDaemonReconnection];
+                                    // Reconcile timed-mode state: while this session was inactive
+                                    // (e.g. fast user switching) the daemon may have ended a
+                                    // session and the leave notification was missed.
+                                    [self.statusItemManager reconcileTimedModeState];
                                   }];
 
   // Watch for windows being closed, so that we can restore the activation policy to accessory.

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -390,6 +390,24 @@ objc_library(
     ],
 )
 
+objc_library(
+    name = "SNTLoginWindowSessionHandlerProtocol",
+    hdrs = ["SNTLoginWindowSessionHandlerProtocol.h"],
+    sdk_dylibs = ["EndpointSecurity"],
+)
+
+objc_library(
+    name = "SNTLoginWindowSessionHandler",
+    srcs = ["SNTLoginWindowSessionHandler.mm"],
+    hdrs = ["SNTLoginWindowSessionHandler.h"],
+    sdk_dylibs = ["EndpointSecurity"],
+    deps = [
+        ":SNTLoginWindowSessionHandlerProtocol",
+        ":TemporaryAdminMode",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
+    ],
+)
+
 santa_unit_test(
     name = "TemporaryAdminModeTest",
     srcs = ["TemporaryAdminModeTest.mm"],
@@ -404,6 +422,22 @@ santa_unit_test(
         "//Source/common:SNTSystemInfo",
         "//Source/common:SNTTemporaryAdminPolicy",
         "//Source/common:SystemResources",
+        "@OCMock",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTLoginWindowSessionHandlerTest",
+    srcs = ["SNTLoginWindowSessionHandlerTest.mm"],
+    deps = [
+        ":AdminGroupMembership",
+        ":SNTLoginWindowSessionHandler",
+        ":SNTNotificationQueue",
+        ":TemporaryAdminMode",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTError",
+        "//Source/common:SNTStoredTemporaryAdminModeAuditEvent",
+        "//Source/common:SNTTemporaryAdminPolicy",
         "@OCMock",
     ],
 )
@@ -568,6 +602,7 @@ objc_library(
         ":EndpointSecurityLogger",
         ":SNTCompilerController",
         ":SNTEndpointSecurityTreeAwareClient",
+        ":SNTLoginWindowSessionHandlerProtocol",
         "//Source/common:Platform",
         "//Source/common:PrefixTree",
         "//Source/common:SNTConfigurator",
@@ -1229,6 +1264,7 @@ objc_library(
         ":SNTEndpointSecurityTamperResistance",
         ":SNTEventTable",
         ":SNTExecutionController",
+        ":SNTLoginWindowSessionHandler",
         ":SNTNetworkExtensionQueue",
         ":SNTNotificationQueue",
         ":SNTRuleTable",
@@ -1964,6 +2000,7 @@ test_suite(
         ":SNTEndpointSecurityTreeAwareClientTest",
         ":SNTEventTableTest",
         ":SNTExecutionControllerTest",
+        ":SNTLoginWindowSessionHandlerTest",
         ":SNTNetworkExtensionQueueTest",
         ":SNTNotificationQueueTest",
         ":SNTPolicyProcessorTest",

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
@@ -25,6 +25,8 @@
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
 #import "Source/santad/SNTCompilerController.h"
 
+@protocol SNTLoginWindowSessionHandler;
+
 /// ES Client focused on subscribing to NOTIFY event variants with the intention of enriching
 /// received messages and logging the information.
 @interface SNTEndpointSecurityRecorder
@@ -35,6 +37,7 @@
                        logger:(std::shared_ptr<santa::Logger>)logger
                      enricher:(std::shared_ptr<santa::Enricher>)enricher
            compilerController:(SNTCompilerController*)compilerController
+    loginWindowSessionHandler:(id<SNTLoginWindowSessionHandler>)loginWindowSessionHandler
               authResultCache:(std::shared_ptr<santa::AuthResultCache>)authResultCache
                    prefixTree:(std::shared_ptr<santa::PrefixTree<santa::Unit>>)prefixTree
                   processTree:

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -16,6 +16,8 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityRecorder.h"
 #include <os/base.h>
 
+#import "Source/santad/SNTLoginWindowSessionHandlerProtocol.h"
+
 #include <EndpointSecurity/EndpointSecurity.h>
 
 #include "Source/common/Platform.h"
@@ -56,6 +58,7 @@ es_file_t* GetTargetFileForPrefixTree(const es_message_t* msg) {
 
 @interface SNTEndpointSecurityRecorder ()
 @property SNTCompilerController* compilerController;
+@property(nonatomic, strong) id<SNTLoginWindowSessionHandler> loginWindowSessionHandler;
 @property SNTConfigurator* configurator;
 @end
 
@@ -71,6 +74,7 @@ es_file_t* GetTargetFileForPrefixTree(const es_message_t* msg) {
                        logger:(std::shared_ptr<Logger>)logger
                      enricher:(std::shared_ptr<Enricher>)enricher
            compilerController:(SNTCompilerController*)compilerController
+    loginWindowSessionHandler:(id<SNTLoginWindowSessionHandler>)loginWindowSessionHandler
               authResultCache:(std::shared_ptr<AuthResultCache>)authResultCache
                    prefixTree:(std::shared_ptr<PrefixTree<Unit>>)prefixTree
                   processTree:(std::shared_ptr<ProcessTree>)processTree {
@@ -82,6 +86,7 @@ es_file_t* GetTargetFileForPrefixTree(const es_message_t* msg) {
     _enricher = enricher;
     _logger = logger;
     _compilerController = compilerController;
+    _loginWindowSessionHandler = loginWindowSessionHandler;
     _authResultCache = authResultCache;
     _prefixTree = prefixTree;
     _configurator = [SNTConfigurator configurator];
@@ -121,6 +126,22 @@ es_file_t* GetTargetFileForPrefixTree(const es_message_t* msg) {
   }
 
   [self.compilerController handleEvent:esMsg withLogger:self->_logger];
+
+  switch (esMsg->event_type) {
+    case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK:
+      [self.loginWindowSessionHandler
+          handleLoginWindowSessionEvent:esMsg->event_type
+                               username:santa::StringToNSString(santa::StringTokenToStringView(
+                                            esMsg->event.lw_session_lock->username))];
+      break;
+    case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT:
+      [self.loginWindowSessionHandler
+          handleLoginWindowSessionEvent:esMsg->event_type
+                               username:santa::StringToNSString(santa::StringTokenToStringView(
+                                            esMsg->event.lw_session_logout->username))];
+      break;
+    default: break;
+  }
 
   // The logger will take care of this, but we check early so we
   // don't do any unnecessary work

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -217,6 +217,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
                                                   logger:mockLogger
                                                 enricher:mockEnricher
                                       compilerController:mockCC
+                               loginWindowSessionHandler:nil
                                          authResultCache:mockAuthCache
                                               prefixTree:prefixTree
                                              processTree:nullptr];
@@ -621,6 +622,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
                                                   logger:mockLogger
                                                 enricher:mockEnricher
                                       compilerController:mockCC
+                               loginWindowSessionHandler:nil
                                          authResultCache:mockAuthCache
                                               prefixTree:prefixTree
                                              processTree:nullptr];
@@ -694,6 +696,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
                                                   logger:mockLogger
                                                 enricher:mockEnricher
                                       compilerController:mockCC
+                               loginWindowSessionHandler:nil
                                          authResultCache:mockAuthCache
                                               prefixTree:prefixTree
                                              processTree:nullptr];
@@ -766,6 +769,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
                                                   logger:mockLogger
                                                 enricher:mockEnricher
                                       compilerController:mockCC
+                               loginWindowSessionHandler:nil
                                          authResultCache:mockAuthCache
                                               prefixTree:prefixTree
                                              processTree:nullptr];

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -25,6 +25,10 @@
 #include "Source/santad/SNTBinaryUploadController.h"
 #include "Source/santad/SandboxExpectations.h"
 
+namespace santa {
+class TemporaryAdminMode;
+}
+
 @class SNTNotificationQueue;
 @class SNTSyncdQueue;
 @class SNTNetworkExtensionQueue;
@@ -53,5 +57,9 @@
 /// When force is YES, delegates to installNetworkExtension: as long as installation is authorized.
 /// When force is NO, skips install if the loaded version already matches the on-disk version.
 - (void)installNetworkExtensionForce:(BOOL)force reply:(void (^)(BOOL))reply;
+
+// The Temporary Admin Mode orchestrator owned by this controller. Exposed so the ES login-window
+// session handler can drive lock/logout revocation through the same instance.
+- (std::shared_ptr<santa::TemporaryAdminMode>)temporaryAdminMode;
 
 @end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -1257,7 +1257,9 @@ static const char* const kAllowedCanonicalBundlePaths[] = {
   // user's active session.
   audit_token_t peer = [MOLXPCConnection currentPeerAuditToken];
   uid_t uid = audit_token_to_euid(peer);
-  _temporaryAdminMode->EndForUserEvent(uid, SNTTemporaryAdminModeLeaveReasonSessionEnded);
+  // The audit-token uid is authoritative on this path, so match on uid only (no login username is
+  // available here); pass nil to skip the name match.
+  _temporaryAdminMode->EndForUserEvent(uid, nil, SNTTemporaryAdminModeLeaveReasonSessionEnded);
   reply(nil);
 }
 

--- a/Source/santad/SNTLoginWindowSessionHandler.h
+++ b/Source/santad/SNTLoginWindowSessionHandler.h
@@ -1,0 +1,29 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <memory>
+
+#import "Source/santad/SNTLoginWindowSessionHandlerProtocol.h"
+#include "Source/santad/TemporaryAdminMode.h"
+
+@interface SNTLoginWindowSessionHandler : NSObject <SNTLoginWindowSessionHandler>
+// Designated initializer. `queue` is the serial queue on which the (potentially slow) revoke
+// runs; tests inject a queue they can drain.
+- (instancetype)initWithTemporaryAdminMode:(std::shared_ptr<santa::TemporaryAdminMode>)tam
+                                     queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTemporaryAdminMode:(std::shared_ptr<santa::TemporaryAdminMode>)tam;
+- (instancetype)init NS_UNAVAILABLE;
+@end

--- a/Source/santad/SNTLoginWindowSessionHandler.mm
+++ b/Source/santad/SNTLoginWindowSessionHandler.mm
@@ -70,6 +70,11 @@
     if (!tam->SecondsRemaining().has_value()) {
       return;
     }
+    // Best-effort resolve the login username to a uid. Resolution is NOT required: EndForUserEvent
+    // matches on the uid OR the stored username, so a transient directory failure or a
+    // local-vs-directory uid collision still revokes via the username. A uid of 0 (unresolved, or
+    // the root/loginwindow pseudo-user) never matches a real target uid.
+    uid_t uid = 0;
     struct passwd pwd;
     struct passwd* result = NULL;
     long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
@@ -86,12 +91,10 @@
            buf.size() < (1 << 20)) {
       buf.resize(buf.size() * 2);
     }
-    if (rc != 0 || result == NULL || pwd.pw_uid == 0) {
-      // Unresolved, or the loginwindow/root pseudo-user — never a TAM target. The timer remains
-      // the backstop if a real revoke was somehow missed.
-      return;
+    if (rc == 0 && result != NULL && pwd.pw_uid != 0) {
+      uid = pwd.pw_uid;
     }
-    tam->EndForUserEvent(pwd.pw_uid, reason);
+    tam->EndForUserEvent(uid, username, reason);
   });
 }
 

--- a/Source/santad/SNTLoginWindowSessionHandler.mm
+++ b/Source/santad/SNTLoginWindowSessionHandler.mm
@@ -14,7 +14,11 @@
 
 #import "Source/santad/SNTLoginWindowSessionHandler.h"
 
+#include <errno.h>
 #include <pwd.h>
+#include <unistd.h>
+
+#include <vector>
 
 @implementation SNTLoginWindowSessionHandler {
   std::shared_ptr<santa::TemporaryAdminMode> _temporaryAdminMode;
@@ -61,9 +65,21 @@
   dispatch_async(_queue, ^{
     struct passwd pwd;
     struct passwd* result = NULL;
-    char buf[1024];
-    if (getpwnam_r(username.UTF8String, &pwd, buf, sizeof(buf), &result) != 0 || result == NULL ||
-        pwd.pw_uid == 0) {
+    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufsize <= 0) {
+      bufsize = 1024;
+    }
+    std::vector<char> buf(bufsize);
+    // getpwnam_r returns ERANGE when the entry doesn't fit; grow and retry so directory-backed
+    // (LDAP/AD) entries larger than the initial buffer still resolve. Cap the growth so a
+    // pathological entry can't drive unbounded allocation.
+    int rc;
+    while ((rc = getpwnam_r(username.UTF8String, &pwd, buf.data(), buf.size(), &result)) ==
+               ERANGE &&
+           buf.size() < (1 << 20)) {
+      buf.resize(buf.size() * 2);
+    }
+    if (rc != 0 || result == NULL || pwd.pw_uid == 0) {
       // Unresolved, or the loginwindow/root pseudo-user — never a TAM target. The timer remains
       // the backstop if a real revoke was somehow missed.
       return;

--- a/Source/santad/SNTLoginWindowSessionHandler.mm
+++ b/Source/santad/SNTLoginWindowSessionHandler.mm
@@ -1,0 +1,75 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/SNTLoginWindowSessionHandler.h"
+
+#include <pwd.h>
+
+@implementation SNTLoginWindowSessionHandler {
+  std::shared_ptr<santa::TemporaryAdminMode> _temporaryAdminMode;
+  dispatch_queue_t _queue;
+}
+
+- (instancetype)initWithTemporaryAdminMode:(std::shared_ptr<santa::TemporaryAdminMode>)tam
+                                     queue:(dispatch_queue_t)queue {
+  self = [super init];
+  if (self) {
+    _temporaryAdminMode = std::move(tam);
+    _queue = queue;
+  }
+  return self;
+}
+
+- (instancetype)initWithTemporaryAdminMode:(std::shared_ptr<santa::TemporaryAdminMode>)tam {
+  return
+      [self initWithTemporaryAdminMode:std::move(tam)
+                                 queue:dispatch_queue_create_with_target(
+                                           "com.northpolesec.santa.lwsession",
+                                           DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
+                                           dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0))];
+}
+
+- (void)handleLoginWindowSessionEvent:(es_event_type_t)eventType username:(NSString*)username {
+  SNTTemporaryAdminModeLeaveReason reason;
+  switch (eventType) {
+    case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK:
+      reason = SNTTemporaryAdminModeLeaveReasonScreenLocked;
+      break;
+    case ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT:
+      reason = SNTTemporaryAdminModeLeaveReasonSessionEnded;
+      break;
+    default: return;
+  }
+  // Guard against an empty/nil username (invalid UTF-8, or the loginwindow pseudo-user).
+  if (username.length == 0) {
+    return;
+  }
+  // Resolve the uid and run the revoke (RemoveMember can be a slow OpenDirectory write) off the
+  // ES handler thread. `username` is retained by the block; UTF8String is read on the queue.
+  auto tam = _temporaryAdminMode;
+  dispatch_async(_queue, ^{
+    struct passwd pwd;
+    struct passwd* result = NULL;
+    char buf[1024];
+    if (getpwnam_r(username.UTF8String, &pwd, buf, sizeof(buf), &result) != 0 || result == NULL ||
+        pwd.pw_uid == 0) {
+      // Unresolved, or the loginwindow/root pseudo-user — never a TAM target. The timer remains
+      // the backstop if a real revoke was somehow missed.
+      return;
+    }
+    tam->EndForUserEvent(pwd.pw_uid, reason);
+  });
+}
+
+@end

--- a/Source/santad/SNTLoginWindowSessionHandler.mm
+++ b/Source/santad/SNTLoginWindowSessionHandler.mm
@@ -63,6 +63,13 @@
   // ES handler thread. `username` is retained by the block; UTF8String is read on the queue.
   auto tam = _temporaryAdminMode;
   dispatch_async(_queue, ^{
+    // Short-circuit before the potentially slow (directory-backed) username resolution: if no
+    // session is active there is nothing to revoke. SecondsRemaining takes lock_, so this check
+    // runs here on the queue rather than on the ES handler thread. EndForUserEvent still re-checks
+    // authoritatively under the lock, so this is only an optimization, not the guard.
+    if (!tam->SecondsRemaining().has_value()) {
+      return;
+    }
     struct passwd pwd;
     struct passwd* result = NULL;
     long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);

--- a/Source/santad/SNTLoginWindowSessionHandlerProtocol.h
+++ b/Source/santad/SNTLoginWindowSessionHandlerProtocol.h
@@ -1,0 +1,25 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <EndpointSecurity/EndpointSecurity.h>
+#import <Foundation/Foundation.h>
+
+// Collaborator the Recorder calls for login-window LOCK / LOGOUT events. The protocol is kept in
+// its own header so the Recorder stays unaware of Temporary Admin Mode internals (mirrors the
+// SNTCompilerController collaborator pattern).
+@protocol SNTLoginWindowSessionHandler <NSObject>
+// Called for ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK / _LOGOUT only. `username` is the login-window
+// session user. Must return quickly (runs on the ES handler thread).
+- (void)handleLoginWindowSessionEvent:(es_event_type_t)eventType username:(NSString*)username;
+@end

--- a/Source/santad/SNTLoginWindowSessionHandlerTest.mm
+++ b/Source/santad/SNTLoginWindowSessionHandlerTest.mm
@@ -1,0 +1,305 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/TemporaryAdminMode.h"
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#include <pwd.h>
+#include <unistd.h>
+
+#include <memory>
+#include <set>
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTError.h"
+#import "Source/common/SNTStoredTemporaryAdminModeAuditEvent.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+#include "Source/santad/AdminGroupMembership.h"
+#import "Source/santad/SNTLoginWindowSessionHandler.h"
+#import "Source/santad/SNTNotificationQueue.h"
+
+namespace santa {
+
+// In-memory fake admin-group membership for tests. Never touches the real group 80.
+class FakeAdminGroupMembership : public AdminGroupMembership {
+ public:
+  bool IsMember(uid_t uid) override { return members_.count(uid) > 0; }
+
+  bool AddMember(uid_t uid, NSError** error) override {
+    if (fail_add_) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"fake add"];
+      return false;
+    }
+    members_.insert(uid);
+    return true;
+  }
+
+  bool RemoveMember(uid_t uid, NSError** error) override {
+    if (fail_remove_) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"fake remove"];
+      return false;
+    }
+    members_.erase(uid);
+    return true;
+  }
+
+  std::set<uid_t> members_;
+  bool fail_add_ = false;
+  bool fail_remove_ = false;
+};
+
+}  // namespace santa
+
+using santa::FakeAdminGroupMembership;
+
+@interface SNTLoginWindowSessionHandlerTest : XCTestCase
+@property id mockConfigurator;
+@property id mockNotQueue;
+@end
+
+@implementation SNTLoginWindowSessionHandlerTest
+
+- (void)setUp {
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  self.mockNotQueue = OCMClassMock([SNTNotificationQueue class]);
+}
+
+// Stub an available on-demand policy.
+- (void)stubPolicyAvailable {
+  OCMStub([self.mockConfigurator temporaryAdminPolicy])
+      .andReturn([[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:60
+                                                      defaultDuration:5
+                                                 requireJustification:YES]);
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
+  OCMStub([self.mockConfigurator syncBaseURL])
+      .andReturn([NSURL URLWithString:@"https://foo.workshop.cloud"]);
+}
+
+- (void)stubAuthReply:(BOOL)authed reason:(NSString*)reason {
+  OCMStub([self.mockNotQueue
+      authorizeTemporaryAdminModeRequiringJustification:YES
+                                                  reply:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(
+                                                                                         authed),
+                                                                                     reason,
+                                                                                     nil])]);
+}
+
+// Build a real TemporaryAdminMode backed by a FakeAdminGroupMembership.
+// Returns the TAM; sets *fakeOut and populates eventsOut on each audit event.
+- (std::shared_ptr<santa::TemporaryAdminMode>)
+    buildTAMWithFake:(FakeAdminGroupMembership**)fakeOut
+              events:(NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>*)events {
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  *fakeOut = fakeOwned.get();
+  return santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+}
+
+// Helper: grant a session for uid / username, asserting success.
+- (void)grantTAM:(std::shared_ptr<santa::TemporaryAdminMode>&)tam
+             uid:(uid_t)uid
+        username:(NSString*)username {
+  NSError* err = nil;
+  XCTAssertGreaterThan(tam->RequestMinutes(@5, uid, username, &err), 0u);
+  XCTAssertNil(err);
+}
+
+#pragma mark - Test cases
+
+// Case 1: LW_SESSION_LOCK with matching username → uid removed, Leave audit with ScreenLocked.
+- (void)testLockRevokesSession {
+  if (getuid() == 0) {
+    XCTSkip(@"handler ignores uid 0; skip when running as root");
+  }
+
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need admin"];
+
+  uid_t uid = getuid();
+  struct passwd* pw = getpwuid(uid);
+  NSString* username = @(pw->pw_name);
+
+  FakeAdminGroupMembership* fake = nullptr;
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = [self buildTAMWithFake:&fake events:events];
+
+  [self grantTAM:tam uid:uid username:username];
+  XCTAssertTrue(fake->IsMember(uid));
+
+  dispatch_queue_t q =
+      dispatch_queue_create("com.test.lwsession", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+  SNTLoginWindowSessionHandler* handler =
+      [[SNTLoginWindowSessionHandler alloc] initWithTemporaryAdminMode:tam queue:q];
+
+  [handler handleLoginWindowSessionEvent:ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK username:username];
+  // Drain the serial queue to let the async block complete.
+  dispatch_sync(q, ^{
+                });
+
+  XCTAssertFalse(fake->IsMember(uid), @"uid should have been removed from admin group");
+  SNTStoredTemporaryAdminModeLeaveAuditEvent* leave =
+      (SNTStoredTemporaryAdminModeLeaveAuditEvent*)events.lastObject;
+  XCTAssertTrue([leave isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+  XCTAssertEqual(leave.reason, SNTTemporaryAdminModeLeaveReasonScreenLocked);
+}
+
+// Case 2: LW_SESSION_LOGOUT with matching username → uid removed, Leave audit with SessionEnded.
+- (void)testLogoutRevokesSession {
+  if (getuid() == 0) {
+    XCTSkip(@"handler ignores uid 0; skip when running as root");
+  }
+
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need admin"];
+
+  uid_t uid = getuid();
+  struct passwd* pw = getpwuid(uid);
+  NSString* username = @(pw->pw_name);
+
+  FakeAdminGroupMembership* fake = nullptr;
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = [self buildTAMWithFake:&fake events:events];
+
+  [self grantTAM:tam uid:uid username:username];
+  XCTAssertTrue(fake->IsMember(uid));
+
+  dispatch_queue_t q =
+      dispatch_queue_create("com.test.lwsession", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+  SNTLoginWindowSessionHandler* handler =
+      [[SNTLoginWindowSessionHandler alloc] initWithTemporaryAdminMode:tam queue:q];
+
+  [handler handleLoginWindowSessionEvent:ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOGOUT username:username];
+  dispatch_sync(q, ^{
+                });
+
+  XCTAssertFalse(fake->IsMember(uid));
+  SNTStoredTemporaryAdminModeLeaveAuditEvent* leave =
+      (SNTStoredTemporaryAdminModeLeaveAuditEvent*)events.lastObject;
+  XCTAssertTrue([leave isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
+  XCTAssertEqual(leave.reason, SNTTemporaryAdminModeLeaveReasonSessionEnded);
+}
+
+// Case 3: LW_SESSION_LOCK with empty username → early synchronous return; session remains active.
+- (void)testLockWithEmptyUsernameIsNoOp {
+  if (getuid() == 0) {
+    XCTSkip(@"handler ignores uid 0; skip when running as root");
+  }
+
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need admin"];
+
+  uid_t uid = getuid();
+  struct passwd* pw = getpwuid(uid);
+  NSString* username = @(pw->pw_name);
+
+  FakeAdminGroupMembership* fake = nullptr;
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = [self buildTAMWithFake:&fake events:events];
+
+  [self grantTAM:tam uid:uid username:username];
+  NSUInteger eventsAfterGrant = events.count;
+
+  dispatch_queue_t q =
+      dispatch_queue_create("com.test.lwsession", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+  SNTLoginWindowSessionHandler* handler =
+      [[SNTLoginWindowSessionHandler alloc] initWithTemporaryAdminMode:tam queue:q];
+
+  // Empty username → synchronous early return, no dispatch_async.
+  [handler handleLoginWindowSessionEvent:ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK username:@""];
+
+  // Session must still be active, no additional audit events.
+  XCTAssertTrue(fake->IsMember(uid), @"session should still be active");
+  XCTAssertTrue(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(events.count, eventsAfterGrant, @"no Leave audit should have been emitted");
+}
+
+// Case 4: LW_SESSION_LOCK with a non-resolvable username → session remains active.
+- (void)testLockWithUnresolvableUsernameIsNoOp {
+  if (getuid() == 0) {
+    XCTSkip(@"handler ignores uid 0; skip when running as root");
+  }
+
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need admin"];
+
+  uid_t uid = getuid();
+  struct passwd* pw = getpwuid(uid);
+  NSString* username = @(pw->pw_name);
+
+  FakeAdminGroupMembership* fake = nullptr;
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = [self buildTAMWithFake:&fake events:events];
+
+  [self grantTAM:tam uid:uid username:username];
+  NSUInteger eventsAfterGrant = events.count;
+
+  dispatch_queue_t q =
+      dispatch_queue_create("com.test.lwsession", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+  SNTLoginWindowSessionHandler* handler =
+      [[SNTLoginWindowSessionHandler alloc] initWithTemporaryAdminMode:tam queue:q];
+
+  [handler handleLoginWindowSessionEvent:ES_EVENT_TYPE_NOTIFY_LW_SESSION_LOCK
+                                username:@"no_such_user_zzqq"];
+  dispatch_sync(q, ^{
+                });
+
+  XCTAssertTrue(fake->IsMember(uid), @"session should still be active for original uid");
+  XCTAssertTrue(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(events.count, eventsAfterGrant, @"no Leave audit should have been emitted");
+}
+
+// Case 5: A non-LW event type (e.g. ES_EVENT_TYPE_NOTIFY_EXEC) → no removal, session intact.
+- (void)testNonLWEventTypeIsNoOp {
+  if (getuid() == 0) {
+    XCTSkip(@"handler ignores uid 0; skip when running as root");
+  }
+
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need admin"];
+
+  uid_t uid = getuid();
+  struct passwd* pw = getpwuid(uid);
+  NSString* username = @(pw->pw_name);
+
+  FakeAdminGroupMembership* fake = nullptr;
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = [self buildTAMWithFake:&fake events:events];
+
+  [self grantTAM:tam uid:uid username:username];
+  NSUInteger eventsAfterGrant = events.count;
+
+  dispatch_queue_t q =
+      dispatch_queue_create("com.test.lwsession", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+  SNTLoginWindowSessionHandler* handler =
+      [[SNTLoginWindowSessionHandler alloc] initWithTemporaryAdminMode:tam queue:q];
+
+  [handler handleLoginWindowSessionEvent:ES_EVENT_TYPE_NOTIFY_EXEC username:username];
+  // No async work is dispatched for unrecognized events; no drain needed.
+
+  XCTAssertTrue(fake->IsMember(uid), @"session should still be active");
+  XCTAssertTrue(tam->SecondsRemaining().has_value());
+  XCTAssertEqual(events.count, eventsAfterGrant, @"no Leave audit should have been emitted");
+}
+
+@end

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -51,6 +51,7 @@
 #import "Source/santad/SNTDaemonControlController.h"
 #import "Source/santad/SNTDatabaseController.h"
 #import "Source/santad/SNTDecisionCache.h"
+#import "Source/santad/SNTLoginWindowSessionHandler.h"
 #include "Source/santad/SleighLauncher.h"
 #include "Source/santad/TTYWriter.h"
 
@@ -160,12 +161,16 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                          [SNTConfigurator configurator])];
   };
 
+  SNTLoginWindowSessionHandler* lw_session_handler =
+      [[SNTLoginWindowSessionHandler alloc] initWithTemporaryAdminMode:[dc temporaryAdminMode]];
+
   SNTEndpointSecurityRecorder* monitor_client =
       [[SNTEndpointSecurityRecorder alloc] initWithESAPI:esapi
                                                  metrics:metrics
                                                   logger:logger
                                                 enricher:enricher
                                       compilerController:compiler_controller
+                               loginWindowSessionHandler:lw_session_handler
                                          authResultCache:auth_result_cache
                                               prefixTree:prefix_tree
                                              processTree:process_tree];

--- a/Source/santad/TemporaryAdminMode.h
+++ b/Source/santad/TemporaryAdminMode.h
@@ -64,10 +64,12 @@ class TemporaryAdminMode : public TimedSyncSession, public PassKey<TemporaryAdmi
   // On a Revoke policy, cancel any active session; always re-notify GUI availability.
   void NewPolicyReceived(SNTTemporaryAdminPolicy* policy);
 
-  // End the active session iff it belongs to `uid`, with the given leave reason and no revoke
-  // policy. No-op (returns false) if no session is active or the uid does not match. Used by
-  // the session-presence triggers (screen lock / logout / fast-user-switch).
-  bool EndForUserEvent(uid_t uid, SNTTemporaryAdminModeLeaveReason reason);
+  // End the active session iff it belongs to the target user, with the given leave reason and no
+  // revoke policy. Matches on EITHER `uid` (when non-zero) OR `username` (case-insensitive), so a
+  // failed or colliding uid resolution on one trigger can still revoke via the other key. No-op
+  // (returns false) if no session is active or neither key matches. Used by the session-presence
+  // triggers (screen lock / logout / fast-user-switch).
+  bool EndForUserEvent(uid_t uid, NSString* username, SNTTemporaryAdminModeLeaveReason reason);
 
   friend class TemporaryAdminModePeer;
 

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -148,9 +148,22 @@ uint32_t TemporaryAdminMode::RequestMinutes(NSNumber* requested_duration, uid_t 
   }
 }
 
-bool TemporaryAdminMode::EndForUserEvent(uid_t uid, SNTTemporaryAdminModeLeaveReason reason) {
+bool TemporaryAdminMode::EndForUserEvent(uid_t uid, NSString* username,
+                                         SNTTemporaryAdminModeLeaveReason reason) {
   absl::MutexLock lock(lock_);
-  if (!IsStartedLocked() || target_uid_ != uid) {
+  if (!IsStartedLocked()) {
+    return false;
+  }
+  // Match on either key. Each trigger has one trustworthy identifier and one derived one: the ES
+  // lock/logout path has the login username but a getpwnam-derived (fallible) uid, while the
+  // fast-user-switch path has the audit-token uid but no username. Accepting either lets a session
+  // be ended even when the derived key is missing (uid 0) or collides (local vs directory account).
+  // The length guards must precede the compare: -[nil caseInsensitiveCompare:] returns
+  // NSOrderedSame and would otherwise false-match.
+  bool uid_match = (uid != 0 && uid == target_uid_);
+  bool name_match = (username.length > 0 && target_username_.length > 0 &&
+                     [username caseInsensitiveCompare:target_username_] == NSOrderedSame);
+  if (!uid_match && !name_match) {
     return false;
   }
   return EndForReasonLocked((NSInteger)reason);

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -379,7 +379,7 @@ static uint64_t MakeDeadline(uint64_t want) {
   XCTAssertTrue(fake->IsMember(501));
 
   // EndForUserEvent with the matching uid must return true.
-  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertTrue(tam->EndForUserEvent(501, @"alice", SNTTemporaryAdminModeLeaveReasonScreenLocked));
 
   // The user must be removed from the admin group.
   XCTAssertFalse(fake->IsMember(501));
@@ -410,13 +410,14 @@ static uint64_t MakeDeadline(uint64_t want) {
   // Available() must be true before and after; EndForUserEvent must not call WriteRevokePolicy.
   XCTAssertTrue(tam->Available());
 
-  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertTrue(tam->EndForUserEvent(501, @"alice", SNTTemporaryAdminModeLeaveReasonScreenLocked));
 
   // The feature must still be available — no revoke policy was written.
   XCTAssertTrue(tam->Available());
 }
 
-// With an active session for uid 501, EndForUserEvent for a different uid is a no-op.
+// With an active session for uid 501 / "alice", EndForUserEvent for a different uid AND a
+// different username is a no-op.
 - (void)testEndForUserEventWrongUidIsNoOp {
   [self stubPolicyAvailable];
   [self stubAuthReply:YES reason:@"reason"];
@@ -434,8 +435,8 @@ static uint64_t MakeDeadline(uint64_t want) {
   XCTAssertNil(err);
   XCTAssertTrue(fake->IsMember(501));
 
-  // A different uid must be rejected.
-  XCTAssertFalse(tam->EndForUserEvent(502, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  // A different uid and a different username must be rejected.
+  XCTAssertFalse(tam->EndForUserEvent(502, @"bob", SNTTemporaryAdminModeLeaveReasonScreenLocked));
 
   // Session for 501 must remain intact.
   XCTAssertTrue(fake->IsMember(501));
@@ -459,7 +460,7 @@ static uint64_t MakeDeadline(uint64_t want) {
   // No session was started.
   XCTAssertFalse(tam->SecondsRemaining().has_value());
 
-  XCTAssertFalse(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertFalse(tam->EndForUserEvent(501, @"alice", SNTTemporaryAdminModeLeaveReasonScreenLocked));
 
   // No audit events must have been emitted.
   XCTAssertEqual(events.count, 0u);
@@ -482,11 +483,11 @@ static uint64_t MakeDeadline(uint64_t want) {
   XCTAssertNil(err);
 
   // First call succeeds.
-  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertTrue(tam->EndForUserEvent(501, @"alice", SNTTemporaryAdminModeLeaveReasonScreenLocked));
   NSUInteger countAfterFirst = events.count;
 
   // Second call must return false and must not emit another audit event.
-  XCTAssertFalse(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertFalse(tam->EndForUserEvent(501, @"alice", SNTTemporaryAdminModeLeaveReasonScreenLocked));
   XCTAssertEqual(events.count, countAfterFirst);
 }
 
@@ -506,13 +507,99 @@ static uint64_t MakeDeadline(uint64_t want) {
   XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
   XCTAssertNil(err);
 
-  XCTAssertTrue(tam->EndForUserEvent(501, SNTTemporaryAdminModeLeaveReasonSessionEnded));
+  XCTAssertTrue(tam->EndForUserEvent(501, @"alice", SNTTemporaryAdminModeLeaveReasonSessionEnded));
 
   XCTAssertTrue(
       [events.lastObject isKindOfClass:[SNTStoredTemporaryAdminModeLeaveAuditEvent class]]);
   SNTStoredTemporaryAdminModeLeaveAuditEvent* leave =
       (SNTStoredTemporaryAdminModeLeaveAuditEvent*)events.lastObject;
   XCTAssertEqual(leave.reason, SNTTemporaryAdminModeLeaveReasonSessionEnded);
+}
+
+// uid unresolved (0) but the username matches the stored target -> revokes via the name. This is
+// the transient-directory-failure case where getpwnam yields no uid.
+- (void)testEndForUserEventNameMatchWhenUidUnresolved {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+
+  XCTAssertTrue(tam->EndForUserEvent(0, @"alice", SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertFalse(fake->IsMember(501));
+}
+
+// uid does not match but the username does (local-vs-directory uid collision) -> revokes.
+- (void)testEndForUserEventNameMatchWhenUidDiffers {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+
+  XCTAssertTrue(tam->EndForUserEvent(999, @"alice", SNTTemporaryAdminModeLeaveReasonSessionEnded));
+  XCTAssertFalse(fake->IsMember(501));
+}
+
+// The username match is case-insensitive (login name vs canonical pw_name can differ in case).
+- (void)testEndForUserEventNameMatchIsCaseInsensitive {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+
+  XCTAssertTrue(tam->EndForUserEvent(0, @"ALICE", SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertFalse(fake->IsMember(501));
+}
+
+// Neither key resolvable/matching (uid 0, empty username) -> no-op even with an active session.
+- (void)testEndForUserEventNoKeyIsNoOp {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  NSMutableArray<SNTStoredTemporaryAdminModeAuditEvent*>* events = [NSMutableArray array];
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  XCTAssertNil(err);
+
+  XCTAssertFalse(tam->EndForUserEvent(0, @"", SNTTemporaryAdminModeLeaveReasonScreenLocked));
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(tam->SecondsRemaining().has_value());
 }
 
 @end


### PR DESCRIPTION
Part of WS-1128, stacked on #1037

- Ends an active Temporary Admin Mode elevation when the console user's login session leaves, so a grant cannot outlive its session.
- SNTLoginWindowSessionHandler subscribes to Endpoint Security login-window session events; on a leave it resolves the departing uid and asks TemporaryAdminMode to end that user's session 