### PR TITLE
TimedSyncSession: fix lock_ <-> timer-queue deadlock

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -448,6 +448,7 @@ santa_unit_test(
     deps = [
         ":SNTTimer",
         ":TestUtils",
+        ":Timer",
     ],
 )
 

--- a/Source/common/SNTTimerTest.mm
+++ b/Source/common/SNTTimerTest.mm
@@ -15,8 +15,33 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
+#include <memory>
+
 #import "Source/common/SNTTimer.h"
 #import "Source/common/TestUtils.h"
+#include "Source/common/Timer.h"
+
+namespace {
+
+// Minimal CRTP Timer subclass for exercising the async variants directly.
+// Must be owned by a shared_ptr: starting the timer takes shared_from_this().
+class AsyncTestTimer : public santa::Timer<AsyncTestTimer> {
+ public:
+  AsyncTestTimer()
+      : Timer(1, 60, OnStart::kWaitOneCycle, "AsyncTestTimer", RescheduleMode::kTrailingEdge,
+              QOS_CLASS_USER_INTERACTIVE) {}
+
+  bool OnTimer() {
+    if (on_timer_entered_) dispatch_semaphore_signal(on_timer_entered_);
+    if (on_timer_block_) dispatch_semaphore_wait(on_timer_block_, DISPATCH_TIME_FOREVER);
+    return false;
+  }
+
+  dispatch_semaphore_t on_timer_entered_;
+  dispatch_semaphore_t on_timer_block_;
+};
+
+}  // namespace
 
 @interface SNTTimerTest : XCTestCase
 @end
@@ -385,6 +410,36 @@
 
   // Brief sleep to let any async cleanup settle
   SleepMS(100);
+}
+
+- (void)testAsyncStartStop {
+  auto timer = std::make_shared<AsyncTestTimer>();
+
+  // IsStarted() dispatch_syncs onto the serial timer queue, so it doubles as a
+  // barrier: the pending async operation is guaranteed to have executed first.
+  timer->StartTimerWithIntervalAsync(60);
+  XCTAssertTrue(timer->IsStarted());
+
+  timer->StopTimerAsync();
+  XCTAssertFalse(timer->IsStarted());
+}
+
+- (void)testAsyncStopDoesNotBlockWhileOnTimerRuns {
+  // A blocking stop here would deadlock: OnTimer holds the timer queue until
+  // this test signals on_timer_block_, and that signal is sent only after the
+  // stop call returns. StopTimerAsync must return without waiting.
+  auto timer = std::make_shared<AsyncTestTimer>();
+  timer->on_timer_entered_ = dispatch_semaphore_create(0);
+  timer->on_timer_block_ = dispatch_semaphore_create(0);
+
+  timer->StartTimerWithIntervalAsync(1);
+  XCTAssertSemaTrue(timer->on_timer_entered_, 5, "OnTimer did not start");
+
+  // OnTimer is now parked on the timer queue. This must not block.
+  timer->StopTimerAsync();
+
+  dispatch_semaphore_signal(timer->on_timer_block_);
+  XCTAssertFalse(timer->IsStarted());
 }
 
 @end

--- a/Source/common/Timer.h
+++ b/Source/common/Timer.h
@@ -20,6 +20,7 @@
 #include <sys/qos.h>
 
 #include <algorithm>
+#include <memory>
 #include <string>
 
 #import "Source/common/SNTLogging.h"
@@ -125,6 +126,51 @@ class Timer : public std::enable_shared_from_this<Timer<T>> {
       did_start_new_timer = StartTimerSerialized();
     });
     return did_start_new_timer;
+  }
+
+  /// Stop the timer if running. Unlike StopTimer(), this never waits for the
+  /// timer queue: the stop is enqueued (or runs inline when already on the
+  /// timer queue) and the call returns immediately.
+  ///
+  /// Use this variant when holding a lock that OnTimer() acquires. In that
+  /// situation the blocking StopTimer() can deadlock: it waits for the timer
+  /// queue, but the queue may be running OnTimer(), which is waiting for the
+  /// caller's lock. Enqueuing instead of waiting breaks that cycle.
+  ///
+  /// Ordering: the timer queue is serial, so operations enqueued under a lock
+  /// execute in the order the lock was acquired.
+  ///
+  /// Lifetime: the enqueued block holds a weak_ptr and no-ops if the Timer is
+  /// destroyed before the block runs (the destructor already stops the timer).
+  void StopTimerAsync() {
+    if (OnTimerQueue()) {
+      StopTimerSerialized();
+      return;
+    }
+    std::weak_ptr<Timer<T>> weak_self = this->weak_from_this();
+    dispatch_async(timer_queue_, ^{
+      if (auto strong_self = weak_self.lock()) {
+        strong_self->StopTimerSerialized();
+      }
+    });
+  }
+
+  /// Set the interval and start (or re-arm) the timer, without waiting for the
+  /// timer queue. See StopTimerAsync for the locking, ordering, and lifetime
+  /// rationale.
+  void StartTimerWithIntervalAsync(uint32_t interval_seconds) {
+    if (OnTimerQueue()) {
+      SetTimerIntervalSerialized(interval_seconds);
+      StartTimerSerialized();
+      return;
+    }
+    std::weak_ptr<Timer<T>> weak_self = this->weak_from_this();
+    dispatch_async(timer_queue_, ^{
+      if (auto strong_self = weak_self.lock()) {
+        strong_self->SetTimerIntervalSerialized(interval_seconds);
+        strong_self->StartTimerSerialized();
+      }
+    });
   }
 
   /// Set new timer parameters. If the timer is running, the new parameters will take effect

--- a/Source/santad/TemporaryMonitorModeTest.mm
+++ b/Source/santad/TemporaryMonitorModeTest.mm
@@ -45,9 +45,7 @@ class TemporaryMonitorModePeer : public TemporaryMonitorMode {
   // dispatch source is stopped while the session state is still active. Uses a
   // qualified call because TimedSyncSession hides the blocking Timer methods;
   // the queue is idle in tests, so the blocking call is safe here.
-  bool StopTimerDirectForTesting() {
-    return santa::Timer<santa::TimedSyncSession>::StopTimer();
-  }
+  bool StopTimerDirectForTesting() { return santa::Timer<santa::TimedSyncSession>::StopTimer(); }
 };
 }  // namespace santa
 

--- a/Source/santad/TemporaryMonitorModeTest.mm
+++ b/Source/santad/TemporaryMonitorModeTest.mm
@@ -33,6 +33,21 @@ class TemporaryMonitorModePeer : public TemporaryMonitorMode {
       : santa::TemporaryMonitorMode(MakeKey(), configurator, notQueue, block) {}
 
   using santa::TimedSyncSession::GetSecondsRemainingFromStateLocked;
+
+  // Force the session deadline into the past so a subsequent OnTimer() observes
+  // a genuinely expired session (mach_continuous_time is far past 1).
+  void ExpireDeadlineForTesting() {
+    absl::MutexLock lock(lock_);
+    deadline_ = 1;
+  }
+
+  // Simulate the trailing-edge TimerCallback having consumed the fire: the
+  // dispatch source is stopped while the session state is still active. Uses a
+  // qualified call because TimedSyncSession hides the blocking Timer methods;
+  // the queue is idle in tests, so the blocking call is safe here.
+  bool StopTimerDirectForTesting() {
+    return santa::Timer<santa::TimedSyncSession>::StopTimer();
+  }
 };
 }  // namespace santa
 
@@ -275,6 +290,8 @@ uint64_t MakeDeadline(uint64_t want) {
   NSError* err = nil;
   XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
 
+  tmm->ExpireDeadlineForTesting();
+
   // OnTimer returns false: the session expired, do not reschedule.
   XCTAssertFalse(tmm->OnTimer());
 
@@ -283,6 +300,91 @@ uint64_t MakeDeadline(uint64_t want) {
       [events.lastObject isKindOfClass:[SNTStoredTemporaryMonitorModeLeaveAuditEvent class]]);
   XCTAssertEqual(((SNTStoredTemporaryMonitorModeLeaveAuditEvent*)events.lastObject).reason,
                  SNTTemporaryMonitorModeLeaveReasonSessionExpired);
+}
+
+- (void)testOnTimerWithTimeRemainingIsStaleFire {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  // The deadline is ~5 minutes out, so this fire is stale (a refresh raced the
+  // expiry). OnTimer must re-arm (return true) and preserve the session.
+  XCTAssertTrue(tmm->OnTimer());
+  XCTAssertTrue(tmm->SecondsRemaining().has_value());
+  XCTAssertEqual(events.count, 1u);
+}
+
+- (void)testOnTimerAfterCancelIsNoOp {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+  XCTAssertTrue(tmm->Cancel());
+  XCTAssertEqual(events.count, 2u);
+
+  // A fire that lost the race to Cancel must not tear down again or emit a
+  // second leave audit.
+  XCTAssertFalse(tmm->OnTimer());
+  XCTAssertEqual(events.count, 2u);
+}
+
+- (void)testCancelWhenFireAlreadyConsumedTimer {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  // Race window at expiry: the trailing-edge callback stopped the dispatch
+  // source, but the session state is still active. Cancel decides from
+  // active_, so it must still end the session.
+  XCTAssertTrue(tmm->StopTimerDirectForTesting());
+  XCTAssertTrue(tmm->Cancel());
+
+  XCTAssertFalse(tmm->SecondsRemaining().has_value());
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryMonitorModeLeaveReasonCancelled);
+}
+
+- (void)testRefreshWhenFireAlreadyConsumedTimer {
+  [self stubOnDemandAvailableMaxMinutes:60 defaultDuration:5];
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  // Same race window: a grant landing here is a refresh of the still-active
+  // session (keyed on active_), not a new session with a new UUID.
+  XCTAssertTrue(tmm->StopTimerDirectForTesting());
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  XCTAssertEqual(events.count, 2u);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeEnterAuditEvent*)events[1]).reason,
+                 SNTTemporaryMonitorModeEnterReasonOnDemandRefresh);
+  XCTAssertEqualObjects(events[0].uuid, events[1].uuid);
 }
 
 @end

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -239,12 +239,14 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   bool SyncServerGateSatisfied();
 
   // Hide the base-class timer methods from subclasses and external callers.
-  // The blocking trio dispatch_syncs onto the timer queue: never call them
+  // The blocking methods dispatch_sync onto the timer queue: never call them
   // while holding lock_ (see the class threading comment). Session code uses
   // the *Async shims, always invoked with lock_ held.
   bool StartTimer();
   bool StopTimer();
   bool StartTimerWithInterval(uint32_t interval_seconds);
+  bool IsStarted() const;
+  void SetTimerInterval(uint32_t interval_seconds);
   void StopTimerAsync();
   void StartTimerWithIntervalAsync(uint32_t interval_seconds);
 };

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -44,9 +44,22 @@ namespace santa {
 // Threading: `grant_mutex_` serializes a whole grant (pre-checks + auth + apply)
 // against other grants; `lock_` guards the session fields. Ordering is always
 // `grant_mutex_` then `lock_`; nothing takes `grant_mutex_` while holding `lock_`,
-// so there is no inversion. Fast readers (SecondsRemaining/Available) take only
-// `lock_` and read the `active_` flag rather than Timer::IsStarted(), which
-// dispatch_syncs to the timer queue and would deadlock against a firing OnTimer.
+// so the two mutexes cannot invert.
+//
+// The Timer mixin's serial queue is a third lock in the graph: OnTimer runs on
+// that queue and takes `lock_`, so a thread holding `lock_` must never BLOCK on
+// the timer queue — the blocking Timer methods (StartTimer/StopTimer/
+// StartTimerWithInterval/IsStarted/SetTimerInterval) all dispatch_sync onto it
+// and would deadlock against a firing OnTimer. Timer management under `lock_`
+// uses the non-blocking *Async variants instead. The async calls are made WHILE
+// `lock_` is held: enqueue order on the serial queue then matches lock order,
+// so a teardown's stop can never land after (and cancel) a successor session's
+// timer. Moving the calls outside `lock_` would introduce exactly that race.
+//
+// `active_` and `deadline_` are the authority on session state; the dispatch
+// timer is only a best-effort alarm. OnTimer validates against `deadline_`
+// before tearing down, and readers (SecondsRemaining/Available) consult
+// `active_`, never Timer::IsStarted().
 class TimedSyncSession : public Timer<TimedSyncSession> {
  public:
   ~TimedSyncSession() override;
@@ -66,6 +79,8 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   bool Revoke(NSInteger leave_reason);
 
   // Timer<> expiry callback (base implements; subclasses do not override).
+  // Validates against active_/deadline_: no-ops after a cancel/revoke, returns
+  // true (re-arm) on a stale fire from a raced refresh, tears down otherwise.
   bool OnTimer();
 
   // Whether the feature is currently available: an on-demand policy is set, the
@@ -207,24 +222,31 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   NSArray<SNTKVOManager*>* kvo_;
 
  private:
-  // Persist the common session state (merged with ExtraStateToPersist), start the
-  // timer, notify the GUI, set `active_`. Returns whether a NEW timer was started
-  // (false on a refresh of an already-running session).
+  // Persist the common session state (merged with ExtraStateToPersist), arm the
+  // timer (async), notify the GUI, set `active_`. Returns whether this began a
+  // NEW session (false on a refresh of an active one); keyed on `active_`.
   bool BeginSessionLocked(uint32_t seconds, bool gen_uuid_on_start)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-  // Stop the timer, clear the persisted state, notify the GUI, clear `active_`.
-  // Returns whether a genuinely-active session was ended. Does NOT clear the
-  // subclass extra state (the leave audit/RevertEffect read it).
+  // End the active session: request async timer cancellation, clear the
+  // persisted state, notify the GUI, clear `active_`. Returns whether a session
+  // was active (keyed on `active_`, not timer state: near expiry the fire has
+  // already consumed the timer while the session is still live). Does NOT clear
+  // the subclass extra state (the leave audit/RevertEffect read it).
   bool EndSessionLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   bool RevokeLocked(NSInteger leave_reason) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   // Whether the sync-server gate is satisfied (`configurator_.isSyncV2Enabled`).
   bool SyncServerGateSatisfied();
 
-  // hide the base class Start/Stop methods
+  // Hide the base-class timer methods from subclasses and external callers.
+  // The blocking trio dispatch_syncs onto the timer queue: never call them
+  // while holding lock_ (see the class threading comment). Session code uses
+  // the *Async shims, always invoked with lock_ held.
   bool StartTimer();
   bool StopTimer();
   bool StartTimerWithInterval(uint32_t interval_seconds);
+  void StopTimerAsync();
+  void StartTimerWithIntervalAsync(uint32_t interval_seconds);
 };
 
 }  // namespace santa

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -325,8 +325,14 @@ std::optional<uint64_t> TimedSyncSession::SecondsRemaining(uint64_t deadline_mac
 }
 
 bool TimedSyncSession::BeginSessionLocked(uint32_t seconds, bool gen_uuid_on_start) {
-  bool did_start_new_timer = StartTimerWithInterval(seconds);
-  if (did_start_new_timer && gen_uuid_on_start) {
+  // New-vs-refresh keys on active_, not on timer state: at expiry the
+  // trailing-edge callback stops the dispatch source before the session state
+  // is torn down, so a live session can momentarily have no timer. The async
+  // start is enqueued while lock_ is held so timer operations execute in lock
+  // order.
+  bool new_session = !active_;
+  StartTimerWithIntervalAsync(seconds);
+  if (new_session && gen_uuid_on_start) {
     current_uuid_ = [NSUUID UUID];
   }
 
@@ -349,17 +355,22 @@ bool TimedSyncSession::BeginSessionLocked(uint32_t seconds, bool gen_uuid_on_sta
 
   NotifyEnter([NSDate dateWithTimeIntervalSinceNow:seconds]);
 
-  return did_start_new_timer;
+  return new_session;
 }
 
 bool TimedSyncSession::EndSessionLocked() {
-  if (StopTimer()) {
-    [configurator_ persistTimedSessionState:nil forKey:StateKey()];
-    active_ = false;
-    NotifyLeave();
-    return true;
+  // Decide from active_, not from the timer: at expiry the trailing-edge
+  // callback has already stopped the source while the session is still live.
+  // The stop is enqueued while lock_ is held so it cannot land after (and
+  // cancel) a successor session's timer.
+  if (!active_) {
+    return false;
   }
-  return false;
+  StopTimerAsync();
+  [configurator_ persistTimedSessionState:nil forKey:StateKey()];
+  active_ = false;
+  NotifyLeave();
+  return true;
 }
 
 void TimedSyncSession::PersistExpiredForRetryLocked() {
@@ -415,10 +426,20 @@ bool TimedSyncSession::RevokeLocked(NSInteger leave_reason) {
 }
 
 bool TimedSyncSession::OnTimer() {
+  // Runs on the timer queue. Taking lock_ here is safe because no thread
+  // blocks on the timer queue while holding lock_ (all timer management under
+  // lock_ is async); see the threading comment in the header.
   absl::MutexLock lock(lock_);
-  // OnTimer fires only for a running timer, so a session is active. The Timer
-  // mixin (trailing edge) has already stopped the timer; just tear down the
-  // session state here.
+  if (!active_) {
+    // A cancel/revoke won the race with this fire and already tore down.
+    return false;
+  }
+  if (SecondsRemaining(deadline_).has_value()) {
+    // Stale fire: a refresh moved deadline_ after this fire was scheduled.
+    // Return true so the trailing-edge callback re-arms; the fire that
+    // eventually lands past deadline_ takes the teardown path below.
+    return true;
+  }
   if (RevertEffect()) {
     [configurator_ persistTimedSessionState:nil forKey:StateKey()];
   } else {
@@ -446,6 +467,14 @@ bool TimedSyncSession::StartTimerWithInterval(uint32_t interval_seconds) {
 
 bool TimedSyncSession::StopTimer() {
   return Timer<TimedSyncSession>::StopTimer();
+}
+
+void TimedSyncSession::StopTimerAsync() {
+  Timer<TimedSyncSession>::StopTimerAsync();
+}
+
+void TimedSyncSession::StartTimerWithIntervalAsync(uint32_t interval_seconds) {
+  Timer<TimedSyncSession>::StartTimerWithIntervalAsync(interval_seconds);
 }
 
 }  // namespace santa

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -469,6 +469,14 @@ bool TimedSyncSession::StopTimer() {
   return Timer<TimedSyncSession>::StopTimer();
 }
 
+bool TimedSyncSession::IsStarted() const {
+  return Timer<TimedSyncSession>::IsStarted();
+}
+
+void TimedSyncSession::SetTimerInterval(uint32_t interval_seconds) {
+  Timer<TimedSyncSession>::SetTimerInterval(interval_seconds);
+}
+
 void TimedSyncSession::StopTimerAsync() {
   Timer<TimedSyncSession>::StopTimerAsync();
 }


### PR DESCRIPTION
Fixes SNT-468

- Holding lock_ while calling a blocking Timer method (StopTimer/StartTimerWithInterval) could deadlock: they dispatch_sync onto the timer queue, which may be running OnTimer(), which is waiting for lock_.
- Adds non-blocking StopTimerAsync/StartTimerWithIntervalAsync to the Timer<T> mixin (weak_ptr-guarded); session code enqueues them while lock_ is held so timer operations execute in lock order.
- active_/deadline_ are now the sole authority on session state; OnTimer validates against them, so a fire that loses a race to a cancel/refresh no-ops or re-arms instead of tearing down.