### PR TITLE
santad: fix out-of-bounds read in SleighLauncherTest

### DIFF
--- a/Source/santad/SleighLauncherTest.mm
+++ b/Source/santad/SleighLauncherTest.mm
@@ -86,10 +86,11 @@ class TestableSleighLauncher : public santa::SleighLauncher {
   NSString* stub = [self writeStubWithBody:body];
 
   TestableSleighLauncher launcher(stub.UTF8String);
-  int fd = [self openTempFileWithBytes:std::string("\xfe\xed\xfa\xcf binary", 14)];
+  std::string binary("\xfe\xed\xfa\xcf binary");
+  int fd = [self openTempFileWithBytes:binary];
 
   ::santa::telemetry::v1::BinaryMetadata meta;
-  meta.set_file_size(14);
+  meta.set_file_size(binary.size());
   absl::StatusOr<::santa::commands::v1::BinaryUploadResponse> resp = launcher.LaunchBinaryUpload(
       fd, "https://example.com/post", {{"key", "objects/x"}}, "", meta, {}, /*timeout_seconds=*/10);
 


### PR DESCRIPTION
## What

`testLaunchBinaryUploadParsesStdout` constructed `std::string("\xfe\xed\xfa\xcf binary", 14)`, but that literal is only 11 bytes (4-byte magic + `" binary"`). The length-counting `std::string` constructor then `memcpy`'d 2 bytes past the end of the literal.

This is a **test-only** bug — `SleighLauncher` itself is fine.

Observed ASan stack (from the failing job):

```
wrap_memcpy
std::__1::basic_string<...>::__init(char const*, unsigned long)
std::__1::basic_string<...>::basic_string(char const*, unsigned long)
-[SleighLauncherTest testLaunchBinaryUploadParsesStdout]
```

## Fix

The payload content is arbitrary — the stub drains stdin and never reads the fd — so bind the length to the literal instead of hand-counting it, and derive `file_size` from the same string. No change to what the test exercises or asserts.

## Testing

Ran the asan config locally, matching the workflow flags, 5 runs:

```
//Source/santad:SleighLauncherTest    PASSED in 3.4s
Executed 1 out of 1 test: 1 test passes.
```

All 5 runs pass; no `global-buffer-overflow`.