### PR TITLE
santasyncservice: support repeated paths in EventUpload command

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "5b4f5944d7efa8f601e972fcefda26709579dd85",
+    commit = "d20bed2daf0b8b874d586d23d02ef3c683b19aff",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santasyncservice/SNTPushClientNATS+Commands.mm
+++ b/Source/santasyncservice/SNTPushClientNATS+Commands.mm
@@ -323,9 +323,18 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
                                                  onArena:(google::protobuf::Arena*)arena {
   auto pbResponse = google::protobuf::Arena::Create<::pbv1::EventUploadResponse>(arena);
 
-  NSString* path = StringToNSString(eventUploadRequest.path());
-  if (path.length == 0) {
-    LOGE(@"NATS: EventUploadRequest has empty path");
+  // Collect the non-empty paths from the repeated `paths` field.
+  NSMutableArray<NSString*>* paths =
+      [NSMutableArray arrayWithCapacity:eventUploadRequest.paths_size()];
+  for (const std::string& path : eventUploadRequest.paths()) {
+    NSString* nsPath = StringToNSString(path);
+    if (nsPath.length > 0) {
+      [paths addObject:nsPath];
+    }
+  }
+
+  if (paths.count == 0) {
+    LOGE(@"NATS: EventUploadRequest has no valid paths");
     pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INVALID_PATH);
     return pbResponse;
   }
@@ -337,16 +346,16 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
     return pbResponse;
   }
 
-  // Fire off the event upload asynchronously - don't wait for completion
-  [strongSyncDelegate
-      eventUploadForPath:path
-                   reply:^(NSError* error) {
-                     if (error) {
-                       LOGE(@"NATS: EventUploadRequest failed for path %@: %@", path, error);
-                     } else {
-                       LOGI(@"NATS: EventUploadRequest completed for path %@", path);
-                     }
-                   }];
+  // Fire off the event uploads asynchronously - don't wait for completion. The delegate
+  // processes the paths serially and invokes the reply block once per path.
+  [strongSyncDelegate eventUploadForPaths:paths
+                                    reply:^(NSError* error) {
+                                      if (error) {
+                                        LOGE(@"NATS: EventUploadRequest failed: %@", error);
+                                      } else {
+                                        LOGI(@"NATS: EventUploadRequest completed");
+                                      }
+                                    }];
 
   return pbResponse;
 }

--- a/Source/santasyncservice/SNTPushClientNATSCommandTest.mm
+++ b/Source/santasyncservice/SNTPushClientNATSCommandTest.mm
@@ -1013,7 +1013,7 @@ static constexpr NSUInteger kMaxCommandNonceCacheCount = kMaxCommandAgeSeconds;
   SNTPushClientNATS* clientWithoutDelegate = [[SNTPushClientNATS alloc] initWithSyncDelegate:nil];
 
   ::pbv1::EventUploadRequest eventUploadRequest;
-  eventUploadRequest.set_path("/Applications/Safari.app");
+  eventUploadRequest.add_paths("/Applications/Safari.app");
 
   // When: Handling the event upload request without a sync delegate
   ::pbv1::EventUploadResponse* response =
@@ -1031,11 +1031,11 @@ static constexpr NSUInteger kMaxCommandNonceCacheCount = kMaxCommandAgeSeconds;
 - (void)testHandleEventUploadRequestSuccess {
   // Given: An EventUploadRequest with a valid path
   ::pbv1::EventUploadRequest eventUploadRequest;
-  eventUploadRequest.set_path("/Applications/Safari.app");
+  eventUploadRequest.add_paths("/Applications/Safari.app");
 
   // Mock delegate - handler fires and forgets, so we just need the stub
-  OCMStub([self.mockSyncDelegate eventUploadForPath:@"/Applications/Safari.app"
-                                              reply:[OCMArg any]]);
+  OCMStub([self.mockSyncDelegate eventUploadForPaths:@[ @"/Applications/Safari.app" ]
+                                               reply:[OCMArg any]]);
 
   // When: Handling the event upload request
   ::pbv1::EventUploadResponse* response = [self.client handleEventUploadRequest:eventUploadRequest
@@ -1050,11 +1050,11 @@ static constexpr NSUInteger kMaxCommandNonceCacheCount = kMaxCommandAgeSeconds;
 - (void)testHandleEventUploadRequestFiresDelegate {
   // Given: An EventUploadRequest with a valid path
   ::pbv1::EventUploadRequest eventUploadRequest;
-  eventUploadRequest.set_path("/Applications/Safari.app");
+  eventUploadRequest.add_paths("/Applications/Safari.app");
 
   // Mock delegate to verify it gets called (fire-and-forget)
-  OCMExpect([self.mockSyncDelegate eventUploadForPath:@"/Applications/Safari.app"
-                                                reply:[OCMArg any]]);
+  OCMExpect([self.mockSyncDelegate eventUploadForPaths:@[ @"/Applications/Safari.app" ]
+                                                 reply:[OCMArg any]]);
 
   // When: Handling the event upload request
   ::pbv1::EventUploadResponse* response = [self.client handleEventUploadRequest:eventUploadRequest
@@ -1067,17 +1067,80 @@ static constexpr NSUInteger kMaxCommandNonceCacheCount = kMaxCommandAgeSeconds;
   OCMVerifyAll(self.mockSyncDelegate);
 }
 
+- (void)testHandleEventUploadRequestMultiplePaths {
+  // Given: An EventUploadRequest with multiple paths
+  ::pbv1::EventUploadRequest eventUploadRequest;
+  eventUploadRequest.add_paths("/Applications/Safari.app");
+  eventUploadRequest.add_paths("/Applications/Mail.app");
+
+  // Mock delegate - the handler passes all paths through in a single call.
+  // Hoisted into a local: a comma inside an @[] literal would be parsed as a
+  // separate macro argument by OCMExpect.
+  NSArray<NSString*>* expectedPaths = @[ @"/Applications/Safari.app", @"/Applications/Mail.app" ];
+  OCMExpect([self.mockSyncDelegate eventUploadForPaths:expectedPaths reply:[OCMArg any]]);
+
+  // When: Handling the event upload request
+  ::pbv1::EventUploadResponse* response = [self.client handleEventUploadRequest:eventUploadRequest
+                                                                withCommandUUID:@"uuid"
+                                                                        onArena:self.arena];
+
+  // Then: Should return a successful response and forward all paths to the delegate
+  XCTAssertNotEqual(response, nullptr, @"Should return non-nil response");
+  XCTAssertFalse(response->has_error(), @"Successful request should not have error");
+  OCMVerifyAll(self.mockSyncDelegate);
+}
+
+- (void)testHandleEventUploadRequestFiltersEmptyPaths {
+  // Given: An EventUploadRequest with a mix of empty and valid paths
+  ::pbv1::EventUploadRequest eventUploadRequest;
+  eventUploadRequest.add_paths("");
+  eventUploadRequest.add_paths("/Applications/Safari.app");
+  eventUploadRequest.add_paths("");
+
+  // Mock delegate - only the non-empty path should be forwarded
+  OCMExpect([self.mockSyncDelegate eventUploadForPaths:@[ @"/Applications/Safari.app" ]
+                                                 reply:[OCMArg any]]);
+
+  // When: Handling the event upload request
+  ::pbv1::EventUploadResponse* response = [self.client handleEventUploadRequest:eventUploadRequest
+                                                                withCommandUUID:@"uuid"
+                                                                        onArena:self.arena];
+
+  // Then: Should succeed and forward only the non-empty path
+  XCTAssertNotEqual(response, nullptr, @"Should return non-nil response");
+  XCTAssertFalse(response->has_error(), @"Successful request should not have error");
+  OCMVerifyAll(self.mockSyncDelegate);
+}
+
+- (void)testHandleEventUploadRequestOnlyEmptyPaths {
+  // Given: An EventUploadRequest whose paths are all empty
+  ::pbv1::EventUploadRequest eventUploadRequest;
+  eventUploadRequest.add_paths("");
+  eventUploadRequest.add_paths("");
+
+  // When: Handling the event upload request
+  ::pbv1::EventUploadResponse* response = [self.client handleEventUploadRequest:eventUploadRequest
+                                                                withCommandUUID:@"uuid"
+                                                                        onArena:self.arena];
+
+  // Then: Should return ERROR_INVALID_PATH since no valid paths remain
+  XCTAssertNotEqual(response, nullptr, @"Should return non-nil response");
+  XCTAssertTrue(response->has_error(), @"Should have error set");
+  XCTAssertEqual(response->error(), ::pbv1::EventUploadResponse::ERROR_INVALID_PATH,
+                 @"Only-empty paths should return ERROR_INVALID_PATH");
+}
+
 - (void)testDispatchSantaCommandToHandlerEventUpload {
   // Given: An EventUploadRequest command
   ::pbv1::SantaCommandRequest command;
   command.set_uuid([[NSUUID UUID] UUIDString].UTF8String);
-  command.mutable_event_upload()->set_path("/Applications/Safari.app");
+  command.mutable_event_upload()->add_paths("/Applications/Safari.app");
 
   [self signCommandRequest:&command];
 
   // Mock delegate - handler fires and forgets
-  OCMStub([self.mockSyncDelegate eventUploadForPath:@"/Applications/Safari.app"
-                                              reply:[OCMArg any]]);
+  OCMStub([self.mockSyncDelegate eventUploadForPaths:@[ @"/Applications/Safari.app" ]
+                                               reply:[OCMArg any]]);
 
   // When: Dispatching the command
   ::pbv1::SantaCommandResponse* response = [self.client dispatchSantaCommandToHandler:command
@@ -1092,7 +1155,7 @@ static constexpr NSUInteger kMaxCommandNonceCacheCount = kMaxCommandAgeSeconds;
 - (void)testHandleEventUploadRequestErrorDoesNotEnqueueSync {
   // Given: An EventUploadRequest with a valid path
   ::pbv1::EventUploadRequest eventUploadRequest;
-  eventUploadRequest.set_path("/Applications/Safari.app");
+  eventUploadRequest.add_paths("/Applications/Safari.app");
 
   // Mock delegate to invoke the reply block with an error
   NSError* uploadError =
@@ -1100,8 +1163,8 @@ static constexpr NSUInteger kMaxCommandNonceCacheCount = kMaxCommandAgeSeconds;
                           code:4
                       userInfo:@{NSLocalizedDescriptionKey : @"Failed to upload"}];
   OCMStub([self.mockSyncDelegate
-      eventUploadForPath:@"/Applications/Safari.app"
-                   reply:([OCMArg invokeBlockWithArgs:uploadError, nil])]);
+      eventUploadForPaths:@[ @"/Applications/Safari.app" ]
+                    reply:([OCMArg invokeBlockWithArgs:uploadError, nil])]);
   OCMReject([self.mockSyncDelegate sync]);
 
   // When: Handling the event upload request

--- a/Source/santasyncservice/SNTPushNotifications.h
+++ b/Source/santasyncservice/SNTPushNotifications.h
@@ -25,7 +25,7 @@
 - (void)preflightSync;
 - (void)pushNotificationSyncSecondsFromNow:(uint64_t)seconds;
 - (MOLXPCConnection*)daemonConnection;
-- (void)eventUploadForPath:(NSString*)path reply:(void (^)(NSError* error))reply;
+- (void)eventUploadForPaths:(NSArray<NSString*>*)paths reply:(void (^)(NSError* error))reply;
 @end
 
 @class SNTSyncState;

--- a/Source/santasyncservice/SNTSyncManager.mm
+++ b/Source/santasyncservice/SNTSyncManager.mm
@@ -56,6 +56,12 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
 @property(nonatomic, readonly) dispatch_queue_t syncQueue;
 @property(nonatomic, readonly) dispatch_semaphore_t syncLimiter;
 
+// Serial queue for out-of-band event uploads (NATS EventUpload command). Kept
+// separate from syncQueue so uploads can't starve regular syncs, and serial so a
+// single command carrying many paths processes them one at a time instead of
+// fanning out into concurrent bundle-service connections and sync POSTs.
+@property(nonatomic, readonly) dispatch_queue_t eventUploadQueue;
+
 @property(nonatomic) MOLXPCConnection* daemonConn;
 
 @property(nonatomic) BOOL reachable;
@@ -130,6 +136,8 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     }];
     _syncQueue = dispatch_queue_create("com.northpolesec.santa.syncservice", DISPATCH_QUEUE_SERIAL);
     _syncLimiter = dispatch_semaphore_create(kMaxEnqueuedSyncs);
+    _eventUploadQueue = dispatch_queue_create("com.northpolesec.santa.syncservice.eventupload",
+                                              DISPATCH_QUEUE_SERIAL);
 
     _eventBatchSize = kDefaultEventBatchSize;
     _metricsQueue = dispatch_queue_create_with_target(
@@ -487,6 +495,14 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
   return self.daemonConn;
 }
 
+- (void)eventUploadForPaths:(NSArray<NSString*>*)paths reply:(void (^)(NSError* error))reply {
+  // Enqueue each path individually. eventUploadForPath: dispatches onto the serial
+  // eventUploadQueue, so the paths are processed one at a time rather than fanning out.
+  for (NSString* path in paths) {
+    [self eventUploadForPath:path reply:reply];
+  }
+}
+
 - (void)eventUploadForPath:(NSString*)path reply:(void (^)(NSError* error))reply {
   if (path.length == 0) {
     reply([NSError errorWithDomain:@"com.northpolesec.santa.syncservice"
@@ -495,9 +511,12 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     return;
   }
 
-  // Run on a dedicated queue to avoid blocking syncQueue (which would starve regular syncs).
-  // postEventsToSyncServer: is thread-safe and doesn't require syncQueue serialization.
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+  // Run on the dedicated serial event-upload queue: it avoids blocking syncQueue (which would
+  // starve regular syncs), and serializing here means a single EventUpload command carrying many
+  // paths processes them one at a time rather than fanning out into concurrent bundle-service
+  // connections and sync POSTs. postEventsToSyncServer: is thread-safe and doesn't require
+  // syncQueue serialization.
+  dispatch_async(self.eventUploadQueue, ^{
     auto replied = std::make_shared<std::atomic<bool>>(false);
     void (^guardedReply)(NSError*) = ^(NSError* e) {
       if (replied->exchange(true)) return;


### PR DESCRIPTION
Adds support for the repeated `paths` field in the EventUpload santa command.

- Bump the `protos` (santa commands) `git_override` to the commit where `EventUploadRequest.path` (single `string`) became `repeated string paths`.
- Update the NATS command handler (`handleEventUploadRequest:`) to collect all non-empty paths and forward them to the sync delegate; still returns `ERROR_INVALID_PATH` when no valid path is present.
- Replace the delegate method `eventUploadForPath:reply:` with `eventUploadForPaths:reply:`.
- Process the uploads on a dedicated **serial** `eventUploadQueue` (kept separate from `syncQueue` so uploads can't starve regular syncs) so a single command with many paths is handled one path at a time rather than fanning out into concurrent bundle-service connections and sync POSTs.

A part of WS-1443