### PR TITLE
Reduce locks and copies on the process-tree ingest path

### DIFF
--- a/Source/common/processtree/SNTEndpointSecurityAdapter.mm
+++ b/Source/common/processtree/SNTEndpointSecurityAdapter.mm
@@ -34,13 +34,6 @@ namespace santa::santad::process_tree {
 
 void InformFromESEvent(ProcessTree& tree, const Message& msg) {
   struct Pid event_pid = PidFromAuditToken(msg->process->audit_token);
-  auto proc = tree.Get(event_pid);
-
-  if (!proc) {
-    return;
-  }
-
-  std::shared_ptr<EndpointSecurityAPI> esapi = msg.ESAPI();
 
   switch (msg->event_type) {
     case ES_EVENT_TYPE_AUTH_EXEC:
@@ -48,15 +41,21 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
       const es_process_t* target = msg->event.exec.target;
       struct Pid target_pid = PidFromAuditToken(target->audit_token);
 
-      // The same exec is delivered to every tree-aware client (and to the
-      // Authorizer as both AUTH_EXEC and NOTIFY_EXEC). Building the arg list and
-      // Program below is the expensive part, so skip it when the tree has
-      // already recorded this exact exec. HandleExec re-checks under the write
-      // lock, so a racing novel exec is never dropped.
-      if (tree.HasSeenExec(msg->mach_time, event_pid, target_pid)) {
+      // One reader lock: learn whether this exact exec was already recorded and,
+      // if not, fetch the execing process. The same exec is delivered to every
+      // tree-aware client (and to the Authorizer as both AUTH_EXEC and
+      // NOTIFY_EXEC); building the arg list and Program below is the expensive
+      // part, so skip it for a duplicate delivery. HandleExec re-checks under
+      // the write lock, so a racing novel exec is never dropped.
+      auto [proc, already_seen] = tree.GetExecActor(msg->mach_time, event_pid, target_pid);
+      if (already_seen) {
         break;
       }
+      if (!proc) {
+        return;
+      }
 
+      std::shared_ptr<EndpointSecurityAPI> esapi = msg.ESAPI();
       uint32_t arg_count = esapi->ExecArgCount(&msg->event.exec);
       std::vector<std::string> args;
       args.reserve(arg_count);
@@ -84,20 +83,29 @@ void InformFromESEvent(ProcessTree& tree, const Message& msg) {
       tree.HandleExec(msg->mach_time, **proc, target_pid,
                       (struct Program){.executable = StringTokenToString(executable),
                                        .arguments = std::move(args),
-                                       .code_signing = cs_info},
+                                       .code_signing = std::move(cs_info)},
                       (struct Cred){
                           .uid = audit_token_to_euid(target->audit_token),
                           .gid = audit_token_to_egid(target->audit_token),
                       });
-
       break;
     }
     case ES_EVENT_TYPE_NOTIFY_FORK: {
-      tree.HandleFork(msg->mach_time, **proc,
-                      PidFromAuditToken(msg->event.fork.child->audit_token));
+      auto proc = tree.Get(event_pid);
+      if (!proc) {
+        return;
+      }
+      tree.HandleFork(msg->mach_time, *proc, PidFromAuditToken(msg->event.fork.child->audit_token));
       break;
     }
-    case ES_EVENT_TYPE_NOTIFY_EXIT: tree.HandleExit(msg->mach_time, **proc); break;
+    case ES_EVENT_TYPE_NOTIFY_EXIT: {
+      auto proc = tree.Get(event_pid);
+      if (!proc) {
+        return;
+      }
+      tree.HandleExit(msg->mach_time, **proc);
+      break;
+    }
     default: return;
   }
 }

--- a/Source/common/processtree/annotations/originator_test.mm
+++ b/Source/common/processtree/annotations/originator_test.mm
@@ -44,7 +44,7 @@ namespace ptpb = ::santa::pb::v1::process_tree;
 
   // PID 1.1: fork() -> PID 2.2
   const struct Pid login_pid = {.pid = 2, .pidversion = 2};
-  self.tree->HandleFork(event_id++, *self.initProc, login_pid);
+  self.tree->HandleFork(event_id++, self.initProc, login_pid);
 
   // PID 2.2: exec("/usr/bin/login") -> PID 2.3
   const struct Pid login_exec_pid = {.pid = 2, .pidversion = 3};
@@ -63,7 +63,7 @@ namespace ptpb = ::santa::pb::v1::process_tree;
 
   // PID 2.3: fork() -> PID 3.3
   const struct Pid shell_pid = {.pid = 3, .pidversion = 3};
-  self.tree->HandleFork(event_id++, *login, shell_pid);
+  self.tree->HandleFork(event_id++, login, shell_pid);
   // PID 3.3: exec("/bin/zsh") -> PID 3.4
   const struct Pid shell_exec_pid = {.pid = 3, .pidversion = 4};
   const struct Program shell_prog = {.executable = "/bin/zsh", .arguments = {}};

--- a/Source/common/processtree/process.h
+++ b/Source/common/processtree/process.h
@@ -24,6 +24,7 @@
 #include <optional>
 #include <string>
 #include <typeindex>
+#include <utility>
 #include <vector>
 
 #include "Source/common/processtree/annotations/annotator.h"
@@ -131,9 +132,9 @@ class Process {
                    std::shared_ptr<const Process> parent)
       : pid_(pid),
         effective_cred_(cred),
-        program_(program),
+        program_(std::move(program)),
         annotations_(),
-        parent_(parent),
+        parent_(std::move(parent)),
         refcnt_(0),
         tombstoned_(false) {}
   Process(const Process&) = delete;

--- a/Source/common/processtree/process_tree.cc
+++ b/Source/common/processtree/process_tree.cc
@@ -83,32 +83,28 @@ void ProcessTree::BackfillInsertChildren(
   }
 }
 
-void ProcessTree::HandleFork(uint64_t timestamp, const Process& parent,
+void ProcessTree::HandleFork(uint64_t timestamp,
+                             const std::shared_ptr<const Process>& parent,
                              const Pid new_pid) {
-  std::shared_ptr<Process> child;
+  // Allocate the child OUTSIDE the write lock (as HandleExec does): the caller
+  // supplies the parent handle, so no lock-held lookup is needed to build it.
+  auto child = std::make_shared<Process>(new_pid, parent->effective_cred_,
+                                         parent->program_, parent);
   {
     // Dedup and the map insert are one critical section: if we released the
     // lock between them, another client could see this event as a duplicate
     // (skip it) and then read the tree before the child was inserted.
     absl::MutexLock lock(mtx_);
-    if (!StepLocked({timestamp, EventKind::kFork, parent.pid_, new_pid})) {
+    if (!StepLocked({timestamp, EventKind::kFork, parent->pid_, new_pid})) {
       return;
     }
     // Test seam (no-op in production): the claim just succeeded and mtx_ is
     // still held; fire here, BEFORE the insert, so the concurrency test can
     // verify a reader blocks at this boundary — i.e. claim and insert are a
-    // single lock hold. Placed in the handler (not StepLocked) on purpose: if
-    // the insert were ever moved to a separate critical section, this point
-    // would fall in the unlocked gap and the test would deterministically fail.
+    // single lock hold.
     if (on_event_claimed_for_test_) {
       on_event_claimed_for_test_();
     }
-    // Look up the parent rather than using map_[]: operator[] would insert a
-    // null entry (and orphan the child) if the parent were ever absent.
-    auto parent_proc = GetLocked(parent.pid_);
-    child = std::make_shared<Process>(new_pid, parent.effective_cred_,
-                                      parent.program_,
-                                      parent_proc ? *parent_proc : nullptr);
     map_.emplace(new_pid, child);
     // Reap AFTER applying, so a late event can never reap the actor it needs.
     DrainRemovals();
@@ -117,7 +113,7 @@ void ProcessTree::HandleFork(uint64_t timestamp, const Process& parent,
   // propagation is therefore NOT atomic with the structural insert above; that
   // is intentional and does not affect CEL ancestry (see StepLocked).
   for (const auto& annotator : annotators_) {
-    annotator->AnnotateFork(*this, parent, *child);
+    annotator->AnnotateFork(*this, *parent, *child);
   }
 }
 
@@ -132,7 +128,7 @@ void ProcessTree::HandleExec(uint64_t timestamp, const Process& p,
   // exact-duplicate delivery is rejected, while distinct deliveries that share
   // a pid but carry a different mach_time both pass and the later one is a
   // first-wins map_.emplace no-op. Callers building the Program eagerly can
-  // skip known duplicates up front via HasSeenExec (see InformFromESEvent).
+  // skip known duplicates up front via GetExecActor (see InformFromESEvent).
 
   // Allocate the new process OUTSIDE the write lock to keep the shared tree
   // lock short on the serial ES handler path; prog is moved in, not copied.
@@ -161,10 +157,14 @@ void ProcessTree::HandleExit(uint64_t timestamp, const Process& p) {
   DrainRemovals();
 }
 
-bool ProcessTree::HasSeenExec(uint64_t timestamp, const Pid actor,
-                              const Pid target) const {
+ProcessTree::ExecActor ProcessTree::GetExecActor(uint64_t timestamp,
+                                                 const Pid actor,
+                                                 const Pid target) const {
   absl::ReaderMutexLock lock(mtx_);
-  return seen_.contains({timestamp, EventKind::kExec, actor, target});
+  if (seen_.contains({timestamp, EventKind::kExec, actor, target})) {
+    return {std::nullopt, /*already_seen=*/true};
+  }
+  return {GetLocked(actor), /*already_seen=*/false};
 }
 
 bool ProcessTree::StepLocked(const EventKey& key) {

--- a/Source/common/processtree/process_tree.h
+++ b/Source/common/processtree/process_tree.h
@@ -58,8 +58,11 @@ class ProcessTree {
   absl::Status Backfill();
 
   // Inform the tree of a fork event, in which the parent process spawns a child
-  // with the only difference between the two being the pid.
-  void HandleFork(uint64_t timestamp, const Process& parent,
+  // with the only difference between the two being the pid. `parent` is the
+  // handle to the forking process (e.g. from Get); it becomes the child's
+  // parent link directly, so no lookup is needed under the write lock.
+  void HandleFork(uint64_t timestamp,
+                  const std::shared_ptr<const Process>& parent,
                   struct Pid new_pid);
 
   // Inform the tree of an exec event, in which the program and potentially cred
@@ -76,12 +79,24 @@ class ProcessTree {
   // Inform the tree of a process exit.
   void HandleExit(uint64_t timestamp, const Process& p);
 
-  // Returns whether an exec event with this identity has already been recorded
-  // by the tree. Lets a caller skip building the (expensive) Program before
-  // calling HandleExec for a duplicate delivery. Best-effort: HandleExec
-  // re-checks under the write lock, so a racing novel exec is never dropped.
-  bool HasSeenExec(uint64_t timestamp, struct Pid actor,
-                   struct Pid target) const;
+  // Result of GetExecActor. `proc` is the execing (actor) process; it is
+  // populated only when `already_seen` is false (and may still be empty then if
+  // the actor is unknown to the tree), so callers must check `already_seen`
+  // first.
+  struct ExecActor {
+    std::optional<std::shared_ptr<const Process>> proc;
+    bool already_seen;
+  };
+
+  // Single reader-lock lookup for the exec ingest path: reports whether this
+  // exact exec (timestamp+actor+target identity) was already recorded and, if
+  // not, returns the execing (actor) process. Checks the dedup set first and
+  // short-circuits, so a duplicate delivery does no map lookup. Lets a caller
+  // skip building the (expensive) Program for a duplicate delivery.
+  // Best-effort: HandleExec re-checks under the write lock, so a racing novel
+  // exec is never dropped.
+  ExecActor GetExecActor(uint64_t timestamp, struct Pid actor,
+                         struct Pid target) const;
 
   // Mark the given pids as needing to be retained in the tree's map for future
   // access. Normally, Processes are removed once all clients process past the

--- a/Source/common/processtree/process_tree_macos.mm
+++ b/Source/common/processtree/process_tree_macos.mm
@@ -173,7 +173,7 @@ absl::StatusOr<BackfilledProcess> LoadPID(pid_t pid) {
       .cred = {.uid = audit_token_to_euid(token), .gid = audit_token_to_egid(token)},
       .program = std::make_shared<struct Program>((struct Program){
           .executable = path,
-          .arguments = args,
+          .arguments = std::move(args),
           .code_signing = LoadCodeSigningInfoForPID(pid),
       }),
   };

--- a/Source/common/processtree/process_tree_test.mm
+++ b/Source/common/processtree/process_tree_test.mm
@@ -105,7 +105,7 @@ using namespace santa::santad::process_tree;
   uint64_t event_id = 1;
   // PID 1.1: fork() -> PID 2.2
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
-  self.tree->HandleFork(event_id++, *self.initProc, child_pid);
+  self.tree->HandleFork(event_id++, self.initProc, child_pid);
 
   auto child_opt = self.tree->Get(child_pid);
   XCTAssertTrue(child_opt.has_value());
@@ -134,7 +134,7 @@ using namespace santa::santad::process_tree;
 // same exec (identical EventKey) more than once. A duplicate delivery must be
 // deduped: the exec is applied — and thus annotated — exactly once, with the
 // program unchanged. StepLocked is the authoritative dedup gate. (Callers skip
-// the build for known duplicates up front via HasSeenExec; see the adapter.)
+// the build for known duplicates up front via GetExecActor; see the adapter.)
 - (void)testDuplicateExecDeliveryIsIdempotent {
   auto exec_count = std::make_shared<int>(0);
   std::vector<std::unique_ptr<Annotator>> annotators{};
@@ -144,7 +144,7 @@ using namespace santa::santad::process_tree;
 
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
-  tree->HandleFork(event_id++, *init, child_pid);
+  tree->HandleFork(event_id++, init, child_pid);
   auto child = *tree->Get(child_pid);
 
   const struct Pid exec_pid = {.pid = 2, .pidversion = 3};
@@ -168,29 +168,36 @@ using namespace santa::santad::process_tree;
   XCTAssertEqual(slice.back(), init);
 }
 
-// HasSeenExec lets the ES adapter skip building the Program for an exec the tree
-// has already recorded. It must report true for exactly the event identity that
-// HandleExec dedups on, and false for anything else.
-- (void)testHasSeenExec {
+// GetExecActor lets the ES adapter learn, under one reader lock, whether an exec
+// was already recorded and (if not) fetch the execing process. already_seen must
+// flip for exactly the identity HandleExec dedups on; proc resolves the actor on
+// the not-seen path and is suppressed once the exec is seen.
+- (void)testGetExecActor {
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
-  self.tree->HandleFork(event_id++, *self.initProc, child_pid);
+  self.tree->HandleFork(event_id++, self.initProc, child_pid);
   auto child = *self.tree->Get(child_pid);
 
   const struct Pid exec_pid = {.pid = 2, .pidversion = 3};
   const struct Program prog = {.executable = "/bin/bash", .arguments = {}};
   const uint64_t exec_ts = 100;
 
-  // Unknown before the exec is applied.
-  XCTAssertFalse(self.tree->HasSeenExec(exec_ts, child_pid, exec_pid));
+  // Before the exec: not seen, and the actor (child) resolves.
+  auto before = self.tree->GetExecActor(exec_ts, child_pid, exec_pid);
+  XCTAssertFalse(before.already_seen);
+  XCTAssertTrue(before.proc.has_value());
+  XCTAssertEqual(*before.proc, child);
 
   self.tree->HandleExec(exec_ts, *child, exec_pid, prog, child->effective_cred_);
 
-  // Recorded after — matching the identity HandleExec deduped on.
-  XCTAssertTrue(self.tree->HasSeenExec(exec_ts, child_pid, exec_pid));
-  // A different timestamp or pid is a distinct event.
-  XCTAssertFalse(self.tree->HasSeenExec(exec_ts + 1, child_pid, exec_pid));
-  XCTAssertFalse(self.tree->HasSeenExec(exec_ts, child_pid, child_pid));
+  // After: the exact identity is seen, and proc is suppressed on the seen path.
+  auto after = self.tree->GetExecActor(exec_ts, child_pid, exec_pid);
+  XCTAssertTrue(after.already_seen);
+  XCTAssertFalse(after.proc.has_value());
+
+  // A different timestamp or target is a distinct, still-unseen event.
+  XCTAssertFalse(self.tree->GetExecActor(exec_ts + 1, child_pid, exec_pid).already_seen);
+  XCTAssertFalse(self.tree->GetExecActor(exec_ts, child_pid, child_pid).already_seen);
 }
 
 // We can't test the full backfill process, as retrieving information on
@@ -237,7 +244,7 @@ using namespace santa::santad::process_tree;
 
   // PID 1.1: fork() -> PID 2.2
   const struct Pid login_pid = {.pid = 2, .pidversion = 2};
-  self.tree->HandleFork(event_id++, *self.initProc, login_pid);
+  self.tree->HandleFork(event_id++, self.initProc, login_pid);
 
   // PID 2.2: exec("/usr/bin/login") -> PID 2.3
   const struct Pid login_exec_pid = {.pid = 2, .pidversion = 3};
@@ -253,7 +260,7 @@ using namespace santa::santad::process_tree;
 
   // PID 2.3: fork() -> PID 3.3
   const struct Pid shell_pid = {.pid = 3, .pidversion = 3};
-  self.tree->HandleFork(event_id++, *login, shell_pid);
+  self.tree->HandleFork(event_id++, login, shell_pid);
   // PID 3.3: exec("/bin/zsh") -> PID 3.4
   const struct Pid shell_exec_pid = {.pid = 3, .pidversion = 4};
   const struct Program shell_prog = {.executable = "/bin/zsh", .arguments = {}};
@@ -278,7 +285,7 @@ using namespace santa::santad::process_tree;
 
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
-  tree->HandleFork(event_id++, *init, child_pid);  // ts=1
+  tree->HandleFork(event_id++, init, child_pid);  // ts=1
   auto child = *tree->Get(child_pid);
   tree->HandleExit(event_id++, *child);  // ts=2: scheduled for removal
 
@@ -288,14 +295,14 @@ using namespace santa::santad::process_tree;
   // Step forward but stay within the grace (latest_ts - grace <= 2).
   struct Pid churn_pid = {.pid = 3, .pidversion = 3};
   for (int i = 0; i < 10; i++) {  // ts=3..12 -> latest=12, cutoff=2
-    tree->HandleFork(event_id++, *init, churn_pid);
+    tree->HandleFork(event_id++, init, churn_pid);
     churn_pid.pid++;
   }
   XCTAssertTrue(tree->Get(child_pid).has_value());
 
   // Step past the grace (latest_ts - grace > 2): the exited child is reaped.
   for (int i = 0; i < 5; i++) {  // ts=13..17 -> cutoff reaches 7 > 2
-    tree->HandleFork(event_id++, *init, churn_pid);
+    tree->HandleFork(event_id++, init, churn_pid);
     churn_pid.pid++;
   }
   XCTAssertFalse(tree->Get(child_pid).has_value());
@@ -310,7 +317,7 @@ using namespace santa::santad::process_tree;
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
   {
-    tree->HandleFork(event_id++, *init, child_pid);
+    tree->HandleFork(event_id++, init, child_pid);
     auto child = *tree->Get(child_pid);
     tree->HandleExit(event_id++, *child);
   }
@@ -326,7 +333,7 @@ using namespace santa::santad::process_tree;
   // (tombstoned, not erased).
   struct Pid churn_pid = {.pid = 100, .pidversion = 100};
   for (int i = 0; i < 100; i++) {
-    tree->HandleFork(event_id++, *init, churn_pid);
+    tree->HandleFork(event_id++, init, churn_pid);
     churn_pid.pid++;
     churn_pid.pidversion++;
     auto child = tree->Get(child_pid);
@@ -360,7 +367,7 @@ using namespace santa::santad::process_tree;
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
   {
-    tree->HandleFork(event_id++, *init, child_pid);
+    tree->HandleFork(event_id++, init, child_pid);
     auto child = *tree->Get(child_pid);
     tree->HandleExit(event_id++, *child);
   }
@@ -374,7 +381,7 @@ using namespace santa::santad::process_tree;
 
   struct Pid churn_pid = {.pid = 100, .pidversion = 100};
   for (int i = 0; i < 100; i++) {
-    tree->HandleFork(event_id++, *init, churn_pid);
+    tree->HandleFork(event_id++, init, churn_pid);
     churn_pid.pid++;
     churn_pid.pidversion++;
     auto child = tree->Get(child_pid);
@@ -410,7 +417,7 @@ using namespace santa::santad::process_tree;
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
   {
-    tree->HandleFork(event_id++, *init, child_pid);
+    tree->HandleFork(event_id++, init, child_pid);
     auto child = *tree->Get(child_pid);
     tree->HandleExit(event_id++, *child);
   }
@@ -424,7 +431,7 @@ using namespace santa::santad::process_tree;
 
   struct Pid churn_pid = {.pid = 100, .pidversion = 100};
   for (int i = 0; i < 100; i++) {
-    tree->HandleFork(event_id++, *init, churn_pid);
+    tree->HandleFork(event_id++, init, churn_pid);
     churn_pid.pid++;
     churn_pid.pidversion++;
     auto child = tree->Get(child_pid);
@@ -457,7 +464,7 @@ using namespace santa::santad::process_tree;
   uint64_t event_id = 1;
   const struct Pid child_pid = {.pid = 2, .pidversion = 2};
   {
-    tree->HandleFork(event_id++, *init, child_pid);
+    tree->HandleFork(event_id++, init, child_pid);
     auto child = *tree->Get(child_pid);
     tree->HandleExit(event_id++, *child);
   }
@@ -471,7 +478,7 @@ using namespace santa::santad::process_tree;
 
   struct Pid churn_pid = {.pid = 100, .pidversion = 100};
   for (int i = 0; i < 100; i++) {
-    tree->HandleFork(event_id++, *init, churn_pid);
+    tree->HandleFork(event_id++, init, churn_pid);
     churn_pid.pid++;
     churn_pid.pidversion++;
     auto child = tree->Get(child_pid);
@@ -485,7 +492,7 @@ using namespace santa::santad::process_tree;
     if (++fired > 1) return;
     tree->RetainProcess(pids);
     tree->ReleaseProcess(pids);
-    tree->HandleFork(event_id++, *init, child_pid);
+    tree->HandleFork(event_id++, init, child_pid);
   });
   tree->ReleaseProcess(pids);
   XCTAssertEqual(fired, 2);
@@ -509,7 +516,7 @@ using namespace santa::santad::process_tree;
   // Survivor: forked at ts=50, exits at ts=100. Its removal is scheduled FIRST,
   // at the newest timestamp seen, so it stays within the grace (cutoff = 90).
   const struct Pid survivor_pid = {.pid = 2, .pidversion = 2};
-  tree->HandleFork(50, *init, survivor_pid);
+  tree->HandleFork(50, init, survivor_pid);
   auto survivor = *tree->Get(survivor_pid);
   tree->HandleExit(100, *survivor);  // schedules survivor@100, latest_ts=100
 
@@ -517,7 +524,7 @@ using namespace santa::santad::process_tree;
   // scheduled SECOND (behind the survivor) but at an old timestamp (20 < 90), so
   // it is already expired the moment it is scheduled.
   const struct Pid reaped_pid = {.pid = 3, .pidversion = 3};
-  tree->HandleFork(10, *init, reaped_pid);  // novel out-of-order fork, tracked
+  tree->HandleFork(10, init, reaped_pid);  // novel out-of-order fork, tracked
   auto reaped = *tree->Get(reaped_pid);
   tree->HandleExit(20, *reaped);  // schedules reaped@20 -> already expired
 
@@ -537,14 +544,14 @@ using namespace santa::santad::process_tree;
   // Advance the dedup/ordering state well forward with monotonic events.
   struct Pid churn_pid = {.pid = 100, .pidversion = 100};
   for (int i = 0; i < 200; i++) {
-    self.tree->HandleFork(base + i, *self.initProc, churn_pid);
+    self.tree->HandleFork(base + i, self.initProc, churn_pid);
     churn_pid.pid++;
     churn_pid.pidversion++;
   }
 
   // A novel fork stamped far behind the newest timestamp seen (reordered straggler).
   const struct Pid late_child_pid = {.pid = 2, .pidversion = 2};
-  self.tree->HandleFork(base - 500, *self.initProc, late_child_pid);
+  self.tree->HandleFork(base - 500, self.initProc, late_child_pid);
 
   auto late_child_opt = self.tree->Get(late_child_pid);
   XCTAssertTrue(late_child_opt.has_value());
@@ -576,8 +583,8 @@ using namespace santa::santad::process_tree;
   uint64_t ts = 1000;
   const struct Pid a = {.pid = 2, .pidversion = 2};
   const struct Pid b = {.pid = 3, .pidversion = 3};
-  self.tree->HandleFork(ts, *self.initProc, a);
-  self.tree->HandleFork(ts, *self.initProc, b);  // same ts, different child
+  self.tree->HandleFork(ts, self.initProc, a);
+  self.tree->HandleFork(ts, self.initProc, b);  // same ts, different child
 
   XCTAssertTrue(self.tree->Get(a).has_value());
   XCTAssertTrue(self.tree->Get(b).has_value());  // the discriminating assertion
@@ -619,7 +626,7 @@ using namespace santa::santad::process_tree;
   });
 
   // Producer claims the fork and pauses inside the critical section (mtx_ held).
-  std::thread producer([&] { tree->HandleFork(1, *init, child_pid); });
+  std::thread producer([&] { tree->HandleFork(1, init, child_pid); });
   {
     std::unique_lock<std::mutex> lk(m);
     // Bounded wait: if StepLocked ever wrongly rejected this novel fork the hook

--- a/Source/santad/CELActivationTest.mm
+++ b/Source/santad/CELActivationTest.mm
@@ -82,7 +82,7 @@ std::string MakeRawCDHash() {
   // Parent P: fork from init, then exec a code-signed binary whose cdhash is
   // stored as raw bytes (the new tree representation).
   Pid pPid = {.pid = 20, .pidversion = 1};
-  tree->HandleFork(1, *init, pPid);
+  tree->HandleFork(1, init, pPid);
 
   std::string rawCdhash = MakeRawCDHash();
   std::string expectedHex = HexEncode(rawCdhash);
@@ -132,7 +132,7 @@ std::string MakeRawCDHash() {
 
   // Execing process E, forked from init and present in the tree.
   Pid ePid = {.pid = 10, .pidversion = 1};
-  tree->HandleFork(1, *init, ePid);
+  tree->HandleFork(1, init, ePid);
 
   es_file_t procFile = MakeESFile("/bin/e");
   es_process_t proc = MakeESProcess(&procFile, MakeAuditToken(10, 1), MakeAuditToken(1, 1));

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -1543,13 +1543,13 @@ static SNTSandboxExecRequest* MakeSandboxRequest(uint64_t dev, uint64_t ino, con
   uint64_t eventId = 1;
   // B (600, 1): the sandboxed seatbelt process.
   struct Pid bPid = {.pid = 600, .pidversion = 1};
-  tree->HandleFork(eventId++, *init, bPid);
+  tree->HandleFork(eventId++, init, bPid);
   // B fork -> C (601, 2).
   struct Pid cPid = {.pid = 601, .pidversion = 2};
-  tree->HandleFork(eventId++, **tree->Get(bPid), cPid);
+  tree->HandleFork(eventId++, *tree->Get(bPid), cPid);
   // C fork -> D (602, 3).
   struct Pid dPid = {.pid = 602, .pidversion = 3};
-  tree->HandleFork(eventId++, **tree->Get(cPid), dPid);
+  tree->HandleFork(eventId++, *tree->Get(cPid), dPid);
 
   self.sut = [self makeControllerWithProcessTree:tree];
 
@@ -1601,9 +1601,9 @@ static SNTSandboxExecRequest* MakeSandboxRequest(uint64_t dev, uint64_t ino, con
 
   uint64_t eventId = 1;
   struct Pid bPid = {.pid = 700, .pidversion = 1};
-  tree->HandleFork(eventId++, *init, bPid);
+  tree->HandleFork(eventId++, init, bPid);
   struct Pid cPid = {.pid = 701, .pidversion = 2};
-  tree->HandleFork(eventId++, **tree->Get(bPid), cPid);
+  tree->HandleFork(eventId++, *tree->Get(bPid), cPid);
 
   self.sut = [self makeControllerWithProcessTree:tree];
 


### PR DESCRIPTION
Reduces lock acquisitions and copies on the process-tree ingest hot path, all behavior-preserving.

The exec path now takes the tree lock once instead of twice — a single-reader-lock `GetExecActor` replaces the `Get` + `HasSeenExec` pair, and a duplicate delivery (every exec reaches each tree-aware client, and the Authorizer as both AUTH and NOTIFY) does no map lookup at all. Fork ingest threads the already-fetched parent handle into `HandleFork`, dropping a redundant map find and the child allocation out of the exclusive write lock, the way `HandleExec` already does. A few `std::move`/sink-parameter cleanups in `Process` construction, the exec `CodeSigningInfo`, and backfill round it out.

Existing process-tree and santad unit tests pass unchanged, including the concurrency claim→insert guardrail.