### PR TITLE
common: add token-validated csops helpers (csops_audittoken)

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -262,8 +262,18 @@ objc_library(
     name = "CSOpsHelper",
     srcs = ["CSOpsHelper.mm"],
     hdrs = ["CSOpsHelper.h"],
+    sdk_dylibs = ["bsm"],
     deps = [
         ":String",
+    ],
+)
+
+santa_unit_test(
+    name = "CSOpsHelperTest",
+    srcs = ["CSOpsHelperTest.mm"],
+    deps = [
+        ":AuditUtilities",
+        ":CSOpsHelper",
     ],
 )
 
@@ -1277,6 +1287,7 @@ test_suite(
     name = "unit_tests",
     tests = [
         ":AuditUtilitiesTest",
+        ":CSOpsHelperTest",
         ":CodeSigningIdentifierUtilsTest",
         ":EncodeEntitlementsTest",
         ":KeychainTest",

--- a/Source/common/CSOpsHelper.h
+++ b/Source/common/CSOpsHelper.h
@@ -16,6 +16,7 @@
 #define SANTA_COMMON_CSOPSHELPER_H
 
 #include <Kernel/kern/cs_blobs.h>
+#include <bsm/libbsm.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
@@ -26,6 +27,8 @@
 
 __BEGIN_DECLS
 int csops(pid_t pid, unsigned int ops, void* useraddr, size_t usersize);
+int csops_audittoken(pid_t pid, unsigned int ops, void* useraddr,
+                     size_t usersize, audit_token_t* token);
 __END_DECLS
 
 namespace santa {
@@ -63,6 +66,20 @@ std::optional<std::string> CSOpsGetTeamID(pid_t pid,
 // error.
 std::optional<std::string> CSOpsGetSigningID(pid_t pid,
                                              CSOpsFunc csops_func = csops);
+
+// Injectable token-validated csops function signature for testing.
+using CSOpsTokenFunc =
+    std::function<int(pid_t, unsigned int, void*, size_t, audit_token_t*)>;
+
+// Token-validated variants of the getters above
+std::optional<uint32_t> CSOpsStatusFlags(
+    const audit_token_t& tok, CSOpsTokenFunc csops_func = csops_audittoken);
+std::optional<std::string> CSOpsGetCDHash(
+    const audit_token_t& tok, CSOpsTokenFunc csops_func = csops_audittoken);
+std::optional<std::string> CSOpsGetTeamID(
+    const audit_token_t& tok, CSOpsTokenFunc csops_func = csops_audittoken);
+std::optional<std::string> CSOpsGetSigningID(
+    const audit_token_t& tok, CSOpsTokenFunc csops_func = csops_audittoken);
 
 }  // namespace santa
 

--- a/Source/common/CSOpsHelper.mm
+++ b/Source/common/CSOpsHelper.mm
@@ -15,6 +15,7 @@
 #include "Source/common/CSOpsHelper.h"
 
 #include <arpa/inet.h>
+#include <bsm/libbsm.h>
 
 #include <cstring>
 
@@ -39,6 +40,17 @@ std::optional<std::string> CSOpsGetBlobString(pid_t pid, unsigned int op, size_t
     return std::nullopt;
   }
   return std::string(blob->data, data_len - kBlobWrapperOverhead);
+}
+
+// Adapt a token-validated csops function to the pid-keyed CSOpsFunc shape by
+// binding `token`, so the token variants reuse the pid-based implementations
+// (and their blob parsing) unchanged. `token` must outlive the returned
+// callable; every caller below binds a local.
+CSOpsFunc BindToken(audit_token_t* token, CSOpsTokenFunc csops_func) {
+  return [token, csops_func = std::move(csops_func)](pid_t pid, unsigned int ops, void* addr,
+                                                     size_t size) {
+    return csops_func(pid, ops, addr, size, token);
+  };
 }
 
 }  // namespace
@@ -77,6 +89,26 @@ std::optional<std::string> CSOpsGetSigningID(pid_t pid, CSOpsFunc csops_func) {
     return std::nullopt;
   }
   return result;
+}
+
+std::optional<uint32_t> CSOpsStatusFlags(const audit_token_t& tok, CSOpsTokenFunc csops_func) {
+  audit_token_t token = tok;  // csops_audittoken takes a mutable pointer
+  return CSOpsStatusFlags(audit_token_to_pid(token), BindToken(&token, std::move(csops_func)));
+}
+
+std::optional<std::string> CSOpsGetCDHash(const audit_token_t& tok, CSOpsTokenFunc csops_func) {
+  audit_token_t token = tok;
+  return CSOpsGetCDHash(audit_token_to_pid(token), BindToken(&token, std::move(csops_func)));
+}
+
+std::optional<std::string> CSOpsGetTeamID(const audit_token_t& tok, CSOpsTokenFunc csops_func) {
+  audit_token_t token = tok;
+  return CSOpsGetTeamID(audit_token_to_pid(token), BindToken(&token, std::move(csops_func)));
+}
+
+std::optional<std::string> CSOpsGetSigningID(const audit_token_t& tok, CSOpsTokenFunc csops_func) {
+  audit_token_t token = tok;
+  return CSOpsGetSigningID(audit_token_to_pid(token), BindToken(&token, std::move(csops_func)));
 }
 
 }  // namespace santa

--- a/Source/common/CSOpsHelperTest.mm
+++ b/Source/common/CSOpsHelperTest.mm
@@ -1,0 +1,79 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#include <unistd.h>
+
+#include <optional>
+
+#include "Source/common/AuditUtilities.h"
+#include "Source/common/CSOpsHelper.h"
+
+@interface CSOpsHelperTest : XCTestCase
+@end
+
+@implementation CSOpsHelperTest
+
+- (void)testTokenValidatedStatusFlagsForSelf {
+  std::optional<audit_token_t> selfTok = santa::GetMyAuditToken();
+  XCTAssertTrue(selfTok.has_value());
+
+  std::optional<uint32_t> flags = santa::CSOpsStatusFlags(*selfTok);
+  XCTAssertTrue(flags.has_value());
+  XCTAssertNotEqual(*flags, 0u);
+}
+
+- (void)testTokenValidatedReadsRefuseMismatchedPidversion {
+  // Same pid, wrong incarnation: the kernel must refuse every read with
+  // ESRCH — this is the whole point of the token-validated variants.
+  std::optional<audit_token_t> selfTok = santa::GetMyAuditToken();
+  XCTAssertTrue(selfTok.has_value());
+  audit_token_t stale = *selfTok;
+  stale.val[7] += 1;  // pidversion
+
+  XCTAssertFalse(santa::CSOpsStatusFlags(stale).has_value());
+  XCTAssertFalse(santa::CSOpsGetCDHash(stale).has_value());
+  XCTAssertFalse(santa::CSOpsGetTeamID(stale).has_value());
+  XCTAssertFalse(santa::CSOpsGetSigningID(stale).has_value());
+}
+
+- (void)testTokenVariantsDeliverTokenToInjectedFunc {
+  // Every token overload must route the flow token through its own BindToken to
+  // the injected csops function. A shared probe records whether the delivered
+  // token carries our pid; each getter is exercised independently so a
+  // mis-wired overload (wrong token, or none) is caught per-getter.
+  std::optional<audit_token_t> selfTok = santa::GetMyAuditToken();
+  XCTAssertTrue(selfTok.has_value());
+
+  auto probe = [](bool* seen) {
+    return [seen](pid_t pid, unsigned int ops, void* addr, size_t size, audit_token_t* token) {
+      *seen = (token != nullptr && token->val[5] == (unsigned int)getpid());
+      return csops_audittoken(pid, ops, addr, size, token);
+    };
+  };
+
+  bool statusSeen = false, cdhashSeen = false, teamIDSeen = false, signingIDSeen = false;
+  santa::CSOpsStatusFlags(*selfTok, probe(&statusSeen));
+  santa::CSOpsGetCDHash(*selfTok, probe(&cdhashSeen));
+  santa::CSOpsGetTeamID(*selfTok, probe(&teamIDSeen));
+  santa::CSOpsGetSigningID(*selfTok, probe(&signingIDSeen));
+
+  XCTAssertTrue(statusSeen);
+  XCTAssertTrue(cdhashSeen);
+  XCTAssertTrue(teamIDSeen);
+  XCTAssertTrue(signingIDSeen);
+}
+
+@end

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -82,17 +82,27 @@ class FlagsMatcher : public ProcessMatcher {
   CSOpsFunc csops_func_;
 };
 
+// CSOpsHelper.h now also declares audit_token_t-taking overloads of the
+// getters below with the same names, so the bare function name is ambiguous
+// as a make_unique<StringMatcher> argument (overload resolution needs a
+// target type, and make_unique's forwarding-reference deduction doesn't
+// provide one). Cast to the pid-based overload's exact type to disambiguate.
+using StringGetterFunc = std::optional<std::string> (*)(pid_t, CSOpsFunc);
+
 std::unique_ptr<ProcessMatcher> MakeCDHashMatcher(NSString* cdhash, CSOpsFunc csops_func = csops) {
-  return std::make_unique<StringMatcher>(cdhash, CSOpsGetCDHash, std::move(csops_func));
+  return std::make_unique<StringMatcher>(cdhash, static_cast<StringGetterFunc>(CSOpsGetCDHash),
+                                         std::move(csops_func));
 }
 
 std::unique_ptr<ProcessMatcher> MakeTeamIDMatcher(NSString* teamID, CSOpsFunc csops_func = csops) {
-  return std::make_unique<StringMatcher>(teamID, CSOpsGetTeamID, std::move(csops_func));
+  return std::make_unique<StringMatcher>(teamID, static_cast<StringGetterFunc>(CSOpsGetTeamID),
+                                         std::move(csops_func));
 }
 
 std::unique_ptr<ProcessMatcher> MakeSigningIDMatcher(NSString* signingID,
                                                      CSOpsFunc csops_func = csops) {
-  return std::make_unique<StringMatcher>(signingID, CSOpsGetSigningID, std::move(csops_func));
+  return std::make_unique<StringMatcher>(
+      signingID, static_cast<StringGetterFunc>(CSOpsGetSigningID), std::move(csops_func));
 }
 
 std::unique_ptr<ProcessMatcher> MakeStatusFlagsMatcher(uint32_t mask,


### PR DESCRIPTION
## What

Adds `audit_token_t`-taking overloads of the four `CSOpsHelper` getters
(`CSOpsStatusFlags`, `CSOpsGetCDHash`, `CSOpsGetTeamID`, `CSOpsGetSigningID`),
each defaulting to `csops_audittoken(2)`.

## Why

`csops(2)` reads by raw pid, so a pid recycled between the time an identity is
captured and the time it's resolved can be misattributed. `csops_audittoken`
has the kernel verify the token's pid+pidversion against the live process
atomically with each read (ESRCH on mismatch), closing that race.

The overloads bind the token into the existing `CSOpsFunc` injection seam via a
small `BindToken` adapter, so the pid-based implementations and blob parsing
remain the single implementation (no duplicated logic).

## Notes

- `Source/santad/KillingMachine.mm`: the getters are now overloaded, so passing
  a bare name into `make_unique<StringMatcher>(...)` became ambiguous
  (forwarding-reference deduction has no target type to resolve against). Cast
  to the pid-based overload's function-pointer type at the three call sites
  (behavior-preserving) to keep the build green.

## Testing

- New `CSOpsHelperTest` (3 tests), including a live-kernel check that a bumped
  pidversion yields ESRCH on all four reads.
- Broader sweep: `//Source/common:unit_tests` (62 targets) + `KillingMachineTest`
  + `process_tree_test` all pass.

## Context

First of a series: this is the prerequisite for santanetd resolving its
fallback process identity via `csops_audittoken` (separate PR).
