### PR TITLE
Tighten and speed up NSString string conversions

### DIFF
--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -36,24 +36,31 @@ static inline std::string NSStringToUTF8String(NSString* str) {
 }
 
 static inline NSString* StringToNSString(const std::string& str) {
-  return [NSString stringWithUTF8String:str.c_str()];
+  return [[NSString alloc] initWithBytes:str.data()
+                                  length:str.length()
+                                encoding:NSUTF8StringEncoding];
 }
 
 static inline NSString* StringToNSString(const char* str) {
+  if (!str) {
+    return nil;
+  }
   return [NSString stringWithUTF8String:str];
 }
 
 static inline NSString* StringToNSString(std::string_view str) {
-  return [NSString stringWithUTF8String:str.data()];
+  // string_view is not guaranteed NUL-terminated, so pass an explicit length
+  // rather than letting NSString scan past the view's end.
+  return [[NSString alloc] initWithBytes:str.data()
+                                  length:str.length()
+                                encoding:NSUTF8StringEncoding];
 }
 
 static inline NSString* OptionalStringToNSString(const std::optional<std::string>& optional_str) {
-  std::string str = optional_str.value_or("");
-  if (str.length() == 0) {
+  if (!optional_str || optional_str->empty()) {
     return nil;
-  } else {
-    return StringToNSString(str);
   }
+  return StringToNSString(*optional_str);
 }
 
 static inline std::string_view StringTokenToStringView(es_string_token_t es_str) {

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -528,7 +528,7 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
     event.ruleId = policy->rule_id;
     event.decision = decision;
     event.process.fileSHA256 = cd.sha256 ?: @"<unknown sha>";
-    event.process.filePath = StringToNSString(msg->process->executable->path.data);
+    event.process.filePath = StringTokenToNSString(msg->process->executable->path);
     event.process.teamID = StringTokenToNSString(msg->process->team_id);
     event.process.signingID = StringTokenToNSString(msg->process->signing_id);
     event.process.cdhash =

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -175,7 +175,7 @@ es_file_t* GetTargetFileForPrefixTree(const es_message_t* msg) {
       }
 
       // Only log file changes that match the given regex
-      NSString* targetPath = santa::StringToNSString(targetFile->path.data);
+      NSString* targetPath = santa::StringTokenToNSString(targetFile->path);
       if (![[self.configurator fileChangesRegex]
               numberOfMatchesInString:targetPath
                               options:0

--- a/Source/santad/TTYWriter.mm
+++ b/Source/santad/TTYWriter.mm
@@ -97,7 +97,7 @@ void TTYWriter::Write(const es_process_t* proc, bool send_signal,
   if (!CanWrite(proc)) {
     return;
   }
-  Write(santa::StringToNSString(proc->tty->path.data), send_signal, messageCreator);
+  Write(santa::StringTokenToNSString(proc->tty->path), send_signal, messageCreator);
 }
 
 void TTYWriter::Write(const es_process_t* proc, NSString* (^messageCreator)(void)) {


### PR DESCRIPTION
A correctness + hardening pass over the string→NSString helpers in `String.h`.

`StringToNSString` now uses sized `-initWithBytes:length:encoding:` for its `std::string` and `std::string_view` overloads, skipping the `strlen` that `-stringWithUTF8String:` does and — importantly for the `string_view` case — respecting the view's length instead of scanning for a NUL past its end. The `const char*` overload is null-guarded (returns nil rather than crashing), and `OptionalStringToNSString` no longer copies the string. A few `es_string_token` call sites move onto `StringTokenToNSString`, which already carries the token length.

These are primarily correctness and robustness improvements; the skipped scans largely sit off the latency-critical paths, so no measurable macro win is expected.