### PR TITLE
processtree: use PROC_PIDT_SHORTBSDINFO to look up ppid during backfill

### DIFF
--- a/Source/common/processtree/process_tree_macos.mm
+++ b/Source/common/processtree/process_tree_macos.mm
@@ -192,13 +192,13 @@ absl::Status ProcessTree::Backfill() {
       // Determine ppid
       // Alternatively, there's a sysctl interface:
       //  https://chromium.googlesource.com/chromium/chromium/+/master/base/process_util_openbsd.cc#32
-      struct proc_bsdinfo bsdinfo;
-      if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &bsdinfo, sizeof(bsdinfo)) !=
-          PROC_PIDTBSDINFO_SIZE) {
+      struct proc_bsdshortinfo bsdinfo;
+      if (proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &bsdinfo, sizeof(bsdinfo)) !=
+          PROC_PIDT_SHORTBSDINFO_SIZE) {
         continue;
       };
 
-      parent_map[bsdinfo.pbi_ppid].push_back(std::move(backfilled_proc));
+      parent_map[bsdinfo.pbsi_ppid].push_back(std::move(backfilled_proc));
     }
   }
 


### PR DESCRIPTION
## Summary
- `ProcessTree::Backfill()` only ever reads `pbi_ppid` from the full `proc_bsdinfo` struct returned by `proc_pidinfo(..., PROC_PIDTBSDINFO, ...)`.
- Swaps to `PROC_PIDT_SHORTBSDINFO` / `proc_bsdshortinfo` / `pbsi_ppid`, which the kernel fills identically for ppid but skips the pgrp/session lookup and credential reads the full flavor does, and copies out half the bytes (64 vs 136).

## Test plan
- [x] `bazel build //Source/common/processtree:process_tree`
- [x] `bazel test //Source/common/processtree:process_tree_test`
- [x] Benchmarked both flavors head-to-head over all live pids on a running system (500 rounds, interleaved/alternating call order to cancel ordering bias): as root, identical success counts for both flavors (633000/646500), `PROC_PIDT_SHORTBSDINFO` averaged 170.3 ns/call vs `PROC_PIDTBSDINFO`'s 346.2 ns/call (~2x faster).