### PR TITLE
santad: fix BOOL-to-bool narrowing in AdminGroupMembership member list

### DIFF
--- a/Source/santad/AdminGroupMembership.mm
+++ b/Source/santad/AdminGroupMembership.mm
@@ -92,7 +92,8 @@ class AdminGroupMembershipImpl : public AdminGroupMembership {
       }
       CBUserIdentity* user = (CBUserIdentity*)identity;
       members.push_back({user.posixUID, user.posixName ?: @"",
-                         [user.authority isEqual:[CBIdentityAuthority localIdentityAuthority]]});
+                         static_cast<bool>([user.authority
+                             isEqual:[CBIdentityAuthority localIdentityAuthority]])});
     }
     return members;
   }


### PR DESCRIPTION
Fixes a C++11 narrowing error in the x86_64 release build by explicitly casting the BOOL result of -isEqual: to bool when initializing AdminGroupMember.local.