### PR TITLE
common: store process-tree cdhash as raw bytes

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -311,6 +311,7 @@ santa_unit_test(
     deps = [
         ":AuditUtilities",
         ":CSOpsHelper",
+        ":String",
     ],
 )
 

--- a/Source/common/CSOpsHelper.h
+++ b/Source/common/CSOpsHelper.h
@@ -57,6 +57,11 @@ std::optional<uint32_t> CSOpsStatusFlags(pid_t pid,
 std::optional<std::string> CSOpsGetCDHash(pid_t pid,
                                           CSOpsFunc csops_func = csops);
 
+// Retrieve the raw (unencoded) CDHash bytes, exactly CS_CDHASH_LEN long.
+// Callers that need the hex form should use CSOpsGetCDHash instead.
+std::optional<std::string> CSOpsGetCDHashBytes(pid_t pid,
+                                               CSOpsFunc csops_func = csops);
+
 // Retrieve the Team ID string. Returns nullopt for unsigned, adhoc, or on
 // error.
 std::optional<std::string> CSOpsGetTeamID(pid_t pid,

--- a/Source/common/CSOpsHelper.mm
+++ b/Source/common/CSOpsHelper.mm
@@ -63,12 +63,21 @@ std::optional<uint32_t> CSOpsStatusFlags(pid_t pid, CSOpsFunc csops_func) {
   return flags;
 }
 
-std::optional<std::string> CSOpsGetCDHash(pid_t pid, CSOpsFunc csops_func) {
-  std::vector<uint8_t> cdhash(CS_CDHASH_LEN);
+std::optional<std::string> CSOpsGetCDHashBytes(pid_t pid, CSOpsFunc csops_func) {
+  std::string cdhash(CS_CDHASH_LEN, '\0');
   if (csops_func(pid, kCsopCDHash, cdhash.data(), cdhash.size()) != 0) {
     return std::nullopt;
   }
-  std::string hex = BufToHexString(cdhash.data(), cdhash.size());
+  return cdhash;
+}
+
+std::optional<std::string> CSOpsGetCDHash(pid_t pid, CSOpsFunc csops_func) {
+  auto cdhash = CSOpsGetCDHashBytes(pid, std::move(csops_func));
+  if (!cdhash) {
+    return std::nullopt;
+  }
+  std::string hex =
+      BufToHexString(reinterpret_cast<const uint8_t*>(cdhash->data()), cdhash->size());
   if (hex.size() != CS_CDHASH_LEN * 2) {
     return std::nullopt;
   }

--- a/Source/common/CSOpsHelperTest.mm
+++ b/Source/common/CSOpsHelperTest.mm
@@ -20,6 +20,7 @@
 
 #include "Source/common/AuditUtilities.h"
 #include "Source/common/CSOpsHelper.h"
+#include "Source/common/String.h"
 
 @interface CSOpsHelperTest : XCTestCase
 @end
@@ -33,6 +34,21 @@
   std::optional<uint32_t> flags = santa::CSOpsStatusFlags(*selfTok);
   XCTAssertTrue(flags.has_value());
   XCTAssertNotEqual(*flags, 0u);
+}
+
+- (void)testCDHashBytesForSelfIsRawAndHexIsItsEncoding {
+  // The raw variant returns the unencoded csops cdhash (CS_CDHASH_LEN bytes),
+  // and the shared hex variant must be exactly its lowercase-hex encoding.
+  pid_t pid = getpid();
+
+  std::optional<std::string> raw = santa::CSOpsGetCDHashBytes(pid);
+  XCTAssertTrue(raw.has_value());
+  XCTAssertEqual(raw->size(), (size_t)CS_CDHASH_LEN);
+
+  std::optional<std::string> hex = santa::CSOpsGetCDHash(pid);
+  XCTAssertTrue(hex.has_value());
+  XCTAssertEqual(*hex,
+                 santa::BufToHexString(reinterpret_cast<const uint8_t*>(raw->data()), raw->size()));
 }
 
 - (void)testTokenValidatedReadsRefuseMismatchedPidversion {

--- a/Source/common/processtree/SNTEndpointSecurityAdapter.mm
+++ b/Source/common/processtree/SNTEndpointSecurityAdapter.mm
@@ -55,9 +55,11 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
       const es_process_t* target = msg->event.exec.target;
       es_string_token_t executable = target->executable->path;
 
-      // Extract code signing info from the target process
+      // Extract code signing info from the target process. cdhash is stored as
+      // raw bytes; it is hex-encoded lazily where it is consumed (CEL).
       CodeSigningInfo cs_info{
-          .cdhash = santa::BufToHexString(target->cdhash, sizeof(target->cdhash)),
+          .cdhash =
+              std::string(reinterpret_cast<const char*>(target->cdhash), sizeof(target->cdhash)),
           .is_platform_binary = target->is_platform_binary,
       };
 

--- a/Source/common/processtree/process.h
+++ b/Source/common/processtree/process.h
@@ -91,7 +91,7 @@ struct Cred {
 struct CodeSigningInfo {
   std::string signing_id;
   std::string team_id;
-  std::string cdhash;  // hex string
+  std::string cdhash;  // raw CS_CDHASH_LEN bytes; hex-encoded lazily at use
   bool is_platform_binary;
 
   friend bool operator==(const struct CodeSigningInfo& lhs,

--- a/Source/common/processtree/process_tree_macos.mm
+++ b/Source/common/processtree/process_tree_macos.mm
@@ -50,8 +50,8 @@ std::optional<CodeSigningInfo> LoadCodeSigningInfoForPID(pid_t pid) {
   CodeSigningInfo info;
   info.is_platform_binary = (*flags & CS_PLATFORM_BINARY) != 0;
 
-  auto cdhash = santa::CSOpsGetCDHash(pid);
-  if (cdhash) {
+  auto cdhash = santa::CSOpsGetCDHashBytes(pid);
+  if (cdhash && cdhash->size() == CS_CDHASH_LEN) {
     info.cdhash = *cdhash;
   }
 

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -16,6 +16,7 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
+#include <Kernel/kern/cs_blobs.h>
 #include <bsm/libbsm.h>
 
 #include <atomic>
@@ -139,6 +140,12 @@ using namespace santa::santad::process_tree;
           XCTAssertEqualObjects(@(program->executable.c_str()), obj);
         }
       }];
+
+  // The backfill path stores cdhash as raw bytes, not a hex string. The test
+  // binary is code signed, so its cdhash is present and exactly CS_CDHASH_LEN.
+  if (program->code_signing.has_value() && !program->code_signing->cdhash.empty()) {
+    XCTAssertEqual(program->code_signing->cdhash.size(), (size_t)CS_CDHASH_LEN);
+  }
 }
 
 - (void)testAnnotation {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -551,6 +551,27 @@ objc_library(
     ],
 )
 
+santa_unit_test(
+    name = "CELActivationTest",
+    srcs = ["CELActivationTest.mm"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+        "bsm",
+    ],
+    deps = [
+        ":CELActivation",
+        "//Source/common:TestUtils",
+        "//Source/common/cel:CEL",
+        "//Source/common/es:EndpointSecurityMessage",
+        "//Source/common/es:MockEndpointSecurityAPI",
+        "//Source/common/processtree:SNTEndpointSecurityAdapter",
+        "//Source/common/processtree:process",
+        "//Source/common/processtree:process_tree",
+        "//Source/common/processtree:process_tree_test_helpers",
+        "@googletest//:gtest",
+    ],
+)
+
 objc_library(
     name = "SNTExecutionController",
     srcs = ["SNTExecutionController.mm"],
@@ -2028,6 +2049,7 @@ test_suite(
     tests = [
         ":AdminUserStateTest",
         ":AuthResultCacheTest",
+        ":CELActivationTest",
         ":DaemonConfigBundleTest",
         ":EndpointSecurityLoggerTest",
         ":EndpointSecuritySanitizableStringTest",

--- a/Source/santad/CELActivation.mm
+++ b/Source/santad/CELActivation.mm
@@ -72,7 +72,9 @@ std::vector<santa::cel::CELProtoTraits<true>::AncestorT> Ancestors<true>(
         ancestor.set_signing_id(cs.team_id + ":" + cs.signing_id);
       }
       ancestor.set_team_id(cs.team_id);
-      ancestor.set_cdhash(cs.cdhash);
+      // The tree stores cdhash as raw bytes; CEL exposes it as a hex string.
+      ancestor.set_cdhash(santa::BufToHexString(reinterpret_cast<const uint8_t*>(cs.cdhash.data()),
+                                                cs.cdhash.size()));
     }
 
     ancestors.push_back(std::move(ancestor));

--- a/Source/santad/CELActivationTest.mm
+++ b/Source/santad/CELActivationTest.mm
@@ -1,0 +1,168 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/CELActivation.h"
+
+#import <EndpointSecurity/EndpointSecurity.h>
+#import <Foundation/Foundation.h>
+#include <Kernel/kern/cs_blobs.h>
+#import <XCTest/XCTest.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Source/common/TestUtils.h"
+#include "Source/common/cel/Activation.h"
+#include "Source/common/cel/CELProtoTraits.h"
+#include "Source/common/cel/Evaluator.h"
+#include "Source/common/es/Message.h"
+#include "Source/common/es/MockEndpointSecurityAPI.h"
+#include "Source/common/processtree/SNTEndpointSecurityAdapter.h"
+#include "Source/common/processtree/process.h"
+#include "Source/common/processtree/process_tree_test_helpers.h"
+
+using santa::Message;
+using santa::santad::process_tree::CodeSigningInfo;
+using santa::santad::process_tree::Cred;
+using santa::santad::process_tree::Pid;
+using santa::santad::process_tree::ProcessTreeTestPeer;
+using santa::santad::process_tree::Program;
+
+namespace {
+
+// Lowercase-hex encode without going through the code under test.
+std::string HexEncode(const std::string& bytes) {
+  static const char kHexDigits[] = "0123456789abcdef";
+  std::string hex(bytes.size() * 2, '\0');
+  for (size_t i = 0; i < bytes.size(); i++) {
+    uint8_t b = static_cast<uint8_t>(bytes[i]);
+    hex[2 * i] = kHexDigits[b >> 4];
+    hex[2 * i + 1] = kHexDigits[b & 0x0f];
+  }
+  return hex;
+}
+
+// A distinctive CS_CDHASH_LEN-byte raw cdhash.
+std::string MakeRawCDHash() {
+  std::string raw(CS_CDHASH_LEN, '\0');
+  for (size_t i = 0; i < raw.size(); i++) {
+    raw[i] = static_cast<char>(0xA0 + i);
+  }
+  return raw;
+}
+
+}  // namespace
+
+@interface CELActivationTest : XCTestCase
+@end
+
+@implementation CELActivationTest
+
+// The process tree stores cdhash as raw bytes, but CEL exposes it as a hex
+// string. CreateCELActivationBlock must hex-encode at the boundary so existing
+// `ancestors[...].cdhash` rules keep matching.
+- (void)testAncestorCDHashExposedAsHex {
+  auto tree = std::make_shared<ProcessTreeTestPeer>(
+      std::vector<std::unique_ptr<santa::santad::process_tree::Annotator>>{});
+  auto init = tree->InsertInit();
+
+  // Parent P: fork from init, then exec a code-signed binary whose cdhash is
+  // stored as raw bytes (the new tree representation).
+  Pid pPid = {.pid = 20, .pidversion = 1};
+  tree->HandleFork(1, *init, pPid);
+
+  std::string rawCdhash = MakeRawCDHash();
+  std::string expectedHex = HexEncode(rawCdhash);
+
+  CodeSigningInfo cs;
+  cs.cdhash = rawCdhash;
+  cs.signing_id = "com.example.parent";
+  cs.team_id = "TEAMID1234";
+  cs.is_platform_binary = false;
+  Pid pExecPid = {.pid = 20, .pidversion = 2};
+  Program prog = {.executable = "/bin/parent", .arguments = {"/bin/parent"}, .code_signing = cs};
+  tree->HandleExec(2, **tree->Get(pPid), pExecPid, prog, (Cred){.uid = 0, .gid = 0});
+
+  // A child exec whose parent is P-after-exec drives the ancestors walk.
+  es_file_t childFile = MakeESFile("/bin/child");
+  es_process_t childProc = MakeESProcess(&childFile, MakeAuditToken(30, 1), MakeAuditToken(20, 2));
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, &childProc);
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+
+  Message msg(mockESApi, &esMsg);
+  ActivationCallbackBlock block = santa::CreateCELActivationBlock(
+      msg, /*signingID=*/nil, /*teamID=*/nil, /*isPlatformBinary=*/NO, /*signingTime=*/nil,
+      /*secureSigningTime=*/nil, /*entitlements=*/nil, tree);
+
+  std::unique_ptr<::google::api::expr::runtime::BaseActivation> base = block(/*useV2=*/true);
+  // block(useV2=true) always builds a concrete Activation<true>, so this
+  // downcast is safe; the evaluator needs the concrete type.
+  auto* activation = static_cast<santa::cel::Activation<true>*>(base.get());
+
+  auto evaluator = santa::cel::Evaluator<true>::Create();
+  XCTAssertTrue(evaluator.ok());
+
+  std::string expr = "ancestors.exists(a, a.cdhash == '" + expectedHex + "')";
+  auto result = evaluator.value()->CompileAndEvaluate(expr, *activation);
+  XCTAssertTrue(result.ok());
+  XCTAssertEqual(result.value().value, santa::cel::CELProtoTraits<true>::ReturnValue::ALLOWLIST);
+}
+
+// The exec ingest path (InformFromESEvent) must store the ES cdhash as raw
+// bytes in the tree, not a hex string.
+- (void)testExecIngestStoresRawCDHash {
+  auto tree = std::make_shared<ProcessTreeTestPeer>(
+      std::vector<std::unique_ptr<santa::santad::process_tree::Annotator>>{});
+  auto init = tree->InsertInit();
+
+  // Execing process E, forked from init and present in the tree.
+  Pid ePid = {.pid = 10, .pidversion = 1};
+  tree->HandleFork(1, *init, ePid);
+
+  es_file_t procFile = MakeESFile("/bin/e");
+  es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(10, 1), MakeAuditToken(1, 1));
+  es_file_t targetFile = MakeESFile("/bin/t");
+  es_process_t targetProc =
+      MakeESProcess(&targetFile, MakeAuditToken(10, 2), MakeAuditToken(10, 1));
+  targetProc.codesigning_flags = CS_SIGNED | CS_VALID;
+
+  std::string rawCdhash = MakeRawCDHash();
+  std::memcpy(targetProc.cdhash, rawCdhash.data(), CS_CDHASH_LEN);
+
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXEC, &proc);
+  esMsg.mach_time = 100;
+  esMsg.event.exec.target = &targetProc;
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+  EXPECT_CALL(*mockESApi, ExecArgCount).WillRepeatedly(testing::Return(0));
+
+  {
+    Message msg(mockESApi, &esMsg);
+    santa::santad::process_tree::InformFromESEvent(*tree, msg);
+  }
+
+  auto execd = tree->Get((Pid){.pid = 10, .pidversion = 2});
+  XCTAssertTrue(execd.has_value());
+  XCTAssertTrue((*execd)->program_->code_signing.has_value());
+  const std::string& stored = (*execd)->program_->code_signing->cdhash;
+  XCTAssertEqual(stored.size(), (size_t)CS_CDHASH_LEN);
+  XCTAssertEqual(0, std::memcmp(stored.data(), rawCdhash.data(), CS_CDHASH_LEN));
+}
+
+@end


### PR DESCRIPTION
The process tree hex-encoded every exec's cdhash eagerly, though it is read only lazily by CEL `ancestors` rules. This stores the raw csops bytes in the tree and hex-encodes at the CEL boundary, deferring the encode to the rare read path and shrinking each process's cdhash (dropping a heap allocation, since raw fits libc++ SSO).

Both ingest paths — the exec adapter and PID backfill — store raw. `CSOpsHelper` gains a raw `CSOpsGetCDHashBytes` variant while `CSOpsGetCDHash` keeps its hex contract for its other callers. The CEL ancestor `cdhash` remains a hex string, so existing rules are unaffected.