### PR TITLE
Replace builtin casts with proto-specific casts for protobuf types.

### DIFF
--- a/Source/common/cel/BUILD
+++ b/Source/common/cel/BUILD
@@ -77,6 +77,7 @@ objc_library(
         "@cel-cpp//runtime:function_adapter",
         "@northpolesec_protos//cel:v1_cc_proto",
         "@northpolesec_protos//celv2:v2_cc_proto",
+        "@protobuf//:protobuf_lite",
     ],
 )
 

--- a/Source/common/cel/Evaluator.mm
+++ b/Source/common/cel/Evaluator.mm
@@ -27,6 +27,7 @@
 #include "eval/public/cel_function_adapter.h"
 #include "eval/public/transform_utility.h"
 #include "extensions/strings.h"
+#include "google/protobuf/message_lite.h"
 #include "parser/parser.h"
 
 #include "Source/common/cel/Activation.h"
@@ -193,7 +194,7 @@ absl::StatusOr<typename Evaluator<IsV2>::EvaluationResultT> Evaluator<IsV2>::Eva
     if (result->IsMessage()) {
       const auto* msg = result->MessageOrDie();
       if (msg->GetDescriptor()->full_name() == "santa.cel.Result") {
-        const auto* cel_result = dynamic_cast<const ::santa::cel::Result*>(msg);
+        const auto* cel_result = google::protobuf::DynamicCastMessage<::santa::cel::Result>(msg);
         if (cel_result) {
           auto rv = static_cast<ReturnValue>(cel_result->value());
           // Check if cooldown was explicitly set (distinguishes constants from functions)


### PR DESCRIPTION
There is a protobuf experiment to "devirtualize" messages, allowing protobuf to manage the dynamic dispatch of messages. When enabled, it breaks builtin dynamic/down casts, so the protobuf-specific alternatives should be preferred.