### PR TITLE
Fix uninitialized stat use in SNTFileInfo

### DIFF
--- a/Source/common/SNTFileInfo.mm
+++ b/Source/common/SNTFileInfo.mm
@@ -70,8 +70,11 @@
 
 - (instancetype)initWithResolvedPath:(NSString*)path error:(NSError**)error {
   struct stat fileStat;
-  if (path.length) {
-    lstat(path.UTF8String, &fileStat);
+  if (path.length && lstat(path.UTF8String, &fileStat) != 0) {
+    [SNTError populateError:error
+                   withCode:SNTErrorCodeFailedToOpen
+                     format:@"Unable to stat file: %s", strerror(errno)];
+    return nil;
   }
   return [self initWithResolvedPath:path stat:&fileStat error:error];
 }

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -45,6 +45,18 @@
   XCTAssertEqualObjects(sut.path, @"/usr/libexec/dspluginhelperd");
 }
 
+- (void)testResolvedPathStatFailure {
+  NSString* path = [NSTemporaryDirectory()
+      stringByAppendingPathComponent:[NSString stringWithFormat:@"SNTFileInfo-%@",
+                                                                NSUUID.UUID.UUIDString]];
+  NSError* error;
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithResolvedPath:path error:&error];
+
+  XCTAssertNil(sut);
+  XCTAssertNotNil(error);
+  XCTAssertTrue([error.localizedDescription containsString:@"Unable to stat file"]);
+}
+
 - (void)testSHA1 {
   NSString* path = [[NSBundle bundleForClass:[self class]] pathForResource:@"missing_pagezero"
                                                                     ofType:@""];


### PR DESCRIPTION
`- [SNTFileInfo initWithResolvedPath]` constructs a FileInfo even if `lstat` fails on the path (e.g. potential racyness with a file being deleted right before).

Relatively trivial / low impact.