### PR TITLE
common: take a reader lock in ProcessTree::ReleaseProcess

### DIFF
--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -236,16 +236,37 @@ void ProcessTree::RetainProcess(const PidList& pids) {
 }
 
 void ProcessTree::ReleaseProcess(const PidList& pids) {
-  absl::MutexLock lock(mtx_);
-  for (const struct Pid& p : pids) {
-    auto proc = GetLocked(p);
-    if (proc) {
-      // relaxed is safe: the exclusive lock provides ordering for
-      // tombstoned_ and map_.erase().
-      if ((*proc)->refcnt_.fetch_sub(1, std::memory_order_relaxed) == 1 &&
+  // Fast path under the reader lock: the decrement is atomic, and tombstoned_
+  // is stable here (written only in DrainRemovals under the exclusive lock).
+  // Only the rare erase of a tombstoned process needs the exclusive lock.
+  PidList to_erase;
+  {
+    absl::ReaderMutexLock lock(mtx_);
+    for (const struct Pid& p : pids) {
+      auto proc = GetLocked(p);
+      if (proc &&
+          (*proc)->refcnt_.fetch_sub(1, std::memory_order_relaxed) == 1 &&
           (*proc)->tombstoned_) {
-        map_.erase(p);
+        to_erase.push_back(p);
       }
+    }
+  }
+  if (to_erase.empty()) {
+    return;
+  }
+  if (on_release_collected_for_test_) {
+    on_release_collected_for_test_();
+  }
+
+  absl::MutexLock lock(mtx_);
+  for (const struct Pid& p : to_erase) {
+    // Re-verify: between the two lock holds the process may have been
+    // retained again, already erased by a concurrent releaser, or erased
+    // and a fresh process re-inserted under the same pid.
+    auto proc = GetLocked(p);
+    if (proc && (*proc)->refcnt_.load(std::memory_order_relaxed) == 0 &&
+        (*proc)->tombstoned_) {
+      map_.erase(p);
     }
   }
 }

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -206,6 +206,11 @@ class ProcessTree {
   // regression test interpose there. Set via ProcessTreeTestPeer (a friend).
   // The per-event null check is negligible.
   std::function<void()> on_event_claimed_for_test_;
+
+  // Test-only seam (empty in production): invoked by ReleaseProcess between
+  // the reader-lock collect and the exclusive-lock erase — the window the
+  // erase re-verify guards. Set via ProcessTreeTestPeer.
+  std::function<void()> on_release_collected_for_test_;
 };
 
 template <typename T>

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -263,6 +263,151 @@ using namespace santa::santad::process_tree;
   }
 }
 
+// Regression: ReleaseProcess collects erase candidates under a reader lock,
+// then re-verifies under the exclusive lock before erasing. If a retain lands
+// in that window, the re-verify must see it and skip the erase.
+- (void)testReleaseRaceRetainInWindowSkipsErase {
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators),
+                                                    /*removal_grace_ticks=*/10);
+  auto init = tree->InsertInit();
+
+  uint64_t event_id = 1;
+  const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+  {
+    tree->HandleFork(event_id++, *init, child_pid);
+    auto child = *tree->Get(child_pid);
+    tree->HandleExit(event_id++, *child);
+  }
+
+  {
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+    PidList pids = {(*child)->pid_};
+    tree->RetainProcess(pids);
+  }
+
+  struct Pid churn_pid = {.pid = 100, .pidversion = 100};
+  for (int i = 0; i < 100; i++) {
+    tree->HandleFork(event_id++, *init, churn_pid);
+    churn_pid.pid++;
+    churn_pid.pidversion++;
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+  }
+
+  PidList pids = {child_pid};
+  int fired = 0;
+  tree->SetOnReleaseCollectedForTest([&] {
+    fired++;
+    tree->RetainProcess(pids);
+  });
+  tree->ReleaseProcess(pids);
+  XCTAssertEqual(fired, 1);
+  // The re-verify must observe the resurrection and skip the erase.
+  XCTAssertTrue(tree->Get(child_pid).has_value());
+
+  // Releasing the resurrected retain erases it.
+  tree->SetOnReleaseCollectedForTest(nullptr);
+  tree->ReleaseProcess(pids);
+  XCTAssertFalse(tree->Get(child_pid).has_value());
+}
+
+// Regression: if a concurrent releaser erases the entry first, the outer
+// release's re-verify must find it gone and skip gracefully rather than
+// double-erasing or crashing.
+- (void)testReleaseRaceConcurrentEraseIsSafe {
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators),
+                                                    /*removal_grace_ticks=*/10);
+  auto init = tree->InsertInit();
+
+  uint64_t event_id = 1;
+  const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+  {
+    tree->HandleFork(event_id++, *init, child_pid);
+    auto child = *tree->Get(child_pid);
+    tree->HandleExit(event_id++, *child);
+  }
+
+  {
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+    PidList pids = {(*child)->pid_};
+    tree->RetainProcess(pids);
+  }
+
+  struct Pid churn_pid = {.pid = 100, .pidversion = 100};
+  for (int i = 0; i < 100; i++) {
+    tree->HandleFork(event_id++, *init, churn_pid);
+    churn_pid.pid++;
+    churn_pid.pidversion++;
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+  }
+
+  PidList pids = {child_pid};
+  int fired = 0;
+  tree->SetOnReleaseCollectedForTest([&] {
+    // The nested ReleaseProcess re-enters this seam; only act on the first fire.
+    if (++fired > 1) return;
+    tree->RetainProcess(pids);
+    tree->ReleaseProcess(pids);
+  });
+  tree->ReleaseProcess(pids);
+  XCTAssertEqual(fired, 2);
+  XCTAssertFalse(tree->Get(child_pid).has_value());
+}
+
+// Regression: if the entry is erased and a fresh process re-inserted under the
+// same pid within the window, the outer release's re-verify must not erase the
+// newcomer. tombstoned_ is the only conjunct that distinguishes it from the
+// stale entry it replaced (refcnt is 0 either way).
+- (void)testReleaseRaceReinsertInWindowKeepsFreshProcess {
+  std::vector<std::unique_ptr<Annotator>> annotators{};
+  auto tree = std::make_shared<ProcessTreeTestPeer>(std::move(annotators),
+                                                    /*removal_grace_ticks=*/10);
+  auto init = tree->InsertInit();
+
+  uint64_t event_id = 1;
+  const struct Pid child_pid = {.pid = 2, .pidversion = 2};
+  {
+    tree->HandleFork(event_id++, *init, child_pid);
+    auto child = *tree->Get(child_pid);
+    tree->HandleExit(event_id++, *child);
+  }
+
+  {
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+    PidList pids = {(*child)->pid_};
+    tree->RetainProcess(pids);
+  }
+
+  struct Pid churn_pid = {.pid = 100, .pidversion = 100};
+  for (int i = 0; i < 100; i++) {
+    tree->HandleFork(event_id++, *init, churn_pid);
+    churn_pid.pid++;
+    churn_pid.pidversion++;
+    auto child = tree->Get(child_pid);
+    XCTAssertTrue(child.has_value());
+  }
+
+  PidList pids = {child_pid};
+  int fired = 0;
+  tree->SetOnReleaseCollectedForTest([&] {
+    // The nested ReleaseProcess re-enters this seam; only act on the first fire.
+    if (++fired > 1) return;
+    tree->RetainProcess(pids);
+    tree->ReleaseProcess(pids);
+    tree->HandleFork(event_id++, *init, child_pid);
+  });
+  tree->ReleaseProcess(pids);
+  XCTAssertEqual(fired, 2);
+  // The outer re-verify must not erase the freshly re-inserted process.
+  XCTAssertTrue(tree->Get(child_pid).has_value());
+}
+
 // Regression: reaping must be a per-entry decision keyed on each removal's own
 // timestamp, independent of the order removals were scheduled in. ES delivers
 // events out of mach_time order, so a still-within-grace removal can sit AHEAD

--- a/Source/common/processtree/process_tree_test_helpers.h
+++ b/Source/common/processtree/process_tree_test_helpers.h
@@ -37,6 +37,12 @@ class ProcessTreeTestPeer : public ProcessTree {
   void SetOnEventClaimedForTest(std::function<void()> hook) {
     on_event_claimed_for_test_ = std::move(hook);
   }
+
+  // Install the ReleaseProcess test seam (ProcessTreeTestPeer is a friend of
+  // ProcessTree, so it can reach the private member).
+  void SetOnReleaseCollectedForTest(std::function<void()> hook) {
+    on_release_collected_for_test_ = std::move(hook);
+  }
 };
 
 }  // namespace santa::santad::process_tree


### PR DESCRIPTION
ReleaseProcess took the exclusive tree lock on every token release (one per ES message on each tree-aware client), making it the dominant writer-lock acquisition on the tree mutex for non-lifecycle events. Only the rare erase of a tombstoned process (a token outliving the exit plus the reap grace) needs write access, so decrement the refcount under a reader lock, collect erase candidates, and re-verify under the exclusive lock before erasing — the re-verify closes the window where a concurrent retain, release, or re-insert of the same pid can slip in between the two lock holds. A test-only seam fires in that window, and three deterministic race tests pin the semantics (late retain skips the erase, concurrent erase is a safe no-op, a re-inserted fresh process survives).