### PR TITLE
santad: demote and restore admins with Temporary Admin Mode

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -887,6 +887,33 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 ///
 - (nullable NSDictionary*)savedTimedSessionStateForKey:(nonnull NSString*)key;
 
+#pragma mark - Demoted Admins State
+
+///
+///  Persist (or delete, when `demotedAdmins` is nil) the record of admin users
+///  demoted to standard while the Temporary Admin Mode policy is enabled. Each
+///  entry is a dictionary with Username (NSString) and UID (NSNumber). An
+///  empty array is a present record: it marks the demotion as applied.
+///  Returns NO — and leaves the in-memory record unchanged — when the record
+///  cannot be written to disk; callers must not demote on a NO.
+///
+- (BOOL)persistDemotedAdmins:(nullable NSArray<NSDictionary*>*)demotedAdmins;
+
+///
+///  Returns the persisted demoted-admins record, or nil if none exists.
+///
+- (nullable NSArray<NSDictionary*>*)savedDemotedAdmins;
+
+///
+///  State-file key under which Temporary Admin Mode persists its session state
+///  (an active session, or a deadline-0 demote-retry residue after a failed
+///  teardown), and the field within it naming the session's target uid.
+///  Exported so AdminUserState can cross-check TAM ownership at capture and
+///  restore.
+///
+extern NSString* _Nonnull const kStateTempAdminModeKey;
+extern NSString* _Nonnull const kStateTempAdminTargetUIDKey;
+
 #pragma mark - USB Settings
 
 ///

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -113,7 +113,9 @@ NSString* const kStateFilePath = @"/var/db/santa/state.plist";
 
 /// Keys associated with the state file.
 static NSString* const kStateTempMonitorModeKey = @"TMM";
-static NSString* const kStateTempAdminModeKey = @"TempAdmin";
+NSString* const kStateTempAdminModeKey = @"TempAdmin";
+NSString* const kStateTempAdminTargetUIDKey = @"TargetUID";
+static NSString* const kStateDemotedAdminsKey = @"DemotedAdmins";
 static NSString* const kStateLastBootUUIDKey = @"LastBootUUID";
 
 /// User defaults key for user override of the menu item enabled setting.
@@ -986,6 +988,24 @@ static SNTConfigurator* sharedConfigurator = nil;
 
 - (nullable NSDictionary*)savedTimedSessionStateForKey:(NSString*)key {
   return self.state[key];
+}
+
+- (BOOL)persistDemotedAdmins:(NSArray<NSDictionary*>*)demotedAdmins {
+  @synchronized(self) {
+    NSDictionary* previous = self.state;
+    if ([self updateStateSynchronizedKey:kStateDemotedAdminsKey value:demotedAdmins]) {
+      return YES;
+    }
+    // Roll back the in-memory record so callers (and a later restart) see the
+    // same state: a record that exists only in memory would let capture demote
+    // users whose restore list vanishes with the daemon.
+    self.state = previous;
+    return NO;
+  }
+}
+
+- (nullable NSArray<NSDictionary*>*)savedDemotedAdmins {
+  return self.state[kStateDemotedAdminsKey];
 }
 
 - (void)updateLastBootUUID:(NSString*)bootUUID {
@@ -2205,6 +2225,10 @@ static SNTConfigurator* sharedConfigurator = nil;
     newState[kStateTempAdminModeKey] = state[kStateTempAdminModeKey];
   }
 
+  if ([state[kStateDemotedAdminsKey] isKindOfClass:[NSArray class]]) {
+    newState[kStateDemotedAdminsKey] = state[kStateDemotedAdminsKey];
+  }
+
   if ([state[kStateLastBootUUIDKey] isKindOfClass:[NSString class]]) {
     _lastBootUUID = state[kStateLastBootUUIDKey];
     newState[kStateLastBootUUIDKey] = _lastBootUUID;
@@ -2213,13 +2237,13 @@ static SNTConfigurator* sharedConfigurator = nil;
   return newState;
 }
 
-- (void)updateStateSynchronizedKey:(NSString*)key value:(id)value {
-  NSMutableDictionary* newState = [self.state mutableCopy];
+- (BOOL)updateStateSynchronizedKey:(NSString*)key value:(id)value {
+  NSMutableDictionary* newState = [self.state mutableCopy] ?: [NSMutableDictionary dictionary];
 
   newState[key] = value;
   self.state = newState;
 
-  [self saveStateToDiskSynchronized:self.state];
+  return [self saveStateToDiskSynchronized:self.state];
 }
 
 - (BOOL)saveStateToDiskSynchronized:(NSDictionary*)state {

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -614,4 +614,66 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   XCTAssertEqualWithAccuracy(sut.dnsUpstreamTimeoutSecs, 30.0, 0.0001);
 }
 
+- (void)testDemotedAdminsPersistReloadAndFilter {
+  NSString* syncStatePath = [NSString stringWithFormat:@"%@/sync-state.plist", self.testDir];
+  NSString* statePath = [NSString stringWithFormat:@"%@/state.plist", self.testDir];
+  SNTConfigurator* (^makeConfigurator)(void) = ^SNTConfigurator* {
+    return [[SNTConfigurator alloc] initWithSyncStateFile:syncStatePath
+        stateFile:statePath
+        syncStateAccessAuthorizer:^BOOL {
+          return YES;
+        }
+        stateAccessAuthorizer:^BOOL {
+          return YES;
+        }];
+  };
+
+  SNTConfigurator* cfg = makeConfigurator();
+  XCTAssertNil([cfg savedDemotedAdmins]);
+
+  // Persisted record round-trips in memory and across a re-read from disk.
+  NSArray<NSDictionary*>* record = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+  XCTAssertTrue([cfg persistDemotedAdmins:record]);
+  XCTAssertEqualObjects([cfg savedDemotedAdmins], record);
+  XCTAssertEqualObjects([makeConfigurator() savedDemotedAdmins], record);
+
+  // An empty array is a present entry, distinct from nil.
+  XCTAssertTrue([cfg persistDemotedAdmins:@[]]);
+  XCTAssertNotNil([cfg savedDemotedAdmins]);
+  XCTAssertEqual([cfg savedDemotedAdmins].count, 0u);
+  XCTAssertNotNil([makeConfigurator() savedDemotedAdmins]);
+
+  // nil deletes the entry, on disk too.
+  XCTAssertTrue([cfg persistDemotedAdmins:nil]);
+  XCTAssertNil([cfg savedDemotedAdmins]);
+  XCTAssertNil([makeConfigurator() savedDemotedAdmins]);
+
+  // A non-array value on disk is stripped by the readStateFromDisk allowlist.
+  XCTAssertTrue([@{@"DemotedAdmins" : @"not-an-array"} writeToFile:statePath atomically:YES]);
+  XCTAssertNil([makeConfigurator() savedDemotedAdmins]);
+}
+
+- (void)testDemotedAdminsPersistFailureRollsBack {
+  NSString* syncStatePath = [NSString stringWithFormat:@"%@/sync-state-rb.plist", self.testDir];
+  NSString* statePath = [NSString stringWithFormat:@"%@/state-rb.plist", self.testDir];
+  __block BOOL allowStateWrites = NO;
+  SNTConfigurator* cfg = [[SNTConfigurator alloc] initWithSyncStateFile:syncStatePath
+      stateFile:statePath
+      syncStateAccessAuthorizer:^BOOL {
+        return YES;
+      }
+      stateAccessAuthorizer:^BOOL {
+        return allowStateWrites;
+      }];
+
+  // Blocked disk write: reports failure and rolls back the in-memory record.
+  XCTAssertFalse([cfg persistDemotedAdmins:(@[ @{@"Username" : @"jane", @"UID" : @501} ])]);
+  XCTAssertNil([cfg savedDemotedAdmins]);
+
+  // Write path recovers: the same persist succeeds and is visible.
+  allowStateWrites = YES;
+  XCTAssertTrue([cfg persistDemotedAdmins:(@[ @{@"Username" : @"jane", @"UID" : @501} ])]);
+  XCTAssertNotNil([cfg savedDemotedAdmins]);
+}
+
 @end

--- a/Source/santad/AdminGroupMembership.h
+++ b/Source/santad/AdminGroupMembership.h
@@ -19,8 +19,20 @@
 
 #include <sys/types.h>
 #include <memory>
+#include <optional>
+#include <vector>
 
 namespace santa {
+
+// A direct user member of the admin group, as observed at enumeration time.
+struct AdminGroupMember {
+  uid_t uid;
+  NSString* username;
+  // Whether the account resolved from the local identity authority. Restore
+  // treats unresolvable directory (network) accounts as retryable, not
+  // deleted: off-network, "gone" and "unreachable" are indistinguishable.
+  bool local = true;
+};
 
 // Abstracts mutation of admin-group (GID 80) membership. The orchestrator depends
 // only on this interface so it can be unit-tested with a fake, and so the
@@ -38,6 +50,10 @@ class AdminGroupMembership {
   // Adds `uid` to the admin group and commits. A committed add is authoritative;
   // a post-commit verification mismatch (opendirectoryd cache latency) is logged,
   // not failed. Returns true on a committed change; populates `error` on failure.
+  // Failure to resolve the user identity itself (account no longer exists)
+  // populates SNTErrorCodeTAMNoConsoleUser; every other failure, including
+  // group resolution, uses SNTErrorCodeTAMMembershipChangeFailed. Restore
+  // callers branch on this distinction — keep it intact.
   virtual bool AddMember(uid_t uid, NSError** error) = 0;
 
   // Removes `uid` from the admin group and commits. Fails closed: a committed
@@ -46,6 +62,18 @@ class AdminGroupMembership {
   // revocation for a user who is still elevated. Returns true only on a verified
   // removal; populates `error` on failure.
   virtual bool RemoveMember(uid_t uid, NSError** error) = 0;
+
+  // Enumerates the direct user members of the admin group. Nested groups are
+  // not expanded, matching the known TAM nested-group gap. Returns
+  // std::nullopt if the group cannot be resolved; an empty vector means the
+  // group resolved but has no direct user members.
+  virtual std::optional<std::vector<AdminGroupMember>> ListDirectUserMembers() = 0;
+
+  // Returns the username (posixName) `uid` currently resolves to, or nil when
+  // the identity does not resolve. Restore callers use this to detect uid
+  // reuse: a recorded username that no longer matches means the uid now names
+  // a different account, which must never inherit the original's admin.
+  virtual NSString* UsernameForUID(uid_t uid) = 0;
 };
 
 // Returns the in-process CoreServices-backed implementation.

--- a/Source/santad/AdminGroupMembership.mm
+++ b/Source/santad/AdminGroupMembership.mm
@@ -80,11 +80,48 @@ class AdminGroupMembershipImpl : public AdminGroupMembership {
     return ChangeMembership(uid, /*add=*/false, error);
   }
 
+  std::optional<std::vector<AdminGroupMember>> ListDirectUserMembers() override {
+    CBGroupIdentity* group = AdminGroupIdentity();
+    if (!group) {
+      return std::nullopt;
+    }
+    std::vector<AdminGroupMember> members;
+    for (CBIdentity* identity in group.memberIdentities) {
+      if (![identity isKindOfClass:[CBUserIdentity class]]) {
+        continue;
+      }
+      CBUserIdentity* user = (CBUserIdentity*)identity;
+      members.push_back({user.posixUID, user.posixName ?: @"",
+                         [user.authority isEqual:[CBIdentityAuthority localIdentityAuthority]]});
+    }
+    return members;
+  }
+
+  NSString* UsernameForUID(uid_t uid) override {
+    CBIdentity* identity = UserIdentityForUID(uid);
+    if (![identity isKindOfClass:[CBUserIdentity class]]) {
+      return nil;
+    }
+    return ((CBUserIdentity*)identity).posixName;
+  }
+
  private:
   bool ChangeMembership(uid_t uid, bool add, NSError** error) {
     CBIdentity* user = UserIdentityForUID(uid);
     CBGroupIdentity* group = AdminGroupIdentity();
-    if (!user || !group) {
+    // The two resolution failures carry distinct codes because restore callers
+    // branch on them: an unresolvable group is a systemic directory-services
+    // failure (the local admin group always exists) and must read as
+    // retryable, while an unresolvable user with a healthy group means the
+    // account no longer exists. Merging these branches would let a transient
+    // opendirectoryd failure be misread as mass account deletion.
+    if (!group) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"Unable to resolve admin group identity"];
+      return false;
+    }
+    if (!user) {
       [SNTError populateError:error
                      withCode:SNTErrorCodeTAMNoConsoleUser
                        format:@"Unable to resolve identity for uid %u", uid];

--- a/Source/santad/AdminUserState.h
+++ b/Source/santad/AdminUserState.h
@@ -17,11 +17,10 @@
 
 #include <memory>
 
-#include "absl/synchronization/mutex.h"
-
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTTemporaryAdminPolicy.h"
 #include "Source/santad/AdminGroupMembership.h"
+#include "absl/synchronization/mutex.h"
 
 namespace santa {
 

--- a/Source/santad/AdminUserState.h
+++ b/Source/santad/AdminUserState.h
@@ -1,0 +1,65 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_SANTAD_ADMINUSERSTATE_H
+#define SANTA_SANTAD_ADMINUSERSTATE_H
+
+#include <memory>
+
+#include "absl/synchronization/mutex.h"
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+#include "Source/santad/AdminGroupMembership.h"
+
+namespace santa {
+
+// Reconciles pre-existing ("natural") admin users against the Temporary Admin
+// Mode policy. When the policy turns on, the direct admin-group members with
+// uid >= kMinDemotableUID are recorded in the tamper-protected state file and
+// demoted to standard; when it turns off, exactly the recorded users are
+// restored and the record is deleted.
+//
+// Record presence is the only edge detector. Workshop broadcasts the policy in
+// every preflight, so HandlePolicy runs every sync and must be idempotent:
+// on-with-a-record and off-without-a-record are no-ops. This is what keeps
+// Santa from fighting other user-management software — a user promoted by an
+// admin tool during the enabled window is never re-demoted.
+class AdminUserState {
+ public:
+  // System accounts below this uid (including root, uid 0, which is always a
+  // direct member of the admin group) are never demoted, recorded, or restored.
+  static constexpr uid_t kMinDemotableUID = 500;
+
+  AdminUserState(SNTConfigurator* configurator,
+                 std::unique_ptr<AdminGroupMembership> membership);
+
+  // Reconciles local admin users against `policy`. Called after each sync
+  // batch commits, after TemporaryAdminMode::NewPolicyReceived, so on a revoke
+  // TAM tears down its own elevation before natural admins are restored. A nil
+  // policy or a type other than OnDemand/Revoke is a no-op.
+  void HandlePolicy(SNTTemporaryAdminPolicy* policy);
+
+ private:
+  void CaptureAndDemoteLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  void RestoreAndClearLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+
+  SNTConfigurator* configurator_;
+  std::unique_ptr<AdminGroupMembership> membership_;
+  absl::Mutex lock_;
+};
+
+}  // namespace santa
+
+#endif  // SANTA_SANTAD_ADMINUSERSTATE_H

--- a/Source/santad/AdminUserState.h
+++ b/Source/santad/AdminUserState.h
@@ -18,6 +18,7 @@
 #include <memory>
 
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTKVOManager.h"
 #import "Source/common/SNTTemporaryAdminPolicy.h"
 #include "Source/santad/AdminGroupMembership.h"
 #include "absl/synchronization/mutex.h"
@@ -41,8 +42,10 @@ class AdminUserState {
   // direct member of the admin group) are never demoted, recorded, or restored.
   static constexpr uid_t kMinDemotableUID = 500;
 
-  AdminUserState(SNTConfigurator* configurator,
-                 std::unique_ptr<AdminGroupMembership> membership);
+  // `revoke_tam` must synchronously revoke any active Temporary Admin Mode
+  // session; HandleSyncServerChange calls it before restoring (see there).
+  AdminUserState(SNTConfigurator* configurator, std::unique_ptr<AdminGroupMembership> membership,
+                 void (^revoke_tam)(void));
 
   // Reconciles local admin users against `policy`. Called after each sync
   // batch commits, after TemporaryAdminMode::NewPolicyReceived, so on a revoke
@@ -50,12 +53,28 @@ class AdminUserState {
   // policy or a type other than OnDemand/Revoke is a no-op.
   void HandlePolicy(SNTTemporaryAdminPolicy* policy);
 
+  // Watches for the sync server being removed or replaced and restores the
+  // recorded users when that happens: a machine that can no longer sync can
+  // never receive the Revoke that would otherwise restore them. Also runs one
+  // reconcile immediately, catching a server that went away while the daemon
+  // was not running; a restore that fails there is retried at the next daemon
+  // start. Called once at daemon startup, after TemporaryAdminMode's
+  // SetupFromState; not from the constructor because the sync-v2 gate read is
+  // daemon-only.
+  void SetupFromState();
+
+  // Restores the recorded users and deletes the record, revoking any active
+  // TAM session first. A no-op without a record. Public for tests.
+  void HandleSyncServerChange();
+
  private:
   void CaptureAndDemoteLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   void RestoreAndClearLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   SNTConfigurator* configurator_;
   std::unique_ptr<AdminGroupMembership> membership_;
+  void (^revoke_tam_)(void);
+  NSArray<SNTKVOManager*>* kvo_;
   absl::Mutex lock_;
 };
 

--- a/Source/santad/AdminUserState.mm
+++ b/Source/santad/AdminUserState.mm
@@ -41,7 +41,7 @@ AdminUserState::AdminUserState(SNTConfigurator* configurator,
       revoke_tam_([revoke_tam copy]) {}
 
 void AdminUserState::HandlePolicy(SNTTemporaryAdminPolicy* policy) {
-  absl::MutexLock lock(&lock_);
+  absl::MutexLock lock(lock_);
   bool have_record = [configurator_ savedDemotedAdmins] != nil;
   // A record that survives a revoke (kept to retry a failed restore) also
   // suppresses capture for the whole next enabled window: restored users keep
@@ -104,7 +104,7 @@ void AdminUserState::SetupFromState() {
 }
 
 void AdminUserState::HandleSyncServerChange() {
-  absl::MutexLock lock(&lock_);
+  absl::MutexLock lock(lock_);
   if ([configurator_ savedDemotedAdmins] == nil) {
     return;
   }

--- a/Source/santad/AdminUserState.mm
+++ b/Source/santad/AdminUserState.mm
@@ -1,0 +1,195 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/AdminUserState.h"
+
+#import "Source/common/SNTError.h"
+#import "Source/common/SNTLogging.h"
+
+namespace santa {
+
+// Keys for one entry in the persisted DemotedAdmins record.
+static NSString* const kDemotedAdminUsername = @"Username";
+static NSString* const kDemotedAdminUID = @"UID";
+static NSString* const kDemotedAdminLocal = @"Local";
+
+// Returns the uid TAM currently owns — an active session's target or a
+// deadline-0 demote-retry residue left by a failed teardown — or nil if no
+// TAM session state is persisted.
+static NSNumber* TAMOwnedUID(SNTConfigurator* configurator) {
+  NSDictionary* session = [configurator savedTimedSessionStateForKey:kStateTempAdminModeKey];
+  NSNumber* uid = session[kStateTempAdminTargetUIDKey];
+  return [uid isKindOfClass:[NSNumber class]] ? uid : nil;
+}
+
+AdminUserState::AdminUserState(SNTConfigurator* configurator,
+                               std::unique_ptr<AdminGroupMembership> membership)
+    : configurator_(configurator), membership_(std::move(membership)) {}
+
+void AdminUserState::HandlePolicy(SNTTemporaryAdminPolicy* policy) {
+  absl::MutexLock lock(&lock_);
+  bool have_record = [configurator_ savedDemotedAdmins] != nil;
+  if (policy.type == SNTTemporaryAdminPolicyTypeOnDemand && !have_record) {
+    CaptureAndDemoteLocked();
+  } else if (policy.type == SNTTemporaryAdminPolicyTypeRevoke && have_record) {
+    RestoreAndClearLocked();
+  }
+}
+
+void AdminUserState::CaptureAndDemoteLocked() {
+  std::optional<std::vector<AdminGroupMember>> members = membership_->ListDirectUserMembers();
+  if (!members.has_value()) {
+    LOGE(@"DemotedAdmins: admin group enumeration failed; retrying at next sync");
+    return;
+  }
+
+  NSNumber* tam_uid = TAMOwnedUID(configurator_);
+  NSMutableArray<NSDictionary*>* record = [NSMutableArray array];
+  for (const AdminGroupMember& member : *members) {
+    if (member.uid < kMinDemotableUID) {
+      continue;
+    }
+    if (tam_uid && member.uid == tam_uid.unsignedIntValue) {
+      // This membership is TAM's (an active grant, or a failed-teardown
+      // residue pending its restart retry), not a natural admin. Recording it
+      // would launder a temporary elevation into a permanent one at restore.
+      LOGI(@"DemotedAdmins: excluding TAM session target uid=%u from capture",
+           member.uid);
+      continue;
+    }
+    [record addObject:@{
+      kDemotedAdminUsername : member.username,
+      kDemotedAdminUID : @(member.uid),
+      kDemotedAdminLocal : @(member.local),
+    }];
+  }
+
+  // The record must be durable before any membership mutation: a record
+  // without a flip is recovered by an idempotent restore, but a flip without
+  // a record strands demoted users. An empty record is still written — its
+  // presence marks the flip as applied.
+  if (![configurator_ persistDemotedAdmins:record]) {
+    LOGE(@"DemotedAdmins: failed to persist record; no users demoted; retrying at next sync");
+    return;
+  }
+
+  for (NSDictionary* user in record) {
+    uid_t uid = [user[kDemotedAdminUID] unsignedIntValue];
+    NSError* err;
+    if (membership_->RemoveMember(uid, &err)) {
+      LOGI(@"DemotedAdmins: demoted %@ (uid=%u) to standard", user[kDemotedAdminUsername], uid);
+    } else {
+      // Deliberately not retried: re-applying demotions would fight other
+      // user-management software. The user stays recorded and stays admin;
+      // remediation is toggling the policy off then on.
+      LOGE(@"DemotedAdmins: failed to demote %@ (uid=%u): %@", user[kDemotedAdminUsername], uid,
+           err.localizedDescription);
+    }
+  }
+}
+
+// A record entry is treated as local unless it carries an explicit
+// Local == NO. Missing or mistyped values (only possible via tampering or
+// corruption) default to local so the entry stays terminal on unresolvable
+// accounts and cannot keep the record alive forever.
+static bool EntryIsLocal(NSDictionary* entry) {
+  NSNumber* local = entry[kDemotedAdminLocal];
+  return ![local isKindOfClass:[NSNumber class]] || local.boolValue;
+}
+
+void AdminUserState::RestoreAndClearLocked() {
+  NSArray<NSDictionary*>* record = [configurator_ savedDemotedAdmins];
+  bool all_restored = true;
+  NSMutableSet<NSNumber*>* restored_uids = [NSMutableSet set];
+  for (NSDictionary* user in record) {
+    NSNumber* uid_number =
+        [user isKindOfClass:[NSDictionary class]] ? user[kDemotedAdminUID] : nil;
+    if (![uid_number isKindOfClass:[NSNumber class]]) {
+      // Only possible via on-disk tampering or corruption. The entry can never
+      // be restored, so it must not keep the whole record alive forever.
+      LOGE(@"DemotedAdmins: malformed record entry %@; skipping", user);
+      continue;
+    }
+    uid_t uid = [uid_number unsignedIntValue];
+    if (uid < kMinDemotableUID) {
+      // Capture never records system accounts, so this is tampering or
+      // corruption. Never promote it; like the malformed case above, it must
+      // not keep the record alive forever.
+      LOGE(@"DemotedAdmins: record entry %@ is below the minimum uid; skipping", user);
+      continue;
+    }
+    NSString* recorded_username = [user[kDemotedAdminUsername] isKindOfClass:[NSString class]]
+                                      ? user[kDemotedAdminUsername]
+                                      : nil;
+    NSString* current_username = membership_->UsernameForUID(uid);
+    if (recorded_username.length && current_username.length &&
+        [current_username caseInsensitiveCompare:recorded_username] != NSOrderedSame) {
+      // The uid resolves to a different account than was demoted: the
+      // original was deleted and the uid reused. Never promote the new
+      // account; like the deleted-account case, the entry is complete.
+      [restored_uids addObject:@(uid)];
+      LOGW(@"DemotedAdmins: uid=%u now resolves to %@, not recorded %@; treating as removed",
+           uid, current_username, recorded_username);
+      continue;
+    }
+    NSError* err;
+    if (membership_->AddMember(uid, &err)) {
+      [restored_uids addObject:@(uid)];
+      LOGI(@"DemotedAdmins: restored %@ (uid=%u) to admin", user[kDemotedAdminUsername], uid);
+    } else if (err.code == SNTErrorCodeTAMNoConsoleUser && EntryIsLocal(user)) {
+      [restored_uids addObject:@(uid)];
+      // A local identity that no longer resolves was deleted during the
+      // enabled window. Nothing to restore. (Entries missing the Local key —
+      // tampering or corruption — land here too, so a damaged entry can
+      // never pin the record alive forever.)
+      LOGW(@"DemotedAdmins: %@ (uid=%u) no longer resolves; treating as restored",
+           user[kDemotedAdminUsername], uid);
+    } else if (err.code == SNTErrorCodeTAMNoConsoleUser) {
+      all_restored = false;
+      // An unresolvable directory account may be deleted OR merely
+      // unreachable (off-network, directory outage). Consuming the entry on
+      // an outage would strand a real admin, so it is retried instead; the
+      // restore stays an idempotent no-op for everyone already handled.
+      LOGW(@"DemotedAdmins: directory account %@ (uid=%u) unresolvable; cannot "
+           @"distinguish deleted from unreachable; retrying at next sync",
+           user[kDemotedAdminUsername], uid);
+    } else {
+      all_restored = false;
+      LOGE(@"DemotedAdmins: failed to restore %@ (uid=%u): %@; retrying at next sync",
+           user[kDemotedAdminUsername], uid, err.localizedDescription);
+    }
+  }
+
+  if (all_restored) {
+    // If TAM persisted a demote-retry residue for a user this restore just
+    // deliberately re-promoted, executing that retry at the next daemon start
+    // would strand a restored natural admin — policy off, record gone. The
+    // restore supersedes the owed demotion. (A residue for a uid outside the
+    // record is TAM's business; leave it.)
+    NSNumber* tam_uid = TAMOwnedUID(configurator_);
+    if (tam_uid && [restored_uids containsObject:tam_uid]) {
+      LOGI(@"DemotedAdmins: clearing TAM demote-retry residue for restored uid=%u",
+           tam_uid.unsignedIntValue);
+      [configurator_ persistTimedSessionState:nil forKey:kStateTempAdminModeKey];
+    }
+    if (![configurator_ persistDemotedAdmins:nil]) {
+      // The rollback keeps the in-memory record, so the next revoke delivery
+      // re-runs the (idempotent) restore and retries the deletion.
+      LOGE(@"DemotedAdmins: restore complete but record deletion did not persist; "
+           @"retrying at next sync");
+    }
+  }
+}
+
+}  // namespace santa

--- a/Source/santad/AdminUserState.mm
+++ b/Source/santad/AdminUserState.mm
@@ -34,17 +34,89 @@ static NSNumber* TAMOwnedUID(SNTConfigurator* configurator) {
 }
 
 AdminUserState::AdminUserState(SNTConfigurator* configurator,
-                               std::unique_ptr<AdminGroupMembership> membership)
-    : configurator_(configurator), membership_(std::move(membership)) {}
+                               std::unique_ptr<AdminGroupMembership> membership,
+                               void (^revoke_tam)(void))
+    : configurator_(configurator),
+      membership_(std::move(membership)),
+      revoke_tam_([revoke_tam copy]) {}
 
 void AdminUserState::HandlePolicy(SNTTemporaryAdminPolicy* policy) {
   absl::MutexLock lock(&lock_);
   bool have_record = [configurator_ savedDemotedAdmins] != nil;
+  // A record that survives a revoke (kept to retry a failed restore) also
+  // suppresses capture for the whole next enabled window: restored users keep
+  // admin, and new admins are never demoted, until the record drains and a
+  // later off-to-on edge captures fresh. Deliberate: the record cannot hold
+  // two capture generations, and re-capturing while one exists would turn the
+  // one-shot demotion into continuous enforcement that fights other
+  // user-management software.
   if (policy.type == SNTTemporaryAdminPolicyTypeOnDemand && !have_record) {
     CaptureAndDemoteLocked();
   } else if (policy.type == SNTTemporaryAdminPolicyTypeRevoke && have_record) {
     RestoreAndClearLocked();
   }
+}
+
+void AdminUserState::SetupFromState() {
+  // The callbacks capture `this` unretained: AdminUserState lives for the
+  // daemon's lifetime, and kvo_ (which owns the observations) dies with it.
+  kvo_ = @[
+    [[SNTKVOManager alloc]
+        initWithObject:configurator_
+              selector:@selector(syncBaseURL)
+                  type:[NSURL class]
+              callback:^(NSURL* oldValue, NSURL* newValue) {
+                if ((!newValue && !oldValue) ||
+                    [newValue.absoluteString isEqualToString:oldValue.absoluteString]) {
+                  return;
+                }
+                // Any change — removal or replacement — restores: the record
+                // was captured under the old server's policy, and a new
+                // server's first on-policy delivery finds no record and
+                // captures fresh.
+                HandleSyncServerChange();
+              }],
+    [[SNTKVOManager alloc] initWithObject:configurator_
+                                 selector:@selector(pushTokenChain)
+                                     type:[NSArray class]
+                                 callback:^(NSArray* oldValue, NSArray* newValue) {
+                                   // Ignore no-op fires. pushTokenChain is a KVO dependent key on
+                                   // the whole syncState, so every syncState write fires this
+                                   // callback even when the chain is unchanged — including the
+                                   // write revoke_tam_ makes while HandleSyncServerChange holds
+                                   // lock_. Without this guard that re-entrant fire would re-take
+                                   // lock_ on the same thread and deadlock.
+                                   if ((!newValue && !oldValue) ||
+                                       [newValue isEqualToArray:oldValue]) {
+                                     return;
+                                   }
+                                   if (!configurator_.isSyncV2Enabled) {
+                                     HandleSyncServerChange();
+                                   }
+                                 }],
+  ];
+
+  // The watchers only fire on changes: a sync server that went away while the
+  // daemon was not running is reconciled directly.
+  if (!configurator_.isSyncV2Enabled) {
+    HandleSyncServerChange();
+  }
+}
+
+void AdminUserState::HandleSyncServerChange() {
+  absl::MutexLock lock(&lock_);
+  if ([configurator_ savedDemotedAdmins] == nil) {
+    return;
+  }
+  // Tear down any active TAM session before restoring, mirroring the sync
+  // path's NewPolicyReceived-before-HandlePolicy ordering. TAM's own watchers
+  // also revoke on these events, but KVO observer order is unspecified: if the
+  // restore ran first it would mistake an active session for a demote-retry
+  // residue, clear its state, and TAM's later revoke would then demote a
+  // just-restored admin with the record already gone. Revoke is idempotent, so
+  // the extra call is safe in either observer order.
+  revoke_tam_();
+  RestoreAndClearLocked();
 }
 
 void AdminUserState::CaptureAndDemoteLocked() {

--- a/Source/santad/AdminUserState.mm
+++ b/Source/santad/AdminUserState.mm
@@ -64,8 +64,7 @@ void AdminUserState::CaptureAndDemoteLocked() {
       // This membership is TAM's (an active grant, or a failed-teardown
       // residue pending its restart retry), not a natural admin. Recording it
       // would launder a temporary elevation into a permanent one at restore.
-      LOGI(@"DemotedAdmins: excluding TAM session target uid=%u from capture",
-           member.uid);
+      LOGI(@"DemotedAdmins: excluding TAM session target uid=%u from capture", member.uid);
       continue;
     }
     [record addObject:@{
@@ -113,8 +112,7 @@ void AdminUserState::RestoreAndClearLocked() {
   bool all_restored = true;
   NSMutableSet<NSNumber*>* restored_uids = [NSMutableSet set];
   for (NSDictionary* user in record) {
-    NSNumber* uid_number =
-        [user isKindOfClass:[NSDictionary class]] ? user[kDemotedAdminUID] : nil;
+    NSNumber* uid_number = [user isKindOfClass:[NSDictionary class]] ? user[kDemotedAdminUID] : nil;
     if (![uid_number isKindOfClass:[NSNumber class]]) {
       // Only possible via on-disk tampering or corruption. The entry can never
       // be restored, so it must not keep the whole record alive forever.
@@ -139,8 +137,8 @@ void AdminUserState::RestoreAndClearLocked() {
       // original was deleted and the uid reused. Never promote the new
       // account; like the deleted-account case, the entry is complete.
       [restored_uids addObject:@(uid)];
-      LOGW(@"DemotedAdmins: uid=%u now resolves to %@, not recorded %@; treating as removed",
-           uid, current_username, recorded_username);
+      LOGW(@"DemotedAdmins: uid=%u now resolves to %@, not recorded %@; treating as removed", uid,
+           current_username, recorded_username);
       continue;
     }
     NSError* err;

--- a/Source/santad/AdminUserStateTest.mm
+++ b/Source/santad/AdminUserStateTest.mm
@@ -113,6 +113,8 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
 // In-memory stand-in for TAM's persisted session state under the TempAdmin
 // key: nil means no session/residue.
 @property(copy) NSDictionary* tamSessionState;
+// Number of times the injected revoke-TAM block was called.
+@property NSInteger revokeTAMCalls;
 @end
 
 @implementation AdminUserStateTest
@@ -147,11 +149,19 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
       });
 }
 
-- (std::unique_ptr<AdminUserState>)makeStateWithFake:(FakeAdminGroupMembership**)fakeOut {
+- (std::unique_ptr<AdminUserState>)makeStateWithFake:(FakeAdminGroupMembership**)fakeOut
+                                           revokeTAM:(void (^)(void))revokeTAM {
   auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
   *fakeOut = fakeOwned.get();
   return std::make_unique<AdminUserState>((SNTConfigurator*)self.mockConfigurator,
-                                          std::move(fakeOwned));
+                                          std::move(fakeOwned), revokeTAM);
+}
+
+- (std::unique_ptr<AdminUserState>)makeStateWithFake:(FakeAdminGroupMembership**)fakeOut {
+  return [self makeStateWithFake:fakeOut
+                       revokeTAM:^{
+                         self.revokeTAMCalls++;
+                       }];
 }
 
 #pragma mark Capture + demote
@@ -459,6 +469,99 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
 
   XCTAssertFalse(fake->IsMember(501));
   XCTAssertNil(self.storedRecord);  // entry is complete, not retried
+}
+
+#pragma mark Sync server change
+
+- (void)testSyncServerChangeRestoresAndDeletesRecord {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+
+  state->HandleSyncServerChange();
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+  XCTAssertEqual(self.revokeTAMCalls, 1);
+}
+
+- (void)testSyncServerChangeWithoutRecordIsNoOp {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+
+  state->HandleSyncServerChange();
+
+  XCTAssertNil(self.storedRecord);
+  XCTAssertEqual(self.revokeTAMCalls, 0);
+}
+
+- (void)testSyncServerChangeRevokesTAMBeforeRestoring {
+  // If the restore ran before TAM's teardown, an active TAM session whose
+  // target is also recorded would already be restored — and TAM's teardown
+  // would then re-demote it with the record gone. Assert the ordering the
+  // injected block guarantees: at revoke time, nobody has been restored yet.
+  __block FakeAdminGroupMembership* fake = nullptr;
+  __block BOOL memberAtRevoke = YES;
+  auto state = [self makeStateWithFake:&fake
+                             revokeTAM:^{
+                               memberAtRevoke = fake->IsMember(501);
+                             }];
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+
+  state->HandleSyncServerChange();
+
+  XCTAssertFalse(memberAtRevoke);
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testSyncServerChangePartialRestoreKeepsRecordForRetry {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  NSArray* record = @[
+    @{@"Username" : @"jane", @"UID" : @501},
+    @{@"Username" : @"adadmin", @"UID" : @503, @"Local" : @NO},
+  ];
+  self.storedRecord = record;
+  fake->gone_uids_ = {503};  // directory unreachable at unenroll time
+
+  state->HandleSyncServerChange();
+
+  // jane restored; the directory account is retried at the next daemon start.
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));
+  XCTAssertEqualObjects(self.storedRecord, record);
+
+  fake->gone_uids_.clear();
+  state->HandleSyncServerChange();
+  XCTAssertTrue(fake->IsMember(503));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testSetupFromStateRestoresWhenSyncServerAlreadyGone {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(NO);
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+
+  state->SetupFromState();
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+  XCTAssertEqual(self.revokeTAMCalls, 1);
+}
+
+- (void)testSetupFromStateLeavesRecordWhileSyncServerPresent {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+
+  state->SetupFromState();
+
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertNotNil(self.storedRecord);
+  XCTAssertEqual(self.revokeTAMCalls, 0);
 }
 
 #pragma mark Idempotency across the full cycle

--- a/Source/santad/AdminUserStateTest.mm
+++ b/Source/santad/AdminUserStateTest.mm
@@ -1,0 +1,518 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/AdminUserState.h"
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#include <map>
+#include <memory>
+#include <set>
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTError.h"
+#import "Source/common/SNTTemporaryAdminPolicy.h"
+#include "Source/santad/AdminGroupMembership.h"
+
+namespace santa {
+
+// In-memory fake admin-group membership for tests. Never touches the real group 80.
+class FakeAdminGroupMembership : public AdminGroupMembership {
+ public:
+  bool IsMember(uid_t uid) override { return members_.count(uid) > 0; }
+
+  bool AddMember(uid_t uid, NSError** error) override {
+    if (gone_uids_.count(uid)) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMNoConsoleUser
+                       format:@"fake unresolvable uid"];
+      return false;
+    }
+    if (fail_add_uids_.count(uid)) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"fake add"];
+      return false;
+    }
+    members_.insert(uid);
+    return true;
+  }
+
+  bool RemoveMember(uid_t uid, NSError** error) override {
+    if (fail_remove_uids_.count(uid)) {
+      [SNTError populateError:error
+                     withCode:SNTErrorCodeTAMMembershipChangeFailed
+                       format:@"fake remove"];
+      return false;
+    }
+    members_.erase(uid);
+    return true;
+  }
+
+  std::optional<std::vector<AdminGroupMember>> ListDirectUserMembers() override {
+    if (fail_list_) {
+      return std::nullopt;
+    }
+    std::vector<AdminGroupMember> out;
+    for (uid_t uid : members_) {
+      out.push_back({uid, names_.count(uid) ? names_[uid] : @"", !network_uids_.count(uid)});
+    }
+    return out;
+  }
+
+  NSString* UsernameForUID(uid_t uid) override {
+    if (gone_uids_.count(uid)) return nil;
+    return names_.count(uid) ? names_[uid] : nil;
+  }
+
+  std::set<uid_t> members_;           // current group-80 members (sorted => deterministic order)
+  std::map<uid_t, NSString*> names_;  // uid -> username reported by enumeration
+  std::set<uid_t> fail_add_uids_;     // AddMember fails (transient commit failure)
+  std::set<uid_t> fail_remove_uids_;  // RemoveMember fails
+  std::set<uid_t> gone_uids_;         // AddMember fails as unresolvable (account deleted)
+  std::set<uid_t> network_uids_;      // enumerated as non-local (directory) accounts
+  bool fail_list_ = false;
+};
+
+}  // namespace santa
+
+using santa::AdminUserState;
+using santa::FakeAdminGroupMembership;
+
+static SNTTemporaryAdminPolicy* OnDemandPolicy() {
+  return [[SNTTemporaryAdminPolicy alloc] initOnDemandMinutes:60
+                                              defaultDuration:5
+                                         requireJustification:NO];
+}
+
+static SNTTemporaryAdminPolicy* RevokePolicy() {
+  return [[SNTTemporaryAdminPolicy alloc] initRevocation];
+}
+
+@interface AdminUserStateTest : XCTestCase
+@property id mockConfigurator;
+// In-memory stand-in for the persisted DemotedAdmins record: nil means no
+// record, mirroring persistDemotedAdmins:/savedDemotedAdmins semantics.
+@property(copy) NSArray<NSDictionary*>* storedRecord;
+// When YES, persistDemotedAdmins: reports failure and leaves storedRecord
+// unchanged, mirroring the production rollback semantics.
+@property BOOL persistFails;
+// In-memory stand-in for TAM's persisted session state under the TempAdmin
+// key: nil means no session/residue.
+@property(copy) NSDictionary* tamSessionState;
+@end
+
+@implementation AdminUserStateTest
+
+- (void)setUp {
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  self.storedRecord = nil;
+
+  OCMStub([self.mockConfigurator persistDemotedAdmins:[OCMArg any]]).andDo(^(NSInvocation* inv) {
+    BOOL ok = !self.persistFails;
+    if (ok) {
+      __unsafe_unretained NSArray* record = nil;
+      [inv getArgument:&record atIndex:2];
+      self.storedRecord = record;
+    }
+    [inv setReturnValue:&ok];
+  });
+  OCMStub([self.mockConfigurator savedDemotedAdmins]).andDo(^(NSInvocation* inv) {
+    __unsafe_unretained NSArray* record = self.storedRecord;
+    [inv setReturnValue:&record];
+  });
+  OCMStub([self.mockConfigurator savedTimedSessionStateForKey:[OCMArg any]])
+      .andDo(^(NSInvocation* inv) {
+        __unsafe_unretained NSDictionary* ret = self.tamSessionState;
+        [inv setReturnValue:&ret];
+      });
+  OCMStub([self.mockConfigurator persistTimedSessionState:[OCMArg any] forKey:[OCMArg any]])
+      .andDo(^(NSInvocation* inv) {
+        __unsafe_unretained NSDictionary* state = nil;
+        [inv getArgument:&state atIndex:2];
+        self.tamSessionState = state;
+      });
+}
+
+- (std::unique_ptr<AdminUserState>)makeStateWithFake:(FakeAdminGroupMembership**)fakeOut {
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  *fakeOut = fakeOwned.get();
+  return std::make_unique<AdminUserState>((SNTConfigurator*)self.mockConfigurator,
+                                          std::move(fakeOwned));
+}
+
+#pragma mark Capture + demote
+
+- (void)testPolicyOnCapturesAndDemotesOnlyRealUsers {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {0, 200, 501, 503};
+  fake->names_ = {{0, @"root"}, {200, @"_swupdate"}, {501, @"jane"}, {503, @"itadmin"}};
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  NSArray* expected = @[
+    @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES},
+    @{@"Username" : @"itadmin", @"UID" : @503, @"Local" : @YES},
+  ];
+  XCTAssertEqualObjects(self.storedRecord, expected);
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));
+  // System accounts are neither demoted nor recorded.
+  XCTAssertTrue(fake->IsMember(0));
+  XCTAssertTrue(fake->IsMember(200));
+}
+
+- (void)testFailedDemoteStaysRecordedAndRestoreIsIdempotent {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501, 503};
+  fake->names_ = {{501, @"jane"}, {503, @"itadmin"}};
+  fake->fail_remove_uids_ = {503};
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  // Persist-before-flip: the failed remove leaves itadmin recorded AND admin.
+  NSArray* expected = @[
+    @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES},
+    @{@"Username" : @"itadmin", @"UID" : @503, @"Local" : @YES},
+  ];
+  XCTAssertEqualObjects(self.storedRecord, expected);
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertTrue(fake->IsMember(503));
+
+  // Restore: AddMember on the still-admin itadmin is an idempotent no-op.
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(fake->IsMember(503));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testEnumerationFailureWritesNoRecord {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501};
+  fake->names_ = {{501, @"jane"}};
+  fake->fail_list_ = true;
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  XCTAssertNil(self.storedRecord);     // no record written
+  XCTAssertTrue(fake->IsMember(501));  // no flip applied
+}
+
+- (void)testZeroAdminsWritesEmptyRecordAsEdgeDetector {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {0};  // only root
+  fake->names_ = {{0, @"root"}};
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  // The empty record still marks the flip as applied ...
+  XCTAssertNotNil(self.storedRecord);
+  XCTAssertEqual(self.storedRecord.count, 0u);
+
+  // ... so a user promoted later is not demoted by the repeated on-policy.
+  fake->members_.insert(501);
+  fake->names_[501] = @"jane";
+  state->HandlePolicy(OnDemandPolicy());
+  XCTAssertTrue(fake->IsMember(501));
+
+  // Turning off deletes the record.
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testPersistFailureAbortsDemote {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501};
+  fake->names_ = {{501, @"jane"}};
+  self.persistFails = YES;
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  // No durable record means no flip: nobody is demoted, nothing is recorded.
+  XCTAssertNil(self.storedRecord);
+  XCTAssertTrue(fake->IsMember(501));
+
+  // The write path recovers; the next delivery performs the full edge.
+  self.persistFails = NO;
+  state->HandlePolicy(OnDemandPolicy());
+  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
+  XCTAssertFalse(fake->IsMember(501));
+}
+
+#pragma mark Restore + delete
+
+- (void)testPolicyOffRestoresAndDeletesRecord {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[
+    @{@"Username" : @"jane", @"UID" : @501},
+    @{@"Username" : @"itadmin", @"UID" : @503},
+  ];
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(fake->IsMember(503));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testPartialRestoreKeepsRecordUntilComplete {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  NSArray* record = @[
+    @{@"Username" : @"jane", @"UID" : @501},
+    @{@"Username" : @"itadmin", @"UID" : @503},
+  ];
+  self.storedRecord = record;
+  fake->fail_add_uids_ = {503};
+
+  state->HandlePolicy(RevokePolicy());
+
+  // jane restored, itadmin failed: the record survives in full for the retry
+  // at the next sync (Workshop re-sends revoke every preflight).
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));
+  XCTAssertEqualObjects(self.storedRecord, record);
+
+  // The failure clears; the next delivery completes the restore.
+  fake->fail_add_uids_.clear();
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertTrue(fake->IsMember(503));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testRestoreWithDeletedAccountCompletes {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[
+    @{@"Username" : @"jane", @"UID" : @501},
+    @{@"Username" : @"deleted", @"UID" : @503},
+  ];
+  fake->gone_uids_ = {503};
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));  // nothing to restore
+  XCTAssertNil(self.storedRecord);      // treated as done; record deleted
+}
+
+- (void)testMalformedRecordEntrySkippedAndRecordDeleted {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[
+    @{@"Username" : @"jane", @"UID" : @501},
+    @{@"Username" : @"no-uid"},
+  ];
+
+  state->HandlePolicy(RevokePolicy());
+
+  // The parsable entry restores; the malformed one can never be restored, so
+  // the record is deleted rather than retried forever.
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testRecordEntryBelowMinUIDIsNeverRestored {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  // Capture never records system accounts; a uid-0 entry means the record was
+  // tampered with or corrupted. It must not be promoted.
+  self.storedRecord = @[
+    @{@"Username" : @"root", @"UID" : @0},
+    @{@"Username" : @"jane", @"UID" : @501},
+  ];
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertFalse(fake->IsMember(0));
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+}
+
+#pragma mark TAM cross-check
+
+- (void)testCaptureExcludesTAMSessionTargetUnlessStateIsMalformed {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501, 503};
+  fake->names_ = {{501, @"jane"}, {503, @"tamuser"}};
+  // 503 is in group 80 only because of TAM (active grant or failed-teardown
+  // residue) — not a natural admin.
+  self.tamSessionState = @{@"TargetUID" : @503};
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertTrue(fake->IsMember(503));  // left to TAM's own teardown/retry
+
+  // Same capture with malformed TAM state (no TargetUID): nobody is excluded,
+  // so the uid the well-formed state protected above is now captured normally.
+  self.storedRecord = nil;
+  fake->members_ = {501, 503};
+  self.tamSessionState = @{@"TargetUsername" : @"tamuser"};
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  XCTAssertEqualObjects(self.storedRecord, (@[
+    @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES},
+    @{@"Username" : @"tamuser", @"UID" : @503, @"Local" : @YES},
+  ]));
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));
+}
+
+- (void)testRestoreClearsMatchingTAMRetryResidue {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+  // TAM still owes a demotion for jane from a failed teardown; executing it at
+  // the next daemon start would strand her after this deliberate restore.
+  self.tamSessionState = @{@"TargetUID" : @501};
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+  XCTAssertNil(self.tamSessionState);  // the restore supersedes the owed demotion
+}
+
+- (void)testRestoreLeavesUnrelatedTAMStateAlone {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501} ];
+  self.tamSessionState = @{@"TargetUID" : @999};
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+  XCTAssertEqualObjects(self.tamSessionState, @{@"TargetUID" : @999});
+}
+
+#pragma mark Directory accounts + uid reuse
+
+- (void)testUnresolvableDirectoryAccountAtRestoreRetries {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501, 503};
+  fake->names_ = {{501, @"jane"}, {503, @"adadmin"}};
+  fake->network_uids_ = {503};
+
+  state->HandlePolicy(OnDemandPolicy());
+
+  NSArray* expected = @[
+    @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES},
+    @{@"Username" : @"adadmin", @"UID" : @503, @"Local" : @NO},
+  ];
+  XCTAssertEqualObjects(self.storedRecord, expected);
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));
+
+  // The directory is unreachable at revoke time: the account resolves to
+  // nothing, which for a directory account must NOT be read as deleted.
+  fake->gone_uids_ = {503};
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertFalse(fake->IsMember(503));
+  XCTAssertNotNil(self.storedRecord);  // retained for retry
+
+  // Back on the network: the next delivery completes and deletes the record.
+  fake->gone_uids_.clear();
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertTrue(fake->IsMember(503));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testReusedUIDIsNeverPromoted {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  self.storedRecord = @[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ];
+  // jane's account was deleted during the window and uid 501 was reassigned
+  // to a new account. The new account must not inherit jane's admin.
+  fake->names_ = {{501, @"newhire"}};
+
+  state->HandlePolicy(RevokePolicy());
+
+  XCTAssertFalse(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);  // entry is complete, not retried
+}
+
+#pragma mark Idempotency across the full cycle
+
+- (void)testRepeatedDeliveryIsIdempotent {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501};
+  fake->names_ = {{501, @"jane"}};
+
+  // Revoke before any capture (fleet where the policy was never on): no-op.
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+
+  state->HandlePolicy(OnDemandPolicy());
+  XCTAssertFalse(fake->IsMember(501));
+
+  // During the enabled window jane is re-promoted and 505 newly promoted, out
+  // of band (e.g. by other management software). The repeated on-policy at the
+  // next sync must demote neither — no fighting — and must not re-capture the
+  // record.
+  fake->members_ = {501, 505};
+  fake->names_[505] = @"newadmin";
+  state->HandlePolicy(OnDemandPolicy());
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(fake->IsMember(505));
+  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
+
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertTrue(fake->IsMember(505));  // untouched: not in the record
+  XCTAssertNil(self.storedRecord);
+
+  // Repeated revoke with no record: no-op.
+  state->HandlePolicy(RevokePolicy());
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+}
+
+- (void)testNilOrUnspecifiedPolicyIsNoOp {
+  FakeAdminGroupMembership* fake = nullptr;
+  auto state = [self makeStateWithFake:&fake];
+  fake->members_ = {501};
+  fake->names_ = {{501, @"jane"}};
+
+  // No record: neither branch fires. (A nil policy reads as type 0/Unspecified.)
+  state->HandlePolicy(nil);
+  XCTAssertTrue(fake->IsMember(501));
+  XCTAssertNil(self.storedRecord);
+
+  // Record present: still neither branch fires.
+  self.storedRecord = @[ @{@"Username" : @"gone", @"UID" : @504} ];
+  state->HandlePolicy(nil);
+  XCTAssertFalse(fake->IsMember(504));
+  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"gone", @"UID" : @504} ]));
+}
+
+@end

--- a/Source/santad/AdminUserStateTest.mm
+++ b/Source/santad/AdminUserStateTest.mm
@@ -253,7 +253,8 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
   // The write path recovers; the next delivery performs the full edge.
   self.persistFails = NO;
   state->HandlePolicy(OnDemandPolicy());
-  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
+  XCTAssertEqualObjects(self.storedRecord,
+                        (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
   XCTAssertFalse(fake->IsMember(501));
 }
 
@@ -361,7 +362,8 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
 
   state->HandlePolicy(OnDemandPolicy());
 
-  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
+  XCTAssertEqualObjects(self.storedRecord,
+                        (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
   XCTAssertFalse(fake->IsMember(501));
   XCTAssertTrue(fake->IsMember(503));  // left to TAM's own teardown/retry
 
@@ -374,9 +376,9 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
   state->HandlePolicy(OnDemandPolicy());
 
   XCTAssertEqualObjects(self.storedRecord, (@[
-    @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES},
-    @{@"Username" : @"tamuser", @"UID" : @503, @"Local" : @YES},
-  ]));
+                          @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES},
+                          @{@"Username" : @"tamuser", @"UID" : @503, @"Local" : @YES},
+                        ]));
   XCTAssertFalse(fake->IsMember(501));
   XCTAssertFalse(fake->IsMember(503));
 }
@@ -484,7 +486,8 @@ static SNTTemporaryAdminPolicy* RevokePolicy() {
   state->HandlePolicy(OnDemandPolicy());
   XCTAssertTrue(fake->IsMember(501));
   XCTAssertTrue(fake->IsMember(505));
-  XCTAssertEqualObjects(self.storedRecord, (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
+  XCTAssertEqualObjects(self.storedRecord,
+                        (@[ @{@"Username" : @"jane", @"UID" : @501, @"Local" : @YES} ]));
 
   state->HandlePolicy(RevokePolicy());
   XCTAssertTrue(fake->IsMember(501));

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1207,6 +1207,7 @@ objc_library(
         ":AdminGroupMembership",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTError",
+        "//Source/common:SNTKVOManager",
         "//Source/common:SNTLogging",
         "//Source/common:SNTTemporaryAdminPolicy",
         "@abseil-cpp//absl/synchronization",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -433,6 +433,19 @@ santa_unit_test(
 )
 
 santa_unit_test(
+    name = "AdminUserStateTest",
+    srcs = ["AdminUserStateTest.mm"],
+    deps = [
+        ":AdminGroupMembership",
+        ":AdminUserState",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTError",
+        "//Source/common:SNTTemporaryAdminPolicy",
+        "@OCMock",
+    ],
+)
+
+santa_unit_test(
     name = "SNTLoginWindowSessionHandlerTest",
     srcs = ["SNTLoginWindowSessionHandlerTest.mm"],
     deps = [
@@ -1187,11 +1200,26 @@ objc_library(
 )
 
 objc_library(
+    name = "AdminUserState",
+    srcs = ["AdminUserState.mm"],
+    hdrs = ["AdminUserState.h"],
+    deps = [
+        ":AdminGroupMembership",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTError",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTTemporaryAdminPolicy",
+        "@abseil-cpp//absl/synchronization",
+    ],
+)
+
+objc_library(
     name = "SNTDaemonControlController",
     srcs = ["SNTDaemonControlController.mm"],
     hdrs = ["SNTDaemonControlController.h"],
     deps = [
         ":AdminGroupMembership",
+        ":AdminUserState",
         ":AuthResultCache",
         ":EndpointSecurityLogger",
         ":KillingMachine",
@@ -1995,6 +2023,7 @@ santa_unit_test(
 test_suite(
     name = "unit_tests",
     tests = [
+        ":AdminUserStateTest",
         ":AuthResultCacheTest",
         ":DaemonConfigBundleTest",
         ":EndpointSecurityLoggerTest",

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -26,8 +26,9 @@
 #include "Source/santad/SandboxExpectations.h"
 
 namespace santa {
+class AdminUserState;
 class TemporaryAdminMode;
-}
+}  // namespace santa
 
 @class SNTNotificationQueue;
 @class SNTSyncdQueue;
@@ -61,5 +62,9 @@ class TemporaryAdminMode;
 // The Temporary Admin Mode orchestrator owned by this controller. Exposed so the ES login-window
 // session handler can drive lock/logout revocation through the same instance.
 - (std::shared_ptr<santa::TemporaryAdminMode>)temporaryAdminMode;
+
+// The natural-admin reconciler owned by this controller. Exposed so daemon startup can run its
+// SetupFromState after TemporaryAdminMode's (which the controller init already guarantees).
+- (santa::AdminUserState*)adminUserState;
 
 @end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -208,8 +208,8 @@ static NSString* TAMUsernameForUID(uid_t uid) {
           [syncdQueue addStoredEvent:auditEvent];
         });
 
-    _adminUserState = std::make_unique<santa::AdminUserState>(
-        [SNTConfigurator configurator], santa::CreateAdminGroupMembership());
+    _adminUserState = std::make_unique<santa::AdminUserState>([SNTConfigurator configurator],
+                                                              santa::CreateAdminGroupMembership());
   }
   return self;
 }

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -208,8 +208,14 @@ static NSString* TAMUsernameForUID(uid_t uid) {
           [syncdQueue addStoredEvent:auditEvent];
         });
 
-    _adminUserState = std::make_unique<santa::AdminUserState>([SNTConfigurator configurator],
-                                                              santa::CreateAdminGroupMembership());
+    // Captured as a local so the block does not retain self. The block gives
+    // AdminUserState the TAM-teardown-before-restore ordering on the
+    // sync-server-change path; see AdminUserState::HandleSyncServerChange.
+    std::shared_ptr<santa::TemporaryAdminMode> tam = _temporaryAdminMode;
+    _adminUserState = std::make_unique<santa::AdminUserState>(
+        [SNTConfigurator configurator], santa::CreateAdminGroupMembership(), ^{
+          tam->Revoke(SNTTemporaryAdminModeLeaveReasonSyncServerChanged);
+        });
   }
   return self;
 }
@@ -1273,6 +1279,10 @@ static const char* const kAllowedCanonicalBundlePaths[] = {
 
 - (std::shared_ptr<santa::TemporaryAdminMode>)temporaryAdminMode {
   return _temporaryAdminMode;
+}
+
+- (santa::AdminUserState*)adminUserState {
+  return _adminUserState.get();
 }
 
 #pragma mark Network Extension Ops

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -58,6 +58,7 @@
 #include "Source/common/faa/WatchItems.h"
 #import "Source/common/ne/SNTSyncNetworkExtensionSettings.h"
 #include "Source/santad/AdminGroupMembership.h"
+#include "Source/santad/AdminUserState.h"
 #import "Source/santad/DataLayer/SNTEventTable.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #include "Source/santad/KillingMachine.h"
@@ -144,6 +145,7 @@ static NSString* TAMUsernameForUID(uid_t uid) {
   std::shared_ptr<WatchItems> _watchItems;
   std::shared_ptr<santa::TemporaryMonitorMode> _temporaryMonitorMode;
   std::shared_ptr<santa::TemporaryAdminMode> _temporaryAdminMode;
+  std::unique_ptr<santa::AdminUserState> _adminUserState;
   std::shared_ptr<santa::SandboxExpectations> _sandboxExpectations;
   std::shared_ptr<santa::SNTBinaryUploadController> _binaryUploadController;
 }
@@ -205,6 +207,9 @@ static NSString* TAMUsernameForUID(uid_t uid) {
           [[SNTDatabaseController eventTable] addStoredEvent:auditEvent];
           [syncdQueue addStoredEvent:auditEvent];
         });
+
+    _adminUserState = std::make_unique<santa::AdminUserState>(
+        [SNTConfigurator configurator], santa::CreateAdminGroupMembership());
   }
   return self;
 }
@@ -745,6 +750,9 @@ static NSString* TAMUsernameForUID(uid_t uid) {
   // availability against just-committed state.
   [result temporaryAdminPolicy:^(SNTTemporaryAdminPolicy* val) {
     _temporaryAdminMode->NewPolicyReceived(val);
+    // After TAM's own teardown: on a revoke, TAM removes its elevated user
+    // before the natural admins recorded at the flip are restored.
+    _adminUserState->HandlePolicy(val);
   }];
 
   if (committed) {

--- a/Source/santad/SNTLoginWindowSessionHandlerTest.mm
+++ b/Source/santad/SNTLoginWindowSessionHandlerTest.mm
@@ -60,6 +60,16 @@ class FakeAdminGroupMembership : public AdminGroupMembership {
     return true;
   }
 
+  std::optional<std::vector<AdminGroupMember>> ListDirectUserMembers() override {
+    // Unused by these tests.
+    return std::nullopt;
+  }
+
+  NSString* UsernameForUID(uid_t uid) override {
+    // Unused by these tests.
+    return nil;
+  }
+
   std::set<uid_t> members_;
   bool fail_add_ = false;
   bool fail_remove_ = false;

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -35,6 +35,7 @@
 #include "Source/common/es/Enricher.h"
 #include "Source/common/faa/WatchItemPolicy.h"
 #include "Source/common/faa/WatchItems.h"
+#include "Source/santad/AdminUserState.h"
 #include "Source/santad/DaemonConfigBundle.h"
 #import "Source/santad/DataLayer/SNTEventTable.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
@@ -126,6 +127,12 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
             }
           }
           binaryUploadController:binary_upload_controller];
+
+  // Watch for the sync server being removed or replaced, and restore any
+  // recorded natural admins if that already happened while the daemon was not
+  // running. After the controller init, whose TemporaryAdminMode::Create has
+  // already settled any TAM teardown owed from before the restart.
+  [dc adminUserState]->SetupFromState();
 
   control_connection.exportedObject = dc;
   [control_connection resume];

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -182,8 +182,25 @@ void TemporaryAdminMode::NewPolicyReceived(SNTTemporaryAdminPolicy* policy) {
 #pragma mark Hooks
 
 // Effect hooks run UNDER lock_ (the base invokes them while holding lock_).
-bool TemporaryAdminMode::ApplyEffect(NSError** err) {
-  return membership_->AddMember(target_uid_, err);
+// Annotated here (unlike the sibling hooks) because the body calls the
+// lock_-guarded PersistExpiredForRetryLocked(); the annotation matches the base
+// pure-virtual and lets thread-safety analysis see the lock is already held.
+bool TemporaryAdminMode::ApplyEffect(NSError** err) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
+  // Persist-before-flip: name the target on disk before the elevation, so a
+  // crash between the two leaves a deadline-0 record the next daemon start
+  // reverts — never an elevated user with no on-disk state. It also
+  // guarantees AdminUserState's capture exclusion sees the target: capture
+  // reads membership first and TAM state second, so member-visible implies
+  // state-visible. BeginSessionLocked overwrites this record immediately
+  // after a successful add.
+  PersistExpiredForRetryLocked();
+  if (!membership_->AddMember(target_uid_, err)) {
+    // The elevation never happened; nothing is owed. Clear the provisional
+    // record so it cannot refuse future grants as a stale residue.
+    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    return false;
+  }
+  return true;
 }
 
 bool TemporaryAdminMode::RevertEffect() {

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -23,7 +23,6 @@
 
 namespace santa {
 
-static NSString* const kTAMTargetUIDKey = @"TargetUID";
 static NSString* const kTAMTargetUsernameKey = @"TargetUsername";
 
 std::shared_ptr<TemporaryAdminMode> TemporaryAdminMode::Create(
@@ -244,7 +243,7 @@ bool TemporaryAdminMode::ExtraPreconditions() {
 }
 
 NSString* TemporaryAdminMode::StateKey() {
-  return @"TempAdmin";
+  return kStateTempAdminModeKey;
 }
 
 bool TemporaryAdminMode::HasOnDemandPolicy() {
@@ -282,15 +281,18 @@ void TemporaryAdminMode::RequestAuthorization(void (^reply)(BOOL, NSString*)) {
 }
 
 NSDictionary* TemporaryAdminMode::ExtraStateToPersist() {
-  return @{kTAMTargetUIDKey : @(target_uid_), kTAMTargetUsernameKey : target_username_ ?: @""};
+  return @{
+    kStateTempAdminTargetUIDKey : @(target_uid_),
+    kTAMTargetUsernameKey : target_username_ ?: @""
+  };
 }
 
 bool TemporaryAdminMode::RestoreAndValidateExtraState(NSDictionary* state) {
-  if (![state[kTAMTargetUIDKey] isKindOfClass:[NSNumber class]] ||
+  if (![state[kStateTempAdminTargetUIDKey] isKindOfClass:[NSNumber class]] ||
       ![state[kTAMTargetUsernameKey] isKindOfClass:[NSString class]]) {
     return false;
   }
-  uid_t uid = [state[kTAMTargetUIDKey] unsignedIntValue];
+  uid_t uid = [state[kStateTempAdminTargetUIDKey] unsignedIntValue];
   // Reject uid 0 and any uid that no longer resolves to a user (deleted account).
   if (uid == 0 || getpwuid(uid) == NULL) {
     return false;

--- a/Source/santad/TemporaryAdminMode.mm
+++ b/Source/santad/TemporaryAdminMode.mm
@@ -192,11 +192,22 @@ bool TemporaryAdminMode::ApplyEffect(NSError** err) ABSL_EXCLUSIVE_LOCKS_REQUIRE
   // reads membership first and TAM state second, so member-visible implies
   // state-visible. BeginSessionLocked overwrites this record immediately
   // after a successful add.
-  PersistExpiredForRetryLocked();
+  //
+  // A refresh already has all of that: the live session's record is on disk,
+  // and the elevation it tracks stays owed even if the refresh fails. Leave
+  // it alone — overwriting it and then clearing it on failure would leave an
+  // elevated user with no record, which a daemon restart would turn into a
+  // permanent untracked admin.
+  bool is_refresh = IsStartedLocked();
+  if (!is_refresh) {
+    PersistExpiredForRetryLocked();
+  }
   if (!membership_->AddMember(target_uid_, err)) {
-    // The elevation never happened; nothing is owed. Clear the provisional
-    // record so it cannot refuse future grants as a stale residue.
-    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    if (!is_refresh) {
+      // The elevation never happened; nothing is owed. Clear the provisional
+      // record so it cannot refuse future grants as a stale residue.
+      [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+    }
     return false;
   }
   return true;

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -249,6 +249,42 @@ static uint64_t MakeDeadline(uint64_t want) {
                  SNTTemporaryAdminModeDeniedReasonMembershipChangeFailed);
 }
 
+// A failed refresh must not destroy the live session's on-disk record: the
+// original elevation is still applied and still owed a revert, and clearing
+// the record would leave the user permanently elevated across a daemon restart.
+- (void)testFailedRefreshKeepsLiveSessionRecord {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"reason"];
+  __block NSDictionary* lastPersisted = nil;
+  OCMStub([self.mockConfigurator persistTimedSessionState:[OCMArg any] forKey:@"TempAdmin"])
+      .andDo(^(NSInvocation* inv) {
+        __unsafe_unretained NSDictionary* s = nil;
+        [inv getArgument:&s atIndex:2];
+        lastPersisted = s;
+      });
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  auto tam = santa::TemporaryAdminMode::Create((SNTConfigurator*)self.mockConfigurator,
+                                               (SNTNotificationQueue*)self.mockNotQueue,
+                                               std::move(fakeOwned),
+                                               ^(SNTStoredTemporaryAdminModeAuditEvent* e){
+                                               });
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+  NSDictionary* liveRecord = lastPersisted;
+  XCTAssertNotNil(liveRecord);
+
+  fake->fail_add_ = true;  // directory unreachable at refresh time
+  err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 0u);
+  XCTAssertEqual(err.code, SNTErrorCodeTAMMembershipChangeFailed);
+
+  XCTAssertEqualObjects(lastPersisted, liveRecord);    // record never touched
+  XCTAssertTrue(fake->IsMember(501));                  // still elevated
+  XCTAssertTrue(tam->SecondsRemaining().has_value());  // original session still live
+}
+
 - (void)testGrantRefusedWhileTeardownRetryPending {
   [self stubPolicyAvailable];
   [self stubAuthReply:YES reason:@"need to install"];

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -61,6 +61,16 @@ class FakeAdminGroupMembership : public AdminGroupMembership {
     return true;
   }
 
+  std::optional<std::vector<AdminGroupMember>> ListDirectUserMembers() override {
+    // Unused by these tests.
+    return std::nullopt;
+  }
+
+  NSString* UsernameForUID(uid_t uid) override {
+    // Unused by these tests.
+    return nil;
+  }
+
   std::set<uid_t> members_;
   bool fail_add_ = false;
   bool fail_remove_ = false;

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -254,9 +254,11 @@ static uint64_t MakeDeadline(uint64_t want) {
   [self stubAuthReply:YES reason:@"need to install"];
   auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
   FakeAdminGroupMembership* fake = fakeOwned.get();
-  auto tam = santa::TemporaryAdminMode::Create(
-      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
-      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e){});
+  auto tam = santa::TemporaryAdminMode::Create((SNTConfigurator*)self.mockConfigurator,
+                                               (SNTNotificationQueue*)self.mockNotQueue,
+                                               std::move(fakeOwned),
+                                               ^(SNTStoredTemporaryAdminModeAuditEvent* e){
+                                               });
 
   // A deadline-0 record left by a failed teardown, owed to the next daemon
   // start. Stubbed after Create so startup reconciliation does not consume it.
@@ -648,9 +650,11 @@ static uint64_t MakeDeadline(uint64_t want) {
         [writes addObject:state ? (id)[state copy] : (id)[NSNull null]];
       });
   auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
-  auto tam = santa::TemporaryAdminMode::Create(
-      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
-      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e){});
+  auto tam = santa::TemporaryAdminMode::Create((SNTConfigurator*)self.mockConfigurator,
+                                               (SNTNotificationQueue*)self.mockNotQueue,
+                                               std::move(fakeOwned),
+                                               ^(SNTStoredTemporaryAdminModeAuditEvent* e){
+                                               });
 
   NSError* err = nil;
   XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
@@ -679,9 +683,11 @@ static uint64_t MakeDeadline(uint64_t want) {
   auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
   FakeAdminGroupMembership* fake = fakeOwned.get();
   fake->fail_add_ = true;
-  auto tam = santa::TemporaryAdminMode::Create(
-      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
-      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e){});
+  auto tam = santa::TemporaryAdminMode::Create((SNTConfigurator*)self.mockConfigurator,
+                                               (SNTNotificationQueue*)self.mockNotQueue,
+                                               std::move(fakeOwned),
+                                               ^(SNTStoredTemporaryAdminModeAuditEvent* e){
+                                               });
 
   NSError* err = nil;
   XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 0u);

--- a/Source/santad/TemporaryAdminModeTest.mm
+++ b/Source/santad/TemporaryAdminModeTest.mm
@@ -239,6 +239,31 @@ static uint64_t MakeDeadline(uint64_t want) {
                  SNTTemporaryAdminModeDeniedReasonMembershipChangeFailed);
 }
 
+- (void)testGrantRefusedWhileTeardownRetryPending {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need to install"];
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e){});
+
+  // A deadline-0 record left by a failed teardown, owed to the next daemon
+  // start. Stubbed after Create so startup reconciliation does not consume it.
+  OCMStub([self.mockConfigurator savedTimedSessionStateForKey:@"TempAdmin"])
+      .andReturn([self stateWithBootUUID:@"boot"
+                                deadline:0
+                                syncHost:@"foo.workshop.cloud"
+                                     uid:501]);
+
+  // Granting now would overwrite the residue and orphan uid 501's stuck
+  // elevation forever; the grant must be refused instead.
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 502, @"bob", &err), 0u);
+  XCTAssertNotNil(err);
+  XCTAssertFalse(fake->IsMember(502));
+}
+
 #pragma mark Reconciliation tests
 
 - (void)testReconcileRebootRemovesMember {
@@ -600,6 +625,66 @@ static uint64_t MakeDeadline(uint64_t want) {
   XCTAssertFalse(tam->EndForUserEvent(0, @"", SNTTemporaryAdminModeLeaveReasonScreenLocked));
   XCTAssertTrue(fake->IsMember(501));
   XCTAssertTrue(tam->SecondsRemaining().has_value());
+}
+
+- (void)testGrantPersistsTargetBeforeElevation {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need to install"];
+  NSMutableArray* writes = [NSMutableArray array];
+  OCMStub([self.mockConfigurator persistTimedSessionState:[OCMArg any] forKey:@"TempAdmin"])
+      .andDo(^(NSInvocation* inv) {
+        __unsafe_unretained NSDictionary* state = nil;
+        [inv getArgument:&state atIndex:2];
+        [writes addObject:state ? (id)[state copy] : (id)[NSNull null]];
+      });
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e){});
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 5u);
+
+  // Persist-before-flip: a provisional deadline-0 record names the target on
+  // disk BEFORE the elevation; the real session state follows.
+  XCTAssertEqual(writes.count, 2u);
+  NSDictionary* provisional = writes[0];
+  NSDictionary* session = writes[1];
+  XCTAssertEqualObjects(provisional[@"TargetUID"], @501);
+  XCTAssertEqualObjects(provisional[kTimedSessionDeadlineKey], @0);
+  XCTAssertEqualObjects(session[@"TargetUID"], @501);
+  XCTAssertTrue([session[kTimedSessionDeadlineKey] unsignedLongLongValue] > 0);
+}
+
+- (void)testFailedElevationClearsProvisionalState {
+  [self stubPolicyAvailable];
+  [self stubAuthReply:YES reason:@"need to install"];
+  NSMutableArray* writes = [NSMutableArray array];
+  OCMStub([self.mockConfigurator persistTimedSessionState:[OCMArg any] forKey:@"TempAdmin"])
+      .andDo(^(NSInvocation* inv) {
+        __unsafe_unretained NSDictionary* state = nil;
+        [inv getArgument:&state atIndex:2];
+        [writes addObject:state ? (id)[state copy] : (id)[NSNull null]];
+      });
+  auto fakeOwned = std::make_unique<FakeAdminGroupMembership>();
+  FakeAdminGroupMembership* fake = fakeOwned.get();
+  fake->fail_add_ = true;
+  auto tam = santa::TemporaryAdminMode::Create(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      std::move(fakeOwned), ^(SNTStoredTemporaryAdminModeAuditEvent* e){});
+
+  NSError* err = nil;
+  XCTAssertEqual(tam->RequestMinutes(@5, 501, @"alice", &err), 0u);
+  XCTAssertFalse(fake->IsMember(501));
+
+  // The elevation never happened, so nothing is owed: the provisional record
+  // is written, then cleared — it must not linger as a fake residue (which
+  // would block future grants via the Task 1 guard).
+  XCTAssertEqual(writes.count, 2u);
+  NSDictionary* provisional = writes[0];
+  XCTAssertEqualObjects(provisional[@"TargetUID"], @501);
+  XCTAssertEqualObjects(provisional[kTimedSessionDeadlineKey], @0);
+  XCTAssertEqualObjects(writes[1], [NSNull null]);
 }
 
 @end

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -118,6 +118,13 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   // feature stays available for immediate re-entry). Returns whether a session was active.
   bool EndForReasonLocked(NSInteger leave_reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
+  // Persists an already-expired (deadline-0) session record carrying
+  // ExtraStateToPersist(). The next daemon start finds it non-resumable and
+  // retries RevertEffect. Used by teardown paths when a revert fails, and by
+  // subclasses to write a provisional record BEFORE applying an effect
+  // (persist-before-flip), which BeginSessionLocked then overwrites.
+  void PersistExpiredForRetryLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+
   // ---- Hooks (subclass provides) ----
 
   // Apply / revert / re-apply the effect. All run UNDER lock_. Apply may fail
@@ -210,9 +217,6 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   // subclass extra state (the leave audit/RevertEffect read it).
   bool EndSessionLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   bool RevokeLocked(NSInteger leave_reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-  // Persist an already-expired session record (used when RevertEffect fails) so the
-  // next daemon start reconciles the persisted state and retries the revert.
-  void PersistExpiredForRetryLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   // Whether the sync-server gate is satisfied (`configurator_.isSyncV2Enabled`).
   bool SyncServerGateSatisfied();

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -129,6 +129,8 @@ void TimedSyncSession::SetupFromState() {
     if (RevertEffect()) {
       [configurator_ persistTimedSessionState:nil forKey:StateKey()];
     } else {
+      LOGE(@"Timed sync session revert failed; persisting an expired session record so the "
+           @"next daemon start retries the revert.");
       PersistExpiredForRetryLocked();
     }
     NotifyLeave();
@@ -271,15 +273,28 @@ TimedSyncSession::GrantOutcome TimedSyncSession::BeginGrant(NSNumber* requested_
     return GrantOutcome::kJustificationRequired;
   }
 
-  // Re-check availability after the auth window: a sync Revoke that arrived while
-  // the user was authenticating must not be elevated against.
+  // Re-check availability after the auth window, under lock_: a sync Revoke
+  // tears down under lock_ after the policy commits, so whichever side wins
+  // this lock, the loser observes the winner — a grant can never be created
+  // on the losing side of a revoke, where it would survive the teardown and
+  // later expire into an untracked demotion.
+  absl::MutexLock lock(lock_);
   if (!Available()) {
+    return GrantOutcome::kNotEligible;
+  }
+
+  // A persisted session record with no live session is a teardown-retry
+  // residue: a previous elevation whose revert failed, owed to the next
+  // daemon start. Granting now would overwrite the single-slot record and
+  // permanently orphan that elevation. Refuse until the retry has run.
+  if (!active_ && [configurator_ savedTimedSessionStateForKey:StateKey()] != nil) {
+    LOGW(@"Timed sync session grant refused: a previous session's teardown is "
+         @"still pending retry.");
     return GrantOutcome::kNotEligible;
   }
 
   uint32_t minutes = ClampDuration(requested_duration);
 
-  absl::MutexLock lock(lock_);
   NSError* err = nil;
   if (!ApplyEffect(&err)) {
     LOGE(@"Timed sync session failed to apply effect: %@", err.localizedDescription);
@@ -354,8 +369,6 @@ void TimedSyncSession::PersistExpiredForRetryLocked() {
   // record. On the next daemon start, reconciliation reads it, finds it non-resumable
   // (deadline in the past, or a reboot/sync change), and calls RevertEffect again,
   // retrying until the revert succeeds.
-  LOGE(@"Timed sync session revert failed; persisting an expired session record so the "
-       @"next daemon start retries the revert.");
   NSMutableDictionary* state = [@{
     kTimedSessionBootUUIDKey : [SNTSystemInfo bootSessionUUID],
     kTimedSessionDeadlineKey : @0,  // already in the past -> non-resumable -> retry revert
@@ -372,6 +385,8 @@ bool TimedSyncSession::EndForReasonLocked(NSInteger leave_reason) {
     // EndSessionLocked already cleared the persisted state; if the revert fails,
     // re-persist an expired record so the next daemon start retries the revert.
     if (!RevertEffect()) {
+      LOGE(@"Timed sync session revert failed; persisting an expired session record so the "
+           @"next daemon start retries the revert.");
       PersistExpiredForRetryLocked();
     }
     EmitAudit(BuildLeaveAuditEvent([current_uuid_ UUIDString], leave_reason));
@@ -407,6 +422,8 @@ bool TimedSyncSession::OnTimer() {
   if (RevertEffect()) {
     [configurator_ persistTimedSessionState:nil forKey:StateKey()];
   } else {
+    LOGE(@"Timed sync session revert failed; persisting an expired session record so the "
+         @"next daemon start retries the revert.");
     PersistExpiredForRetryLocked();
   }
   active_ = false;


### PR DESCRIPTION
Part of WS-1128. Looks large, but ~65% are tests. 

- When the TAM policy turns on, santad snapshots direct group-80 admins
  (uid >= 500) into a `DemotedAdmins` record in the tamper-protected
  state.plist and makes them standard; on revoke it restores exactly those
  users and deletes the record.
- Record presence is the only edge detector, so reconciliation runs every
  sync and is idempotent: demote once per off-to-on edge, never re-demote,
  never fight other user-management tools.
- Persist-before-flip with rollback: no path to a demoted user with no
  record. Restore retries every sync until it converges.
- Also hardens the TAM grant path: availability re-check under the session
  lock, grants refused while a teardown residue is pending, and session
  state persisted before elevating.
  