### PR TITLE
Reduce work on the exec-decision and file-change regex paths

### DIFF
--- a/Source/common/SNTRuleIdentifiers.h
+++ b/Source/common/SNTRuleIdentifiers.h
@@ -62,6 +62,13 @@ struct RuleIdentifiers {
 - (instancetype)initWithRuleIdentifiers:(struct RuleIdentifiers)ri
                        andSigningStatus:(SNTSigningStatus)signingStatus;
 
+/// Returns a copy of `ri` with only the identifiers valid for policy matching
+/// at the given signing status; the rest are cleared. This is the struct-level
+/// primitive behind initWithRuleIdentifiers:andSigningStatus:, exposed so hot
+/// callers can filter identifiers without allocating a short-lived object.
++ (struct RuleIdentifiers)filterIdentifiers:(struct RuleIdentifiers)ri
+                           forSigningStatus:(SNTSigningStatus)signingStatus;
+
 - (struct RuleIdentifiers)toStruct;
 
 @end

--- a/Source/common/SNTRuleIdentifiers.mm
+++ b/Source/common/SNTRuleIdentifiers.mm
@@ -38,6 +38,12 @@
 
 - (instancetype)initWithRuleIdentifiers:(struct RuleIdentifiers)ri
                        andSigningStatus:(SNTSigningStatus)signingStatus {
+  return [self initWithRuleIdentifiers:[SNTRuleIdentifiers filterIdentifiers:ri
+                                                            forSigningStatus:signingStatus]];
+}
+
++ (struct RuleIdentifiers)filterIdentifiers:(struct RuleIdentifiers)ri
+                           forSigningStatus:(SNTSigningStatus)signingStatus {
   NSString* cdhash;
   NSString* binarySHA256;
   NSString* signingID;
@@ -75,13 +81,13 @@
   }
   // clang-format on
 
-  return [self initWithRuleIdentifiers:(struct RuleIdentifiers){
-                                           .cdhash = cdhash,
-                                           .binarySHA256 = binarySHA256,
-                                           .signingID = signingID,
-                                           .certificateSHA256 = certificateSHA256,
-                                           .teamID = teamID,
-                                       }];
+  return (struct RuleIdentifiers){
+      .cdhash = cdhash,
+      .binarySHA256 = binarySHA256,
+      .signingID = signingID,
+      .certificateSHA256 = certificateSHA256,
+      .teamID = teamID,
+  };
 }
 
 - (NSData*)cdhashBytes {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -174,16 +174,22 @@ es_file_t* GetTargetFileForPrefixTree(const es_message_t* msg) {
         break;
       }
 
-      // Only log file changes that match the given regex
-      NSString* targetPath = santa::StringTokenToNSString(targetFile->path);
-      if (![[self.configurator fileChangesRegex]
-              numberOfMatchesInString:targetPath
-                              options:0
-                                range:NSMakeRange(0, targetPath.length)]) {
+      // Only log file changes that match the given regex. When no regex is
+      // configured these events are never logged, so bail before transcoding
+      // the path to an NSString.
+      NSRegularExpression* fileChangesRegex = [self.configurator fileChangesRegex];
+      if (!fileChangesRegex) {
         // Note: Do not record metrics in this case. These are not considered "drops"
         // because this is not a failure case.
         // TODO(mlw): Consider changes to configuration that would allow muting paths
         // to filter on the kernel side rather than in user space.
+        return;
+      }
+      NSString* targetPath = santa::StringTokenToNSString(targetFile->path);
+      if ([fileChangesRegex rangeOfFirstMatchInString:targetPath
+                                              options:0
+                                                range:NSMakeRange(0, targetPath.length)]
+              .location == NSNotFound) {
         return;
       }
 

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -58,17 +58,14 @@ struct CELEvaluationResult {
 static void ApplySilentBlock(SNTCachedDecision* cd, SNTRuleState state);
 
 struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd) {
-  SNTRuleIdentifiers* ri =
-      [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:{
-                                                              .cdhash = cd.cdhash,
-                                                              .binarySHA256 = cd.sha256,
-                                                              .signingID = cd.signingID,
-                                                              .certificateSHA256 = cd.certSHA256,
-                                                              .teamID = cd.teamID,
-                                                          }
-                                         andSigningStatus:cd.signingStatus];
-
-  return [ri toStruct];
+  return [SNTRuleIdentifiers filterIdentifiers:{
+                                                   .cdhash = cd.cdhash,
+                                                   .binarySHA256 = cd.sha256,
+                                                   .signingID = cd.signingID,
+                                                   .certificateSHA256 = cd.certSHA256,
+                                                   .teamID = cd.teamID,
+                                               }
+                              forSigningStatus:cd.signingStatus];
 }
 
 namespace {
@@ -283,7 +280,7 @@ struct FallbackBatch {
     if (!evalResult.ok()) {
       LOGE(@"Failed to evaluate CEL expression: %s",
            std::string(evalResult.status().message()).c_str());
-      if ([SNTConfigurator configurator].failClosed) {
+      if (self.configurator.failClosed) {
         cd.decision = SNTEventStateBlockUnknown;
         return {.succeeded = false, .decisionMade = true, .resultState = {}};
       }
@@ -301,7 +298,7 @@ struct FallbackBatch {
     if (!evalResult.ok()) {
       LOGE(@"Failed to evaluate CEL expression: %s",
            std::string(evalResult.status().message()).c_str());
-      if ([SNTConfigurator configurator].failClosed) {
+      if (self.configurator.failClosed) {
         cd.decision = SNTEventStateBlockUnknown;
         return {.succeeded = false, .decisionMade = true, .resultState = {}};
       }
@@ -400,7 +397,7 @@ struct FallbackBatch {
 
   if ((useV2 && !celPlanCacheV2_) || (!useV2 && !celPlanCacheV1_)) {
     LOGE(@"CEL v%d evaluator unavailable", useV2 ? 2 : 1);
-    if ([SNTConfigurator configurator].failClosed) {
+    if (self.configurator.failClosed) {
       cd.decision = SNTEventStateBlockUnknown;
       return {.succeeded = false, .decisionMade = true, .resultState = {}};
     }
@@ -414,7 +411,7 @@ struct FallbackBatch {
   if (!planResult.ok()) {
     LOGE(@"Failed to compile CEL rule (%@): %s", rule.celExpr,
          std::string(planResult.status().message()).c_str());
-    if ([SNTConfigurator configurator].failClosed) {
+    if (self.configurator.failClosed) {
       cd.decision = SNTEventStateBlockUnknown;
       return {.succeeded = false, .decisionMade = true, .resultState = {}};
     }
@@ -676,7 +673,7 @@ static void UpdateCachedDecisionSigningInfo(
     }
   }
 
-  if ([[SNTConfigurator configurator] enableBadSignatureProtection] && csInfoError &&
+  if ([self.configurator enableBadSignatureProtection] && csInfoError &&
       csInfoError.code != errSecCSUnsigned) {
     cd.decisionExtra =
         [NSString stringWithFormat:@"Blocked due to signature error: %ld", (long)csInfoError.code];
@@ -746,15 +743,15 @@ static void UpdateCachedDecisionSigningInfo(
       if (targetProc->signing_id.length > 0) {
         if (targetProc->team_id.length > 0) {
           entitlementsFilterTeamID = targetProc->team_id.data;
-          cd.teamID = [NSString stringWithUTF8String:targetProc->team_id.data];
-          cd.signingID = [NSString
-              stringWithFormat:@"%@:%@", cd.teamID,
-                               [NSString stringWithUTF8String:targetProc->signing_id.data]];
+          cd.teamID = santa::StringTokenToNSString(targetProc->team_id);
+          cd.signingID =
+              [NSString stringWithFormat:@"%@:%@", cd.teamID,
+                                         santa::StringTokenToNSString(targetProc->signing_id)];
         } else if (targetProc->is_platform_binary) {
           entitlementsFilterTeamID = "platform";
-          cd.signingID = [NSString
-              stringWithFormat:@"platform:%@",
-                               [NSString stringWithUTF8String:targetProc->signing_id.data]];
+          cd.signingID =
+              [NSString stringWithFormat:@"platform:%@",
+                                         santa::StringTokenToNSString(targetProc->signing_id)];
         }
       }
 
@@ -810,10 +807,17 @@ static void UpdateCachedDecisionSigningInfo(
 - (NSString*)fileIsScopeAllowed:(SNTFileInfo*)fi {
   if (!fi) return nil;
 
-  // Determine if file is within an allowed path
-  NSRegularExpression* re = [[SNTConfigurator configurator] allowedPathRegex];
-  if ([re numberOfMatchesInString:fi.path options:0 range:NSMakeRange(0, fi.path.length)]) {
-    return @"Allowed Path Regex";
+  // Determine if file is within an allowed path. Guard on a non-nil regex:
+  // rangeOfFirstMatchInString: returns a zeroed NSRange (location 0, not
+  // NSNotFound) when messaged on a nil regex, which would otherwise read as a
+  // spurious match.
+  NSRegularExpression* re = [self.configurator allowedPathRegex];
+  if (re) {
+    NSString* path = fi.path;
+    if ([re rangeOfFirstMatchInString:path options:0 range:NSMakeRange(0, path.length)].location !=
+        NSNotFound) {
+      return @"Allowed Path Regex";
+    }
   }
 
   // If file is not a Mach-O file, we're not interested.
@@ -827,12 +831,18 @@ static void UpdateCachedDecisionSigningInfo(
 - (NSString*)fileIsScopeBlocked:(SNTFileInfo*)fi {
   if (!fi) return nil;
 
-  NSRegularExpression* re = [[SNTConfigurator configurator] blockedPathRegex];
-  if ([re numberOfMatchesInString:fi.path options:0 range:NSMakeRange(0, fi.path.length)]) {
-    return @"Blocked Path Regex";
+  // Guard on a non-nil regex; see fileIsScopeAllowed: for why the nil case
+  // must be handled explicitly with rangeOfFirstMatchInString:.
+  NSRegularExpression* re = [self.configurator blockedPathRegex];
+  if (re) {
+    NSString* path = fi.path;
+    if ([re rangeOfFirstMatchInString:path options:0 range:NSMakeRange(0, path.length)].location !=
+        NSNotFound) {
+      return @"Blocked Path Regex";
+    }
   }
 
-  if ([[SNTConfigurator configurator] enablePageZeroProtection] && fi.isMissingPageZero) {
+  if ([self.configurator enablePageZeroProtection] && fi.isMissingPageZero) {
     return @"Missing __PAGEZERO";
   }
 

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -43,9 +43,12 @@
 extern struct RuleIdentifiers CreateRuleIDs(SNTCachedDecision* cd);
 
 @interface SNTPolicyProcessor (Testing)
+@property SNTConfigurator* configurator;
 - (BOOL)evaluateCELFallbackExpressions:(SNTCachedDecision*)cd
                     activationCallback:(ActivationCallbackBlock)activationCallback;
 - (void)compileFallbackRules:(NSArray<SNTCELFallbackRule*>*)rules;
+- (NSString*)fileIsScopeAllowed:(SNTFileInfo*)fi;
+- (NSString*)fileIsScopeBlocked:(SNTFileInfo*)fi;
 @end
 
 BOOL CompareMaybeNilStrings(NSString* s1, NSString* s2) {
@@ -717,6 +720,37 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
                                                                .certificateSHA256 = nil,
                                                                .teamID = nil,
                                                            })));
+}
+
+- (void)testDecisionBuildsSigningIDAndTeamIDFromProcess {
+  // The cached decision's teamID/signingID are built from the target process's
+  // team_id/signing_id string tokens, with signingID formatted as
+  // "teamID:signingID". Characterizes that format across the token conversion.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:@"/bin/ls"];
+  XCTAssertNotNil(fi);
+
+  es_file_t file = MakeESFile("/bin/ls");
+  es_process_t proc = MakeESProcess(&file);
+  proc.codesigning_flags = CS_SIGNED | CS_VALID;
+  proc.signing_id = MakeESStringToken("com.apple.ls");
+  proc.team_id = MakeESStringToken("EQHXZ8M8AV");
+
+  SNTConfigState* configState =
+      [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  SNTCachedDecision* cd = [processor decisionForFileInfo:fi
+                                           targetProcess:&proc
+                                             configState:configState
+                                      activationCallback:nil
+                                          cachedDecision:nil];
+
+  XCTAssertEqualObjects(cd.teamID, @"EQHXZ8M8AV");
+  XCTAssertEqualObjects(cd.signingID, @"EQHXZ8M8AV:com.apple.ls");
 }
 
 - (void)testCELDecisions {
@@ -1661,6 +1695,66 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   SNTCachedDecision* cd = [self decisionForPlatformBinary:NO];
   XCTAssertNotEqual(cd.decision, SNTEventStateAllowPlatform);
   XCTAssertNotEqualObjects(cd.decisionExtra, @"Platform Binary");
+}
+
+#pragma mark fileIsScopeAllowed:/fileIsScopeBlocked:
+
+// /bin/ls is an Apple-signed Mach-O executable (with a __PAGEZERO segment)
+// present on every macOS host, so it exercises the Mach-O and page-zero paths
+// without needing a fixture.
+- (SNTFileInfo*)lsFileInfo {
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:@"/bin/ls"];
+  XCTAssertNotNil(fi);
+  return fi;
+}
+
+- (void)testFileIsScopeAllowedWithNoRegexReturnsNilForMachO {
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator allowedPathRegex]).andReturn(nil);
+  self.processor.configurator = mockConfigurator;
+
+  // No allowed-path regex: a Mach-O must not be reported as allowed-by-path.
+  // (Guards against a nil regex being treated as a match.)
+  XCTAssertNil([self.processor fileIsScopeAllowed:[self lsFileInfo]]);
+
+  [mockConfigurator stopMocking];
+}
+
+- (void)testFileIsScopeAllowedWithMatchingRegexReturnsReason {
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator allowedPathRegex])
+      .andReturn([NSRegularExpression regularExpressionWithPattern:@"^/bin/" options:0 error:NULL]);
+  self.processor.configurator = mockConfigurator;
+
+  XCTAssertEqualObjects([self.processor fileIsScopeAllowed:[self lsFileInfo]],
+                        @"Allowed Path Regex");
+
+  [mockConfigurator stopMocking];
+}
+
+- (void)testFileIsScopeBlockedWithNoRegexReturnsNil {
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator blockedPathRegex]).andReturn(nil);
+  OCMStub([mockConfigurator enablePageZeroProtection]).andReturn(NO);
+  self.processor.configurator = mockConfigurator;
+
+  // No blocked-path regex: a normal Mach-O must not be reported as
+  // blocked-by-path. (Guards against a nil regex being treated as a match.)
+  XCTAssertNil([self.processor fileIsScopeBlocked:[self lsFileInfo]]);
+
+  [mockConfigurator stopMocking];
+}
+
+- (void)testFileIsScopeBlockedWithMatchingRegexReturnsReason {
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator blockedPathRegex])
+      .andReturn([NSRegularExpression regularExpressionWithPattern:@"^/bin/" options:0 error:NULL]);
+  self.processor.configurator = mockConfigurator;
+
+  XCTAssertEqualObjects([self.processor fileIsScopeBlocked:[self lsFileInfo]],
+                        @"Blocked Path Regex");
+
+  [mockConfigurator stopMocking];
 }
 
 @end


### PR DESCRIPTION
Micro-optimizations on two hot paths.

The three perf-sensitive path-regex checks (allowed/blocked path scope in `SNTPolicyProcessor`, and the recorder's file-change filter) now use `rangeOfFirstMatchInString:` instead of `numberOfMatchesInString:` — they only need a boolean match, so this stops at the first hit and drops the result-object allocation. Each guards a nil regex explicitly, since a struct-return message to a nil regex yields a zeroed `NSRange` rather than `NSNotFound`; the recorder additionally skips transcoding the path when no regex is set.

`SNTPolicyProcessor` also uses the cached configurator property rather than re-resolving the singleton, builds rule identifiers without a short-lived `SNTRuleIdentifiers` allocation, and uses a length-aware token-to-NSString conversion. Behavior-preserving; adds characterization tests for the scope checks and the signing/team id construction.