### PR TITLE
common: reduce per-evaluation copies in CEL activations

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -248,6 +248,12 @@ objc_library(
     hdrs = ["Memoizer.h"],
 )
 
+santa_unit_test(
+    name = "MemoizerTest",
+    srcs = ["MemoizerTest.mm"],
+    deps = [":Memoizer"],
+)
+
 objc_library(
     name = "Platform",
     hdrs = ["Platform.h"],
@@ -1295,6 +1301,7 @@ test_suite(
         ":MOLCertificateTest",
         ":MOLCodesignCheckerTest",
         ":MOLXPCConnectionTest",
+        ":MemoizerTest",
         ":NKeyTokenValidatorTest",
         ":NSDataZlibTest",
         ":PowerMonitorTest",

--- a/Source/common/Memoizer.h
+++ b/Source/common/Memoizer.h
@@ -22,24 +22,34 @@ namespace santa {
 
 // Memoizer is a template class that memoizes the result of a function call that
 // requires no arguments, to avoid expensive recalculations.
+//
+// Not thread-safe: a given instance must only be accessed from one thread.
 template <typename T>
 class Memoizer {
  public:
   // Constructor takes the function to be memoized
   Memoizer(std::function<T()> func) : func_(func) {}
 
+  // References returned by operator() are tied to this instance; copying or
+  // moving would let them silently outlive the storage they point into.
+  Memoizer(const Memoizer&) = delete;
+  Memoizer& operator=(const Memoizer&) = delete;
+  Memoizer(Memoizer&&) = delete;
+  Memoizer& operator=(Memoizer&&) = delete;
+
   // Overload the operator() to enable calling the Memoizer like a function
   // Mark this as const to allow it to be called from const methods. It
   // technically isn't const given that cache_ is updated but we mark that field
   // as mutable.
-  T operator()() const {
-    if (cache_.has_value()) {
-      return *cache_;
+  //
+  // The returned reference is valid for the lifetime of the Memoizer and is
+  // never invalidated; callers may hold pointers into the returned value for
+  // as long as the Memoizer is alive.
+  const T& operator()() const {
+    if (!cache_.has_value()) {
+      cache_ = func_();
     }
-
-    T result = func_();
-    cache_ = result;
-    return result;
+    return *cache_;
   }
 
   bool HasValue() const { return cache_.has_value(); }

--- a/Source/common/MemoizerTest.mm
+++ b/Source/common/MemoizerTest.mm
@@ -1,0 +1,96 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#include <type_traits>
+
+#include "Source/common/Memoizer.h"
+
+namespace {
+
+// Counts copy constructions/assignments so tests can assert that accessing a
+// memoized value does not duplicate it.
+struct Counted {
+  static int copies;
+
+  int value = 0;
+
+  Counted() = default;
+  explicit Counted(int v) : value(v) {}
+  Counted(const Counted& other) : value(other.value) { ++copies; }
+  Counted& operator=(const Counted& other) {
+    value = other.value;
+    ++copies;
+    return *this;
+  }
+  Counted(Counted&&) = default;
+  Counted& operator=(Counted&&) = default;
+};
+
+int Counted::copies = 0;
+
+}  // namespace
+
+// Copying or moving a Memoizer would detach outstanding references from the
+// instance that owns their storage; both are forbidden.
+static_assert(!std::is_copy_constructible_v<santa::Memoizer<int>>);
+static_assert(!std::is_copy_assignable_v<santa::Memoizer<int>>);
+static_assert(!std::is_move_constructible_v<santa::Memoizer<int>>);
+static_assert(!std::is_move_assignable_v<santa::Memoizer<int>>);
+
+@interface MemoizerTest : XCTestCase
+@end
+
+@implementation MemoizerTest
+
+- (void)testComputesOnce {
+  int calls = 0;
+  santa::Memoizer<int> m([&calls] {
+    ++calls;
+    return 42;
+  });
+
+  XCTAssertFalse(m.HasValue());
+  XCTAssertEqual(m(), 42);
+  XCTAssertTrue(m.HasValue());
+  XCTAssertEqual(m(), 42);
+  XCTAssertEqual(calls, 1);
+}
+
+- (void)testAccessDoesNotCopyValue {
+  Counted::copies = 0;
+  santa::Memoizer<Counted> m([] { return Counted(42); });
+
+  XCTAssertEqual(m().value, 42);
+  XCTAssertEqual(m().value, 42);
+
+  // Neither materialization nor repeated access may copy the stored value.
+  // Callers (e.g. cel::Activation) hand out references into the memoized
+  // storage, so the value must be produced once and never duplicated.
+  XCTAssertEqual(Counted::copies, 0);
+}
+
+- (void)testReturnsStableReference {
+  santa::Memoizer<Counted> m([] { return Counted(7); });
+
+  // Every access must return the same object: callers hold pointers into the
+  // memoized storage across accesses (e.g. CEL evaluation wraps protos stored
+  // in the cache), so the cache must never be re-materialized or moved.
+  const Counted* first = &m();
+  const Counted* second = &m();
+  XCTAssertEqual(first, second);
+}
+
+@end

--- a/Source/common/cel/Activation.mm
+++ b/Source/common/cel/Activation.mm
@@ -163,25 +163,23 @@ std::optional<cel_runtime::CelValue> Activation<IsV2>::FindValue(
 
   // Handle the V2 specific fields
   if constexpr (IsV2) {
+    // The wrapped protos below are stored in the Memoizers, which guarantee
+    // reference stability for the lifetime of the activation. The activation
+    // outlives evaluation, so no arena copy is needed (same lifetime contract
+    // as `target` above).
     if (name == "ancestors") {
       // Convert ancestors to CEL list of proto messages
       std::vector<cel_runtime::CelValue> ancestorValues;
       for (const auto& ancestor : ancestors_()) {
-        // Create a copy of the proto on the arena and wrap it
-        auto* proto = arena->Create<AncestorT>(arena);
-        proto->CopyFrom(ancestor);
-        ancestorValues.push_back(cel_runtime::CelProtoWrapper::CreateMessage(proto, arena));
+        ancestorValues.push_back(cel_runtime::CelProtoWrapper::CreateMessage(&ancestor, arena));
       }
       return cel_runtime::CelValue::CreateList(
           arena->Create<cel_runtime::ContainerBackedListImpl>(arena, ancestorValues));
     }
     if (name == "fds") {
-      using FileDescriptorT = typename Traits::FileDescriptorT;
       std::vector<cel_runtime::CelValue> fdValues;
       for (const auto& fd : fds_()) {
-        auto* proto = arena->Create<FileDescriptorT>(arena);
-        proto->CopyFrom(fd);
-        fdValues.push_back(cel_runtime::CelProtoWrapper::CreateMessage(proto, arena));
+        fdValues.push_back(cel_runtime::CelProtoWrapper::CreateMessage(&fd, arena));
       }
       return cel_runtime::CelValue::CreateList(
           arena->Create<cel_runtime::ContainerBackedListImpl>(arena, fdValues));

--- a/Source/common/cel/Test.mm
+++ b/Source/common/cel/Test.mm
@@ -202,7 +202,10 @@
     }
   }
   {
-    // Test memoization
+    // Activation integration: a producer runs at most once per evaluation even
+    // when its variable is referenced multiple times, so per-exec work like
+    // ExecArgs is not repeated. (The Memoizer unit contract — compute-once,
+    // no-copy, stable reference — is covered directly by MemoizerTest.)
     __block int argsCallCount = 0;
     santa::cel::Activation<true> activation(
         std::move(f),
@@ -614,104 +617,6 @@
     // Test no match with exists
     auto result =
         sut.value()->CompileAndEvaluate("fds.exists(f, f.type == FD_TYPE_KQUEUE)", activation);
-    if (!result.ok()) {
-      XCTFail("Failed to evaluate: %s", result.status().message().data());
-    } else {
-      XCTAssertEqual(result.value().value, ReturnValue::BLOCKLIST);
-      XCTAssertEqual(result.value().cacheable, false);
-    }
-  }
-}
-
-- (void)testAncestors {
-  using ReturnValue = santa::cel::CELProtoTraits<true>::ReturnValue;
-  using ExecutableFileT = santa::cel::CELProtoTraits<true>::ExecutableFileT;
-  using AncestorT = santa::cel::CELProtoTraits<true>::AncestorT;
-  using FileDescriptorT = santa::cel::CELProtoTraits<true>::FileDescriptorT;
-  auto f = std::make_unique<ExecutableFileT>();
-  santa::cel::Activation<true> activation(
-      std::move(f),
-      ^std::vector<std::string>() {
-        return {};
-      },
-      ^std::map<std::string, std::string>() {
-        return {};
-      },
-      ^uid_t() {
-        return 0;
-      },
-      ^std::string() {
-        return "/";
-      },
-      ^std::string() {
-        return "/usr/bin/test";
-      },
-      ^std::vector<AncestorT>() {
-        AncestorT launchd;
-        launchd.set_path("/sbin/launchd");
-        launchd.add_args("/sbin/launchd");
-        launchd.set_signing_id("platform:com.apple.xpc.launchd");
-        AncestorT shell;
-        shell.set_path("/bin/zsh");
-        shell.add_args("-zsh");
-        shell.add_args("-il");
-        shell.set_signing_id("platform:com.apple.zsh");
-        shell.set_team_id("");
-        shell.set_cdhash("d5b04ff62b334f1dcb287d15d0bdc5b553840b30");
-        return {shell, launchd};
-      },
-      ^std::vector<FileDescriptorT>() {
-        return {};
-      });
-
-  auto sut = santa::cel::Evaluator<true>::Create();
-  XCTAssertTrue(sut.ok());
-
-  {
-    // Test ancestors size
-    auto result = sut.value()->CompileAndEvaluate("size(ancestors) == 2", activation);
-    if (!result.ok()) {
-      XCTFail("Failed to evaluate: %s", result.status().message().data());
-    } else {
-      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
-      XCTAssertEqual(result.value().cacheable, false);
-    }
-  }
-  {
-    // Test indexed field access
-    auto result = sut.value()->CompileAndEvaluate("ancestors[0].path == '/bin/zsh'", activation);
-    if (!result.ok()) {
-      XCTFail("Failed to evaluate: %s", result.status().message().data());
-    } else {
-      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
-      XCTAssertEqual(result.value().cacheable, false);
-    }
-  }
-  {
-    // Test repeated field access within an ancestor
-    auto result = sut.value()->CompileAndEvaluate("ancestors[0].args[1] == '-il'", activation);
-    if (!result.ok()) {
-      XCTFail("Failed to evaluate: %s", result.status().message().data());
-    } else {
-      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
-      XCTAssertEqual(result.value().cacheable, false);
-    }
-  }
-  {
-    // Test exists comprehension over ancestors
-    auto result = sut.value()->CompileAndEvaluate(
-        "ancestors.exists(a, a.signing_id == 'platform:com.apple.xpc.launchd')", activation);
-    if (!result.ok()) {
-      XCTFail("Failed to evaluate: %s", result.status().message().data());
-    } else {
-      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
-      XCTAssertEqual(result.value().cacheable, false);
-    }
-  }
-  {
-    // Test no match with exists
-    auto result = sut.value()->CompileAndEvaluate(
-        "ancestors.exists(a, a.signing_id == 'EQHXZ8M8AV:com.example.tool')", activation);
     if (!result.ok()) {
       XCTFail("Failed to evaluate: %s", result.status().message().data());
     } else {

--- a/Source/common/cel/Test.mm
+++ b/Source/common/cel/Test.mm
@@ -623,6 +623,104 @@
   }
 }
 
+- (void)testAncestors {
+  using ReturnValue = santa::cel::CELProtoTraits<true>::ReturnValue;
+  using ExecutableFileT = santa::cel::CELProtoTraits<true>::ExecutableFileT;
+  using AncestorT = santa::cel::CELProtoTraits<true>::AncestorT;
+  using FileDescriptorT = santa::cel::CELProtoTraits<true>::FileDescriptorT;
+  auto f = std::make_unique<ExecutableFileT>();
+  santa::cel::Activation<true> activation(
+      std::move(f),
+      ^std::vector<std::string>() {
+        return {};
+      },
+      ^std::map<std::string, std::string>() {
+        return {};
+      },
+      ^uid_t() {
+        return 0;
+      },
+      ^std::string() {
+        return "/";
+      },
+      ^std::string() {
+        return "/usr/bin/test";
+      },
+      ^std::vector<AncestorT>() {
+        AncestorT launchd;
+        launchd.set_path("/sbin/launchd");
+        launchd.add_args("/sbin/launchd");
+        launchd.set_signing_id("platform:com.apple.xpc.launchd");
+        AncestorT shell;
+        shell.set_path("/bin/zsh");
+        shell.add_args("-zsh");
+        shell.add_args("-il");
+        shell.set_signing_id("platform:com.apple.zsh");
+        shell.set_team_id("");
+        shell.set_cdhash("d5b04ff62b334f1dcb287d15d0bdc5b553840b30");
+        return {shell, launchd};
+      },
+      ^std::vector<FileDescriptorT>() {
+        return {};
+      });
+
+  auto sut = santa::cel::Evaluator<true>::Create();
+  XCTAssertTrue(sut.ok());
+
+  {
+    // Test ancestors size
+    auto result = sut.value()->CompileAndEvaluate("size(ancestors) == 2", activation);
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
+      XCTAssertEqual(result.value().cacheable, false);
+    }
+  }
+  {
+    // Test indexed field access
+    auto result = sut.value()->CompileAndEvaluate("ancestors[0].path == '/bin/zsh'", activation);
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
+      XCTAssertEqual(result.value().cacheable, false);
+    }
+  }
+  {
+    // Test repeated field access within an ancestor
+    auto result = sut.value()->CompileAndEvaluate("ancestors[0].args[1] == '-il'", activation);
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
+      XCTAssertEqual(result.value().cacheable, false);
+    }
+  }
+  {
+    // Test exists comprehension over ancestors
+    auto result = sut.value()->CompileAndEvaluate(
+        "ancestors.exists(a, a.signing_id == 'platform:com.apple.xpc.launchd')", activation);
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value().value, ReturnValue::ALLOWLIST);
+      XCTAssertEqual(result.value().cacheable, false);
+    }
+  }
+  {
+    // Test no match with exists
+    auto result = sut.value()->CompileAndEvaluate(
+        "ancestors.exists(a, a.signing_id == 'EQHXZ8M8AV:com.example.tool')", activation);
+    if (!result.ok()) {
+      XCTFail("Failed to evaluate: %s", result.status().message().data());
+    } else {
+      XCTAssertEqual(result.value().value, ReturnValue::BLOCKLIST);
+      XCTAssertEqual(result.value().cacheable, false);
+    }
+  }
+}
+
 - (void)testTouchIDCooldownFunctions {
   using ReturnValue = santa::cel::CELProtoTraits<true>::ReturnValue;
   using ExecutableFileT = santa::cel::CELProtoTraits<true>::ExecutableFileT;

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -974,6 +974,8 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 
               AncestorT curl;
               curl.set_path("/usr/bin/curl");
+              curl.add_args("curl");
+              curl.add_args("-fsSL");
               curl.set_signing_id("platform:com.apple.curl");
               curl.set_team_id("");
               curl.set_cdhash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
@@ -1099,6 +1101,19 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   {
     SNTRule* r = createCELRule(
         @"ancestors.exists(a, a.cdhash == 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')", true);
+    SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+    cd.sha256 = r.identifier;
+    [self.processor decision:cd
+                         forRule:r
+             withTransitiveRules:YES
+        andCELActivationCallback:activation];
+    XCTAssertEqual(cd.decision, SNTEventStateAllowBinary);
+    XCTAssertFalse(cd.cacheable);
+  }
+
+  // Test: Index into a repeated field nested within an ancestor (ancestors[0] is curl).
+  {
+    SNTRule* r = createCELRule(@"ancestors[0].args[1] == '-fsSL'", true);
     SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
     cd.sha256 = r.identifier;
     [self.processor decision:cd


### PR DESCRIPTION
Two changes that reduce per-evaluation copying in the CEL activation path. When a fallback rule's result is non-cacheable (expressions touching `args`, `ancestors`, etc.) this cost is paid on every exec, so it scales with system exec rate.

1. `Memoizer<T>::operator()` returns `const T&` instead of copying the cached value on every access. Copy/move members are deleted so references can't outlive their storage; contracts documented and tested.
2. `Activation::FindValue` wraps the memoized `ancestors`/`fds` protos in place instead of `CopyFrom`-ing each onto the eval arena — the same lifetime contract `target` already uses. Ancestor data now materializes once per evaluation instead of three times.

**Reviewer note:** commit 2 is only memory-safe on top of commit 1 (the old by-value return would leave the wrapped pointers dangling mid-evaluation) — don't cherry-pick it alone. `MemoizerTest` pins the contract; new populated-`ancestors` CELTest coverage gives the nightly ASan run visibility into this path (previously empty fixtures only).

Tested: `common`, `cel`, and `santad` suites pass; the unsafe combination was verified to crash `testAncestors` under `MallocScribble`.