### PR TITLE
common: reduce per-exec copies and duplicate work in the process tree

### DIFF
--- a/Source/common/processtree/SNTEndpointSecurityAdapter.mm
+++ b/Source/common/processtree/SNTEndpointSecurityAdapter.mm
@@ -45,6 +45,18 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
   switch (msg->event_type) {
     case ES_EVENT_TYPE_AUTH_EXEC:
     case ES_EVENT_TYPE_NOTIFY_EXEC: {
+      const es_process_t* target = msg->event.exec.target;
+      struct Pid target_pid = PidFromAuditToken(target->audit_token);
+
+      // The same exec is delivered to every tree-aware client (and to the
+      // Authorizer as both AUTH_EXEC and NOTIFY_EXEC). Building the arg list and
+      // Program below is the expensive part, so skip it when the tree has
+      // already recorded this exact exec. HandleExec re-checks under the write
+      // lock, so a racing novel exec is never dropped.
+      if (tree.HasSeenExec(msg->mach_time, event_pid, target_pid)) {
+        break;
+      }
+
       uint32_t arg_count = esapi->ExecArgCount(&msg->event.exec);
       std::vector<std::string> args;
       args.reserve(arg_count);
@@ -53,7 +65,6 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
         args.push_back(StringTokenToString(arg));
       }
 
-      const es_process_t* target = msg->event.exec.target;
       es_string_token_t executable = target->executable->path;
 
       // Extract code signing info from the target process
@@ -68,7 +79,7 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
         cs_info.signing_id = StringTokenToString(target->signing_id);
       }
 
-      tree.HandleExec(msg->mach_time, **proc, PidFromAuditToken(target->audit_token),
+      tree.HandleExec(msg->mach_time, **proc, target_pid,
                       (struct Program){.executable = StringTokenToString(executable),
                                        .arguments = std::move(args),
                                        .code_signing = cs_info},

--- a/Source/common/processtree/SNTEndpointSecurityAdapter.mm
+++ b/Source/common/processtree/SNTEndpointSecurityAdapter.mm
@@ -45,9 +45,10 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
   switch (msg->event_type) {
     case ES_EVENT_TYPE_AUTH_EXEC:
     case ES_EVENT_TYPE_NOTIFY_EXEC: {
+      uint32_t arg_count = esapi->ExecArgCount(&msg->event.exec);
       std::vector<std::string> args;
-      args.reserve(esapi->ExecArgCount(&msg->event.exec));
-      for (int i = 0; i < esapi->ExecArgCount(&msg->event.exec); i++) {
+      args.reserve(arg_count);
+      for (uint32_t i = 0; i < arg_count; i++) {
         es_string_token_t arg = esapi->ExecArg(&msg->event.exec, i);
         args.push_back(StringTokenToString(arg));
       }
@@ -69,7 +70,7 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
 
       tree.HandleExec(msg->mach_time, **proc, PidFromAuditToken(target->audit_token),
                       (struct Program){.executable = StringTokenToString(executable),
-                                       .arguments = args,
+                                       .arguments = std::move(args),
                                        .code_signing = cs_info},
                       (struct Cred){
                           .uid = audit_token_to_euid(target->audit_token),

--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -122,26 +122,36 @@ void ProcessTree::HandleFork(uint64_t timestamp, const Process& parent,
 }
 
 void ProcessTree::HandleExec(uint64_t timestamp, const Process& p,
-                             const Pid new_pid, const Program prog,
-                             const Cred c) {
+                             const Pid new_pid, Program prog, const Cred c) {
   // TODO(nickmg): should struct pid be reworked and only pid_version be passed?
   assert(new_pid.pid == p.pid_.pid);
 
-  // Expected double-apply: a tree-aware auth client (the Authorizer) subscribes
-  // to both AUTH_EXEC and NOTIFY_EXEC, so an uncached exec reaches here twice.
-  // The two ES messages carry different mach_time, so they form distinct
-  // EventKeys and both pass dedup; the second is a first-wins no-op (the
-  // map_.emplace below). This is intentional and benign — it costs one extra
-  // emplace/remove_at_/drain on the auth path per uncached exec (accepted).
+  const struct EventKey key = {timestamp, EventKind::kExec, p.pid_, new_pid};
 
-  // Construct the new process (copies program/args/signing) OUTSIDE the lock to
-  // keep the shared tree lock short on the serial ES handler path. A duplicate
-  // wastes this allocation, which is cheaper than lengthening the lock hold.
+  // The same exec is delivered to every tree-aware client, and the Authorizer
+  // also sees it as both AUTH_EXEC and NOTIFY_EXEC, so HandleExec runs
+  // repeatedly for a single exec. Constructing the new Process/Program below
+  // copies the args and signing info and is the expensive part, so peek under a
+  // read lock and skip the build entirely when this exact event was already
+  // applied. Best-effort only: StepLocked (under the write lock) remains the
+  // authoritative dedup gate, and skipping here is behavior-preserving because
+  // a seen key has already advanced latest_ts_ past its timestamp. Distinct
+  // deliveries that share a pid but carry a different mach_time still fall
+  // through to the first-wins map_.emplace below.
+  {
+    absl::ReaderMutexLock lock(mtx_);
+    if (seen_.contains(key)) {
+      return;
+    }
+  }
+
+  // Construct the new process (copies program/args/signing) OUTSIDE the write
+  // lock to keep the shared tree lock short on the serial ES handler path.
   auto new_proc = std::make_shared<Process>(
-      new_pid, c, std::make_shared<const Program>(prog), p.parent_);
+      new_pid, c, std::make_shared<const Program>(std::move(prog)), p.parent_);
   {
     absl::MutexLock lock(mtx_);
-    if (!StepLocked({timestamp, EventKind::kExec, p.pid_, new_pid})) {
+    if (!StepLocked(key)) {
       return;
     }
     remove_at_.push({timestamp, p.pid_});

--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -126,32 +126,21 @@ void ProcessTree::HandleExec(uint64_t timestamp, const Process& p,
   // TODO(nickmg): should struct pid be reworked and only pid_version be passed?
   assert(new_pid.pid == p.pid_.pid);
 
-  const struct EventKey key = {timestamp, EventKind::kExec, p.pid_, new_pid};
-
   // The same exec is delivered to every tree-aware client, and the Authorizer
-  // also sees it as both AUTH_EXEC and NOTIFY_EXEC, so HandleExec runs
-  // repeatedly for a single exec. Constructing the new Process/Program below
-  // copies the args and signing info and is the expensive part, so peek under a
-  // read lock and skip the build entirely when this exact event was already
-  // applied. Best-effort only: StepLocked (under the write lock) remains the
-  // authoritative dedup gate, and skipping here is behavior-preserving because
-  // a seen key has already advanced latest_ts_ past its timestamp. Distinct
-  // deliveries that share a pid but carry a different mach_time still fall
-  // through to the first-wins map_.emplace below.
-  {
-    absl::ReaderMutexLock lock(mtx_);
-    if (seen_.contains(key)) {
-      return;
-    }
-  }
+  // sees it as both AUTH_EXEC and NOTIFY_EXEC, so HandleExec may run more than
+  // once per exec. StepLocked is the authoritative dedup gate: an
+  // exact-duplicate delivery is rejected, while distinct deliveries that share
+  // a pid but carry a different mach_time both pass and the later one is a
+  // first-wins map_.emplace no-op. Callers building the Program eagerly can
+  // skip known duplicates up front via HasSeenExec (see InformFromESEvent).
 
-  // Construct the new process (copies program/args/signing) OUTSIDE the write
-  // lock to keep the shared tree lock short on the serial ES handler path.
+  // Allocate the new process OUTSIDE the write lock to keep the shared tree
+  // lock short on the serial ES handler path; prog is moved in, not copied.
   auto new_proc = std::make_shared<Process>(
       new_pid, c, std::make_shared<const Program>(std::move(prog)), p.parent_);
   {
     absl::MutexLock lock(mtx_);
-    if (!StepLocked(key)) {
+    if (!StepLocked({timestamp, EventKind::kExec, p.pid_, new_pid})) {
       return;
     }
     remove_at_.push({timestamp, p.pid_});
@@ -170,6 +159,12 @@ void ProcessTree::HandleExit(uint64_t timestamp, const Process& p) {
   }
   remove_at_.push({timestamp, p.pid_});
   DrainRemovals();
+}
+
+bool ProcessTree::HasSeenExec(uint64_t timestamp, const Pid actor,
+                              const Pid target) const {
+  absl::ReaderMutexLock lock(mtx_);
+  return seen_.contains({timestamp, EventKind::kExec, actor, target});
 }
 
 bool ProcessTree::StepLocked(const EventKey& key) {

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -76,6 +76,13 @@ class ProcessTree {
   // Inform the tree of a process exit.
   void HandleExit(uint64_t timestamp, const Process& p);
 
+  // Returns whether an exec event with this identity has already been recorded
+  // by the tree. Lets a caller skip building the (expensive) Program before
+  // calling HandleExec for a duplicate delivery. Best-effort: HandleExec
+  // re-checks under the write lock, so a racing novel exec is never dropped.
+  bool HasSeenExec(uint64_t timestamp, struct Pid actor,
+                   struct Pid target) const;
+
   // Mark the given pids as needing to be retained in the tree's map for future
   // access. Normally, Processes are removed once all clients process past the
   // event which would remove the Process (e.g. exit), however in cases where

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -114,6 +114,34 @@ using namespace santa::santad::process_tree;
   XCTAssertEqual(child->effective_cred_, self.initProc->effective_cred_);
 }
 
+// A given exec is delivered to every tree-aware client, so HandleExec sees the
+// same exec (identical EventKey) more than once. A duplicate delivery must be a
+// no-op: the process is applied exactly once and its program is unchanged.
+// HandleExec skips the expensive Process/Program rebuild on the duplicate via a
+// seen_ fast path; StepLocked remains the authoritative dedup gate either way.
+- (void)testDuplicateExecDeliveryIsIdempotent {
+  uint64_t event_id = 1;
+  const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+  self.tree->HandleFork(event_id++, *self.initProc, child_pid);
+  auto child = *self.tree->Get(child_pid);
+
+  const struct Pid exec_pid = {.pid = 2, .pidversion = 3};
+  const struct Program prog = {.executable = "/bin/bash", .arguments = {"/bin/bash", "-i"}};
+  const uint64_t exec_ts = event_id++;
+
+  // Deliver the same exec (identical EventKey) twice.
+  self.tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
+  self.tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
+
+  auto post = self.tree->Get(exec_pid);
+  XCTAssertTrue(post.has_value());
+  XCTAssertEqual(*(*post)->program_, prog);  // program intact, not corrupted
+  // Applied exactly once and reachable to init.
+  auto slice = self.tree->RootSlice(*post);
+  XCTAssertEqual(slice.size(), 2u);  // [exec, init]
+  XCTAssertEqual(slice.back(), self.initProc);
+}
+
 // We can't test the full backfill process, as retrieving information on
 // processes (with task_name_for_pid) requires privileges.
 // Test what we can by LoadPID'ing ourselves.

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -132,9 +132,8 @@ using namespace santa::santad::process_tree;
 // A given exec is delivered to every tree-aware client, so HandleExec sees the
 // same exec (identical EventKey) more than once. A duplicate delivery must be
 // deduped: the exec is applied — and thus annotated — exactly once, with the
-// program unchanged. HandleExec skips the expensive Process/Program rebuild on
-// the duplicate via a seen_ fast path; StepLocked remains the authoritative
-// dedup gate either way.
+// program unchanged. StepLocked is the authoritative dedup gate. (Callers skip
+// the build for known duplicates up front via HasSeenExec; see the adapter.)
 - (void)testDuplicateExecDeliveryIsIdempotent {
   auto exec_count = std::make_shared<int>(0);
   std::vector<std::unique_ptr<Annotator>> annotators{};
@@ -166,6 +165,31 @@ using namespace santa::santad::process_tree;
   auto slice = tree->RootSlice(*post);
   XCTAssertEqual(slice.size(), 2u);  // [exec, init]
   XCTAssertEqual(slice.back(), init);
+}
+
+// HasSeenExec lets the ES adapter skip building the Program for an exec the tree
+// has already recorded. It must report true for exactly the event identity that
+// HandleExec dedups on, and false for anything else.
+- (void)testHasSeenExec {
+  uint64_t event_id = 1;
+  const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+  self.tree->HandleFork(event_id++, *self.initProc, child_pid);
+  auto child = *self.tree->Get(child_pid);
+
+  const struct Pid exec_pid = {.pid = 2, .pidversion = 3};
+  const struct Program prog = {.executable = "/bin/bash", .arguments = {}};
+  const uint64_t exec_ts = 100;
+
+  // Unknown before the exec is applied.
+  XCTAssertFalse(self.tree->HasSeenExec(exec_ts, child_pid, exec_pid));
+
+  self.tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
+
+  // Recorded after — matching the identity HandleExec deduped on.
+  XCTAssertTrue(self.tree->HasSeenExec(exec_ts, child_pid, exec_pid));
+  // A different timestamp or pid is a distinct event.
+  XCTAssertFalse(self.tree->HasSeenExec(exec_ts + 1, child_pid, exec_pid));
+  XCTAssertFalse(self.tree->HasSeenExec(exec_ts, child_pid, child_pid));
 }
 
 // We can't test the full backfill process, as retrieving information on

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -68,6 +68,21 @@ void TestAnnotator::AnnotateExec(ProcessTree& tree, const Process& orig_process,
 std::optional<::ptpb::Annotations> TestAnnotator::Proto() const {
   return std::nullopt;
 }
+
+// Counts AnnotateExec invocations through a shared counter. Annotators run only
+// after a novel StepLocked, so the count reflects how many times an exec was
+// actually applied (as opposed to deduped).
+class ExecCountingAnnotator : public Annotator {
+ public:
+  explicit ExecCountingAnnotator(std::shared_ptr<int> exec_count)
+      : exec_count_(std::move(exec_count)) {}
+  void AnnotateFork(ProcessTree&, const Process&, const Process&) override {}
+  void AnnotateExec(ProcessTree&, const Process&, const Process&) override { ++(*exec_count_); }
+  std::optional<::ptpb::Annotations> Proto() const override { return std::nullopt; }
+
+ private:
+  std::shared_ptr<int> exec_count_;
+};
 }  // namespace santa::santad::process_tree
 
 using namespace santa::santad::process_tree;
@@ -115,31 +130,42 @@ using namespace santa::santad::process_tree;
 }
 
 // A given exec is delivered to every tree-aware client, so HandleExec sees the
-// same exec (identical EventKey) more than once. A duplicate delivery must be a
-// no-op: the process is applied exactly once and its program is unchanged.
-// HandleExec skips the expensive Process/Program rebuild on the duplicate via a
-// seen_ fast path; StepLocked remains the authoritative dedup gate either way.
+// same exec (identical EventKey) more than once. A duplicate delivery must be
+// deduped: the exec is applied — and thus annotated — exactly once, with the
+// program unchanged. HandleExec skips the expensive Process/Program rebuild on
+// the duplicate via a seen_ fast path; StepLocked remains the authoritative
+// dedup gate either way.
 - (void)testDuplicateExecDeliveryIsIdempotent {
+  auto exec_count = std::make_shared<int>(0);
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  annotators.emplace_back(std::make_unique<ExecCountingAnnotator>(exec_count));
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators));
+  auto init = tree->InsertInit();
+
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
-  self.tree->HandleFork(event_id++, *self.initProc, child_pid);
-  auto child = *self.tree->Get(child_pid);
+  tree->HandleFork(event_id++, *init, child_pid);
+  auto child = *tree->Get(child_pid);
 
   const struct Pid exec_pid = {.pid = 2, .pidversion = 3};
   const struct Program prog = {.executable = "/bin/bash", .arguments = {"/bin/bash", "-i"}};
   const uint64_t exec_ts = event_id++;
 
   // Deliver the same exec (identical EventKey) twice.
-  self.tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
-  self.tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
+  tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
+  tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
 
-  auto post = self.tree->Get(exec_pid);
+  // The duplicate is deduped: the exec passes through StepLocked and is applied
+  // (and annotated) exactly once, not merely coalesced by the first-wins insert.
+  XCTAssertEqual(*exec_count, 1);
+
+  auto post = tree->Get(exec_pid);
   XCTAssertTrue(post.has_value());
   XCTAssertEqual(*(*post)->program_, prog);  // program intact, not corrupted
-  // Applied exactly once and reachable to init.
-  auto slice = self.tree->RootSlice(*post);
+  // Applied once and reachable to init.
+  auto slice = tree->RootSlice(*post);
   XCTAssertEqual(slice.size(), 2u);  // [exec, init]
-  XCTAssertEqual(slice.back(), self.initProc);
+  XCTAssertEqual(slice.back(), init);
 }
 
 // We can't test the full backfill process, as retrieving information on


### PR DESCRIPTION
The exec ingest path deep-copied the `Program` (args vector + strings) two-plus times per delivery and rebuilt it even for deliveries the tree discards as duplicates. This moves the `Program` through `HandleExec` rather than copying it, moves the args vector out of the ES adapter, and hoists the arg count out of the loop.

It also skips constructing the new `Process`/`Program` entirely when a read-locked peek shows the exec was already applied. `StepLocked` remains the authoritative dedup gate; the peek is a best-effort fast path, behavior-preserving because a seen key has already advanced the removal cutoff past its timestamp. Adds a duplicate-delivery regression test; the existing tree tests still pass.
