### PR TITLE
Protect tamper-resistant paths from copyfile

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -122,6 +122,7 @@ void RemoveLegacyLaunchdPlists() {
 static NSString* TamperEventName(es_event_type_t type) {
   switch (type) {
     case ES_EVENT_TYPE_AUTH_CLONE: return @"clone";
+    case ES_EVENT_TYPE_AUTH_COPYFILE: return @"copyfile";
     case ES_EVENT_TYPE_AUTH_UNLINK: return @"unlink";
     case ES_EVENT_TYPE_AUTH_TRUNCATE: return @"truncate";
     case ES_EVENT_TYPE_AUTH_CREATE: return @"create";
@@ -261,6 +262,7 @@ TamperAuthResult ValidateLaunchctlExec(const Message& esMsg) {
 - (TamperAuthResult)processAuthMessage:(Message)esMsg {
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_AUTH_CLONE:
+    case ES_EVENT_TYPE_AUTH_COPYFILE:
     case ES_EVENT_TYPE_AUTH_UNLINK:
     case ES_EVENT_TYPE_AUTH_TRUNCATE:
     case ES_EVENT_TYPE_AUTH_CREATE:
@@ -285,16 +287,14 @@ TamperAuthResult ValidateLaunchctlExec(const Message& esMsg) {
                             (int)target.Path().size(), target.Path().data()]);
         }
       }
-      // CLONE events do not support caching. CREATE destinations may not exist yet, so caching an
-      // ALLOW by vnode has no effect.
-      // OPEN responses cannot currently convey a subset of allowed flags, so they can't be cached
-      // either without risking later opens of different flag combinations being incorrectly
-      // allowed.
-      return (esMsg->event_type == ES_EVENT_TYPE_AUTH_CLONE ||
-              esMsg->event_type == ES_EVENT_TYPE_AUTH_OPEN ||
-              esMsg->event_type == ES_EVENT_TYPE_AUTH_CREATE)
-                 ? TamperAuthResult::AllowNotCacheable()
-                 : TamperAuthResult::AllowCacheable();
+      // OPEN is the only event that must opt out of caching here: its response is delivered as a
+      // flags result (all-or-nothing 0xffffffff), so a cached ALLOW would incorrectly authorize
+      // later opens whose flags differ (e.g. a write open of a protected path following a read
+      // open). Every other event type's decision is a pure function of the target path(s), which
+      // is exactly what ES keys its cache on, so caching is safe. ES ignores the cache flag for
+      // event types that don't support caching, so there's no need to enumerate them.
+      return (esMsg->event_type == ES_EVENT_TYPE_AUTH_OPEN) ? TamperAuthResult::AllowNotCacheable()
+                                                            : TamperAuthResult::AllowCacheable();
     }
 
     case ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME: {
@@ -415,6 +415,7 @@ TamperAuthResult ValidateLaunchctlExec(const Message& esMsg) {
                                     ES_EVENT_TYPE_AUTH_SIGNAL,
                                     ES_EVENT_TYPE_AUTH_EXEC,
                                     ES_EVENT_TYPE_AUTH_CLONE,
+                                    ES_EVENT_TYPE_AUTH_COPYFILE,
                                     ES_EVENT_TYPE_AUTH_UNLINK,
                                     ES_EVENT_TYPE_AUTH_RENAME,
                                     ES_EVENT_TYPE_AUTH_OPEN,

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -63,11 +63,17 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 - (void)testEnable {
   // Ensure the client subscribes to expected event types
   std::set<es_event_type_t> expectedEventSubs{
-      ES_EVENT_TYPE_AUTH_SIGNAL, ES_EVENT_TYPE_AUTH_EXEC,
-      ES_EVENT_TYPE_AUTH_CLONE,  ES_EVENT_TYPE_AUTH_UNLINK,
-      ES_EVENT_TYPE_AUTH_RENAME, ES_EVENT_TYPE_AUTH_OPEN,
-      ES_EVENT_TYPE_AUTH_CREATE, ES_EVENT_TYPE_AUTH_TRUNCATE,
-      ES_EVENT_TYPE_AUTH_LINK,   ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
+      ES_EVENT_TYPE_AUTH_SIGNAL,
+      ES_EVENT_TYPE_AUTH_EXEC,
+      ES_EVENT_TYPE_AUTH_CLONE,
+      ES_EVENT_TYPE_AUTH_COPYFILE,
+      ES_EVENT_TYPE_AUTH_UNLINK,
+      ES_EVENT_TYPE_AUTH_RENAME,
+      ES_EVENT_TYPE_AUTH_OPEN,
+      ES_EVENT_TYPE_AUTH_CREATE,
+      ES_EVENT_TYPE_AUTH_TRUNCATE,
+      ES_EVENT_TYPE_AUTH_LINK,
+      ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
   };
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
@@ -109,11 +115,17 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 
 - (void)testEnableWithAntiSuspendSigningIDs {
   std::set<es_event_type_t> expectedEventSubs{
-      ES_EVENT_TYPE_AUTH_SIGNAL, ES_EVENT_TYPE_AUTH_EXEC,
-      ES_EVENT_TYPE_AUTH_CLONE,  ES_EVENT_TYPE_AUTH_UNLINK,
-      ES_EVENT_TYPE_AUTH_RENAME, ES_EVENT_TYPE_AUTH_OPEN,
-      ES_EVENT_TYPE_AUTH_CREATE, ES_EVENT_TYPE_AUTH_TRUNCATE,
-      ES_EVENT_TYPE_AUTH_LINK,   ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
+      ES_EVENT_TYPE_AUTH_SIGNAL,
+      ES_EVENT_TYPE_AUTH_EXEC,
+      ES_EVENT_TYPE_AUTH_CLONE,
+      ES_EVENT_TYPE_AUTH_COPYFILE,
+      ES_EVENT_TYPE_AUTH_UNLINK,
+      ES_EVENT_TYPE_AUTH_RENAME,
+      ES_EVENT_TYPE_AUTH_OPEN,
+      ES_EVENT_TYPE_AUTH_CREATE,
+      ES_EVENT_TYPE_AUTH_TRUNCATE,
+      ES_EVENT_TYPE_AUTH_LINK,
+      ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
   };
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
@@ -154,11 +166,17 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 
 - (void)testSetAntiSuspendSigningIDsAfterEnable {
   std::set<es_event_type_t> expectedEventSubs{
-      ES_EVENT_TYPE_AUTH_SIGNAL, ES_EVENT_TYPE_AUTH_EXEC,
-      ES_EVENT_TYPE_AUTH_CLONE,  ES_EVENT_TYPE_AUTH_UNLINK,
-      ES_EVENT_TYPE_AUTH_RENAME, ES_EVENT_TYPE_AUTH_OPEN,
-      ES_EVENT_TYPE_AUTH_CREATE, ES_EVENT_TYPE_AUTH_TRUNCATE,
-      ES_EVENT_TYPE_AUTH_LINK,   ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
+      ES_EVENT_TYPE_AUTH_SIGNAL,
+      ES_EVENT_TYPE_AUTH_EXEC,
+      ES_EVENT_TYPE_AUTH_CLONE,
+      ES_EVENT_TYPE_AUTH_COPYFILE,
+      ES_EVENT_TYPE_AUTH_UNLINK,
+      ES_EVENT_TYPE_AUTH_RENAME,
+      ES_EVENT_TYPE_AUTH_OPEN,
+      ES_EVENT_TYPE_AUTH_CREATE,
+      ES_EVENT_TYPE_AUTH_TRUNCATE,
+      ES_EVENT_TYPE_AUTH_LINK,
+      ES_EVENT_TYPE_AUTH_PROC_SUSPEND_RESUME,
   };
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
@@ -380,8 +398,7 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 
       XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
       XCTAssertEqual(gotAuthResult, kv.second);
-      // CLONE events do not support caching.
-      XCTAssertFalse(gotCachable);
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
     }
   }
 
@@ -414,7 +431,94 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 
       XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
       XCTAssertEqual(gotAuthResult, kv.second);
-      XCTAssertFalse(gotCachable);
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
+    }
+  }
+
+  // Check COPYFILE `source` tamper events. Copying a protected source to a benign destination must
+  // be denied to prevent protected data from being copied outside the protected path set.
+  {
+    esMsg.event_type = ES_EVENT_TYPE_AUTH_COPYFILE;
+    es_file_t copyfileBenignDir = MakeESFile("/tmp");
+    es_string_token_t copyfileBenignFilename = MakeESStringToken("benign");
+    for (const auto& kv : pathToResult) {
+      Message msg(mockESApi, &esMsg);
+      esMsg.event.copyfile.source = kv.first;
+      esMsg.event.copyfile.target_file = NULL;
+      esMsg.event.copyfile.target_dir = &copyfileBenignDir;
+      esMsg.event.copyfile.target_name = copyfileBenignFilename;
+
+      [mockTamperClient
+               handleMessage:std::move(msg)
+          recordEventMetrics:^(EventDisposition d) {
+            XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                               : EventDisposition::kDropped);
+            dispatch_semaphore_signal(semaMetrics);
+          }];
+
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
+      XCTAssertEqual(gotAuthResult, kv.second);
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
+    }
+  }
+
+  // Check COPYFILE `dest` tamper events targeting a new path (target_dir + target_name).
+  {
+    esMsg.event_type = ES_EVENT_TYPE_AUTH_COPYFILE;
+    esMsg.event.copyfile.source = &fileBenign;
+    esMsg.event.copyfile.target_file = NULL;
+
+    es_file_t copyfileDestDirProtected = MakeESFile("/Applications/Santa.app/Contents");
+    es_file_t copyfileDestDirBenign = MakeESFile("/some/other");
+    es_string_token_t copyfileDestFilename = MakeESStringToken("test");
+
+    std::map<es_file_t*, es_auth_result_t> copyfileDestToResult{
+        {&copyfileDestDirProtected, ES_AUTH_RESULT_DENY},
+        {&copyfileDestDirBenign, ES_AUTH_RESULT_ALLOW},
+    };
+
+    for (const auto& kv : copyfileDestToResult) {
+      Message msg(mockESApi, &esMsg);
+      esMsg.event.copyfile.target_dir = kv.first;
+      esMsg.event.copyfile.target_name = copyfileDestFilename;
+
+      [mockTamperClient
+               handleMessage:std::move(msg)
+          recordEventMetrics:^(EventDisposition d) {
+            XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                               : EventDisposition::kDropped);
+            dispatch_semaphore_signal(semaMetrics);
+          }];
+
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
+      XCTAssertEqual(gotAuthResult, kv.second);
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
+    }
+  }
+
+  // Check COPYFILE `dest` tamper events overwriting an existing file (target_file). Unlike
+  // clonefile, copyfile can overwrite an existing destination, so copying a benign source over a
+  // protected file must be denied.
+  {
+    esMsg.event_type = ES_EVENT_TYPE_AUTH_COPYFILE;
+    esMsg.event.copyfile.source = &fileBenign;
+    esMsg.event.copyfile.target_dir = NULL;
+    esMsg.event.copyfile.target_name = MakeESStringToken("");
+    for (const auto& kv : pathToResult) {
+      Message msg(mockESApi, &esMsg);
+      esMsg.event.copyfile.target_file = kv.first;
+
+      [mockTamperClient
+               handleMessage:std::move(msg)
+          recordEventMetrics:^(EventDisposition d) {
+            XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                               : EventDisposition::kDropped);
+            dispatch_semaphore_signal(semaMetrics);
+          }];
+
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
+      XCTAssertEqual(gotAuthResult, kv.second);
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
     }
   }
 
@@ -470,8 +574,7 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
       XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
 
       XCTAssertEqual(gotAuthResult, kv.second);
-      // CREATE events are never cached
-      XCTAssertFalse(gotCachable);
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
     }
   }
 
@@ -492,7 +595,8 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
 
     XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
     XCTAssertEqual(gotAuthResult, ES_AUTH_RESULT_ALLOW);
-    XCTAssertFalse(gotCachable);
+    // CREATE with an unexpected EXISTING_FILE destination falls through to a cacheable ALLOW.
+    XCTAssertTrue(gotCachable);
   }
 
   // Check RENAME `source` tamper events
@@ -933,6 +1037,37 @@ static constexpr std::string_view kBenignPath = "/some/other/path";
     esMsg.event.clone.source = cloneCase.source;
     esMsg.event.clone.target_dir = cloneCase.targetDir;
     esMsg.event.clone.target_name = cloneFilename;
+
+    [mockTamperClient handleMessage:std::move(msg)
+                 recordEventMetrics:^(EventDisposition d) {
+                   XCTAssertEqual(d, EventDisposition::kProcessed);
+                   dispatch_semaphore_signal(semaMetrics);
+                 }];
+
+    XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
+    XCTAssertEqual(gotAuthResult, ES_AUTH_RESULT_DENY);
+    XCTAssertFalse(gotCachable);
+  }
+
+  // A truncated path on any COPYFILE target (source, new-path dest, or existing-file dest) is
+  // unreliable and must be denied.
+  struct CopyfileCase {
+    es_file_t* source;
+    es_file_t* targetFile;
+    es_file_t* targetDir;
+  } copyfileCases[] = {
+      {&fileBenignTruncated, NULL, &dirBenign},
+      {&fileBenign, NULL, &dirBenignTruncated},
+      {&fileBenign, &fileBenignTruncated, NULL},
+  };
+
+  esMsg.event_type = ES_EVENT_TYPE_AUTH_COPYFILE;
+  for (const auto& copyfileCase : copyfileCases) {
+    Message msg(mockESApi, &esMsg);
+    esMsg.event.copyfile.source = copyfileCase.source;
+    esMsg.event.copyfile.target_file = copyfileCase.targetFile;
+    esMsg.event.copyfile.target_dir = copyfileCase.targetDir;
+    esMsg.event.copyfile.target_name = cloneFilename;
 
     [mockTamperClient handleMessage:std::move(msg)
                  recordEventMetrics:^(EventDisposition d) {


### PR DESCRIPTION
Tamper resistance doesn't cover `copyfile`, which can both copy protected data out and copy over/into protected paths.

**Fix:** Subscribe to `AUTH_COPYFILE` and pass it through the existing path-target validation. `Message::PathTargets` already extracts the source and destination (either the new path or the existing file to overwrite), so both directions are covered. Under inverted target-path muting ES delivers the event if any target path is protected.

Also simplifies the caching logic: rather than enumerating which events "don't support caching", only `OPEN` opts out (its all-or-nothing flags response can't be safely cached). Every other event's decision is a pure function of the target path(s) — which is what ES keys its cache on — and ES ignores the cache flag for events it can't cache. This flips the pre-existing CLONE/CREATE cases to cacheable; tests updated to match.
