### PR TITLE
santad: hold CEL fallback rules in an atomically-swapped batch

### DIFF
--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -71,26 +71,65 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
   return [ri toStruct];
 }
 
+namespace {
+
+// A compiled CEL fallback rule: the plan plus the customMsg/URL to report when
+// it matches.
+struct CompiledFallbackRule {
+  // unique_ptr: the batch is the sole owner (the vector is never copied, only
+  // the batch pointer is shared). Removes N control blocks.
+  std::unique_ptr<::google::api::expr::runtime::CelExpression> expression;
+  NSString* customMsg;
+  NSString* customURL;
+};
+
+// Immutable once published. arena declared FIRST -> destroyed LAST, because the
+// compiled plans point into its constant-folding data (same rule as
+// CompiledCELPlan and the old celFallbackArena_-before-celFallbackRules_ order).
+struct FallbackBatch {
+  std::unique_ptr<google::protobuf::Arena> arena;
+  std::vector<CompiledFallbackRule> rules;
+
+  FallbackBatch(std::unique_ptr<google::protobuf::Arena> a, std::vector<CompiledFallbackRule> r)
+      : arena(std::move(a)), rules(std::move(r)) {}
+
+  // Compiles each rule's expression with `evaluator` into a fresh shared arena
+  // and returns an immutable batch. Returns nullptr if any expression fails to
+  // compile (logging which); the caller then keeps its currently-published batch.
+  static std::shared_ptr<const FallbackBatch> Create(santa::cel::Evaluator<true>* evaluator,
+                                                     NSArray<SNTCELFallbackRule*>* rules) {
+    auto arena = std::make_unique<google::protobuf::Arena>();
+    std::vector<CompiledFallbackRule> compiled;
+    compiled.reserve(rules.count);
+    for (SNTCELFallbackRule* rule in rules) {
+      auto result = evaluator->Compile(santa::NSStringToUTF8StringView(rule.celExpr), arena.get());
+      if (!result.ok()) {
+        LOGE(@"Failed to compile CEL fallback expression '%@': %s", rule.celExpr,
+             std::string(result.status().message()).c_str());
+        return nullptr;
+      }
+      compiled.push_back({std::move(*result), rule.customMsg, rule.customURL});
+    }
+    return std::make_shared<FallbackBatch>(std::move(arena), std::move(compiled));
+  }
+};
+
+}  // namespace
+
 @interface SNTPolicyProcessor () {
   std::unique_ptr<santa::cel::Evaluator<false>> celEvaluatorV1_;
   std::unique_ptr<santa::cel::Evaluator<true>> celEvaluatorV2_;
   std::shared_ptr<santa::EntitlementsFilter> entitlementsFilter_;
-  // Arena used for constant folding during compilation of fallback rules.
-  // Declared before celFallbackRules_ so that C++ reverse destruction
-  // order destroys rules first, then the arena they reference.
-  std::shared_ptr<google::protobuf::Arena> celFallbackArena_;
-  struct CompiledFallbackRule {
-    std::shared_ptr<::google::api::expr::runtime::CelExpression> expression;
-    NSString* customMsg;
-    NSString* customURL;
-  };
-  std::vector<CompiledFallbackRule> celFallbackRules_;
+  // Immutable, atomically-swapped batch of compiled fallback rules
+  // (CompiledFallbackRule / FallbackBatch are defined in the anonymous namespace
+  // above). Accessed ONLY via the std::atomic_*_explicit shared_ptr free
+  // functions (see compileFallbackRules: / evaluateCELFallbackExpressions:).
+  std::shared_ptr<const FallbackBatch> celFallbackBatch_;
   std::unique_ptr<santa::cel::CELPlanCache<false>> celPlanCacheV1_;
   std::unique_ptr<santa::cel::CELPlanCache<true>> celPlanCacheV2_;
 }
 @property SNTRuleTable* ruleTable;
 @property SNTConfigurator* configurator;
-@property dispatch_queue_t celFallbackQueue;
 @property SNTKVOManager* celFallbackRulesObserver;
 @end
 
@@ -122,9 +161,6 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
       LOGW(@"Failed to create CEL v2 evaluator: %s",
            std::string(evaluatorV2.status().message()).c_str());
     }
-
-    _celFallbackQueue =
-        dispatch_queue_create("com.northpolesec.santa.cel_fallback", DISPATCH_QUEUE_SERIAL);
 
     // Pre-compile any existing fallback rules
     [self compileFallbackRules:_configurator.celFallbackRules];
@@ -165,35 +201,15 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     return;
   }
 
-  // Create a fresh arena for this batch of compiled rules.
-  // The arena must outlive the compiled plans since constant folding stores
-  // data on it.
-  __block auto arena = std::make_shared<google::protobuf::Arena>();
-  __block std::vector<CompiledFallbackRule> compiled;
-  compiled.reserve(rules.count);
-  bool compileFailed = false;
-  for (SNTCELFallbackRule* rule in rules) {
-    auto result =
-        celEvaluatorV2_->Compile(santa::NSStringToUTF8StringView(rule.celExpr), arena.get());
-    if (result.ok()) {
-      compiled.push_back({std::move(*result), rule.customMsg, rule.customURL});
-    } else {
-      LOGE(@"Failed to compile CEL fallback expression '%@': %s", rule.celExpr,
-           std::string(result.status().message()).c_str());
-      compileFailed = true;
-      break;
-    }
+  std::shared_ptr<const FallbackBatch> batch = FallbackBatch::Create(celEvaluatorV2_.get(), rules);
+  if (!batch) {
+    return;  // compile failure already logged; keep the currently-published batch
   }
 
-  if (compileFailed) {
-    return;
-  }
-
-  dispatch_sync(self.celFallbackQueue, ^{
-    // Release old rules before the old arena (order matters).
-    celFallbackRules_ = std::move(compiled);
-    celFallbackArena_ = std::move(arena);
-  });
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  std::atomic_store_explicit(&celFallbackBatch_, std::move(batch), std::memory_order_release);
+#pragma clang diagnostic pop
 }
 
 - (BOOL)evaluateCELFallbackExpressions:(SNTCachedDecision*)cd
@@ -202,17 +218,17 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
     return NO;
   }
 
-  // Snapshot the compiled rules and arena under the lock so their
-  // lifetimes extend through evaluation even if compileFallbackRules
-  // swaps them concurrently.
-  __block std::vector<CompiledFallbackRule> rules;
-  __block std::shared_ptr<google::protobuf::Arena> arenaRef;
-  dispatch_sync(self.celFallbackQueue, ^{
-    rules = celFallbackRules_;
-    arenaRef = celFallbackArena_;
-  });
+  // Snapshot the published batch with a single atomic load + refcount bump
+  // (O(1) regardless of rule count). The snapshot co-owns the arena and all
+  // compiled plans, so this stays valid even if compileFallbackRules: swaps
+  // in a new batch concurrently.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  std::shared_ptr<const FallbackBatch> batch =
+      std::atomic_load_explicit(&celFallbackBatch_, std::memory_order_acquire);
+#pragma clang diagnostic pop
 
-  if (rules.empty()) {
+  if (!batch || batch->rules.empty()) {
     return NO;
   }
 
@@ -221,8 +237,8 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
   // Use a stack-local arena for evaluation temporaries.
   google::protobuf::Arena evalArena;
 
-  for (size_t i = 0; i < rules.size(); ++i) {
-    CELEvaluationResult celResult = [self evaluateCompiledCELExpression:rules[i].expression.get()
+  for (const CompiledFallbackRule& rule : batch->rules) {
+    CELEvaluationResult celResult = [self evaluateCompiledCELExpression:rule.expression.get()
                                                                   useV2:true
                                                          cachedDecision:cd
                                                              activation:*activation
@@ -240,8 +256,8 @@ struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
                    celResult.resultState == SNTRuleStateAllowCompiler)
                       ? SNTEventStateAllowCELFallback
                       : SNTEventStateBlockCELFallback;
-    cd.customMsg = rules[i].customMsg;
-    cd.customURL = rules[i].customURL;
+    cd.customMsg = rule.customMsg;
+    cd.customURL = rule.customURL;
     return YES;
   }
 

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -21,6 +21,10 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #import "Source/common/SNTCELFallbackRule.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTCommonEnums.h"
@@ -41,6 +45,7 @@ extern struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd);
 @interface SNTPolicyProcessor (Testing)
 - (BOOL)evaluateCELFallbackExpressions:(SNTCachedDecision*)cd
                     activationCallback:(ActivationCallbackBlock)activationCallback;
+- (void)compileFallbackRules:(NSArray<SNTCELFallbackRule*>*)rules;
 @end
 
 BOOL CompareMaybeNilStrings(NSString* s1, NSString* s2) {
@@ -1516,6 +1521,72 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   XCTAssertEqual(cd.decision, SNTEventStateBlockCELFallback);
   XCTAssertEqualObjects(cd.customMsg, @"Custom block message");
   XCTAssertEqualObjects(cd.customURL, @"https://example.com/details");
+}
+
+// Concurrent evaluation while another thread repeatedly recompiles/swaps the
+// fallback rule set. Reader threads must never observe a crash, a UAF, or a
+// garbage decision value — a `handled == NO` result is acceptable (the writer
+// may momentarily install a rule set that doesn't match, or interleave with
+// the swap) and is not treated as a failure. This is a safety net for the
+// upcoming refactor from queue-guarded ivars to an atomically-swapped
+// shared_ptr<const FallbackBatch>; it must pass against the current
+// (dispatch-queue-serialized) implementation.
+- (void)testCELFallbackConcurrentEvalDuringRecompile {
+  // Sanity: install rules directly through the writer entry point and confirm
+  // the eval path is wired before introducing any concurrency.
+  [self.processor compileFallbackRules:@[ [self ruleWithExpr:@"ALLOWLIST"] ]];
+  SNTCachedDecision* sanityCD = [[SNTCachedDecision alloc] init];
+  sanityCD.sha256 = @"aabbccdd";
+  BOOL sanityHandled =
+      [self.processor evaluateCELFallbackExpressions:sanityCD
+                                  activationCallback:[self fallbackTestActivationCallback]];
+  XCTAssertTrue(sanityHandled);
+  XCTAssertEqual(sanityCD.decision, SNTEventStateAllowCELFallback);
+
+  // Three distinct non-empty rule sets the writer thread cycles through.
+  NSArray<NSArray<SNTCELFallbackRule*>*>* ruleSets = @[
+    @[ [self ruleWithExpr:@"ALLOWLIST"] ],
+    @[ [self ruleWithExpr:@"BLOCKLIST"] ],
+    @[ [self ruleWithExpr:@"BLOCKLIST"], [self ruleWithExpr:@"ALLOWLIST"] ],
+  ];
+
+  constexpr int kWriterIters = 500;
+  constexpr int kReaderThreads = 8;
+  constexpr int kReaderIters = 1500;
+  std::atomic<int> failures{0};
+
+  SNTPolicyProcessor* processor = self.processor;
+
+  std::thread writer([processor, ruleSets]() {
+    for (int i = 0; i < kWriterIters; i++) {
+      [processor compileFallbackRules:ruleSets[i % 3]];
+    }
+  });
+
+  std::vector<std::thread> readers;
+  readers.reserve(kReaderThreads);
+  for (int t = 0; t < kReaderThreads; t++) {
+    readers.emplace_back([self, processor, &failures]() {
+      for (int i = 0; i < kReaderIters; i++) {
+        SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+        cd.sha256 = @"aabbccdd";
+        BOOL handled =
+            [processor evaluateCELFallbackExpressions:cd
+                                   activationCallback:[self fallbackTestActivationCallback]];
+        if (handled && cd.decision != SNTEventStateAllowCELFallback &&
+            cd.decision != SNTEventStateBlockCELFallback) {
+          failures.fetch_add(1);
+        }
+      }
+    });
+  }
+
+  writer.join();
+  for (auto& th : readers) {
+    th.join();
+  }
+
+  XCTAssertEqual(failures.load(), 0);
 }
 
 - (void)testRuleIdPropagation {

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1524,13 +1524,13 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 }
 
 // Concurrent evaluation while another thread repeatedly recompiles/swaps the
-// fallback rule set. Reader threads must never observe a crash, a UAF, or a
-// garbage decision value — a `handled == NO` result is acceptable (the writer
-// may momentarily install a rule set that doesn't match, or interleave with
-// the swap) and is not treated as a failure. This is a safety net for the
-// upcoming refactor from queue-guarded ivars to an atomically-swapped
-// shared_ptr<const FallbackBatch>; it must pass against the current
-// (dispatch-queue-serialized) implementation.
+// fallback rule set (held in the atomically-swapped shared_ptr<const
+// FallbackBatch>). Every rule set installed here is non-empty and matches
+// unconditionally (ALLOWLIST/BLOCKLIST), and the initial set is published before
+// any thread starts, so a correct swap always yields a fallback decision. A
+// handled == NO result, a decision that is neither allow nor block, a crash, or
+// a UAF would each mean a reader observed a torn/lost/empty batch (a broken
+// swap), so all are treated as failures.
 - (void)testCELFallbackConcurrentEvalDuringRecompile {
   // Sanity: install rules directly through the writer entry point and confirm
   // the eval path is wired before introducing any concurrency.
@@ -1573,8 +1573,10 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
         BOOL handled =
             [processor evaluateCELFallbackExpressions:cd
                                    activationCallback:[self fallbackTestActivationCallback]];
-        if (handled && cd.decision != SNTEventStateAllowCELFallback &&
-            cd.decision != SNTEventStateBlockCELFallback) {
+        // A correct swap always yields a fallback decision (see the test's doc
+        // comment), so NO — or any other decision — is a failure.
+        if (!handled || (cd.decision != SNTEventStateAllowCELFallback &&
+                         cd.decision != SNTEventStateBlockCELFallback)) {
           failures.fetch_add(1);
         }
       }


### PR DESCRIPTION
Each fallback-context exec deep-copied the entire compiled CEL-fallback rule set — two separately-locked ivars snapshotted under a serial dispatch queue — which is O(N) per exec and grows as the fallback rule count grows. This bundles the compiled plans and the arena they reference into one immutable `FallbackBatch` (built by a factory) held behind a single `shared_ptr<const FallbackBatch>`, published and snapshotted via the atomic `shared_ptr` free functions (the macOS SDK's libc++ has no `std::atomic<std::shared_ptr>`). Evaluation now snapshots in O(1) — one atomic load plus a refcount bump — and the serial queue is removed. Behavior is unchanged, including the per-rule error logging and the fallback-rule limit.

A concurrency stress test (readers evaluating the fallback path while a writer recompiles/swaps the rule set) covers the swap-during-eval path; it can't run under TSAN locally (a dyld interposition limitation) but is exercised by the nightly sanitizer job.
