### PR TITLE
santad: write network-flow block message to the controlling TTY

### DIFF
--- a/Source/common/SNTStoredNetworkFlowEvent.h
+++ b/Source/common/SNTStoredNetworkFlowEvent.h
@@ -93,4 +93,8 @@ typedef NS_ENUM(int32_t, SNTNetworkFlowTier) {
 @property(nullable) NSString* customMsg;
 @property(nullable) NSString* customURL;
 
+// santad-local, NOT mapped to the proto: originating process's controlling TTY (from the
+// exec-time snapshot on the wire), used to write the loud-deny block message to that terminal.
+@property(nullable) NSString* ttyPath;
+
 @end

--- a/Source/common/SNTStoredNetworkFlowEvent.mm
+++ b/Source/common/SNTStoredNetworkFlowEvent.mm
@@ -53,6 +53,7 @@
   ENCODE_BOXABLE(coder, silent);
   ENCODE(coder, customMsg);
   ENCODE(coder, customURL);
+  ENCODE(coder, ttyPath);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
@@ -79,6 +80,7 @@
     DECODE_SELECTOR(decoder, silent, NSNumber, boolValue);
     DECODE(decoder, customMsg, NSString);
     DECODE(decoder, customURL, NSString);
+    DECODE(decoder, ttyPath, NSString);
   }
   return self;
 }

--- a/Source/common/SNTStoredNetworkFlowEventTest.mm
+++ b/Source/common/SNTStoredNetworkFlowEventTest.mm
@@ -59,6 +59,7 @@
   e.silent = YES;
   e.customMsg = @"Contact IT before reaching this host";
   e.customURL = @"https://example.com/why?rule=%rule_name%";
+  e.ttyPath = @"/dev/ttys003";
   e.process.filePath = @"/usr/bin/curl";
   e.process.cdhash = @"deadbeef";
   e.process.parent = [[SNTStoredProcess alloc] init];
@@ -94,6 +95,7 @@
   XCTAssertTrue(d.silent);  // local field survives the round-trip
   XCTAssertEqualObjects(d.customMsg, @"Contact IT before reaching this host");
   XCTAssertEqualObjects(d.customURL, @"https://example.com/why?rule=%rule_name%");
+  XCTAssertEqualObjects(d.ttyPath, @"/dev/ttys003");  // santad-local field survives the round-trip
   XCTAssertEqualObjects(d.process.filePath, @"/usr/bin/curl");
   XCTAssertEqualObjects(d.process.parent.pid, @(1));
   XCTAssertEqualObjects([d uniqueID],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -217,7 +217,9 @@ objc_library(
         ":SNTNotificationQueue",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
+        ":TTYWriter",
         "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTBlockMessage",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
@@ -243,11 +245,13 @@ santa_unit_test(
     name = "SNTNetworkExtensionQueueTest",
     srcs = ["SNTNetworkExtensionQueueTest.mm"],
     deps = [
+        ":MockTTYWriter",
         ":SNTDecisionCache",
         ":SNTNetworkExtensionQueue",
         ":SNTNotificationQueue",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
+        ":TTYWriter",
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTConfigurator",
@@ -256,10 +260,12 @@ santa_unit_test(
         "//Source/common:SNTStoredProcess",
         "//Source/common:SNTXPCNotifierInterface",
         "//Source/common:SantaVnode",
+        "//Source/common:TestUtils",
         "//Source/common/ne:SNDXPCNetworkExtensionInterface",
         "//Source/common/ne:SNTNetworkExtensionSettings",
         "//Source/common/ne:SNTSyncNetworkExtensionSettings",
         "@OCMock",
+        "@googletest//:gtest",
         "@santanetd//src/santanetd:SNDNetworkFlowDecision",
     ],
 )
@@ -378,6 +384,14 @@ objc_library(
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
         "//Source/common:String",
+    ],
+)
+
+santa_unit_test(
+    name = "TTYWriterTest",
+    srcs = ["TTYWriterTest.mm"],
+    deps = [
+        ":TTYWriter",
     ],
 )
 
@@ -1329,6 +1343,16 @@ objc_library(
 )
 
 objc_library(
+    name = "MockTTYWriter",
+    testonly = 1,
+    hdrs = ["MockTTYWriter.h"],
+    deps = [
+        ":TTYWriter",
+        "@googletest//:gtest",
+    ],
+)
+
+objc_library(
     name = "MockLogger",
     testonly = 1,
     hdrs = ["Logs/EndpointSecurity/MockLogger.h"],
@@ -1912,6 +1936,7 @@ test_suite(
         ":SandboxExpectationsTest",
         ":SantadTest",
         ":SleighLauncherTest",
+        ":TTYWriterTest",
         ":TemporaryMonitorModeTest",
         "//Source/common/es:EndpointSecurityClientTest",
         "//Source/common/es:EndpointSecurityEnricherTest",

--- a/Source/santad/MockTTYWriter.h
+++ b/Source/santad/MockTTYWriter.h
@@ -1,0 +1,39 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_SANTAD_MOCKTTYWRITER_H
+#define SANTA_SANTAD_MOCKTTYWRITER_H
+
+#import <Foundation/Foundation.h>
+#include <gmock/gmock.h>
+
+#include "Source/santad/TTYWriter.h"
+
+namespace santa {
+
+class MockTTYWriter : public TTYWriter {
+ public:
+  // The mock never dispatches (WriteWithoutSignal is stubbed), so the queue + silent flag
+  // passed to the real base ctor are inert but valid.
+  MockTTYWriter()
+      : TTYWriter(
+            dispatch_queue_create("com.northpolesec.santa.mockttywriter", DISPATCH_QUEUE_SERIAL),
+            /*silent_tty_mode=*/false) {}
+
+  MOCK_METHOD(void, WriteWithoutSignal, (NSString * ttyPath, NSString* msg), (override));
+};
+
+}  // namespace santa
+
+#endif  // SANTA_SANTAD_MOCKTTYWRITER_H

--- a/Source/santad/SNTNetworkExtensionQueue.h
+++ b/Source/santad/SNTNetworkExtensionQueue.h
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#include "Source/santad/TTYWriter.h"
 
 @class SNDNetworkFlowDecision;
 @class SNDProcessFlows;
@@ -36,6 +37,7 @@ extern NSString* const kSantaNetworkExtensionProtocolVersion;
                            syncdQueue:(SNTSyncdQueue*)syncdQueue
                             ruleTable:(SNTRuleTable*)ruleTable
                         decisionCache:(SNTDecisionCache*)decisionCache
+                            ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter
                                logger:(std::shared_ptr<santa::Logger>)logger
     NS_DESIGNATED_INITIALIZER;
 

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -247,12 +247,14 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
 
     [self.syncdQueue addStoredEvent:event];
 
+    // A "loud deny" (blocked, not silenced) drives both the TTY write and the dialog below.
+    const bool loudDeny = event.decision == SNTNetworkFlowDecisionBlock && !event.silent;
+
     // Loud deny with a known controlling TTY: write the block message to that terminal so
     // terminal/SSH users get feedback, mirroring exec/FAA. Independent of the GUI dialog (which
     // may be absent at the loginwindow) and its de-dup. ttyPath is nil for audit-token-resolved
     // processes (no ES exec seen) -> no write. WriteWithoutSignal (no SIGWINCH) matches FAA.
-    if (event.decision == SNTNetworkFlowDecisionBlock && !event.silent &&
-        event.ttyPath.length > 0 && _ttyWriter) {
+    if (loudDeny && event.ttyPath.length > 0 && _ttyWriter) {
       NSAttributedString* attrStr = [SNTBlockMessage
           attributedBlockMessageForNetworkFlowEventWithCustomMessage:event.customMsg];
 
@@ -283,8 +285,7 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
     // dialog once a GUI connects within the window. The uiDedupeKey cache then collapses repeats
     // for the same (process, rule, destination).
     MOLXPCConnection* notifierConnection = self.notifierQueue.notifierConnection;
-    if (event.decision == SNTNetworkFlowDecisionBlock && !event.silent && notifierConnection &&
-        [self shouldPostFlowDialogForKey:event.uiDedupeKey]) {
+    if (loudDeny && notifierConnection && [self shouldPostFlowDialogForKey:event.uiDedupeKey]) {
       [[notifierConnection remoteObjectProxy]
           postNetworkFlowBlockNotification:event
                               configBundle:santa::NetworkFlowConfigBundle(

--- a/Source/santad/SNTNetworkExtensionQueue.mm
+++ b/Source/santad/SNTNetworkExtensionQueue.mm
@@ -19,6 +19,7 @@
 #include <utility>
 
 #import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTBlockMessage.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigurator.h"
@@ -53,6 +54,7 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
 
 @interface SNTNetworkExtensionQueue () {
   std::shared_ptr<santa::Logger> _logger;
+  std::shared_ptr<santa::TTYWriter> _ttyWriter;
 }
 @property MOLXPCConnection* netExtConnection;
 @property(readwrite) NSString* connectedProtocolVersion;
@@ -79,6 +81,7 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
                            syncdQueue:(SNTSyncdQueue*)syncdQueue
                             ruleTable:(SNTRuleTable*)ruleTable
                         decisionCache:(SNTDecisionCache*)decisionCache
+                            ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter
                                logger:(std::shared_ptr<santa::Logger>)logger {
   self = [super init];
   if (self) {
@@ -86,6 +89,7 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
     _syncdQueue = syncdQueue;
     _ruleTable = ruleTable;
     _decisionCache = decisionCache;
+    _ttyWriter = std::move(ttyWriter);
     _logger = std::move(logger);
     _flowDialogDedupeCache = [NSMutableDictionary dictionary];
 
@@ -242,6 +246,36 @@ static const NSTimeInterval kNetworkFlowDialogDedupeInterval = 60;
     }
 
     [self.syncdQueue addStoredEvent:event];
+
+    // Loud deny with a known controlling TTY: write the block message to that terminal so
+    // terminal/SSH users get feedback, mirroring exec/FAA. Independent of the GUI dialog (which
+    // may be absent at the loginwindow) and its de-dup. ttyPath is nil for audit-token-resolved
+    // processes (no ES exec seen) -> no write. WriteWithoutSignal (no SIGWINCH) matches FAA.
+    if (event.decision == SNTNetworkFlowDecisionBlock && !event.silent &&
+        event.ttyPath.length > 0 && _ttyWriter) {
+      NSAttributedString* attrStr = [SNTBlockMessage
+          attributedBlockMessageForNetworkFlowEventWithCustomMessage:event.customMsg];
+
+      NSMutableString* blockMsg = [NSMutableString stringWithCapacity:1024];
+      // \033[1m / \033[0m begin/end bold.
+      [blockMsg appendFormat:@"\n\033[1mSanta\033[0m\n\n%@\n\n", attrStr.string];
+      [blockMsg appendFormat:@"\033[1mRemote:\033[0m %@%@\n"
+                             @"\033[1mRule:  \033[0m %@\n"
+                             @"\033[1mPath:  \033[0m %@\n\n",
+                             event.hostname.length ? event.hostname : event.remoteAddress,
+                             event.remotePort
+                                 ? [NSString stringWithFormat:@":%hu", event.remotePort]
+                                 : @"",
+                             event.ruleName, event.process.filePath];
+
+      NSURL* detailURL = [SNTBlockMessage eventDetailURLForNetworkFlowEvent:event
+                                                                  customURL:event.customURL];
+      if (detailURL) {
+        [blockMsg appendFormat:@"More info:\n%@\n", detailURL.absoluteString];
+      }
+
+      _ttyWriter->WriteWithoutSignal(event.ttyPath, blockMsg);
+    }
 
     // Loud denies (Block decision, not silent) get an informational dialog; audits and silent
     // denies do not. Gate on a live GUI connection before the dedupe check: with none (e.g. at the

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -570,6 +570,23 @@
   XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
 }
 
+- (void)testHandleNetworkFlowDecisionsLoudDenyOmitsMoreInfoWhenNoURL {
+  [self stubNetworkExtensionEnabled];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.ttyPath = @"/dev/ttys003";
+  event.customURL = nil;  // no custom URL resolves -> no "More info:" line in the message
+
+  EXPECT_CALL(*self.mockTTYWriter, WriteWithoutSignal(testing::_, testing::Truly([](NSString* msg) {
+                                                        return ![msg containsString:@"More info:"];
+                                                      })))
+      .Times(1);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
+}
+
 - (void)testHandleNetworkFlowDecisionsLoudDenyWritesTTYWithoutGUIConnection {
   [self stubNetworkExtensionEnabled];
   // No setUpNotifierProxy: notifierQueue stays nil, so the dialog post is a no-op. The TTY

--- a/Source/santad/SNTNetworkExtensionQueueTest.mm
+++ b/Source/santad/SNTNetworkExtensionQueueTest.mm
@@ -29,10 +29,12 @@
 #import "Source/common/SNTStoredProcess.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/common/SantaVnode.h"
+#import "Source/common/TestUtils.h"
 #import "Source/common/ne/SNDXPCNetworkExtensionInterface.h"
 #import "Source/common/ne/SNTNetworkExtensionSettings.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
+#include "Source/santad/MockTTYWriter.h"
 #import "Source/santad/SNTDecisionCache.h"
 #import "Source/santad/SNTNotificationQueue.h"
 #import "Source/santad/SNTSyncdQueue.h"
@@ -45,6 +47,12 @@
 @property SNTNetworkExtensionSettings* lastPushedSettings;
 @property NSString* lastPushedNetworkFlowRulesHash;
 @property(readwrite) NSString* connectedProtocolVersion;
+- (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
+                           syncdQueue:(SNTSyncdQueue*)syncdQueue
+                            ruleTable:(SNTRuleTable*)ruleTable
+                        decisionCache:(SNTDecisionCache*)decisionCache
+                            ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter
+                               logger:(std::shared_ptr<santa::Logger>)logger;
 - (void)establishNetworkExtensionConnection;
 - (void)clearNetworkExtensionConnection;
 - (SNTNetworkExtensionSettings*)generateSettingsForProtocolVersion:(NSString*)protocolVersion;
@@ -61,6 +69,7 @@
 @property id mockNotifierQueue;
 @property id mockNotifierConnection;
 @property id mockNotifierProxy;
+@property std::shared_ptr<santa::MockTTYWriter> mockTTYWriter;
 @end
 
 @implementation SNTNetworkExtensionQueueTest
@@ -70,12 +79,15 @@
   self.mockSyncdQueue = OCMClassMock([SNTSyncdQueue class]);
   self.mockDecisionCache = OCMClassMock([SNTDecisionCache class]);
 
+  self.mockTTYWriter = std::make_shared<santa::MockTTYWriter>();
+
   // Construct the SUT before mocking the configurator so its init-time KVO watchers attach
   // to the real configurator singleton (KVO on a class mock is unreliable).
   self.sut = [[SNTNetworkExtensionQueue alloc] initWithNotifierQueue:nil
                                                           syncdQueue:self.mockSyncdQueue
                                                            ruleTable:self.mockRuleTable
                                                        decisionCache:self.mockDecisionCache
+                                                           ttyWriter:self.mockTTYWriter
                                                               logger:nullptr];
 
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
@@ -91,6 +103,10 @@
 
 - (void)tearDown {
   [self.mockConfigurator stopMocking];
+  // Release the SUT and the injected mock so the gmock MockTTYWriter is destroyed here
+  // (verifying its expectations) rather than leaking to program exit under retained XCTest cases.
+  self.sut = nil;
+  self.mockTTYWriter = nullptr;
 }
 
 // Make the configurator report the given sync-side network extension settings.
@@ -524,6 +540,92 @@
   ]];
 
   OCMVerifyAll(proxy);
+}
+
+- (void)testHandleNetworkFlowDecisionsLoudDenyWritesTTYWhenPathPresent {
+  [self stubNetworkExtensionEnabled];
+  [self setUpNotifierProxy];  // loud-deny branch also posts the dialog
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.ttyPath = @"/dev/ttys003";
+  event.process.filePath = @"/usr/bin/curl";
+  event.ruleName = @"block-example";
+  event.hostname = @"example.com";
+  event.remotePort = 443;
+  event.customURL = @"https://example.com/why";
+
+  EXPECT_CALL(*self.mockTTYWriter,
+              WriteWithoutSignal(
+                  testing::Truly([](NSString* p) { return [p isEqualToString:@"/dev/ttys003"]; }),
+                  testing::Truly([](NSString* msg) {
+                    return [msg containsString:@"block-example"] &&
+                           [msg containsString:@"/usr/bin/curl"] &&
+                           [msg containsString:@"example.com"] && [msg containsString:@":443"] &&
+                           [msg containsString:@"https://example.com/why"];
+                  })))
+      .Times(1);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
+}
+
+- (void)testHandleNetworkFlowDecisionsLoudDenyWritesTTYWithoutGUIConnection {
+  [self stubNetworkExtensionEnabled];
+  // No setUpNotifierProxy: notifierQueue stays nil, so the dialog post is a no-op. The TTY
+  // write must still fire -- it's independent of the GUI connection (e.g. at the loginwindow).
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.ttyPath = @"/dev/ttys003";
+  event.process.filePath = @"/usr/bin/curl";
+
+  EXPECT_CALL(*self.mockTTYWriter, WriteWithoutSignal(testing::Truly([](NSString* p) {
+                                                        return [p isEqualToString:@"/dev/ttys003"];
+                                                      }),
+                                                      testing::_))
+      .Times(1);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
+}
+
+- (void)testHandleNetworkFlowDecisionsLoudDenyNoTTYWhenPathNil {
+  [self stubNetworkExtensionEnabled];
+  [self setUpNotifierProxy];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];  // ttyPath nil
+  EXPECT_CALL(*self.mockTTYWriter, WriteWithoutSignal(testing::_, testing::_)).Times(0);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
+}
+
+- (void)testHandleNetworkFlowDecisionsSilentDenyDoesNotWriteTTY {
+  [self stubNetworkExtensionEnabled];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.silent = YES;
+  event.ttyPath = @"/dev/ttys003";  // present but ignored on a silent deny
+  EXPECT_CALL(*self.mockTTYWriter, WriteWithoutSignal(testing::_, testing::_)).Times(0);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
+}
+
+- (void)testHandleNetworkFlowDecisionsAuditDoesNotWriteTTY {
+  [self stubNetworkExtensionEnabled];
+
+  SNTStoredNetworkFlowEvent* event = [self loudDenyEventWithUIKey:@"k"];
+  event.decision = SNTNetworkFlowDecisionAudit;
+  event.ttyPath = @"/dev/ttys003";
+  EXPECT_CALL(*self.mockTTYWriter, WriteWithoutSignal(testing::_, testing::_)).Times(0);
+
+  [self.sut handleNetworkFlowDecisions:@[ [self decisionForCacheMissWithEvent:event] ]];
+
+  XCTBubbleMockVerifyAndClearExpectations(self.mockTTYWriter.get());
 }
 
 @end

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -199,6 +199,7 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator* configurator,
                                                    syncdQueue:syncd_queue
                                                     ruleTable:rule_table
                                                 decisionCache:[SNTDecisionCache sharedCache]
+                                                    ttyWriter:tty_writer
                                                        logger:logger];
   if (!netext_queue) {
     LOGE(@"Failed to initialize network extension queue.");

--- a/Source/santad/TTYWriter.h
+++ b/Source/santad/TTYWriter.h
@@ -41,15 +41,25 @@ class TTYWriter {
   TTYWriter& operator=(const TTYWriter& other) = delete;
 
   static bool CanWrite(const es_process_t* proc);
+  static bool CanWrite(NSString* ttyPath);
 
   void Write(const es_process_t* proc, NSString* (^messageCreator)(void));
   void Write(const es_process_t* proc, NSString* msg);
   void WriteWithoutSignal(const es_process_t* proc, NSString* msg);
 
+  // Path-based entry point (network-flow blocks have a tty path, not an es_process_t).
+  virtual void WriteWithoutSignal(NSString* ttyPath, NSString* msg);
+
   void EnableSilentTTYMode(bool silent_tty_mode);
+
+  // Virtual so deleting a derived instance (e.g. a test double) through a TTYWriter* is
+  // well-defined once the class has virtual methods; public so unique_ptr/shared_ptr
+  // deleters can reach it.
+  virtual ~TTYWriter() = default;
 
  private:
   void Write(const es_process_t* proc, bool send_signal, NSString* (^messageCreator)(void));
+  void Write(NSString* ttyPath, bool send_signal, NSString* (^messageCreator)(void));
 
   dispatch_queue_t q_;
   std::atomic<bool> silent_tty_mode_;

--- a/Source/santad/TTYWriter.mm
+++ b/Source/santad/TTYWriter.mm
@@ -47,17 +47,17 @@ bool TTYWriter::CanWrite(const es_process_t* proc) {
   return proc && proc->tty && proc->tty->path.length > 0;
 }
 
-void TTYWriter::Write(const es_process_t* proc, bool send_signal,
-                      NSString* (^messageCreator)(void)) {
-  if (silent_tty_mode_.load(std::memory_order_relaxed) || !CanWrite(proc)) {
+bool TTYWriter::CanWrite(NSString* ttyPath) {
+  return ttyPath.length > 0;
+}
+
+void TTYWriter::Write(NSString* ttyPath, bool send_signal, NSString* (^messageCreator)(void)) {
+  if (silent_tty_mode_.load(std::memory_order_relaxed) || !CanWrite(ttyPath)) {
     return;
   }
 
-  // Copy the data from the es_process_t so the ES message doesn't
-  // need to be retained
-  NSString* tty = santa::StringToNSString(proc->tty->path.data);
-  // Realize the message string before going async so as not to need to worry about
-  // lifetimes of objects in the provided block.
+  // Copy the path so callers needn't keep it alive across the async hop.
+  NSString* tty = [ttyPath copy];
   NSString* msg = messageCreator();
   NSString* companyName = [[SNTConfigurator configurator] brandingCompanyName];
   if (companyName) {
@@ -92,6 +92,14 @@ void TTYWriter::Write(const es_process_t* proc, bool send_signal,
   });
 }
 
+void TTYWriter::Write(const es_process_t* proc, bool send_signal,
+                      NSString* (^messageCreator)(void)) {
+  if (!CanWrite(proc)) {
+    return;
+  }
+  Write(santa::StringToNSString(proc->tty->path.data), send_signal, messageCreator);
+}
+
 void TTYWriter::Write(const es_process_t* proc, NSString* (^messageCreator)(void)) {
   Write(proc, true, messageCreator);
 }
@@ -104,6 +112,12 @@ void TTYWriter::Write(const es_process_t* proc, NSString* msg) {
 
 void TTYWriter::WriteWithoutSignal(const es_process_t* proc, NSString* msg) {
   Write(proc, false, ^NSString* {
+    return msg;
+  });
+}
+
+void TTYWriter::WriteWithoutSignal(NSString* ttyPath, NSString* msg) {
+  Write(ttyPath, false, ^NSString* {
     return msg;
   });
 }

--- a/Source/santad/TTYWriterTest.mm
+++ b/Source/santad/TTYWriterTest.mm
@@ -17,8 +17,6 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
-#include <unistd.h>
-
 using santa::TTYWriter;
 
 @interface TTYWriterTest : XCTestCase
@@ -33,13 +31,7 @@ using santa::TTYWriter;
   return path;
 }
 
-// TTYWriter writes on a private serial queue; poll for content (~2s budget).
-- (NSString*)waitForContentsAtPath:(NSString*)path {
-  for (int i = 0; i < 200; i++) {
-    NSString* s = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
-    if (s.length > 0) return s;
-    usleep(10000);
-  }
+- (NSString*)contentsAtPath:(NSString*)path {
   return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
 }
 
@@ -50,38 +42,50 @@ using santa::TTYWriter;
 }
 
 - (void)testWriteWithoutSignalPathWritesMessage {
-  auto writer = TTYWriter::Create(/*silent_tty_mode=*/false);
-  XCTAssertNotEqual(writer.get(), nullptr);
+  // Inject a serial queue we own so the async write can be flushed deterministically:
+  // dispatch_sync on the same serial queue runs only after the enqueued write completes.
+  dispatch_queue_t q =
+      dispatch_queue_create("com.northpolesec.santa.ttywritertest", DISPATCH_QUEUE_SERIAL);
+  TTYWriter writer(q, /*silent_tty_mode=*/false);
   NSString* path = [self tempPathNamed:@"ttywriter-write.txt"];
 
-  writer->WriteWithoutSignal(path, @"hello-from-flow-block");
+  writer.WriteWithoutSignal(path, @"hello-from-flow-block");
+  dispatch_sync(q, ^{
+                });  // wait for the write to land
 
-  NSString* got = [self waitForContentsAtPath:path];
+  NSString* got = [self contentsAtPath:path];
   XCTAssertTrue([got containsString:@"hello-from-flow-block"], @"got: %@", got);
 }
 
 - (void)testSilentModeSuppressesPathWrite {
-  auto writer = TTYWriter::Create(/*silent_tty_mode=*/true);
+  dispatch_queue_t q =
+      dispatch_queue_create("com.northpolesec.santa.ttywritertest", DISPATCH_QUEUE_SERIAL);
+  TTYWriter writer(q, /*silent_tty_mode=*/true);
   NSString* path = [self tempPathNamed:@"ttywriter-silent.txt"];
 
-  writer->WriteWithoutSignal(path, @"should-not-appear");
+  writer.WriteWithoutSignal(path, @"should-not-appear");
+  dispatch_sync(q, ^{
+                });  // silent mode enqueues no write; this drains immediately
 
-  usleep(200000);  // give any erroneous async write a chance to land
-  NSString* got = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+  NSString* got = [self contentsAtPath:path];
   XCTAssertEqual(got.length, 0u, @"got: %@", got);
 }
 
 // Non-writable paths (nil, empty) are silent no-ops that leave the writer
 // functional; a subsequent valid write still lands.
 - (void)testNilPathIsNoOp {
-  auto writer = TTYWriter::Create(/*silent_tty_mode=*/false);
-  writer->WriteWithoutSignal((NSString*)nil, @"nope");
-  writer->WriteWithoutSignal(@"", @"nope");
+  dispatch_queue_t q =
+      dispatch_queue_create("com.northpolesec.santa.ttywritertest", DISPATCH_QUEUE_SERIAL);
+  TTYWriter writer(q, /*silent_tty_mode=*/false);
+  writer.WriteWithoutSignal((NSString*)nil, @"nope");
+  writer.WriteWithoutSignal(@"", @"nope");
 
   NSString* path = [self tempPathNamed:@"ttywriter-nil-then-valid.txt"];
-  writer->WriteWithoutSignal(path, @"still-works");
+  writer.WriteWithoutSignal(path, @"still-works");
+  dispatch_sync(q, ^{
+                });  // wait for the valid write to land
 
-  NSString* got = [self waitForContentsAtPath:path];
+  NSString* got = [self contentsAtPath:path];
   XCTAssertTrue([got containsString:@"still-works"], @"got: %@", got);
 }
 

--- a/Source/santad/TTYWriterTest.mm
+++ b/Source/santad/TTYWriterTest.mm
@@ -1,0 +1,88 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/TTYWriter.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include <unistd.h>
+
+using santa::TTYWriter;
+
+@interface TTYWriterTest : XCTestCase
+@end
+
+@implementation TTYWriterTest
+
+- (NSString*)tempPathNamed:(NSString*)name {
+  NSString* path = [NSTemporaryDirectory() stringByAppendingPathComponent:name];
+  [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+  [[NSFileManager defaultManager] createFileAtPath:path contents:nil attributes:nil];
+  return path;
+}
+
+// TTYWriter writes on a private serial queue; poll for content (~2s budget).
+- (NSString*)waitForContentsAtPath:(NSString*)path {
+  for (int i = 0; i < 200; i++) {
+    NSString* s = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+    if (s.length > 0) return s;
+    usleep(10000);
+  }
+  return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+}
+
+- (void)testCanWritePath {
+  XCTAssertTrue(TTYWriter::CanWrite(@"/dev/ttys003"));
+  XCTAssertFalse(TTYWriter::CanWrite((NSString*)nil));
+  XCTAssertFalse(TTYWriter::CanWrite(@""));
+}
+
+- (void)testWriteWithoutSignalPathWritesMessage {
+  auto writer = TTYWriter::Create(/*silent_tty_mode=*/false);
+  XCTAssertNotEqual(writer.get(), nullptr);
+  NSString* path = [self tempPathNamed:@"ttywriter-write.txt"];
+
+  writer->WriteWithoutSignal(path, @"hello-from-flow-block");
+
+  NSString* got = [self waitForContentsAtPath:path];
+  XCTAssertTrue([got containsString:@"hello-from-flow-block"], @"got: %@", got);
+}
+
+- (void)testSilentModeSuppressesPathWrite {
+  auto writer = TTYWriter::Create(/*silent_tty_mode=*/true);
+  NSString* path = [self tempPathNamed:@"ttywriter-silent.txt"];
+
+  writer->WriteWithoutSignal(path, @"should-not-appear");
+
+  usleep(200000);  // give any erroneous async write a chance to land
+  NSString* got = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+  XCTAssertEqual(got.length, 0u, @"got: %@", got);
+}
+
+// Non-writable paths (nil, empty) are silent no-ops that leave the writer
+// functional; a subsequent valid write still lands.
+- (void)testNilPathIsNoOp {
+  auto writer = TTYWriter::Create(/*silent_tty_mode=*/false);
+  writer->WriteWithoutSignal((NSString*)nil, @"nope");
+  writer->WriteWithoutSignal(@"", @"nope");
+
+  NSString* path = [self tempPathNamed:@"ttywriter-nil-then-valid.txt"];
+  writer->WriteWithoutSignal(path, @"still-works");
+
+  NSString* got = [self waitForContentsAtPath:path];
+  XCTAssertTrue([got containsString:@"still-works"], @"got: %@", got);
+}
+
+@end

--- a/Source/santasyncservice/SNTSyncTest.mm
+++ b/Source/santasyncservice/SNTSyncTest.mm
@@ -1015,6 +1015,7 @@
   block.uiDedupeKey = @"4242:1|7|example.com";                  // santa-internal, never uploaded
   block.customMsg = @"Contact IT before reaching this host";    // rule property, never uploaded
   block.customURL = @"https://example.com/why";                 // rule property, never uploaded
+  block.ttyPath = @"/dev/ttys003";                              // santa-internal, never uploaded
   block.process.filePath = @"/usr/bin/curl";
   block.process.cdhash = @"deadbeef";
   block.process.fileSHA256 = @"abc123";
@@ -1088,6 +1089,7 @@
             // Rule block-feedback text is santad-local; never serialized to the proto.
             XCTAssertNil(f[@"customMsg"]);
             XCTAssertNil(f[@"customUrl"]);
+            XCTAssertNil(f[@"ttyPath"]);
 
             return YES;
           }];


### PR DESCRIPTION
Brings network-flow rule blocks to parity with execution and file-access blocks on terminal feedback: on a loud deny, santad writes the block message (the rule's custom text + a "More info" URL) to the originating process's controlling TTY. Adds a santad-local `ttyPath` to `SNTStoredNetworkFlowEvent`, extracts a path-based core in `TTYWriter` that the existing `es_process_t*` overloads delegate to (no exec/FAA change), and injects a `TTYWriter` into `SNTNetworkExtensionQueue` gated on loud denies with a known TTY, independent of the block dialog. The tty path is supplied by santanetd, so the write stays inert until that ships.
