### PR TITLE
santactl: add adminmode command and report user type in status

### DIFF
--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -85,6 +85,17 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTCommandAdminMode",
+    srcs = ["Commands/SNTCommandAdminMode.mm"],
+    deps = [
+        ":santactl_cmd",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTXPCControlInterface",
+    ],
+)
+
+objc_library(
     name = "SNTCommandSandbox",
     srcs = ["Commands/SNTCommandSandbox.mm"],
     deps = [
@@ -126,6 +137,7 @@ objc_library(
         "SystemConfiguration",
     ],
     deps = [
+        ":SNTCommandAdminMode",
         ":SNTCommandCommand",
         ":SNTCommandInstall",
         ":SNTCommandMonitorMode",
@@ -250,12 +262,29 @@ santa_unit_test(
     ],
 )
 
+santa_unit_test(
+    name = "SNTCommandTest",
+    srcs = [
+        "SNTCommand.h",
+        "SNTCommand.mm",
+        "SNTCommandController.h",
+        "SNTCommandController.mm",
+        "SNTCommandTest.mm",
+    ],
+    deps = [
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTXPCControlInterface",
+    ],
+)
+
 test_suite(
     name = "unit_tests",
     tests = [
         ":SNTCommandDoctorTest",
         ":SNTCommandFileInfoTest",
         ":SNTCommandMetricsTest",
+        ":SNTCommandTest",
     ],
     visibility = ["//:santa_package_group"],
 )

--- a/Source/santactl/Commands/SNTCommandAdminMode.mm
+++ b/Source/santactl/Commands/SNTCommandAdminMode.mm
@@ -1,0 +1,140 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <unistd.h>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTXPCControlInterface.h"
+#import "Source/santactl/SNTCommand.h"
+#import "Source/santactl/SNTCommandController.h"
+
+@interface SNTCommandAdminMode : SNTCommand <SNTCommandProtocol>
+@end
+
+@implementation SNTCommandAdminMode
+
+REGISTER_COMMAND_NAME(@"adminmode")
+
++ (BOOL)requiresRoot {
+  return NO;
+}
+
++ (BOOL)requiresDaemonConn {
+  return YES;
+}
+
++ (NSString*)shortHelpText {
+  return @"Temporarily gain administrator rights if eligible.";
+}
+
++ (NSString*)longHelpText {
+  return (@"Usage: santactl adminmode [options]\n"
+          @"  Requests a temporary, time-limited grant of administrator rights for the\n"
+          @"  current user. Available only when the machine has been configured to allow\n"
+          @"  admin elevation. Authorization (and a justification, if required by policy)\n"
+          @"  is requested through the Santa GUI.\n"
+          @"  Options:\n"
+          @"    --duration {minutes}: An optional number of minutes of temporary admin\n"
+          @"                          rights to request. May also be given as a duration\n"
+          @"                          string (e.g. 30m, 2h). By default, uses the time\n"
+          @"                          allotted by policy.\n"
+          @"    --cancel: End the active temporary admin session and drop admin rights.\n"
+          @"\n");
+}
+
++ (NSSet<NSString*>*)aliases {
+  return [NSSet setWithArray:@[ @"am" ]];
+}
+
+- (void)runWithArguments:(NSArray*)arguments {
+  // Admin Mode elevates the invoking user, whom the daemon resolves from the XPC
+  // peer's identity. Under sudo that identity is root, which is already an
+  // administrator, so the daemon would reject the request with a terse
+  // "already an administrator" error. Fail early with a clearer pointer instead.
+  if (getuid() == 0) {
+    TEE_LOGE(@"Run adminmode as your own user, not with sudo. It elevates the invoking user, "
+             @"and under sudo the daemon sees only root (already an administrator).");
+    exit(EXIT_FAILURE);
+  }
+
+  // A request of 0 minutes resolves to the policy-configured default on the daemon.
+  NSTimeInterval requestedDuration = 0;
+  bool shouldCancel = false;
+
+  // Parse arguments
+  for (NSUInteger i = 0; i < arguments.count; ++i) {
+    NSString* arg = arguments[i];
+
+    if ([arg caseInsensitiveCompare:@"--duration"] == NSOrderedSame) {
+      if (++i > arguments.count - 1) {
+        [self printErrorUsageAndExit:@"--duration requires an argument"];
+      }
+
+      arg = arguments[i];
+      if (arg.length == 0) {
+        [self printErrorUsageAndExit:
+                  @"--duration requires a whole number argument or duration string"];
+      }
+
+      requestedDuration = [self parseTimeInterval:arg];
+      if (requestedDuration <= 0) {
+        [self printErrorUsageAndExit:
+                  @"--duration requires a whole number argument or duration string"];
+      }
+    } else if ([arg caseInsensitiveCompare:@"--cancel"] == NSOrderedSame) {
+      shouldCancel = true;
+    }
+  }
+
+  // Default to failure: if the XPC transport dies before the reply block runs
+  // (the request can block for up to ~90s on the GUI authorization prompt), the
+  // block never executes and we must not exit success on an uninitialized value.
+  __block BOOL success = NO;
+
+  if (shouldCancel) {
+    [[self.daemonConn synchronousRemoteObjectProxy] cancelTemporaryAdminMode:^(NSError* err) {
+      success = (err == nil);
+      if (err) {
+        TEE_LOGE(@"Unable to cancel Admin Mode: %@", err.localizedDescription);
+        return;
+      }
+
+      TEE_LOGI(@"Temporary Admin Mode cancelled");
+    }];
+  } else {
+    TEE_LOGI(@"Requesting temporary Admin Mode; respond to the authorization prompt if shown...");
+    [[self.daemonConn synchronousRemoteObjectProxy]
+        requestTemporaryAdminModeWithDurationMinutes:@(requestedDuration)
+                                               reply:^(uint32_t minutes, NSError* err) {
+                                                 success = (err == nil);
+                                                 if (err) {
+                                                   TEE_LOGE(@"Unable to enter Admin Mode: %@",
+                                                            err.localizedDescription);
+                                                   return;
+                                                 }
+
+                                                 TEE_LOGI(@"Admin Mode temporarily authorized "
+                                                          @"for %u %@",
+                                                          minutes,
+                                                          minutes > 1 ? @"minutes" : @"minute");
+                                               }];
+  }
+
+  exit(success ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+@end

--- a/Source/santactl/Commands/SNTCommandMonitorMode.mm
+++ b/Source/santactl/Commands/SNTCommandMonitorMode.mm
@@ -53,47 +53,6 @@ REGISTER_COMMAND_NAME(@"monitormode")
   return [NSSet setWithArray:@[ @"mm" ]];
 }
 
-// Parse a time interval string into a number of minutes.
-// e.g. "10m" -> 10, "2h" -> 120, "3d" -> 3600
-- (NSTimeInterval)parseTimeInterval:(NSString*)duration {
-  NSScanner* scanner = [NSScanner scannerWithString:duration];
-  scanner.charactersToBeSkipped = nil;
-  NSString* unit = nil;
-
-  NSInteger intValue = 0;
-  if ([scanner scanInteger:&intValue]) {
-    // Check if we're at the end (no unit specified)
-    if ([scanner isAtEnd]) {
-      return intValue;
-    }
-
-    // Scan exactly one character from the unit set
-    NSString* scannedUnit = nil;
-    if ([scanner scanCharactersFromSet:[NSCharacterSet characterSetWithCharactersInString:@"smhd"]
-                            intoString:&scannedUnit]) {
-      // Ensure unit is exactly one character and we're at the end
-      if (scannedUnit.length == 1 && [scanner isAtEnd]) {
-        unit = scannedUnit;
-      } else {
-        return 0;  // Invalid: unit is not exactly one char or there's more content
-      }
-    } else {
-      return 0;  // Invalid: characters after integer that aren't a valid unit
-    }
-
-    if ([unit isEqualToString:@"m"]) {
-      return intValue;
-    }
-    if ([unit isEqualToString:@"h"]) {
-      return intValue * 60;
-    }
-    if ([unit isEqualToString:@"d"]) {
-      return intValue * (60 * 24);
-    }
-  }
-  return 0;
-}
-
 - (void)runWithArguments:(NSArray*)arguments {
   NSTimeInterval requestedDuration;
   bool shouldCancel = false;

--- a/Source/santactl/Commands/SNTCommandMonitorMode.mm
+++ b/Source/santactl/Commands/SNTCommandMonitorMode.mm
@@ -54,7 +54,7 @@ REGISTER_COMMAND_NAME(@"monitormode")
 }
 
 - (void)runWithArguments:(NSArray*)arguments {
-  NSTimeInterval requestedDuration;
+  NSTimeInterval requestedDuration = 0;
   bool shouldCancel = false;
 
   // Parse arguments
@@ -82,7 +82,7 @@ REGISTER_COMMAND_NAME(@"monitormode")
     }
   }
 
-  __block BOOL success;
+  __block BOOL success = NO;
 
   if (shouldCancel) {
     [[self.daemonConn synchronousRemoteObjectProxy] cancelTemporaryMonitorMode:^(NSError* err) {

--- a/Source/santactl/Commands/SNTCommandStatus.mm
+++ b/Source/santactl/Commands/SNTCommandStatus.mm
@@ -482,7 +482,7 @@ REGISTER_COMMAND_NAME(@"status")
 
     NSMutableDictionary* temporaryAdminMode = [@{
       @"available" : @(temporaryAdminModeAvailable),
-      @"current_user_is_admin" : @(currentUserIsAdmin),
+      @"current_user_type" : (currentUserIsAdmin ? @"administrator" : @"standard"),
     } mutableCopy];
     if (temporaryAdminModeSecondsRemaining != nil) {
       temporaryAdminMode[@"session_seconds_remaining"] = temporaryAdminModeSecondsRemaining;
@@ -531,7 +531,8 @@ REGISTER_COMMAND_NAME(@"status")
 
     printf(">>> Temporary Admin Mode\n");
     printf("  %-40s | %s\n", "Available", (temporaryAdminModeAvailable ? "Yes" : "No"));
-    printf("  %-40s | %s\n", "Current User Is Admin", (currentUserIsAdmin ? "Yes" : "No"));
+    printf("  %-40s | %s\n", "Current User Type",
+           (currentUserIsAdmin ? "Administrator" : "Standard"));
     if (temporaryAdminModeSecondsRemaining != nil) {
       printf("  %-40s | %s\n", "Session Time Remaining",
              [FormatTimeRemaining([temporaryAdminModeSecondsRemaining unsignedLongLongValue])

--- a/Source/santactl/SNTCommand.h
+++ b/Source/santactl/SNTCommand.h
@@ -77,4 +77,14 @@
 - (void)runWithArguments:(NSArray*)arguments;
 
 - (void)printErrorUsageAndExit:(NSString*)error;
+
+///
+///  Parse a duration string into a whole number of minutes.
+///  Accepts a bare integer (interpreted as minutes) or an integer followed by a
+///  single unit suffix: 'm' (minutes), 'h' (hours), or 'd' (days). Any other
+///  suffix (including 's'), a multi-character suffix, trailing content, or a
+///  non-numeric string returns 0.
+///  e.g. "10" -> 10, "10m" -> 10, "2h" -> 120, "3d" -> 4320.
+///
+- (NSTimeInterval)parseTimeInterval:(NSString*)duration;
 @end

--- a/Source/santactl/SNTCommand.mm
+++ b/Source/santactl/SNTCommand.mm
@@ -44,4 +44,45 @@
   exit(1);
 }
 
+// Parse a time interval string into a number of minutes.
+// e.g. "10m" -> 10, "2h" -> 120, "3d" -> 4320
+- (NSTimeInterval)parseTimeInterval:(NSString*)duration {
+  NSScanner* scanner = [NSScanner scannerWithString:duration];
+  scanner.charactersToBeSkipped = nil;
+  NSString* unit = nil;
+
+  NSInteger intValue = 0;
+  if ([scanner scanInteger:&intValue]) {
+    // Check if we're at the end (no unit specified)
+    if ([scanner isAtEnd]) {
+      return intValue;
+    }
+
+    // Scan exactly one character from the unit set
+    NSString* scannedUnit = nil;
+    if ([scanner scanCharactersFromSet:[NSCharacterSet characterSetWithCharactersInString:@"smhd"]
+                            intoString:&scannedUnit]) {
+      // Ensure unit is exactly one character and we're at the end
+      if (scannedUnit.length == 1 && [scanner isAtEnd]) {
+        unit = scannedUnit;
+      } else {
+        return 0;  // Invalid: unit is not exactly one char or there's more content
+      }
+    } else {
+      return 0;  // Invalid: characters after integer that aren't a valid unit
+    }
+
+    if ([unit isEqualToString:@"m"]) {
+      return intValue;
+    }
+    if ([unit isEqualToString:@"h"]) {
+      return intValue * 60;
+    }
+    if ([unit isEqualToString:@"d"]) {
+      return intValue * (60 * 24);
+    }
+  }
+  return 0;
+}
+
 @end

--- a/Source/santactl/SNTCommandTest.mm
+++ b/Source/santactl/SNTCommandTest.mm
@@ -1,0 +1,75 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "Source/santactl/SNTCommand.h"
+
+@interface SNTCommandTest : XCTestCase
+@property SNTCommand* command;
+@end
+
+@implementation SNTCommandTest
+
+- (void)setUp {
+  self.command = [[SNTCommand alloc] initWithDaemonConnection:nil];
+}
+
+- (void)testParseTimeIntervalBareInteger {
+  XCTAssertEqual([self.command parseTimeInterval:@"10"], 10);
+}
+
+- (void)testParseTimeIntervalMinutes {
+  XCTAssertEqual([self.command parseTimeInterval:@"10m"], 10);
+}
+
+- (void)testParseTimeIntervalHours {
+  XCTAssertEqual([self.command parseTimeInterval:@"2h"], 120);
+}
+
+- (void)testParseTimeIntervalDays {
+  XCTAssertEqual([self.command parseTimeInterval:@"3d"], 4320);
+}
+
+- (void)testParseTimeIntervalZero {
+  XCTAssertEqual([self.command parseTimeInterval:@"0"], 0);
+}
+
+- (void)testParseTimeIntervalEmptyStringIsInvalid {
+  XCTAssertEqual([self.command parseTimeInterval:@""], 0);
+}
+
+- (void)testParseTimeIntervalNonNumericIsInvalid {
+  XCTAssertEqual([self.command parseTimeInterval:@"abc"], 0);
+}
+
+- (void)testParseTimeIntervalUnknownUnitIsInvalid {
+  XCTAssertEqual([self.command parseTimeInterval:@"10x"], 0);
+}
+
+- (void)testParseTimeIntervalSecondsUnitIsInvalid {
+  // 's' is in the scanner's unit charset but has no branch, so it is rejected
+  // like any other unsupported unit.
+  XCTAssertEqual([self.command parseTimeInterval:@"10s"], 0);
+}
+
+- (void)testParseTimeIntervalMultiCharUnitIsInvalid {
+  XCTAssertEqual([self.command parseTimeInterval:@"10mm"], 0);
+}
+
+- (void)testParseTimeIntervalTrailingContentIsInvalid {
+  XCTAssertEqual([self.command parseTimeInterval:@"10m5"], 0);
+}
+
+@end


### PR DESCRIPTION
Part of WS-1128

- Add `santactl adminmode` (alias `am`) to request or cancel a Temporary Admin Mode
  grant for the current user; drives the existing TAM XPC surface, no daemon changes
- Non-root command: the daemon resolves the target uid from the XPC peer audit token
  and handles the GUI authorization (and optional justification) prompt
- A request with no `--duration` resolves to the policy-configured default
- Lift the `--duration` parser from `monitormode` onto the shared `SNTCommand` base and
  add `SNTCommandTest` coverage