### PR TITLE
gui: Honor per-rule custom messages and URLs for blocked network flows

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -453,6 +453,7 @@ objc_library(
         ":SNTLogging",
         ":SNTStoredExecutionEvent",
         ":SNTStoredFileAccessEvent",
+        ":SNTStoredNetworkFlowEvent",
         ":SNTSystemInfo",
     ],
 )
@@ -469,6 +470,7 @@ objc_library(
         ":SNTLogging",
         ":SNTStoredExecutionEvent",
         ":SNTStoredFileAccessEvent",
+        ":SNTStoredNetworkFlowEvent",
         ":SNTSystemInfo",
     ],
 )
@@ -1255,6 +1257,7 @@ santa_unit_test(
         ":SNTConfigurator",
         ":SNTStoredExecutionEvent",
         ":SNTStoredFileAccessEvent",
+        ":SNTStoredNetworkFlowEvent",
         ":SNTSystemInfo",
         "@OCMock",
     ],

--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -24,6 +24,7 @@
 @class SNTDeviceEvent;
 @class SNTStoredExecutionEvent;
 @class SNTStoredFileAccessEvent;
+@class SNTStoredNetworkFlowEvent;
 
 @interface SNTBlockMessage : NSObject
 
@@ -65,6 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
                                 customURL:(nullable NSString*)url;
 + (nullable NSURL*)eventDetailURLForFileAccessEvent:(nullable SNTStoredFileAccessEvent*)event
                                           customURL:(nullable NSString*)url;
++ (nullable NSURL*)eventDetailURLForNetworkFlowEvent:(nullable SNTStoredNetworkFlowEvent*)event
+                                           customURL:(nullable NSString*)url;
 
 ///
 ///  Returns a human-readable string describing the block reason for the given event, including

--- a/Source/common/SNTBlockMessage.mm
+++ b/Source/common/SNTBlockMessage.mm
@@ -20,6 +20,7 @@
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStoredFileAccessEvent.h"
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
 #import "Source/common/SNTSystemInfo.h"
 
 // Percent-encode a string so it is safe in both URL path and query positions.
@@ -372,6 +373,49 @@ static id EncodedValueOrNull(id value) {
       [self eventDetailURLForEvent:event
                          customURL:url ?: [[SNTConfigurator configurator] fileAccessEventDetailURL]
                    templateMapping:[self fileAccessEventDetailTemplateMappingForEvent:event]];
+}
+
+//
+//   Format strings replaced in the URL provided by
+//   `+eventDetailURLForNetworkFlowEvent:customURL:`.
+//
+//   %rule_name%       - Name of the rule that blocked the flow.
+//   %remote_hostname% - Destination hostname, if resolved.
+//   %remote_address%  - Remote IP address of the flow.
+//   %remote_port%     - Remote port of the flow.
+//   %file_identifier% - SHA-256 of the process that opened the flow.
+//   %team_id%         - Team ID from the signature, if present.
+//   %signing_id%      - Signing ID from the signature, if present.
+//   %cdhash%          - CDHash, if signed.
+//   %username%        - Executing user's name.
+//   %machine_id%      - Configured machine ID for this host.
+//   %hostname%        - This host's (machine) hostname.
+//   %uuid%            - Machine UUID.
+//   %serial%          - Machine serial number.
+//
++ (NSDictionary*)networkFlowEventDetailTemplateMappingForEvent:(SNTStoredNetworkFlowEvent*)event {
+  return @{
+    @"%rule_name%" : EncodedValueOrNull(event.ruleName),
+    @"%remote_hostname%" : EncodedValueOrNull(event.hostname),
+    @"%remote_address%" : EncodedValueOrNull(event.remoteAddress),
+    @"%remote_port%" : EncodedValueOrNull(@(event.remotePort).stringValue),
+    @"%file_identifier%" : EncodedValueOrNull(event.process.fileSHA256),
+    @"%team_id%" : EncodedValueOrNull(event.process.teamID),
+    @"%signing_id%" : EncodedValueOrNull(event.process.signingID),
+    @"%cdhash%" : EncodedValueOrNull(event.process.cdhash),
+    @"%username%" : EncodedValueOrNull(event.process.executingUser),
+    @"%machine_id%" : EncodedValueOrNull([[SNTConfigurator configurator] machineID]),
+    @"%hostname%" : EncodedValueOrNull([SNTSystemInfo longHostname]),
+    @"%uuid%" : EncodedValueOrNull([SNTSystemInfo hardwareUUID]),
+    @"%serial%" : EncodedValueOrNull([SNTSystemInfo serialNumber]),
+  };
+}
+
++ (NSURL*)eventDetailURLForNetworkFlowEvent:(SNTStoredNetworkFlowEvent*)event
+                                  customURL:(NSString*)url {
+  return [self eventDetailURLForEvent:event
+                            customURL:url
+                      templateMapping:[self networkFlowEventDetailTemplateMappingForEvent:event]];
 }
 
 @end

--- a/Source/common/SNTBlockMessageTest.mm
+++ b/Source/common/SNTBlockMessageTest.mm
@@ -20,6 +20,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStoredFileAccessEvent.h"
+#import "Source/common/SNTStoredNetworkFlowEvent.h"
 #import "Source/common/SNTSystemInfo.h"
 
 @interface SNTBlockMessageTest : XCTestCase
@@ -111,6 +112,33 @@
 
   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:nil]);
   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
+}
+
+- (void)testEventDetailURLForNetworkFlowEvent {
+  SNTStoredNetworkFlowEvent* nfe = [[SNTStoredNetworkFlowEvent alloc] init];
+  nfe.ruleName = @"my_rn";
+  nfe.hostname = @"evil.example.com";
+  nfe.remoteAddress = @"93.184.216.34";
+  nfe.remotePort = 443;
+  nfe.process.fileSHA256 = @"my_fi";
+  nfe.process.cdhash = @"my_ch";
+  nfe.process.teamID = @"my_ti";
+  nfe.process.signingID = @"my_si";
+  nfe.process.executingUser = @"my_un";
+
+  NSString* url = @"http://localhost?rn=%rule_name%&rh=%remote_hostname%&ra=%remote_address%"
+                  @"&rp=%remote_port%&fi=%file_identifier%&ti=%team_id%&si=%signing_id%"
+                  @"&ch=%cdhash%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
+  NSString* wantUrl =
+      @"http://localhost?rn=my_rn&rh=evil.example.com&ra=93.184.216.34"
+      @"&rp=443&fi=my_fi&ti=my_ti&si=my_si&ch=my_ch&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+
+  NSURL* gotUrl = [SNTBlockMessage eventDetailURLForNetworkFlowEvent:nfe customURL:url];
+  XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
+
+  // Empty/"null"/nil URLs resolve to nil (same guard as exec/FAA).
+  XCTAssertNil([SNTBlockMessage eventDetailURLForNetworkFlowEvent:nfe customURL:nil]);
+  XCTAssertNil([SNTBlockMessage eventDetailURLForNetworkFlowEvent:nfe customURL:@"null"]);
 }
 
 - (void)testEventDetailURLForFileAccessEventFallback {

--- a/Source/common/SNTStoredNetworkFlowEvent.h
+++ b/Source/common/SNTStoredNetworkFlowEvent.h
@@ -88,4 +88,9 @@ typedef NS_ENUM(int32_t, SNTNetworkFlowTier) {
 // santad-local, NOT mapped to the proto: drives the loud-deny dialog only.
 @property BOOL silent;
 
+// Block-feedback text from the winning rule (custom_msg / custom_url).
+// santad-local, NOT uploaded.
+@property(nullable) NSString* customMsg;
+@property(nullable) NSString* customURL;
+
 @end

--- a/Source/common/SNTStoredNetworkFlowEvent.mm
+++ b/Source/common/SNTStoredNetworkFlowEvent.mm
@@ -51,6 +51,8 @@
   ENCODE(coder, eventDedupeKey);
   ENCODE(coder, uiDedupeKey);
   ENCODE_BOXABLE(coder, silent);
+  ENCODE(coder, customMsg);
+  ENCODE(coder, customURL);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
@@ -75,6 +77,8 @@
     DECODE(decoder, eventDedupeKey, NSString);
     DECODE(decoder, uiDedupeKey, NSString);
     DECODE_SELECTOR(decoder, silent, NSNumber, boolValue);
+    DECODE(decoder, customMsg, NSString);
+    DECODE(decoder, customURL, NSString);
   }
   return self;
 }

--- a/Source/common/SNTStoredNetworkFlowEventTest.mm
+++ b/Source/common/SNTStoredNetworkFlowEventTest.mm
@@ -57,6 +57,8 @@
   e.eventDedupeKey = @"TEAM:com.apple.curl|7|example.com";
   e.uiDedupeKey = @"4242:1|7|example.com";
   e.silent = YES;
+  e.customMsg = @"Contact IT before reaching this host";
+  e.customURL = @"https://example.com/why?rule=%rule_name%";
   e.process.filePath = @"/usr/bin/curl";
   e.process.cdhash = @"deadbeef";
   e.process.parent = [[SNTStoredProcess alloc] init];
@@ -90,6 +92,8 @@
   XCTAssertEqualObjects(d.eventDedupeKey, @"TEAM:com.apple.curl|7|example.com");
   XCTAssertEqualObjects(d.uiDedupeKey, @"4242:1|7|example.com");
   XCTAssertTrue(d.silent);  // local field survives the round-trip
+  XCTAssertEqualObjects(d.customMsg, @"Contact IT before reaching this host");
+  XCTAssertEqualObjects(d.customURL, @"https://example.com/why?rule=%rule_name%");
   XCTAssertEqualObjects(d.process.filePath, @"/usr/bin/curl");
   XCTAssertEqualObjects(d.process.parent.pid, @(1));
   XCTAssertEqualObjects([d uniqueID],

--- a/Source/gui/SNTNetworkFlowMessageWindowView.swift
+++ b/Source/gui/SNTNetworkFlowMessageWindowView.swift
@@ -266,12 +266,14 @@ struct SNTNetworkFlowMessageWindowView: View {
   let silenceable: Bool
   let uiStateCallback: ((TimeInterval) -> Void)?
 
+  @Environment(\.openURL) var openURL
+
   @State public var preventFutureNotifications = false
   @State public var preventFutureNotificationPeriod: TimeInterval = NotificationSilencePeriods[0]
 
   var body: some View {
     SNTMessageView(
-      SNTBlockMessage.attributedBlockMessageForNetworkFlowEvent(withCustomMessage: nil)
+      SNTBlockMessage.attributedBlockMessageForNetworkFlowEvent(withCustomMessage: event?.customMsg)
     ) {
       NetworkFlowDetail(e: event)
 
@@ -283,6 +285,9 @@ struct SNTNetworkFlowMessageWindowView: View {
       }
 
       HStack {
+        if shouldAddOpenButton() {
+          OpenEventButton(action: openButton)
+        }
         DismissButton(silence: preventFutureNotifications, action: dismissButton)
       }
     }
@@ -294,5 +299,24 @@ struct SNTNetworkFlowMessageWindowView: View {
       callback(preventFutureNotifications ? preventFutureNotificationPeriod : 0)
     }
     window?.close()
+  }
+
+  func shouldAddOpenButton() -> Bool {
+    guard let customURL = event?.customURL else { return false }
+    return !customURL.isEmpty && customURL != "null"
+  }
+
+  func openButton() {
+    if let callback = uiStateCallback {
+      callback(preventFutureNotifications ? preventFutureNotificationPeriod : 0)
+    }
+    let url = SNTBlockMessage.eventDetailURL(
+      for: event,
+      customURL: event?.customURL
+    )
+    window?.close()
+    if let url = url {
+      openURL(url)
+    }
   }
 }

--- a/Source/gui/SNTTestGUI.swift
+++ b/Source/gui/SNTTestGUI.swift
@@ -478,6 +478,8 @@ struct NetworkFlowView: View {
   @State private var teamID: String = "9X9633G7QW"
   @State private var pid: String = "12345"
   @State private var executingUser: String = NSUserName()
+  @State private var customMsg: String = ""
+  @State private var customURL: String = ""
   @State private var allowNotificationSilence: Bool = true
 
   @State private var brandingCompanyName: String = ""
@@ -501,6 +503,23 @@ struct NetworkFlowView: View {
           TextField(text: $remotePort, label: { Text(verbatim: "Remote Port") })
           TextField(text: $ruleName, label: { Text(verbatim: "Rule Name") })
           TextField(text: $ruleId, label: { Text(verbatim: "Rule ID") })
+          HStack {
+            TextField(text: $customMsg, label: { Text(verbatim: "Custom Message") })
+            Button(action: { customMsg = "Contact IT before reaching this host" }) {
+              Text(verbatim: "Populate").font(Font.subheadline)
+            }
+            Button(action: { customMsg = "" }) { Text(verbatim: "Clear").font(Font.subheadline) }
+          }
+          HStack {
+            TextField(text: $customURL, label: { Text(verbatim: "Custom URL") })
+            Button(action: {
+              customURL =
+                "http://sync-server-hostname/netflow?rule=%rule_name%&host=%remote_hostname%&port=%remote_port%"
+            }) {
+              Text(verbatim: "Populate").font(Font.subheadline)
+            }
+            Button(action: { customURL = "" }) { Text(verbatim: "Clear").font(Font.subheadline) }
+          }
           HStack {
             Picker(selection: $decisionTier, label: Text(verbatim: "Match (decisionTier)")) {
               Text(verbatim: "Exact IP").tag(SNTNetworkFlowTier.exactIP)
@@ -561,6 +580,8 @@ struct NetworkFlowView: View {
         event.ruleName = ruleName
         event.ruleId = Int64(ruleId) ?? 0
         event.decisionTier = decisionTier
+        event.customMsg = customMsg.isEmpty ? nil : customMsg
+        event.customURL = customURL.isEmpty ? nil : customURL
 
         let bundle = SNTConfigBundle()
         bundle.setValue(NSNumber(value: allowNotificationSilence), forKey: "enableNotificationSilences")

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -1012,6 +1012,8 @@
   block.totalCompetingRuleCount = 12;
   block.eventDedupeKey = @"TEAM:com.apple.curl|7|example.com";  // santa-internal, never uploaded
   block.uiDedupeKey = @"4242:1|7|example.com";                  // santa-internal, never uploaded
+  block.customMsg = @"Contact IT before reaching this host";    // rule property, never uploaded
+  block.customURL = @"https://example.com/why";                 // rule property, never uploaded
   block.process.filePath = @"/usr/bin/curl";
   block.process.cdhash = @"deadbeef";
   block.process.fileSHA256 = @"abc123";
@@ -1080,6 +1082,10 @@
             // Internal dedup keys are never serialized to the proto.
             XCTAssertNil(f[@"eventDedupeKey"]);
             XCTAssertNil(f[@"uiDedupeKey"]);
+
+            // Rule block-feedback text is santad-local; never serialized to the proto.
+            XCTAssertNil(f[@"customMsg"]);
+            XCTAssertNil(f[@"customUrl"]);
 
             return YES;
           }];

--- a/stubs/santanetd/src/santanetd/SNDNetworkFlowDecision.h
+++ b/stubs/santanetd/src/santanetd/SNDNetworkFlowDecision.h
@@ -23,7 +23,10 @@ struct SantaVnode;
 // access to the Network Extension repo.
 @interface SNDNetworkFlowDecision : NSObject <NSSecureCoding>
 
-- (SNTStoredNetworkFlowEvent*)storedEvent;
+- (nullable SNTStoredNetworkFlowEvent*)storedEvent;
 - (SantaVnode)vnode;
+
+@property(nullable) NSString* customMsg;
+@property(nullable) NSString* customURL;
 
 @end


### PR DESCRIPTION
Consumes a network-flow rule's custom_msg/custom_url in the block dialog. The fields ride SNTStoredNetworkFlowEvent (santad-local — encoded for XPC and the events DB, never mapped into the NetworkFlowEvent upload proto, guarded by a sync test); the dialog renders the custom message in place of the default text and offers the standard Open... button with flow-specific URL template tokens (%rule_name%, %remote_hostname%, %remote_address%, %remote_port%); the test GUI's Network Flow tab can simulate both. Inert until santanetd starts producing the fields.