### PR TITLE
common: take SantaCache keys by const reference

### DIFF
--- a/Source/common/SantaCache.h
+++ b/Source/common/SantaCache.h
@@ -80,7 +80,7 @@ class SantaCache {
   /**
     Get an element from the cache. Returns zero_ if item doesn't exist.
   */
-  ValueT get(KeyT key) const {
+  ValueT get(const KeyT& key) const {
     struct bucket* bucket = &buckets_[hash(key)];
     lock(bucket);
     struct entry* entry = bucket->head;
@@ -506,7 +506,7 @@ class SantaCache {
   /**
     Hash a key to determine which bucket it belongs in.
   */
-  inline uint64_t hash(KeyT input) const {
+  inline uint64_t hash(const KeyT& input) const {
     return Hasher{}(input) % bucket_count_;
   }
 };


### PR DESCRIPTION
`SantaCache::get` and the private `hash` were the only two methods taking the key by value; every other method already takes `const KeyT&`. Passing keys by const reference avoids copying the key on every lookup — for `std::string` keys (the upload/store/signal backoff caches, the TouchID approval cache) that removes an allocation per `get`/`set`/`contains` once the key exceeds libc++'s SSO threshold. For the small trivially-copyable keys it's a no-op that inlines away entirely under `-c opt`. No behavior change; `SantaCacheTest` and a full santad build both pass.
