### PR TITLE
cel: cache compiled DB CEL plans instead of recompiling per exec

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1360,6 +1360,7 @@ test_suite(
         ":ScopedMachPortTest",
         ":TelemetryEventMapTest",
         "//Source/common/cel:ArenaGrowthTest",
+        "//Source/common/cel:CELPlanCacheTest",
         "//Source/common/cel:CELTest",
         "//Source/common/faa:unit_tests",
         "//Source/common/ne:unit_tests",

--- a/Source/common/cel/BUILD
+++ b/Source/common/cel/BUILD
@@ -32,6 +32,7 @@ objc_library(
     ],
     hdrs = [
         "Activation.h",
+        "CELPlanCache.h",
         "CELProtoTraits.h",
         "Evaluator.h",
         "RelativeTimeFunction.h",
@@ -40,6 +41,7 @@ objc_library(
     deps = [
         ":result_cc_proto",
         "//Source/common:Memoizer",
+        "//Source/common:SantaCache",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
@@ -97,6 +99,19 @@ santa_unit_test(
     deps = [
         ":CEL",
         "@abseil-cpp//absl/status:statusor",
+        "@northpolesec_protos//celv2:v2_cc_proto",
+    ],
+)
+
+santa_unit_test(
+    name = "CELPlanCacheTest",
+    srcs = ["CELPlanCacheTest.mm"],
+    deps = [
+        ":CEL",
+        ":result_cc_proto",
+        "//Source/common:SantaCache",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
         "@northpolesec_protos//celv2:v2_cc_proto",
     ],
 )

--- a/Source/common/cel/CELPlanCache.h
+++ b/Source/common/cel/CELPlanCache.h
@@ -1,0 +1,105 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_COMMON_CEL_CELPLANCACHE_H
+#define SANTA_COMMON_CEL_CELPLANCACHE_H
+
+#include <memory>
+#include <string>
+
+#include "Source/common/SantaCache.h"
+#include "Source/common/cel/Evaluator.h"
+#include "absl/status/statusor.h"
+#include "google/protobuf/arena.h"
+
+// Evaluator.h already wraps the cel-cpp includes (which warn-as-error) in the
+// needed pragma push/pop and exposes CelExpression.
+
+namespace santa {
+namespace cel {
+
+// A compiled CEL plan bundled with the arena it references. The arena holds
+// constant-folding data the CelExpression points into, so it MUST outlive the
+// expression: arena is declared FIRST so it is destroyed LAST (members destruct
+// in reverse declaration order). Mirrors celFallbackArena_/celFallbackRules_ in
+// SNTPolicyProcessor.
+struct CompiledCELPlan {
+  std::unique_ptr<google::protobuf::Arena> arena;
+  std::unique_ptr<::google::api::expr::runtime::CelExpression> expression;
+
+  CompiledCELPlan(
+      std::unique_ptr<google::protobuf::Arena> a,
+      std::unique_ptr<::google::api::expr::runtime::CelExpression> e)
+      : arena(std::move(a)), expression(std::move(e)) {}
+};
+
+// The cache value type is the WHOLE bundle, never a bare
+// shared_ptr<CelExpression> (that would let eviction free the arena under a
+// live plan). get() copies this shared_ptr out under SantaCache's bucket lock,
+// so a caller holding it keeps arena+expression alive across a concurrent
+// eviction. const: the plan is immutable after compilation.
+using PlanPtr = std::shared_ptr<const CompiledCELPlan>;
+
+// Caches compiled CEL plans for ONE evaluator, keyed by expression text.
+// Lazy: compiles on first miss, reuses thereafter. Bounded: SantaCache drains
+// all entries when full (LRU is planned separately). No invalidation is needed
+// or wired — a plan is a pure function of (text, evaluator) and the evaluator
+// is fixed for the process lifetime, so a cached plan is never stale.
+template <bool IsV2>
+class CELPlanCache {
+ public:
+  // evaluator must outlive this cache (owned by the caller, e.g.
+  // SNTPolicyProcessor). maxSize is the entry cap (see kCELPlanCacheMaxSize).
+  CELPlanCache(Evaluator<IsV2>* evaluator, uint64_t maxSize)
+      : evaluator_(evaluator), cache_(maxSize) {}
+
+  CELPlanCache(const CELPlanCache&) = delete;
+  CELPlanCache& operator=(const CELPlanCache&) = delete;
+
+  // Returns the cached plan for expr, compiling and caching it on a miss.
+  // Returns an error status only when compilation fails (never a null PlanPtr
+  // on an ok() result). The benign compile-on-miss race (two threads compiling
+  // the same text) is fine: last writer wins, both hold a valid plan. The
+  // guarantee rests on returning the freshly-compiled local `plan` rather than
+  // re-getting from the cache after set(): a racing thread whose entry was
+  // overwritten still returns its own plan (kept alive by that shared_ptr, not
+  // the cache's reference), so every caller gets a valid, non-null PlanPtr.
+  absl::StatusOr<PlanPtr> GetOrCompile(const std::string& expr) {
+    if (PlanPtr hit = cache_.get(expr)) {
+      return hit;
+    }
+    auto arena = std::make_unique<google::protobuf::Arena>();
+    absl::StatusOr<std::unique_ptr<::google::api::expr::runtime::CelExpression>>
+        compiled = evaluator_->Compile(expr, arena.get());
+    if (!compiled.ok()) {
+      return compiled.status();
+    }
+    PlanPtr plan = std::make_shared<const CompiledCELPlan>(
+        std::move(arena), std::move(compiled).value());
+    cache_.set(expr, plan);
+    return plan;
+  }
+
+  void Clear() { cache_.clear(); }
+  uint64_t Size() const { return cache_.count(); }
+
+ private:
+  Evaluator<IsV2>* evaluator_;  // non-owning; must outlive this cache
+  SantaCache<std::string, PlanPtr> cache_;
+};
+
+}  // namespace cel
+}  // namespace santa
+
+#endif  // SANTA_COMMON_CEL_CELPLANCACHE_H

--- a/Source/common/cel/CELPlanCacheTest.mm
+++ b/Source/common/cel/CELPlanCacheTest.mm
@@ -1,0 +1,175 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "Source/common/cel/Activation.h"
+#include "Source/common/cel/CELPlanCache.h"
+#include "Source/common/cel/CELProtoTraits.h"
+#include "Source/common/cel/Evaluator.h"
+#include "absl/status/statusor.h"
+#include "google/protobuf/arena.h"
+
+using santa::cel::CELPlanCache;
+using santa::cel::Evaluator;
+using santa::cel::PlanPtr;
+
+namespace {
+std::unique_ptr<santa::cel::Activation<true>> MakeActivationWithTeamID(const std::string& teamID) {
+  using ExecutableFileT = santa::cel::CELProtoTraits<true>::ExecutableFileT;
+  using AncestorT = santa::cel::CELProtoTraits<true>::AncestorT;
+  using FileDescriptorT = santa::cel::CELProtoTraits<true>::FileDescriptorT;
+  auto f = std::make_unique<ExecutableFileT>();
+  f->set_team_id(teamID);
+  return std::make_unique<santa::cel::Activation<true>>(
+      std::move(f),
+      ^std::vector<std::string>() {
+        return {};
+      },
+      ^std::map<std::string, std::string>() {
+        return {};
+      },
+      ^uid_t() {
+        return 0;
+      },
+      ^std::string() {
+        return "";
+      },
+      ^std::string() {
+        return "";
+      },
+      ^std::vector<AncestorT>() {
+        return {};
+      },
+      ^std::vector<FileDescriptorT>() {
+        return {};
+      });
+}
+}  // namespace
+
+@interface CELPlanCacheTest : XCTestCase
+@end
+
+@implementation CELPlanCacheTest {
+  std::unique_ptr<Evaluator<true>> _ev;
+}
+
+- (void)setUp {
+  auto ev = Evaluator<true>::Create();
+  XCTAssertTrue(ev.ok());
+  _ev = std::move(*ev);
+}
+
+// Second GetOrCompile of the same text returns the SAME CompiledCELPlan
+// (pointer identity) — i.e. a cache hit, no recompile.
+- (void)testHitReturnsSamePlan {
+  CELPlanCache<true> cache(_ev.get(), 128);
+  const std::string expr = "target.team_id == 'EQHXZ8M8AV'";
+
+  absl::StatusOr<PlanPtr> a = cache.GetOrCompile(expr);
+  absl::StatusOr<PlanPtr> b = cache.GetOrCompile(expr);
+
+  XCTAssertTrue(a.ok());
+  XCTAssertTrue(b.ok());
+  XCTAssertTrue(a->get() != nullptr);
+  XCTAssertEqual(a->get(), b->get());  // same CompiledCELPlan instance
+  XCTAssertEqual(cache.Size(), (uint64_t)1);
+}
+
+// Distinct texts produce distinct plans.
+- (void)testDistinctExprsDistinctPlans {
+  CELPlanCache<true> cache(_ev.get(), 128);
+  auto a = cache.GetOrCompile("target.team_id == 'AAAAAAAAAA'");
+  auto b = cache.GetOrCompile("target.team_id == 'BBBBBBBBBB'");
+  XCTAssertTrue(a.ok());
+  XCTAssertTrue(b.ok());
+  XCTAssertNotEqual(a->get(), b->get());
+  XCTAssertEqual(cache.Size(), (uint64_t)2);
+}
+
+// A syntactically invalid expression returns an error status, not a crash.
+- (void)testInvalidExprReturnsError {
+  CELPlanCache<true> cache(_ev.get(), 128);
+  auto r = cache.GetOrCompile("this is not (valid CEL");
+  XCTAssertFalse(r.ok());
+  XCTAssertEqual(cache.Size(), (uint64_t)0);  // nothing cached on failure
+}
+
+// A PlanPtr held by a caller stays fully usable (arena + expression alive)
+// after the cache is cleared mid-flight. Proves the bundle refcount, not the
+// cache, governs lifetime — no use-after-free.
+- (void)testPlanUsableAfterClear {
+  CELPlanCache<true> cache(_ev.get(), 128);
+  auto r = cache.GetOrCompile("target.team_id == 'TESTTEAMID'");
+  XCTAssertTrue(r.ok());
+  PlanPtr held = *r;
+
+  cache.Clear();
+  XCTAssertEqual(cache.Size(), (uint64_t)0);
+
+  // Evaluate through the held plan AFTER the cache dropped its reference.
+  auto act = MakeActivationWithTeamID("TESTTEAMID");
+  google::protobuf::Arena evalArena;
+  auto result = _ev->Evaluate(held->expression.get(), *act, &evalArena);
+  XCTAssertTrue(result.ok());
+}
+
+// Exceeding the cap drains the cache (SantaCache drains all on overflow), so
+// Size never exceeds the cap.
+- (void)testDrainWhenFull {
+  CELPlanCache<true> cache(_ev.get(), /*maxSize=*/4);
+  for (int i = 0; i < 20; i++) {
+    std::string expr = "target.team_id == 'ID" + std::to_string(i) + "'";
+    auto r = cache.GetOrCompile(expr);
+    XCTAssertTrue(r.ok());
+    XCTAssertLessThanOrEqual(cache.Size(), (uint64_t)4);
+  }
+}
+
+// Concurrent GetOrCompile over a small shared set of expressions from many
+// threads: exercises concurrent reads, the benign compile-on-miss race, and
+// concurrent eviction. The cap (8) is kept below the 10-distinct-key working
+// set so the drain path genuinely fires under contention. Passes if there is
+// no crash/UAF and every returned plan is valid. Models the ES-worker-thread
+// concurrency the cache runs under.
+- (void)testConcurrentGetOrCompile {
+  CELPlanCache<true> cache(_ev.get(), /*maxSize=*/8);
+  constexpr int kThreads = 8;
+  constexpr int kItersPerThread = 2000;
+  std::atomic<int> failures{0};
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; t++) {
+    threads.emplace_back([&cache, &failures]() {
+      for (int i = 0; i < kItersPerThread; i++) {
+        // 10 distinct expressions shared across all threads → contended keys.
+        std::string expr = "target.team_id == 'ID" + std::to_string(i % 10) + "'";
+        auto r = cache.GetOrCompile(expr);
+        if (!r.ok() || r->get() == nullptr) failures.fetch_add(1);
+      }
+    });
+  }
+  for (auto& th : threads)
+    th.join();
+
+  XCTAssertEqual(failures.load(), 0);
+}
+
+@end

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -34,11 +34,14 @@
 #import "Source/common/SNTRule.h"
 #import "Source/common/SigningIDHelpers.h"
 #include "Source/common/String.h"
+#include "Source/common/cel/CELPlanCache.h"
 #include "Source/common/cel/Evaluator.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
 #include "cel/v1.pb.h"
+
+static constexpr uint64_t kCELPlanCacheMaxSize = 128;
 
 enum class PlatformBinaryState {
   kRuntimeTrue = 0,
@@ -82,6 +85,8 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     NSString* customURL;
   };
   std::vector<CompiledFallbackRule> celFallbackRules_;
+  std::unique_ptr<santa::cel::CELPlanCache<false>> celPlanCacheV1_;
+  std::unique_ptr<santa::cel::CELPlanCache<true>> celPlanCacheV2_;
 }
 @property SNTRuleTable* ruleTable;
 @property SNTConfigurator* configurator;
@@ -99,6 +104,8 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     auto evaluatorV1 = santa::cel::Evaluator<false>::Create();
     if (evaluatorV1.ok()) {
       celEvaluatorV1_ = std::move(*evaluatorV1);
+      celPlanCacheV1_ = std::make_unique<santa::cel::CELPlanCache<false>>(celEvaluatorV1_.get(),
+                                                                          kCELPlanCacheMaxSize);
     } else {
       LOGW(@"Failed to create CEL v1 evaluator: %s",
            std::string(evaluatorV1.status().message()).c_str());
@@ -109,6 +116,8 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     auto evaluatorV2 = santa::cel::Evaluator<true>::Create(/*allowUnspecified=*/true);
     if (evaluatorV2.ok()) {
       celEvaluatorV2_ = std::move(*evaluatorV2);
+      celPlanCacheV2_ = std::make_unique<santa::cel::CELPlanCache<true>>(celEvaluatorV2_.get(),
+                                                                         kCELPlanCacheMaxSize);
     } else {
       LOGW(@"Failed to create CEL v2 evaluator: %s",
            std::string(evaluatorV2.status().message()).c_str());
@@ -373,9 +382,7 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
   bool useV2 = (rule.state == SNTRuleStateCELv2);
   auto activation = activationCallback(useV2);
 
-  google::protobuf::Arena arena;
-
-  if ((useV2 && !celEvaluatorV2_) || (!useV2 && !celEvaluatorV1_)) {
+  if ((useV2 && !celPlanCacheV2_) || (!useV2 && !celPlanCacheV1_)) {
     LOGE(@"CEL v%d evaluator unavailable", useV2 ? 2 : 1);
     if ([SNTConfigurator configurator].failClosed) {
       cd.decision = SNTEventStateBlockUnknown;
@@ -384,18 +391,13 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     return {.succeeded = false, .decisionMade = false, .resultState = {}};
   }
 
-  absl::StatusOr<std::unique_ptr<::google::api::expr::runtime::CelExpression>> compileResult;
-  if (useV2) {
-    assert(dynamic_cast<santa::cel::Activation<true>*>(activation.get()) != nullptr);
-    compileResult = celEvaluatorV2_->Compile(santa::NSStringToUTF8StringView(rule.celExpr), &arena);
-  } else {
-    assert(dynamic_cast<santa::cel::Activation<false>*>(activation.get()) != nullptr);
-    compileResult = celEvaluatorV1_->Compile(santa::NSStringToUTF8StringView(rule.celExpr), &arena);
-  }
+  std::string expr = santa::NSStringToUTF8String(rule.celExpr);
+  absl::StatusOr<santa::cel::PlanPtr> planResult =
+      useV2 ? celPlanCacheV2_->GetOrCompile(expr) : celPlanCacheV1_->GetOrCompile(expr);
 
-  if (!compileResult.ok()) {
+  if (!planResult.ok()) {
     LOGE(@"Failed to compile CEL rule (%@): %s", rule.celExpr,
-         std::string(compileResult.status().message()).c_str());
+         std::string(planResult.status().message()).c_str());
     if ([SNTConfigurator configurator].failClosed) {
       cd.decision = SNTEventStateBlockUnknown;
       return {.succeeded = false, .decisionMade = true, .resultState = {}};
@@ -403,11 +405,14 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     return {.succeeded = false, .decisionMade = false, .resultState = {}};
   }
 
-  return [self evaluateCompiledCELExpression:compileResult->get()
+  // Per-exec evaluation temporaries live on a stack arena; the plan's own
+  // (cached) constant arena is long-lived and read-only here.
+  google::protobuf::Arena evalArena;
+  return [self evaluateCompiledCELExpression:(*planResult)->expression.get()
                                        useV2:useV2
                               cachedDecision:cd
                                   activation:*activation
-                                   evalArena:&arena
+                                   evalArena:&evalArena
                            inFallbackContext:NO];
 }
 

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -923,6 +923,92 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   }
 }
 
+// A DB CEL rule (state CELv2) allows a matching binary, and repeated
+// evaluation of the same identity yields the same decision (exercises the
+// compiled-plan cache reuse path introduced in SNTPolicyProcessor).
+- (void)testDBCELRuleCachedAcrossEvaluations {
+  ActivationCallbackBlock activation =
+      ^std::unique_ptr<::google::api::expr::runtime::BaseActivation>(bool useV2) {
+    auto makeActivation =
+        [&]<bool IsV2>() -> std::unique_ptr<::google::api::expr::runtime::BaseActivation> {
+      using ExecutableFileT = typename santa::cel::CELProtoTraits<IsV2>::ExecutableFileT;
+      using AncestorT = typename santa::cel::CELProtoTraits<IsV2>::AncestorT;
+      using FileDescriptorT = typename santa::cel::CELProtoTraits<IsV2>::FileDescriptorT;
+      auto ef = std::make_unique<ExecutableFileT>();
+      ef->mutable_signing_time()->set_seconds(1717987200);
+      ef->mutable_secure_signing_time()->set_seconds(1717987200);
+
+      return std::make_unique<santa::cel::Activation<IsV2>>(
+          std::move(ef),
+          ^std::vector<std::string>() {
+            return std::vector<std::string>{"arg1", "arg2"};
+          },
+          ^std::map<std::string, std::string>() {
+            return std::map<std::string, std::string>{{"ENV_VARIABLE1", "value1"},
+                                                      {"OTHER_ENV_VAR", "value2"}};
+          },
+          ^uid_t() {
+            return 0;
+          },
+          ^std::string() {
+            return "/";
+          },
+          ^std::string() {
+            return "/usr/bin/test";
+          },
+          ^std::vector<AncestorT>() {
+            return {};
+          },
+          ^std::vector<FileDescriptorT>() {
+            return {};
+          });
+    };
+
+    if (useV2) {
+      return makeActivation.operator()<true>();
+    } else {
+      return makeActivation.operator()<false>();
+    }
+  };
+
+  SNTRule* (^createCELRule)(NSString*, BOOL) = ^SNTRule*(NSString* celExpr, BOOL v2) {
+    return [[SNTRule alloc]
+        initWithIdentifier:@"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                     state:v2 ? SNTRuleStateCELv2 : SNTRuleStateCEL
+                      type:SNTRuleTypeBinary
+                 customMsg:nil
+                 customURL:nil
+                 timestamp:0
+                   comment:nil
+                   celExpr:celExpr
+            seatbeltPolicy:nil
+                    ruleId:0
+                     error:NULL];
+  };
+
+  SNTRule* r = createCELRule(@"target.signing_time > timestamp(1717987100)", true);
+
+  // First evaluation: compile-on-miss populates the plan cache.
+  SNTCachedDecision* cd1 = [[SNTCachedDecision alloc] init];
+  cd1.sha256 = r.identifier;
+  [self.processor decision:cd1
+                       forRule:r
+           withTransitiveRules:YES
+      andCELActivationCallback:activation];
+  XCTAssertEqual(cd1.decision, SNTEventStateAllowBinary);
+
+  // Second evaluation of the same rule/identity: cache hit path.
+  SNTCachedDecision* cd2 = [[SNTCachedDecision alloc] init];
+  cd2.sha256 = r.identifier;
+  [self.processor decision:cd2
+                       forRule:r
+           withTransitiveRules:YES
+      andCELActivationCallback:activation];
+  XCTAssertEqual(cd2.decision, SNTEventStateAllowBinary);
+
+  XCTAssertEqual(cd1.decision, cd2.decision);
+}
+
 - (void)testCELAncestors {
   using AncestorT = santa::cel::CELProtoTraits<true>::AncestorT;
 


### PR DESCRIPTION
DB CEL rules (states CEL/CELv2) recompiled their expression on every exec, and compilation is ~98% of per-exec CEL cost. This adds `CELPlanCache` — a bounded, per-CEL-version cache keyed on expression text — so a rule's plan is compiled once and reused, a large speedup on hot CEL-policied binaries. Fallback rules are unaffected (already precompiled at load).

The compiled plan and the protobuf arena its constant-folding data references are bundled in one refcounted `CompiledCELPlan`, so a plan held by an evaluating thread stays valid across a concurrent eviction; evaluation runs on a separate per-exec stack arena, keeping the cached arena read-only. There is no invalidation: a plan is a pure function of (text, evaluator) and the evaluators are fixed for the process lifetime, so a cached plan is never stale — the bounded `SantaCache` eviction (cap 128) is the whole strategy.

Covered by `CELPlanCache` unit tests (hit reuse, lifetime-across-eviction, drain, concurrency stress) plus an `SNTPolicyProcessor` integration test; the full santad suite and the daemon build pass.
