### PR TITLE
common: improve process tree reliability under load

### DIFF
--- a/Source/common/processtree/process.h
+++ b/Source/common/processtree/process.h
@@ -48,6 +48,32 @@ H AbslHashValue(H h, const struct Pid& p) {
   return H::combine(std::move(h), p.pid, p.pidversion);
 }
 
+enum class EventKind : uint32_t { kFork, kExec, kExit };
+
+// Identity of a tree-mutating event, used to dedup redelivery across clients.
+// Keying on the full identity (not bare mach_time) is required because
+// mach_time has coarse (~41 ns) granularity on a system-wide counter, so two
+// distinct events on different cores can share a stamp; keying on mach_time
+// alone would silently drop one of them.
+struct EventKey {
+  uint64_t mach_time;
+  EventKind kind;
+  struct Pid actor;  // parent (fork) / execing proc (exec) / exiting proc (exit)
+  struct Pid other;  // child (fork) / target (exec) / {} for exit
+
+  friend bool operator==(const struct EventKey& lhs,
+                         const struct EventKey& rhs) {
+    return lhs.mach_time == rhs.mach_time && lhs.kind == rhs.kind &&
+           lhs.actor == rhs.actor && lhs.other == rhs.other;
+  }
+};
+
+template <typename H>
+H AbslHashValue(H h, const struct EventKey& k) {
+  return H::combine(std::move(h), k.mach_time, static_cast<uint32_t>(k.kind),
+                    k.actor, k.other);
+}
+
 struct Cred {
   uid_t uid;
   gid_t gid;

--- a/Source/common/processtree/process.h
+++ b/Source/common/processtree/process.h
@@ -58,8 +58,10 @@ enum class EventKind : uint32_t { kFork, kExec, kExit };
 struct EventKey {
   uint64_t mach_time;
   EventKind kind;
-  struct Pid actor;  // parent (fork) / execing proc (exec) / exiting proc (exit)
-  struct Pid other;  // child (fork) / target (exec) / {} for exit
+  // parent (fork) / execing proc (exec) / exiting proc (exit)
+  struct Pid actor;
+  // child (fork) / target (exec) / {} for exit
+  struct Pid other;
 
   friend bool operator==(const struct EventKey& lhs,
                          const struct EventKey& rhs) {

--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -15,6 +15,7 @@
 
 #include "Source/common/processtree/process_tree.h"
 
+#include <mach/mach_time.h>
 #include <sys/types.h>
 
 #include <algorithm>
@@ -37,6 +38,19 @@
 #include "absl/synchronization/mutex.h"
 
 namespace santa::santad::process_tree {
+
+namespace {
+// Convert nanoseconds to mach_time ticks (inverse of mach_time's numer/denom).
+uint64_t MachTicksFromNanos(uint64_t nanos) {
+  static const mach_timebase_info_data_t timebase = [] {
+    mach_timebase_info_data_t tb;
+    mach_timebase_info(&tb);
+    return tb;
+  }();
+  // Safe from overflow for the grace-scale magnitudes used here.
+  return nanos * timebase.denom / timebase.numer;
+}
+}  // namespace
 
 void ProcessTree::BackfillInsertChildren(
     absl::flat_hash_map<pid_t, std::vector<BackfilledProcess>>& parent_map,
@@ -71,79 +85,128 @@ void ProcessTree::BackfillInsertChildren(
 
 void ProcessTree::HandleFork(uint64_t timestamp, const Process& parent,
                              const Pid new_pid) {
-  if (Step(timestamp)) {
-    std::shared_ptr<Process> child;
-    {
-      absl::MutexLock lock(mtx_);
-      child = std::make_shared<Process>(new_pid, parent.effective_cred_,
-                                        parent.program_, map_[parent.pid_]);
-      map_.emplace(new_pid, child);
+  std::shared_ptr<Process> child;
+  {
+    // Dedup and the map insert are one critical section: if we released the
+    // lock between them, another client could see this event as a duplicate
+    // (skip it) and then read the tree before the child was inserted.
+    absl::MutexLock lock(mtx_);
+    if (!StepLocked({timestamp, EventKind::kFork, parent.pid_, new_pid})) {
+      return;
     }
-    for (const auto& annotator : annotators_) {
-      annotator->AnnotateFork(*this, parent, *child);
+    // Test seam (no-op in production): the claim just succeeded and mtx_ is
+    // still held; fire here, BEFORE the insert, so the concurrency test can
+    // verify a reader blocks at this boundary — i.e. claim and insert are a
+    // single lock hold. Placed in the handler (not StepLocked) on purpose: if
+    // the insert were ever moved to a separate critical section, this point
+    // would fall in the unlocked gap and the test would deterministically fail.
+    if (on_event_claimed_for_test_) {
+      on_event_claimed_for_test_();
     }
+    // Look up the parent rather than using map_[]: operator[] would insert a
+    // null entry (and orphan the child) if the parent were ever absent.
+    auto parent_proc = GetLocked(parent.pid_);
+    child = std::make_shared<Process>(new_pid, parent.effective_cred_,
+                                      parent.program_,
+                                      parent_proc ? *parent_proc : nullptr);
+    map_.emplace(new_pid, child);
+    // Reap AFTER applying, so a late event can never reap the actor it needs.
+    DrainRemovals();
+  }
+  // Annotators run outside the lock (they re-enter the tree). Annotation
+  // propagation is therefore NOT atomic with the structural insert above; that
+  // is intentional and does not affect CEL ancestry (see StepLocked).
+  for (const auto& annotator : annotators_) {
+    annotator->AnnotateFork(*this, parent, *child);
   }
 }
 
 void ProcessTree::HandleExec(uint64_t timestamp, const Process& p,
                              const Pid new_pid, const Program prog,
                              const Cred c) {
-  if (Step(timestamp)) {
-    // TODO(nickmg): should struct pid be reworked and only pid_version be
-    // passed?
-    assert(new_pid.pid == p.pid_.pid);
+  // TODO(nickmg): should struct pid be reworked and only pid_version be passed?
+  assert(new_pid.pid == p.pid_.pid);
 
-    auto new_proc = std::make_shared<Process>(
-        new_pid, c, std::make_shared<const Program>(prog), p.parent_);
-    {
-      absl::MutexLock lock(mtx_);
-      remove_at_.push_back({timestamp, p.pid_});
-      map_.emplace(new_proc->pid_, new_proc);
+  // Expected double-apply: a tree-aware auth client (the Authorizer) subscribes
+  // to both AUTH_EXEC and NOTIFY_EXEC, so an uncached exec reaches here twice.
+  // The two ES messages carry different mach_time, so they form distinct
+  // EventKeys and both pass dedup; the second is a first-wins no-op (the
+  // map_.emplace below). This is intentional and benign — it costs one extra
+  // emplace/remove_at_/drain on the auth path per uncached exec (accepted).
+
+  // Construct the new process (copies program/args/signing) OUTSIDE the lock to
+  // keep the shared tree lock short on the serial ES handler path. A duplicate
+  // wastes this allocation, which is cheaper than lengthening the lock hold.
+  auto new_proc = std::make_shared<Process>(
+      new_pid, c, std::make_shared<const Program>(prog), p.parent_);
+  {
+    absl::MutexLock lock(mtx_);
+    if (!StepLocked({timestamp, EventKind::kExec, p.pid_, new_pid})) {
+      return;
     }
-    for (const auto& annotator : annotators_) {
-      annotator->AnnotateExec(*this, p, *new_proc);
-    }
+    remove_at_.push_back({timestamp, p.pid_});
+    map_.emplace(new_proc->pid_, new_proc);
+    DrainRemovals();
+  }
+  for (const auto& annotator : annotators_) {
+    annotator->AnnotateExec(*this, p, *new_proc);
   }
 }
 
 void ProcessTree::HandleExit(uint64_t timestamp, const Process& p) {
-  if (Step(timestamp)) {
-    absl::MutexLock lock(mtx_);
-    remove_at_.push_back({timestamp, p.pid_});
+  absl::MutexLock lock(mtx_);
+  if (!StepLocked({timestamp, EventKind::kExit, p.pid_, Pid{}})) {
+    return;
   }
+  remove_at_.push_back({timestamp, p.pid_});
+  DrainRemovals();
 }
 
-bool ProcessTree::Step(uint64_t timestamp) {
-  absl::MutexLock lock(mtx_);
-  uint64_t new_cutoff = seen_timestamps_.front();
-  if (timestamp < new_cutoff) {
-    // Event timestamp is before the rolling list of seen events.
-    // This event may or may not have been processed, but be conservative and
-    // do not reprocess.
+bool ProcessTree::StepLocked(const EventKey& key) {
+  latest_ts_ = std::max(latest_ts_, key.mach_time);
+
+  // Dedup on the event's identity: the same kernel event is delivered to every
+  // tree-aware client, and each informs the tree, so apply it exactly once. A
+  // genuinely-novel event that arrives out of mach_time order is NEVER dropped
+  // (this is the fix for the "too-old" drop that lost reordered fork/exec events
+  // under load); only an exact duplicate is skipped. The key carries the event's
+  // identity, not just mach_time, so two distinct events sharing a coarse
+  // mach_time stamp are not mistaken for one and dropped.
+  if (seen_.contains(key)) {
     return false;
   }
-
-  // seen_timestamps_ is sorted, so only look for the value if it's possibly
-  // within the array.
-  if (timestamp < seen_timestamps_.back()) {
-    // TODO(nickmg): If array is made bigger, replace with a binary search.
-    for (const auto seen_ts : seen_timestamps_) {
-      if (seen_ts == timestamp) {
-        // Event seen, signal it should not be reprocessed.
-        return false;
-      }
-    }
+  seen_.insert(key);
+  seen_order_.push_back(key);
+  if (seen_order_.size() > kSeenCap) {
+    // seen_/seen_order_ are bounded ONLY here — DrainRemovals never touches
+    // them. So the dedup window is exactly the last kSeenCap events: steady
+    // state is kSeenCap and this evicts on every insert after warmup. A client
+    // lagging more than kSeenCap events behind the newest event finds its
+    // duplicates already evicted and re-applies them. That is self-healing in
+    // the common case (map_.emplace is first-wins, and a laggard replays a
+    // whole lifecycle so re-created nodes are re-reaped by its own replayed
+    // exec/exit), with one accepted edge: if a fork duplicate has aged out
+    // while its matching exec duplicate has not, the re-inserted pre-exec node
+    // never gets a removal scheduled and leaks (pidversion-distinct, bounded;
+    // NOT wrong ancestry). The proper fix is the deferred delivery watermark;
+    // kSeenCap (16384) is sized so lag beyond it is rare under real load.
+    seen_.erase(seen_order_.front());
+    seen_order_.pop_front();
   }
+  return true;
+}
 
-  auto insert_point =
-      std::find_if(seen_timestamps_.rbegin(), seen_timestamps_.rend(),
-                   [&](uint64_t x) { return x < timestamp; });
-  std::move(seen_timestamps_.begin() + 1, insert_point.base(),
-            seen_timestamps_.begin());
-  *insert_point = timestamp;
+void ProcessTree::DrainRemovals() {
+  // Reap deferred removals once `grace` mach_time ticks have elapsed past the
+  // scheduling event (measured against the newest timestamp seen). The grace
+  // must comfortably exceed worst-case cross-thread/-client delivery reordering
+  // so a straggler cannot reference a process after it is reaped.
+  static const uint64_t kDefaultGrace = MachTicksFromNanos(5000000000ull);  // 5s
+  const uint64_t grace = removal_grace_ticks_ ? removal_grace_ticks_ : kDefaultGrace;
+  const uint64_t cutoff = latest_ts_ > grace ? latest_ts_ - grace : 0;
 
   for (auto it = remove_at_.begin(); it != remove_at_.end();) {
-    if (it->first < new_cutoff) {
+    if (it->first < cutoff) {
       if (auto target = GetLocked(it->second);
           target && (*target)->refcnt_.load(std::memory_order_relaxed) > 0) {
         (*target)->tombstoned_ = true;
@@ -155,8 +218,6 @@ bool ProcessTree::Step(uint64_t timestamp) {
       it++;
     }
   }
-
-  return true;
 }
 
 void ProcessTree::RetainProcess(const PidList& pids) {

--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -168,10 +168,10 @@ bool ProcessTree::StepLocked(const EventKey& key) {
   // Dedup on the event's identity: the same kernel event is delivered to every
   // tree-aware client, and each informs the tree, so apply it exactly once. A
   // genuinely-novel event that arrives out of mach_time order is NEVER dropped
-  // (this is the fix for the "too-old" drop that lost reordered fork/exec events
-  // under load); only an exact duplicate is skipped. The key carries the event's
-  // identity, not just mach_time, so two distinct events sharing a coarse
-  // mach_time stamp are not mistaken for one and dropped.
+  // (this is the fix for the "too-old" drop that lost reordered fork/exec
+  // events under load); only an exact duplicate is skipped. The key carries the
+  // event's identity, not just mach_time, so two distinct events sharing a
+  // coarse mach_time stamp are not mistaken for one and dropped.
   if (seen_.contains(key)) {
     return false;
   }
@@ -201,8 +201,9 @@ void ProcessTree::DrainRemovals() {
   // scheduling event (measured against the newest timestamp seen). The grace
   // must comfortably exceed worst-case cross-thread/-client delivery reordering
   // so a straggler cannot reference a process after it is reaped.
-  static const uint64_t kDefaultGrace = MachTicksFromNanos(5000000000ull);  // 5s
-  const uint64_t grace = removal_grace_ticks_ ? removal_grace_ticks_ : kDefaultGrace;
+  static const uint64_t kDefaultGrace = MachTicksFromNanos(5 * NSEC_PER_SEC);
+  const uint64_t grace =
+      removal_grace_ticks_ ? removal_grace_ticks_ : kDefaultGrace;
   const uint64_t cutoff = latest_ts_ > grace ? latest_ts_ - grace : 0;
 
   for (auto it = remove_at_.begin(); it != remove_at_.end();) {

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -16,12 +16,16 @@
 #ifndef SANTA_COMMON_PROCESSTREE_PROCESSTREE_H
 #define SANTA_COMMON_PROCESSTREE_PROCESSTREE_H
 
+#include <cstdint>
+#include <deque>
+#include <functional>
 #include <memory>
 #include <typeinfo>
 #include <vector>
 
 #include "Source/common/processtree/process.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -40,8 +44,10 @@ class ProcessTreeTestPeer;
 
 class ProcessTree {
  public:
-  explicit ProcessTree(std::vector<std::unique_ptr<Annotator>>&& annotators)
-      : annotators_(std::move(annotators)), seen_timestamps_({}) {}
+  explicit ProcessTree(std::vector<std::unique_ptr<Annotator>>&& annotators,
+                       uint64_t removal_grace_ticks = 0)
+      : annotators_(std::move(annotators)),
+        removal_grace_ticks_(removal_grace_ticks) {}
   ProcessTree(const ProcessTree&) = delete;
   ProcessTree& operator=(const ProcessTree&) = delete;
   ProcessTree(ProcessTree&&) = delete;
@@ -121,10 +127,28 @@ class ProcessTree {
       std::shared_ptr<Process> parent,
       const BackfilledProcess& backfilled_proc);
 
-  // Mark that an event with the given timestamp is being processed.
-  // Returns whether the given timestamp is "novel", and the tree should be
-  // updated with the results of the event.
-  bool Step(uint64_t timestamp);
+  // Record that the event identified by `key` is being processed and report
+  // whether it is "novel" (caller should apply it). A novel event is applied
+  // even if it arrives out of mach_time order (ES does not guarantee global
+  // ordering); only an exact duplicate (the same event redelivered to another
+  // client) is skipped. The key includes the event's identity (not just
+  // mach_time) so two distinct events sharing a coarse mach_time stamp are not
+  // mistaken for one.
+  //
+  // MUST be called with mtx_ held, and the caller MUST perform the resulting
+  // map_/remove_at_ mutation before releasing mtx_. Dedup and mutation are one
+  // atomic step on purpose: the same kernel event is delivered to multiple
+  // clients, and once one client records it as seen, another client will skip
+  // it as a duplicate — so the tree mutation must already be visible when that
+  // skip happens, or the second client (and its subsequent causal reads) would
+  // observe a missing node. "Applied" here means the tree *structure* (the
+  // map_ entry and parent_ chain that CEL ancestry walks); annotation
+  // propagation runs outside the lock and is NOT part of this atomicity
+  // guarantee (see HandleFork/HandleExec).
+  bool StepLocked(const struct EventKey& key) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mtx_);
+
+  // Reap deferred removals whose grace has elapsed. Caller must hold mtx_.
+  void DrainRemovals() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mtx_);
 
   std::optional<std::shared_ptr<Process>> GetLocked(struct Pid target) const
       ABSL_SHARED_LOCKS_REQUIRED(mtx_);
@@ -136,15 +160,37 @@ class ProcessTree {
   mutable absl::Mutex mtx_;
   absl::flat_hash_map<const struct Pid, std::shared_ptr<Process>> map_
       ABSL_GUARDED_BY(mtx_);
-  // List of pids which should be removed from map_, and at the timestamp at
-  // which they should be.
-  // Elements are removed when the timestamp falls out of the seen_timestamps_
-  // list below, signifying that all clients have synced past the timestamp.
+  // List of pids which should be removed from map_, and the timestamp (the
+  // originating exit/exec event's mach_time) at which the removal was scheduled.
+  // An entry is reaped once removal_grace_ticks_ have elapsed past its timestamp
+  // (measured against latest_ts_), so a reordered straggler cannot reference a
+  // process after it is reaped. See DrainRemovals().
   std::vector<std::pair<uint64_t, struct Pid>> remove_at_ ABSL_GUARDED_BY(mtx_);
-  // Rolling list of event timestamps processed by the tree.
-  // This is used to ensure an event only gets processed once, even if events
-  // come out of order.
-  std::array<uint64_t, 32> seen_timestamps_ ABSL_GUARDED_BY(mtx_);
+
+  // Dedup of processed events. The same kernel event is delivered to every
+  // tree-aware client; each informs the tree, so an event must be applied
+  // exactly once. seen_ answers "already applied?" in O(1); seen_order_ ages
+  // entries out in insertion order once seen_ exceeds kSeenCap. Unlike the
+  // previous fixed rolling window, an out-of-order novel event is NEVER dropped.
+  // Keyed on the full EventKey so distinct events sharing a coarse mach_time
+  // stamp do not collide (see EventKey).
+  static constexpr size_t kSeenCap = 16384;
+  absl::flat_hash_set<struct EventKey> seen_ ABSL_GUARDED_BY(mtx_);
+  std::deque<struct EventKey> seen_order_ ABSL_GUARDED_BY(mtx_);
+  // Newest event timestamp seen (monotone); drives the removal grace cutoff.
+  uint64_t latest_ts_ ABSL_GUARDED_BY(mtx_) = 0;
+  // Mach-time ticks an exited process is retained after its removal is
+  // scheduled. 0 => production default (~5 s), computed lazily in
+  // DrainRemovals. Injectable so tests can exercise reaping with small
+  // synthetic timestamps.
+  uint64_t removal_grace_ticks_;
+
+  // Test-only seam (empty in production): invoked by HandleFork at the
+  // claim->apply boundary — after StepLocked reports the event novel and while
+  // mtx_ is still held, just before the map insert. Lets the concurrency
+  // regression test interpose there. Set via ProcessTreeTestPeer (a friend).
+  // The per-event null check is negligible.
+  std::function<void()> on_event_claimed_for_test_;
 };
 
 template <typename T>

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -145,7 +145,8 @@ class ProcessTree {
   // map_ entry and parent_ chain that CEL ancestry walks); annotation
   // propagation runs outside the lock and is NOT part of this atomicity
   // guarantee (see HandleFork/HandleExec).
-  bool StepLocked(const struct EventKey& key) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mtx_);
+  bool StepLocked(const struct EventKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mtx_);
 
   // Reap deferred removals whose grace has elapsed. Caller must hold mtx_.
   void DrainRemovals() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mtx_);
@@ -161,19 +162,19 @@ class ProcessTree {
   absl::flat_hash_map<const struct Pid, std::shared_ptr<Process>> map_
       ABSL_GUARDED_BY(mtx_);
   // List of pids which should be removed from map_, and the timestamp (the
-  // originating exit/exec event's mach_time) at which the removal was scheduled.
-  // An entry is reaped once removal_grace_ticks_ have elapsed past its timestamp
-  // (measured against latest_ts_), so a reordered straggler cannot reference a
-  // process after it is reaped. See DrainRemovals().
+  // originating exit/exec event's mach_time) at which the removal was
+  // scheduled. An entry is reaped once removal_grace_ticks_ have elapsed past
+  // its timestamp (measured against latest_ts_), so a reordered straggler
+  // cannot reference a process after it is reaped. See DrainRemovals().
   std::vector<std::pair<uint64_t, struct Pid>> remove_at_ ABSL_GUARDED_BY(mtx_);
 
   // Dedup of processed events. The same kernel event is delivered to every
   // tree-aware client; each informs the tree, so an event must be applied
   // exactly once. seen_ answers "already applied?" in O(1); seen_order_ ages
   // entries out in insertion order once seen_ exceeds kSeenCap. Unlike the
-  // previous fixed rolling window, an out-of-order novel event is NEVER dropped.
-  // Keyed on the full EventKey so distinct events sharing a coarse mach_time
-  // stamp do not collide (see EventKey).
+  // previous fixed rolling window, an out-of-order novel event is NEVER
+  // dropped. Keyed on the full EventKey so distinct events sharing a coarse
+  // mach_time stamp do not collide (see EventKey).
   static constexpr size_t kSeenCap = 16384;
   absl::flat_hash_set<struct EventKey> seen_ ABSL_GUARDED_BY(mtx_);
   std::deque<struct EventKey> seen_order_ ABSL_GUARDED_BY(mtx_);

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -18,8 +18,13 @@
 
 #include <bsm/libbsm.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include "Source/common/processtree/annotations/annotator.h"
 #include "Source/common/processtree/process.h"
@@ -177,73 +182,218 @@ using namespace santa::santad::process_tree;
 }
 
 - (void)testCleanup {
+  // Removal is time-based: an exited process is retained until removal_grace_ticks
+  // have elapsed past its exit (measured by the newest timestamp seen), so a
+  // reordered straggler cannot reference it after it is reaped. Inject a small
+  // grace so tiny synthetic timestamps exercise the reaping boundary.
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators),
+                                                    /*removal_grace_ticks=*/10);
+  auto init = tree->InsertInit();
+
+  uint64_t event_id = 1;
+  const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+  tree->HandleFork(event_id++, *init, child_pid);  // ts=1
+  auto child = *tree->Get(child_pid);
+  tree->HandleExit(event_id++, *child);  // ts=2: scheduled for removal
+
+  // Still present immediately after exit (well within the grace).
+  XCTAssertTrue(tree->Get(child_pid).has_value());
+
+  // Step forward but stay within the grace (latest_ts - grace <= 2).
+  struct Pid churn_pid = {.pid = 3, .pidversion = 3};
+  for (int i = 0; i < 10; i++) {  // ts=3..12 -> latest=12, cutoff=2
+    tree->HandleFork(event_id++, *init, churn_pid);
+    churn_pid.pid++;
+  }
+  XCTAssertTrue(tree->Get(child_pid).has_value());
+
+  // Step past the grace (latest_ts - grace > 2): the exited child is reaped.
+  for (int i = 0; i < 5; i++) {  // ts=13..17 -> cutoff reaches 7 > 2
+    tree->HandleFork(event_id++, *init, churn_pid);
+    churn_pid.pid++;
+  }
+  XCTAssertFalse(tree->Get(child_pid).has_value());
+}
+
+- (void)testRefcountCleanup {
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators),
+                                                    /*removal_grace_ticks=*/10);
+  auto init = tree->InsertInit();
+
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
   {
-    self.tree->HandleFork(event_id++, *self.initProc, child_pid);
-    auto child = *self.tree->Get(child_pid);
-    self.tree->HandleExit(event_id++, *child);
+    tree->HandleFork(event_id++, *init, child_pid);
+    auto child = *tree->Get(child_pid);
+    tree->HandleExit(event_id++, *child);
   }
 
-  // We should still be able to get a handle to child...
   {
-    auto child = self.tree->Get(child_pid);
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+    PidList pids = {(*child)->pid_};
+    tree->RetainProcess(pids);
+  }
+
+  // Even stepping well past the grace, the retained child stays reachable
+  // (tombstoned, not erased).
+  struct Pid churn_pid = {.pid = 100, .pidversion = 100};
+  for (int i = 0; i < 100; i++) {
+    tree->HandleFork(event_id++, *init, churn_pid);
+    churn_pid.pid++;
+    churn_pid.pidversion++;
+    auto child = tree->Get(child_pid);
     XCTAssertTrue(child.has_value());
   }
 
-  // ... until we step far enough into the future (32 events).
-  struct Pid churn_pid = {.pid = 3, .pidversion = 3};
-  for (int i = 0; i < 32; i++) {
-    self.tree->HandleFork(event_id++, *self.initProc, churn_pid);
-    churn_pid.pid++;
+  // But when released (refcnt -> 0 while tombstoned)...
+  {
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+    PidList pids = {(*child)->pid_};
+    tree->ReleaseProcess(pids);
   }
 
-  // Now when we try processing the next event, it should have fallen out of the tree.
-  self.tree->HandleFork(event_id++, *self.initProc, churn_pid);
+  // ... it is removed.
   {
-    auto child = self.tree->Get(child_pid);
+    auto child = tree->Get(child_pid);
     XCTAssertFalse(child.has_value());
   }
 }
 
-- (void)testRefcountCleanup {
-  uint64_t event_id = 1;
+// Regression: ES does not guarantee global mach_time ordering across threads or
+// clients, so a genuinely-novel fork/exec can arrive stamped "in the past". The
+// tree must still track it. Pre-fix, Step dropped such events as "too old",
+// which left the process (and thus CEL `ancestors`) missing under load.
+- (void)testOutOfOrderEventsNotDropped {
+  uint64_t base = 1000000;
+
+  // Advance the dedup/ordering state well forward with monotonic events.
+  struct Pid churn_pid = {.pid = 100, .pidversion = 100};
+  for (int i = 0; i < 200; i++) {
+    self.tree->HandleFork(base + i, *self.initProc, churn_pid);
+    churn_pid.pid++;
+    churn_pid.pidversion++;
+  }
+
+  // A novel fork stamped far behind the newest timestamp seen (reordered straggler).
+  const struct Pid late_child_pid = {.pid = 2, .pidversion = 2};
+  self.tree->HandleFork(base - 500, *self.initProc, late_child_pid);
+
+  auto late_child_opt = self.tree->Get(late_child_pid);
+  XCTAssertTrue(late_child_opt.has_value());
+  XCTAssertEqual(self.tree->GetParent(**late_child_opt), self.initProc);
+
+  // A novel exec, also stamped in the past, transforms that child.
+  std::shared_ptr<const Process> late_child = *late_child_opt;
+  const struct Pid late_exec_pid = {.pid = 2, .pidversion = 3};
+  const struct Program late_prog = {.executable = "/bin/bash", .arguments = {"/bin/bash"}};
+  self.tree->HandleExec(base - 400, *late_child, late_exec_pid, late_prog,
+                        late_child->effective_cred_);
+
+  auto late_exec_opt = self.tree->Get(late_exec_pid);
+  XCTAssertTrue(late_exec_opt.has_value());
+  XCTAssertEqual(*(*late_exec_opt)->program_, late_prog);
+
+  // Ancestry (what CEL `ancestors` walks) is intact up to init.
+  auto slice = self.tree->RootSlice(*late_exec_opt);
+  XCTAssertEqual(slice.size(), 2u);  // [late_exec, init]
+  XCTAssertEqual(slice.back(), self.initProc);
+}
+
+// Regression: mach_time has ~41 ns granularity on Apple Silicon and the counter
+// is system-wide, so two DISTINCT events on different cores within one tick get
+// the same stamp. Deduping on bare mach_time would drop the second as a
+// "duplicate"; the dedup key must include the event's identity so both apply.
+- (void)testSameMachTimeDistinctEventsBothApplied {
+  // Two distinct forks stamped with the SAME mach_time (a ~41 ns collision).
+  uint64_t ts = 1000;
+  const struct Pid a = {.pid = 2, .pidversion = 2};
+  const struct Pid b = {.pid = 3, .pidversion = 3};
+  self.tree->HandleFork(ts, *self.initProc, a);
+  self.tree->HandleFork(ts, *self.initProc, b);  // same ts, different child
+
+  XCTAssertTrue(self.tree->Get(a).has_value());
+  XCTAssertTrue(self.tree->Get(b).has_value());  // the discriminating assertion
+}
+
+// Regression: dedup (claiming an event as "seen") and the corresponding tree
+// mutation must be one atomic critical section. The same kernel event is
+// delivered to multiple ES clients; once one client claims it, another client
+// skips it as a duplicate. If the claim and the map insert were separate lock
+// holds, the winning client could pause between them while the skipping client
+// (or any reader) observed a missing node. Here the producer pauses INSIDE the
+// critical section (holding mtx_) right after claiming a fork; a reader must
+// block until the insert is visible, so it can never see the child as absent.
+- (void)testConcurrentClaimIsAtomicWithApply {
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators));
+  auto init = tree->InsertInit();
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+
+  std::mutex m;
+  std::condition_variable cv;
+  bool claimed = false;
+  bool release = false;
+  std::atomic<bool> readerFinished{false};
+  std::atomic<bool> readerSawChild{false};
+
+  bool hookFired = false;
+  tree->SetOnEventClaimedForTest([&] {
+    // Runs on the producer thread, holding mtx_, just after the claim.
+    if (hookFired) return;  // interpose only on the first claim
+    hookFired = true;
+    {
+      std::lock_guard<std::mutex> lk(m);
+      claimed = true;
+    }
+    cv.notify_all();
+    std::unique_lock<std::mutex> lk(m);
+    cv.wait(lk, [&] { return release; });  // hold mtx_ until released
+  });
+
+  // Producer claims the fork and pauses inside the critical section (mtx_ held).
+  std::thread producer([&] { tree->HandleFork(1, *init, child_pid); });
   {
-    self.tree->HandleFork(event_id++, *self.initProc, child_pid);
-    auto child = *self.tree->Get(child_pid);
-    self.tree->HandleExit(event_id++, *child);
+    std::unique_lock<std::mutex> lk(m);
+    // Bounded wait: if StepLocked ever wrongly rejected this novel fork the hook
+    // never fires, so fail loudly instead of hanging the suite. The producer has
+    // already returned in that case (HandleFork didn't block), so joining is safe.
+    if (!cv.wait_for(lk, std::chrono::seconds(5), [&] { return claimed; })) {
+      lk.unlock();
+      producer.join();
+      XCTFail(@"producer never claimed the fork (novel event wrongly deduped?)");
+      return;
+    }
   }
 
-  {
-    auto child = self.tree->Get(child_pid);
-    XCTAssertTrue(child.has_value());
-    PidList pids = {(*child)->pid_};
-    self.tree->RetainProcess(pids);
-  }
+  // Reader tries to read the child while the producer holds mtx_. With atomic
+  // claim+apply the reader MUST block until the insert becomes visible.
+  std::thread reader([&] {
+    bool present = tree->Get(child_pid).has_value();
+    readerSawChild = present;
+    readerFinished = true;
+  });
 
-  // Even if we step far into the future, we should still be able to lookup
-  // the child.
-  for (int i = 0; i < 1000; i++) {
-    struct Pid churn_pid = {.pid = 100 + i, .pidversion = (uint64_t)(100 + i)};
-    self.tree->HandleFork(event_id++, *self.initProc, churn_pid);
-    auto child = self.tree->Get(child_pid);
-    XCTAssertTrue(child.has_value());
-  }
+  // The reader cannot finish while the producer holds the lock. If it does, the
+  // insert was not atomic with the claim (the regression this guards).
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  XCTAssertFalse(readerFinished.load(),
+                 @"reader observed the tree mid-apply — claim/insert not atomic");
 
-  // But when released...
+  // Release the producer; the reader then observes the fully-applied child.
   {
-    auto child = self.tree->Get(child_pid);
-    XCTAssertTrue(child.has_value());
-    PidList pids = {(*child)->pid_};
-    self.tree->ReleaseProcess(pids);
+    std::lock_guard<std::mutex> lk(m);
+    release = true;
   }
+  cv.notify_all();
 
-  // ... it should immediately be removed.
-  {
-    auto child = self.tree->Get(child_pid);
-    XCTAssertFalse(child.has_value());
-  }
+  producer.join();
+  reader.join();
+  XCTAssertTrue(readerFinished.load());
+  XCTAssertTrue(readerSawChild.load());  // never saw "absent"
 }
 
 @end

--- a/Source/common/processtree/process_tree_test_helpers.h
+++ b/Source/common/processtree/process_tree_test_helpers.h
@@ -16,7 +16,9 @@
 #ifndef SANTA_COMMON_PROCESSTREE_PROCESSTREETESTHELPERS_H
 #define SANTA_COMMON_PROCESSTREE_PROCESSTREETESTHELPERS_H
 
+#include <functional>
 #include <memory>
+#include <utility>
 
 #include "Source/common/processtree/process_tree.h"
 
@@ -25,9 +27,16 @@ namespace santa::santad::process_tree {
 class ProcessTreeTestPeer : public ProcessTree {
  public:
   explicit ProcessTreeTestPeer(
-      std::vector<std::unique_ptr<Annotator>>&& annotators)
-      : ProcessTree(std::move(annotators)) {}
+      std::vector<std::unique_ptr<Annotator>>&& annotators,
+      uint64_t removal_grace_ticks = 0)
+      : ProcessTree(std::move(annotators), removal_grace_ticks) {}
   std::shared_ptr<const Process> InsertInit();
+
+  // Install the StepLocked test seam (ProcessTreeTestPeer is a friend of
+  // ProcessTree, so it can reach the private member).
+  void SetOnEventClaimedForTest(std::function<void()> hook) {
+    on_event_claimed_for_test_ = std::move(hook);
+  }
 };
 
 }  // namespace santa::santad::process_tree

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -111,8 +111,8 @@ class MockAuthResultCache : public AuthResultCache {
   // tree. The force-added NOTIFY_EXEC feeds the tree and is filtered out before
   // the authorizer's own message handling.
   std::set<es_event_type_t> expectedEventSubs{
-      ES_EVENT_TYPE_AUTH_EXEC, ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
-      ES_EVENT_TYPE_NOTIFY_FORK, ES_EVENT_TYPE_NOTIFY_EXEC, ES_EVENT_TYPE_NOTIFY_EXIT};
+      ES_EVENT_TYPE_AUTH_EXEC, ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME, ES_EVENT_TYPE_NOTIFY_FORK,
+      ES_EVENT_TYPE_NOTIFY_EXEC, ES_EVENT_TYPE_NOTIFY_EXIT};
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -103,12 +103,16 @@ class MockAuthResultCache : public AuthResultCache {
 - (void)testEnable {
   // Ensure the client subscribes to expected event types. As a tree-aware
   // client, the authorizer additionally subscribes to the process-tree
-  // lifecycle events (NOTIFY_FORK and NOTIFY_EXIT) so the tree stays consistent
-  // for the lineage of processes it authorizes. NOTIFY_EXEC is not added because
-  // AUTH_EXEC already supplies exec info to the tree.
-  std::set<es_event_type_t> expectedEventSubs{ES_EVENT_TYPE_AUTH_EXEC,
-                                              ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
-                                              ES_EVENT_TYPE_NOTIFY_FORK, ES_EVENT_TYPE_NOTIFY_EXIT};
+  // lifecycle events (NOTIFY_FORK, NOTIFY_EXEC, NOTIFY_EXIT) so the tree stays
+  // consistent for the lineage of processes it authorizes. NOTIFY_EXEC is
+  // required even though the authorizer sees AUTH_EXEC: ES suppresses AUTH_EXEC
+  // delivery for binaries whose auth result is cached, so relying on AUTH_EXEC
+  // alone would miss cached execs (e.g. a long-lived build server) from the
+  // tree. The force-added NOTIFY_EXEC feeds the tree and is filtered out before
+  // the authorizer's own message handling.
+  std::set<es_event_type_t> expectedEventSubs{
+      ES_EVENT_TYPE_AUTH_EXEC, ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
+      ES_EVENT_TYPE_NOTIFY_FORK, ES_EVENT_TYPE_NOTIFY_EXEC, ES_EVENT_TYPE_NOTIFY_EXIT};
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
@@ -61,8 +61,16 @@ using santa::Processor;
     eventsWithLifecycle.insert(ES_EVENT_TYPE_NOTIFY_FORK);
     _addedEvents[ES_EVENT_TYPE_NOTIFY_FORK] = true;
   }
-  if (events.find(ES_EVENT_TYPE_NOTIFY_EXEC) == events.end() &&
-      events.find(ES_EVENT_TYPE_AUTH_EXEC) == events.end()) {
+  // NOTIFY_EXEC is required for complete tree population even when the client
+  // already subscribes to AUTH_EXEC. ES suppresses AUTH_EXEC delivery for a
+  // binary whose auth result is cached at the ES layer, so an AUTH_EXEC-only
+  // feed silently misses every exec of a cached binary (e.g. a long-lived
+  // build server) — leaving holes in the tree and, because a fork whose actor
+  // is absent is dropped, whole missing subtrees. NOTIFY_EXEC is not
+  // cache-suppressed, so subscribing to it guarantees the client sees every
+  // exec in its own (causally-ordered) stream. It is consumed for tree
+  // population and filtered out before the client's own message handling.
+  if (events.find(ES_EVENT_TYPE_NOTIFY_EXEC) == events.end()) {
     eventsWithLifecycle.insert(ES_EVENT_TYPE_NOTIFY_EXEC);
     _addedEvents[ES_EVENT_TYPE_NOTIFY_EXEC] = true;
   }

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClientTest.mm
@@ -70,7 +70,11 @@ using santa::Processor;
   XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
 
-  // EXEC event is not forced for both AUTH and NOTIFY variants
+  // A client subscribing to AUTH_EXEC still gets NOTIFY_EXEC force-added: ES
+  // suppresses AUTH_EXEC delivery for binaries whose auth result is cached, so
+  // AUTH_EXEC alone would miss those (cached) execs from the tree. NOTIFY_EXEC
+  // is not cache-suppressed. The force-added NOTIFY_EXEC feeds the tree and is
+  // filtered out before the client's own message handling.
   treeClient = [[SNTEndpointSecurityTreeAwareClient alloc] initWithESAPI:mockESApi
                                                                  metrics:nullptr
                                                                processor:Processor::kUnknown
@@ -78,7 +82,7 @@ using santa::Processor;
   [treeClient subscribe:{ES_EVENT_TYPE_AUTH_EXEC}];
 
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_FORK]);
-  XCTAssertFalse([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
+  XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXEC]);
   XCTAssertTrue([treeClient eventWasAdded:ES_EVENT_TYPE_NOTIFY_EXIT]);
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());


### PR DESCRIPTION
Reliably track fork/exec/exit lifecycle events when the kernel delivers
them out of order or to multiple ES clients:

- dedup on event identity (not bare timestamp) and never drop a reordered
  event; reap exited processes on a time-based grace
- tree-aware auth clients also observe `NOTIFY_EXEC` so the tree sees every
  exec, including ES-cache-suppressed ones
- apply dedup and the tree mutation in a single critical section

## Testing

- `bazel build //Source/santad:Santad`
- `bazel test //Source/santad:unit_tests //Source/common/processtree:process_tree_test` (50/50 pass)
