### PR TITLE
gui: notify user when temporary admin session ends

### DIFF
--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "Sie sind bereits Administrator";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Wechsel zum Standardbenutzer";

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "you are already an administrator";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Switching to Standard User";

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "ya es administrador";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Cambiando a usuario estándar";

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -309,3 +309,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "vous êtes déjà administrateur";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Passage à l'utilisateur standard";

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "vous êtes déjà administrateur";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Passage à l'utilisateur standard";

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "すでに管理者です";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "標準ユーザーに切り替えます";

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "вы уже являетесь администратором";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Переключение на стандартного пользователя";

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -306,3 +306,6 @@
 
 /* Reason shown when a natural admin requests elevation */
 "you are already an administrator" = "ви вже є адміністратором";
+
+/* Notification shown when a temporary admin session ends and the user reverts to standard */
+"Switching to Standard User" = "Перехід до стандартного користувача";

--- a/Source/gui/SNTStatusItemManager.mm
+++ b/Source/gui/SNTStatusItemManager.mm
@@ -784,6 +784,11 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
 
 - (void)leaveAdminMode {
   [self leaveModeForState:self.tamState];
+  [self notificationWithIdentifier:@"tam_leave_notification"
+                           andBody:NSLocalizedString(
+                                       @"Switching to Standard User",
+                                       @"Notification shown when a temporary admin "
+                                       @"session ends and the user reverts to standard")];
 }
 
 - (void)setTemporaryAdminModeAvailable:(BOOL)available {


### PR DESCRIPTION
Fixes SNT-479 

Post a "Switching to Standard User" notification from leaveAdminMode
whenever a Temporary Admin Mode session ends and the user is reverted to
standard. Localized in all 8 languages.

<img width="364" height="79" alt="Screenshot 2026-07-15 at 3 01 31 AM" src="https://github.com/user-attachments/assets/782e2849-fda8-42ce-8429-028d03ec01f5" />
