### PR TITLE
Fix file writer buffer growth

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Writers/File.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.mm
@@ -15,6 +15,7 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/File.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "Source/common/BranchPrediction.h"
@@ -123,7 +124,7 @@ void File::Flush() {
 // IMPORTANT: Not thread safe.
 void File::EnsureCapacitySerialized(size_t additional_bytes) {
   if ((buffer_offset_ + additional_bytes) > buffer_.capacity()) {
-    buffer_.resize(buffer_.capacity() * 2);
+    buffer_.resize(std::max(buffer_.capacity() * 2, buffer_offset_ + additional_bytes));
   }
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Writers/FileTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FileTest.mm
@@ -231,6 +231,13 @@ bool WaitForBufferSize(std::shared_ptr<FilePeer> file, size_t expectedSize) {
   XCTAssertEqual(file->InternalBufferCapacity(), initialCapacity * 2);
 }
 
+- (void)testEnsureCapacityBeyondDoubleInitialSize {
+  const size_t initialCapacity = 300;
+  auto file = std::make_shared<FilePeer>(self.logPath, 100, 200, self.q, self.timer);
+  file->EnsureCapacitySerialized((initialCapacity * 2) + 1);
+  XCTAssertGreaterThan(file->InternalBufferCapacity(), initialCapacity * 2);
+}
+
 - (void)testCopyData {
   const size_t batchSize = 100;
   // Use a buffer to copy that's slightly larger than the batch size


### PR DESCRIPTION
`EnsureCapacitySerialized` doesn't necessarily grow the File's buffer to adequately fit `additional_bytes` if 2x the buffer is still below the capacity necessary to actually copy over. 