### PR TITLE
common: reap process tree removals from a min-heap

### DIFF
--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -144,7 +144,7 @@ void ProcessTree::HandleExec(uint64_t timestamp, const Process& p,
     if (!StepLocked({timestamp, EventKind::kExec, p.pid_, new_pid})) {
       return;
     }
-    remove_at_.push_back({timestamp, p.pid_});
+    remove_at_.push({timestamp, p.pid_});
     map_.emplace(new_proc->pid_, new_proc);
     DrainRemovals();
   }
@@ -158,7 +158,7 @@ void ProcessTree::HandleExit(uint64_t timestamp, const Process& p) {
   if (!StepLocked({timestamp, EventKind::kExit, p.pid_, Pid{}})) {
     return;
   }
-  remove_at_.push_back({timestamp, p.pid_});
+  remove_at_.push({timestamp, p.pid_});
   DrainRemovals();
 }
 
@@ -206,17 +206,18 @@ void ProcessTree::DrainRemovals() {
       removal_grace_ticks_ ? removal_grace_ticks_ : kDefaultGrace;
   const uint64_t cutoff = latest_ts_ > grace ? latest_ts_ - grace : 0;
 
-  for (auto it = remove_at_.begin(); it != remove_at_.end();) {
-    if (it->first < cutoff) {
-      if (auto target = GetLocked(it->second);
-          target && (*target)->refcnt_.load(std::memory_order_relaxed) > 0) {
-        (*target)->tombstoned_ = true;
-      } else {
-        map_.erase(it->second);
-      }
-      it = remove_at_.erase(it);
+  // remove_at_ is a min-heap on the scheduling timestamp, so the earliest
+  // deadline is always on top. Reap only the entries that have expired and stop
+  // at the first that has not — every deeper entry is newer. This is O(K log R)
+  // in the number reaped, not O(R) in the number pending.
+  while (!remove_at_.empty() && remove_at_.top().first < cutoff) {
+    const struct Pid pid = remove_at_.top().second;
+    remove_at_.pop();
+    if (auto target = GetLocked(pid);
+        target && (*target)->refcnt_.load(std::memory_order_relaxed) > 0) {
+      (*target)->tombstoned_ = true;
     } else {
-      it++;
+      map_.erase(pid);
     }
   }
 }

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -20,6 +20,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <queue>
 #include <typeinfo>
 #include <vector>
 
@@ -161,12 +162,25 @@ class ProcessTree {
   mutable absl::Mutex mtx_;
   absl::flat_hash_map<const struct Pid, std::shared_ptr<Process>> map_
       ABSL_GUARDED_BY(mtx_);
-  // List of pids which should be removed from map_, and the timestamp (the
-  // originating exit/exec event's mach_time) at which the removal was
-  // scheduled. An entry is reaped once removal_grace_ticks_ have elapsed past
-  // its timestamp (measured against latest_ts_), so a reordered straggler
-  // cannot reference a process after it is reaped. See DrainRemovals().
-  std::vector<std::pair<uint64_t, struct Pid>> remove_at_ ABSL_GUARDED_BY(mtx_);
+  // Pending removals: pids to erase from map_, each paired with the mach_time
+  // of the exit/exec event that scheduled it. An entry is reaped once
+  // removal_grace_ticks_ have elapsed past that timestamp (measured against
+  // latest_ts_), so a reordered straggler cannot reference a process after it
+  // is reaped. Held as a MIN-heap on the timestamp so DrainRemovals reaps only
+  // the entries that have expired (smallest timestamps) rather than scanning
+  // every pending one — ES delivers events out of order, so timestamps are not
+  // appended monotonically and the earliest deadline is not necessarily the
+  // oldest insertion. See DrainRemovals().
+  struct ReapEarliestFirst {
+    bool operator()(const std::pair<uint64_t, struct Pid>& a,
+                    const std::pair<uint64_t, struct Pid>& b) const {
+      return a.first > b.first;  // priority_queue is a max-heap; invert for min
+    }
+  };
+  std::priority_queue<std::pair<uint64_t, struct Pid>,
+                      std::vector<std::pair<uint64_t, struct Pid>>,
+                      ReapEarliestFirst>
+      remove_at_ ABSL_GUARDED_BY(mtx_);
 
   // Dedup of processed events. The same kernel event is delivered to every
   // tree-aware client; each informs the tree, so an event must be applied

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -263,6 +263,40 @@ using namespace santa::santad::process_tree;
   }
 }
 
+// Regression: reaping must be a per-entry decision keyed on each removal's own
+// timestamp, independent of the order removals were scheduled in. ES delivers
+// events out of mach_time order, so a still-within-grace removal can sit AHEAD
+// of an already-expired one in the pending set. A reaper that stops at the first
+// not-yet-expired entry (e.g. a naive front-popping deque) would leak the
+// expired entry behind it; the reaper must consider every pending removal (or be
+// ordered by timestamp, as a min-heap is).
+- (void)testOutOfOrderRemovalsReapedByOwnTimestamp {
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators),
+                                                    /*removal_grace_ticks=*/10);
+  auto init = tree->InsertInit();
+
+  // Survivor: forked at ts=50, exits at ts=100. Its removal is scheduled FIRST,
+  // at the newest timestamp seen, so it stays within the grace (cutoff = 90).
+  const struct Pid survivor_pid = {.pid = 2, .pidversion = 2};
+  tree->HandleFork(50, *init, survivor_pid);
+  auto survivor = *tree->Get(survivor_pid);
+  tree->HandleExit(100, *survivor);  // schedules survivor@100, latest_ts=100
+
+  // Reaped: a reordered straggler forked/exited in the past. Its removal is
+  // scheduled SECOND (behind the survivor) but at an old timestamp (20 < 90), so
+  // it is already expired the moment it is scheduled.
+  const struct Pid reaped_pid = {.pid = 3, .pidversion = 3};
+  tree->HandleFork(10, *init, reaped_pid);  // novel out-of-order fork, tracked
+  auto reaped = *tree->Get(reaped_pid);
+  tree->HandleExit(20, *reaped);  // schedules reaped@20 -> already expired
+
+  // The expired straggler is reaped even though a not-yet-expired removal sits
+  // ahead of it; the survivor (still within grace) is untouched.
+  XCTAssertFalse(tree->Get(reaped_pid).has_value());
+  XCTAssertTrue(tree->Get(survivor_pid).has_value());
+}
+
 // Regression: ES does not guarantee global mach_time ordering across threads or
 // clients, so a genuinely-novel fork/exec can arrive stamped "in the past". The
 // tree must still track it. Pre-fix, Step dropped such events as "too old",


### PR DESCRIPTION
DrainRemovals scanned the entire pending-removal set on every fork/exec/exit, so its cost scaled with the whole backlog rather than the number of entries actually expiring. This holds the pending removals in a min-heap keyed on the scheduling timestamp and reaps only the expired entries from the top, bounding the per-event work when many removals are pending.

Behavior is unchanged: the heap reaps exactly the set the linear scan did, in the same drain call, regardless of the order removals were scheduled. Added test coverage pins down that order-independence, and the existing reap/refcount/out-of-order tests still pass.
