### PR TITLE
Add HTTP Santa commands, drained serially at the end of sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - name: Get clang-format-19
-        run: sudo apt-get install --no-install-recommends -y clang-format-19
-      - name: Set clang-format-19 as default
+      - name: Get clang-format-20
+        run: sudo apt-get install --no-install-recommends -y clang-format-20
+      - name: Set clang-format-20 as default
         run: |
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-19 100
-          sudo update-alternatives --set clang-format /usr/bin/clang-format-19
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-20
           clang-format --version
       - name: Run linters
         run: ./Testing/lint.sh

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "35c9c780b4a05b96b07556b45e32a1cd5c120ded",
+    commit = "bb8d99b20119482cfffdf6ed4f538487bcca27c7",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -15,6 +15,38 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTPushNotifications",
+    hdrs = ["SNTPushNotifications.h"],
+    deps = [
+        "//Source/common:MOLXPCConnection",
+    ],
+)
+
+objc_library(
+    name = "SNTSantaCommandHandler",
+    srcs = [
+        "SNTSantaCommandHandler.mm",
+        "SNTSantaCommandHandler+EventUpload.mm",
+        "SNTSantaCommandHandler+Kill.mm",
+    ],
+    hdrs = [
+        "SNTSantaCommandHandler.h",
+        "SNTSantaCommandHandler+EventUpload.h",
+        "SNTSantaCommandHandler+Kill.h",
+    ],
+    deps = [
+        ":SNTPushNotifications",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTKillCommand",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTXPCControlInterface",
+        "//Source/common:String",
+        "@northpolesec_protos//commands:v1_cc_proto",
+        "@protobuf",
+    ],
+)
+
+objc_library(
     name = "NATS_lib",
     srcs = [
         "SNTPushClientNATS.mm",
@@ -23,13 +55,13 @@ objc_library(
     hdrs = [
         "SNTPushClientNATS.h",
         "SNTPushClientNATS+Commands.h",
-        "SNTPushNotifications.h",
     ],
     deps = [
+        ":SNTPushNotifications",
+        ":SNTSantaCommandHandler",
         ":SNTSyncState",
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTConfigurator",
-        "//Source/common:SNTKillCommand",
         "//Source/common:SNTLogging",
         "//Source/common:SNTSyncConstants",
         "//Source/common:SNTSystemInfo",
@@ -195,6 +227,7 @@ objc_library(
     deps = [
         ":FCM_lib",
         ":NATS_lib",
+        ":SNTPushNotifications",
         ":SNTPushNotificationsTracker",
         ":SNTSyncState",
         "//Source/common:SNTConfigurator",
@@ -299,6 +332,22 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTSyncCommands",
+    srcs = ["SNTSyncCommands.mm"],
+    hdrs = ["SNTSyncCommands.h"],
+    deps = [
+        ":SNTSantaCommandHandler",
+        ":SNTSyncLogging",
+        ":SNTSyncStage",
+        ":SNTSyncState",
+        "//Source/common:String",
+        "@northpolesec_protos//commands:v1_cc_proto",
+        "@northpolesec_protos//syncv2:v2_cc_proto",
+        "@protobuf",
+    ],
+)
+
+objc_library(
     name = "SNTSyncSignalUpload",
     srcs = ["SNTSyncSignalUpload.mm"],
     hdrs = ["SNTSyncSignalUpload.h"],
@@ -324,6 +373,9 @@ objc_library(
     deps = [
         ":NATS_lib",
         ":SNTPushClientFCM",
+        ":SNTPushNotifications",
+        ":SNTSantaCommandHandler",
+        ":SNTSyncCommands",
         ":SNTSyncConfigBundle",
         ":SNTSyncEventUpload",
         ":SNTSyncLogging",
@@ -358,7 +410,10 @@ objc_library(
         ":NATS_lib",
         ":ProtoTraits",
         ":SNTPushClientFCM",
+        ":SNTPushNotifications",
         ":SNTPushNotificationsTracker",
+        ":SNTSantaCommandHandler",
+        ":SNTSyncCommands",
         ":SNTSyncConfigBundle",
         ":SNTSyncEventUpload",
         ":SNTSyncLogging",
@@ -557,6 +612,35 @@ macos_command_line_application(
 )
 
 santa_unit_test(
+    name = "SNTSantaCommandHandlerTest",
+    srcs = ["SNTSantaCommandHandlerTest.mm"],
+    deps = [
+        ":SNTPushNotifications",
+        ":SNTSantaCommandHandler",
+        "//Source/common:SNTConfigurator",
+        "@OCMock",
+        "@northpolesec_protos//commands:v1_cc_proto",
+        "@protobuf",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTSyncCommandsTest",
+    srcs = ["SNTSyncCommandsTest.mm"],
+    deps = [
+        ":SNTPushNotifications",
+        ":SNTSantaCommandHandler",
+        ":SNTSyncCommands",
+        ":SNTSyncState",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTConfigurator",
+        "@OCMock",
+        "@northpolesec_protos//commands:v1_cc_proto",
+        "@northpolesec_protos//syncv2:v2_cc_proto",
+    ],
+)
+
+santa_unit_test(
     name = "SNTPushClientNATSTest",
     srcs = ["SNTPushClientNATSTest.mm"],
     deps = [
@@ -636,6 +720,8 @@ test_suite(
         ":SNTPushClientNATSCommandTest",
         ":SNTPushClientNATSConnectionTest",
         ":SNTPushClientNATSTest",
+        ":SNTSantaCommandHandlerTest",
+        ":SNTSyncCommandsTest",
         ":SNTSyncConfigBundleTest",
         ":SNTSyncManagerNATSTest",
         ":SNTSyncManagerTest",

--- a/Source/santasyncservice/SNTPushClientNATS+Commands.mm
+++ b/Source/santasyncservice/SNTPushClientNATS+Commands.mm
@@ -19,11 +19,12 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#import "Source/common/SNTConfigurator.h"
-#import "Source/common/SNTKillCommand.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #include "Source/common/String.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
 #include "absl/cleanup/cleanup.h"
 #include "commands/v1.pb.h"
 
@@ -36,9 +37,6 @@ __END_DECLS
 
 namespace pbv1 = ::santa::commands::v1;
 using santa::StringToNSString;
-
-// Semi-arbitrary number of seconds to wait for santad to finish killing processes
-static constexpr int64_t kKillResponseTimeoutSeconds = 90;
 
 // Maximum age in seconds for command timestamps (5 minutes)
 static constexpr int64_t kMaxCommandAgeSeconds = 300;
@@ -111,48 +109,6 @@ bool VerifyCommandRequestTimestamp(const ::pbv1::SantaCommandRequest& command) {
   return true;
 }
 
-void SetKillResponseError(SNTKillResponseError error, ::pbv1::KillResponse* pbResponse) {
-  switch (error) {
-    case SNTKillResponseErrorListPids:
-      pbResponse->set_error(::pbv1::KillResponse::ERROR_LIST_PIDS);
-      break;
-    case SNTKillResponseErrorInvalidRequest:
-      pbResponse->set_error(::pbv1::KillResponse::ERROR_INTERNAL);
-      break;
-    case SNTKillResponseErrorNone:
-      // Do not set the error if there was none
-      break;
-    default: pbResponse->set_error(::pbv1::KillResponse::ERROR_INTERNAL); break;
-  }
-}
-
-void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Process* pbProcess) {
-  switch (error) {
-    case SNTKilledProcessErrorUnknown:
-      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INTERNAL);
-      break;
-    case SNTKilledProcessErrorInvalidTarget:
-      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INVALID_TARGET);
-      break;
-    case SNTKilledProcessErrorNotPermitted:
-      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_OPERATION_NOT_PERMITTED);
-      break;
-    case SNTKilledProcessErrorNoSuchProcess:
-      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_NO_SUCH_PROCESS);
-      break;
-    case SNTKilledProcessErrorInvalidArgument:
-      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INVALID_ARGUMENT);
-      break;
-    case SNTKilledProcessErrorBootSessionMismatch:
-      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_BOOT_SESSION_MISMATCH);
-      break;
-    case SNTKilledProcessErrorNone:
-      // Do not set the error if there was none
-      break;
-    default: pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INTERNAL); break;
-  }
-}
-
 }  // namespace
 
 // Forward declaration of private interface to access private properties
@@ -162,6 +118,7 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
 @property(nonatomic) dispatch_queue_t connectionQueue;
 @property(nonatomic) natsConnection* conn;
 @property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
+@property(nonatomic) SNTSantaCommandHandler* commandHandler;
 @property(nonatomic, copy) NSData* hmacKey;
 @property(nonatomic) NSMutableSet<NSString*>* currentNonces;
 @property(nonatomic) NSMutableSet<NSString*>* previousNonces;
@@ -235,129 +192,24 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
   return google::protobuf::Arena::Create<::pbv1::PingResponse>(arena);
 }
 
-// Handle KillRequest command
+// Handle KillRequest command. Blocks until santad replies or the request
+// times out; execution lives in the transport-agnostic command handler.
 - (::pbv1::KillResponse*)handleKillRequest:(const ::pbv1::KillRequest&)pbKillReq
                            withCommandUUID:(NSString*)uuid
                                    onArena:(google::protobuf::Arena*)arena {
-  auto pbKillResponse = google::protobuf::Arena::Create<::pbv1::KillResponse>(arena);
-  SNTKillRequest* req;
-  switch (pbKillReq.process_case()) {
-    case ::pbv1::KillRequest::kRunningProcess:
-      req = [[SNTKillRequestRunningProcess alloc]
-             initWithUUID:uuid
-                      pid:pbKillReq.running_process().pid()
-               pidversion:pbKillReq.running_process().pidversion()
-          bootSessionUUID:StringToNSString(pbKillReq.running_process().boot_session_uuid())];
-      if (!req) {
-        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_RUNNING_PROCESS);
-      }
-      break;
-    case ::pbv1::KillRequest::kCdhash:
-      req = [[SNTKillRequestCDHash alloc] initWithUUID:uuid
-                                                cdHash:StringToNSString(pbKillReq.cdhash())];
-      if (!req) {
-        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_CDHASH);
-      }
-      break;
-    case ::pbv1::KillRequest::kSigningId:
-      req = [[SNTKillRequestSigningID alloc] initWithUUID:uuid
-                                                signingID:StringToNSString(pbKillReq.signing_id())];
-      if (!req) {
-        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_SIGNING_ID);
-      }
-      break;
-    case ::pbv1::KillRequest::kTeamId:
-      req = [[SNTKillRequestTeamID alloc] initWithUUID:uuid
-                                                teamID:StringToNSString(pbKillReq.team_id())];
-      if (!req) {
-        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_TEAM_ID);
-      }
-      break;
-    default: pbKillResponse->set_error(::pbv1::KillResponse::ERROR_UNKNOWN_PROCESS_TYPE);
-  }
-
-  if (!req) {
-    return pbKillResponse;
-  }
-
-  id<SNTPushNotificationsSyncDelegate> strongSyncDelegate = self.syncDelegate;
-  if (!strongSyncDelegate) {
-    pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INTERNAL);
-    return pbKillResponse;
-  }
-
-  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-  __block SNTKillResponse* resp;
-  [[[strongSyncDelegate daemonConnection] remoteObjectProxy]
-      killProcesses:req
-              reply:^(SNTKillResponse* killResponse) {
-                resp = killResponse;
-                dispatch_semaphore_signal(sema);
-              }];
-
-  if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, kKillResponseTimeoutSeconds *
-                                                                         NSEC_PER_SEC)) != 0) {
-    pbKillResponse->set_error(::santa::commands::v1::KillResponse::ERROR_TIMEOUT);
-    return pbKillResponse;
-  }
-
-  SetKillResponseError(resp.error, pbKillResponse);
-
-  for (SNTKilledProcess* killedProc in resp.killedProcesses) {
-    auto pbProc = google::protobuf::Arena::Create<::pbv1::KillResponse::Process>(arena);
-
-    pbProc->set_pid(killedProc.pid);
-    pbProc->set_pidversion(killedProc.pidversion);
-    SetKilledProcessError(killedProc.error, pbProc);
-
-    pbKillResponse->mutable_processes()->UnsafeArenaAddAllocated(pbProc);
-  }
-
-  return pbKillResponse;
+  return [self.commandHandler handleKillRequest:pbKillReq withIdentifier:uuid onArena:arena];
 }
 
-// Handle EventUploadRequest command
+// Handle EventUploadRequest command. Fire-and-forget on NATS: the published
+// response only reflects request validity, per-path results are logged by the
+// command handler as the uploads complete.
 - (::pbv1::EventUploadResponse*)handleEventUploadRequest:
                                     (const ::pbv1::EventUploadRequest&)eventUploadRequest
                                          withCommandUUID:(NSString*)uuid
                                                  onArena:(google::protobuf::Arena*)arena {
-  auto pbResponse = google::protobuf::Arena::Create<::pbv1::EventUploadResponse>(arena);
-
-  // Collect the non-empty paths from the repeated `paths` field.
-  NSMutableArray<NSString*>* paths =
-      [NSMutableArray arrayWithCapacity:eventUploadRequest.paths_size()];
-  for (const std::string& path : eventUploadRequest.paths()) {
-    NSString* nsPath = StringToNSString(path);
-    if (nsPath.length > 0) {
-      [paths addObject:nsPath];
-    }
-  }
-
-  if (paths.count == 0) {
-    LOGE(@"NATS: EventUploadRequest has no valid paths");
-    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INVALID_PATH);
-    return pbResponse;
-  }
-
-  id<SNTPushNotificationsSyncDelegate> strongSyncDelegate = self.syncDelegate;
-  if (!strongSyncDelegate) {
-    LOGE(@"NATS: EventUploadRequest failed - no sync delegate");
-    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INTERNAL);
-    return pbResponse;
-  }
-
-  // Fire off the event uploads asynchronously - don't wait for completion. The delegate
-  // processes the paths serially and invokes the reply block once per path.
-  [strongSyncDelegate eventUploadForPaths:paths
-                                    reply:^(NSError* error) {
-                                      if (error) {
-                                        LOGE(@"NATS: EventUploadRequest failed: %@", error);
-                                      } else {
-                                        LOGI(@"NATS: EventUploadRequest completed");
-                                      }
-                                    }];
-
-  return pbResponse;
+  return [self.commandHandler handleEventUploadRequest:eventUploadRequest
+                                               onArena:arena
+                                            completion:nil];
 }
 
 // Handle BinaryUploadRequest command (async). Forwards the request to santad over
@@ -455,16 +307,16 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
     case ::pbv1::SantaCommandRequest::kKill: commandName = @"kill"; break;
     case ::pbv1::SantaCommandRequest::kEventUpload: commandName = @"event_upload"; break;
     case ::pbv1::SantaCommandRequest::kBinaryUpload: commandName = @"binary_upload"; break;
+    // Not yet implemented; leaving the name unset routes the command to the
+    // ERROR_UNKNOWN_REQUEST_TYPE response below.
+    case ::pbv1::SantaCommandRequest::kInventoryScan: break;
     case ::pbv1::SantaCommandRequest::COMMAND_NOT_SET: break;
   }
 
-  if (commandName) {
-    NSArray<NSString*>* allowed = [[SNTConfigurator configurator] allowedSantaCommands];
-    if (allowed && ![allowed containsObject:commandName]) {
-      LOGW(@"NATS: Command '%@' rejected - not in AllowedSantaCommands", commandName);
-      response->set_error(::pbv1::SantaCommandResponse::ERROR_COMMAND_DISABLED);
-      return response;
-    }
+  if (commandName && ![SNTSantaCommandHandler isCommandAllowed:commandName]) {
+    LOGW(@"NATS: Command '%@' rejected - not in AllowedSantaCommands", commandName);
+    response->set_error(::pbv1::SantaCommandResponse::ERROR_COMMAND_DISABLED);
+    return response;
   }
 
   switch (commandCase) {

--- a/Source/santasyncservice/SNTPushClientNATS.mm
+++ b/Source/santasyncservice/SNTPushClientNATS.mm
@@ -27,6 +27,7 @@
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTSystemInfo.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
 __BEGIN_DECLS
@@ -133,6 +134,8 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
 
 @interface SNTPushClientNATS ()
 @property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
+// Transport-agnostic command execution shared with the HTTP sync command drain.
+@property(nonatomic) SNTSantaCommandHandler* commandHandler;
 @property(nonatomic) natsConnection* conn;
 // Array of natsSubscription pointers wrapped in NSValue
 @property(nonatomic) NSMutableArray<NSValue*>* tagSubscriptions;
@@ -172,6 +175,7 @@ static int NATSSSLVerifyCallback(int preverifyOk, void* ctx) {
   self = [super init];
   if (self) {
     _syncDelegate = syncDelegate;
+    _commandHandler = [[SNTSantaCommandHandler alloc] initWithSyncDelegate:syncDelegate];
     _fullSyncInterval = kDefaultPushNotificationsFullSyncInterval;
     _connectionQueue =
         dispatch_queue_create("com.northpolesec.santa.nats.connection", DISPATCH_QUEUE_SERIAL);

--- a/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h
@@ -36,10 +36,11 @@
                   completion:(void (^)(NSError* error))completion;
 
 /// Blocking variant used for queued (HTTP) command delivery: starts the upload
-/// and waits until every path has been processed, bounded per path and capped
-/// overall. On upload failure or timeout the returned response carries
-/// ERROR_INTERNAL and `errorMessage` (when non-null) receives free-text
-/// context for the command result.
+/// and waits until every path has been processed. Each path is bounded by the
+/// sync delegate's per-path timeouts, so this returns in bounded time without a
+/// separate overall deadline. On upload failure the returned response carries
+/// ERROR_INTERNAL and `errorMessage` (when non-null) receives free-text context
+/// for the command result.
 - (santa::commands::v1::EventUploadResponse*)
     handleEventUploadRequestAndWait:(const santa::commands::v1::EventUploadRequest&)request
                             onArena:(google::protobuf::Arena*)arena

--- a/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h
@@ -1,0 +1,48 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <google/protobuf/arena.h>
+#include <string>
+
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#include "commands/v1.pb.h"
+
+/// Event upload command execution, shared by every command transport.
+@interface SNTSantaCommandHandler (EventUpload)
+
+/// Start an event upload for the requested paths. Returns immediately: the
+/// returned response only reflects request validity, the upload itself runs on
+/// the sync delegate's serial event-upload queue. If `completion` is non-nil it
+/// is invoked exactly once after every path has been processed, with nil on
+/// success or the first per-path error otherwise. When the returned response
+/// carries an error the upload was never started and `completion` is not
+/// invoked.
+- (santa::commands::v1::EventUploadResponse*)
+    handleEventUploadRequest:(const santa::commands::v1::EventUploadRequest&)request
+                     onArena:(google::protobuf::Arena*)arena
+                  completion:(void (^)(NSError* error))completion;
+
+/// Blocking variant used for queued (HTTP) command delivery: starts the upload
+/// and waits until every path has been processed, bounded per path and capped
+/// overall. On upload failure or timeout the returned response carries
+/// ERROR_INTERNAL and `errorMessage` (when non-null) receives free-text
+/// context for the command result.
+- (santa::commands::v1::EventUploadResponse*)
+    handleEventUploadRequestAndWait:(const santa::commands::v1::EventUploadRequest&)request
+                            onArena:(google::protobuf::Arena*)arena
+                       errorMessage:(std::string*)errorMessage;
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.mm
@@ -14,23 +14,12 @@
 
 #import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
 
-#include <algorithm>
-
 #import "Source/common/SNTLogging.h"
 #include "Source/common/String.h"
 
 namespace pbv1 = ::santa::commands::v1;
 using santa::NSStringToUTF8String;
 using santa::StringToNSString;
-
-// Per-path budget when waiting for an event upload command to finish. Each path
-// is bounded by the delegate's bundle-service timeout (600s) plus upload time,
-// and paths are processed serially.
-static constexpr int64_t kEventUploadPerPathTimeoutSeconds = 660;
-
-// Absolute ceiling on how long a single event upload command is waited on,
-// regardless of how many paths it carries.
-static constexpr int64_t kEventUploadMaxWaitSeconds = 3600;
 
 @implementation SNTSantaCommandHandler (EventUpload)
 
@@ -103,14 +92,12 @@ static constexpr int64_t kEventUploadMaxWaitSeconds = 3600;
     return pbResponse;
   }
 
-  int64_t timeoutSeconds =
-      std::min(kEventUploadPerPathTimeoutSeconds * eventUploadRequest.paths_size(),
-               kEventUploadMaxWaitSeconds);
-  if (dispatch_semaphore_wait(
-          sema, dispatch_time(DISPATCH_TIME_NOW, timeoutSeconds * NSEC_PER_SEC)) != 0) {
-    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INTERNAL);
-    if (errorMessage) *errorMessage = "timed out waiting for event upload to complete";
-  } else if (uploadError) {
+  // Each path is bounded by the delegate's per-path timeouts (bundle-service
+  // generation plus upload retries), so the aggregate completion is guaranteed
+  // to fire in bounded time. Wait for it and report the real outcome — there is
+  // no separate outer deadline for the serial per-path work to outlast.
+  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+  if (uploadError) {
     pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INTERNAL);
     if (errorMessage) *errorMessage = NSStringToUTF8String(uploadError.localizedDescription);
   }

--- a/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.mm
@@ -1,0 +1,126 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
+
+#include <algorithm>
+
+#import "Source/common/SNTLogging.h"
+#include "Source/common/String.h"
+
+namespace pbv1 = ::santa::commands::v1;
+using santa::NSStringToUTF8String;
+using santa::StringToNSString;
+
+// Per-path budget when waiting for an event upload command to finish. Each path
+// is bounded by the delegate's bundle-service timeout (600s) plus upload time,
+// and paths are processed serially.
+static constexpr int64_t kEventUploadPerPathTimeoutSeconds = 660;
+
+// Absolute ceiling on how long a single event upload command is waited on,
+// regardless of how many paths it carries.
+static constexpr int64_t kEventUploadMaxWaitSeconds = 3600;
+
+// Forward declaration of private interface to access private properties
+@interface SNTSantaCommandHandler ()
+@property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
+@end
+
+@implementation SNTSantaCommandHandler (EventUpload)
+
+- (::pbv1::EventUploadResponse*)handleEventUploadRequest:
+                                    (const ::pbv1::EventUploadRequest&)eventUploadRequest
+                                                 onArena:(google::protobuf::Arena*)arena
+                                              completion:(void (^)(NSError* error))completion {
+  auto pbResponse = google::protobuf::Arena::Create<::pbv1::EventUploadResponse>(arena);
+
+  // Collect the non-empty paths from the repeated `paths` field.
+  NSMutableArray<NSString*>* paths =
+      [NSMutableArray arrayWithCapacity:eventUploadRequest.paths_size()];
+  for (const std::string& path : eventUploadRequest.paths()) {
+    NSString* nsPath = StringToNSString(path);
+    if (nsPath.length > 0) {
+      [paths addObject:nsPath];
+    }
+  }
+
+  if (paths.count == 0) {
+    LOGE(@"SantaCommand: EventUploadRequest has no valid paths");
+    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INVALID_PATH);
+    return pbResponse;
+  }
+
+  id<SNTPushNotificationsSyncDelegate> strongSyncDelegate = self.syncDelegate;
+  if (!strongSyncDelegate) {
+    LOGE(@"SantaCommand: EventUploadRequest failed - no sync delegate");
+    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INTERNAL);
+    return pbResponse;
+  }
+
+  // The delegate processes the paths serially on its event-upload queue and
+  // invokes the reply block once per path, so the counter below needs no
+  // synchronization. The aggregate completion fires once, after the last path.
+  NSUInteger expectedReplies = paths.count;
+  __block NSUInteger receivedReplies = 0;
+  __block NSError* firstError = nil;
+  [strongSyncDelegate eventUploadForPaths:paths
+                                    reply:^(NSError* error) {
+                                      if (error) {
+                                        LOGE(@"SantaCommand: EventUploadRequest failed: %@", error);
+                                        if (!firstError) firstError = error;
+                                      } else {
+                                        LOGI(@"SantaCommand: EventUploadRequest completed");
+                                      }
+                                      if (++receivedReplies == expectedReplies && completion) {
+                                        completion(firstError);
+                                      }
+                                    }];
+
+  return pbResponse;
+}
+
+- (::pbv1::EventUploadResponse*)handleEventUploadRequestAndWait:
+                                    (const ::pbv1::EventUploadRequest&)eventUploadRequest
+                                                        onArena:(google::protobuf::Arena*)arena
+                                                   errorMessage:(std::string*)errorMessage {
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  __block NSError* uploadError = nil;
+  auto* pbResponse = [self handleEventUploadRequest:eventUploadRequest
+                                            onArena:arena
+                                         completion:^(NSError* error) {
+                                           uploadError = error;
+                                           dispatch_semaphore_signal(sema);
+                                         }];
+  if (pbResponse->has_error()) {
+    // Validation failed: the upload never started and the completion will not
+    // fire, so there is nothing to wait on.
+    return pbResponse;
+  }
+
+  int64_t timeoutSeconds =
+      std::min(kEventUploadPerPathTimeoutSeconds * eventUploadRequest.paths_size(),
+               kEventUploadMaxWaitSeconds);
+  if (dispatch_semaphore_wait(
+          sema, dispatch_time(DISPATCH_TIME_NOW, timeoutSeconds * NSEC_PER_SEC)) != 0) {
+    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INTERNAL);
+    if (errorMessage) *errorMessage = "timed out waiting for event upload to complete";
+  } else if (uploadError) {
+    pbResponse->set_error(::pbv1::EventUploadResponse::ERROR_INTERNAL);
+    if (errorMessage) *errorMessage = NSStringToUTF8String(uploadError.localizedDescription);
+  }
+
+  return pbResponse;
+}
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler+EventUpload.mm
@@ -32,11 +32,6 @@ static constexpr int64_t kEventUploadPerPathTimeoutSeconds = 660;
 // regardless of how many paths it carries.
 static constexpr int64_t kEventUploadMaxWaitSeconds = 3600;
 
-// Forward declaration of private interface to access private properties
-@interface SNTSantaCommandHandler ()
-@property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
-@end
-
 @implementation SNTSantaCommandHandler (EventUpload)
 
 - (::pbv1::EventUploadResponse*)handleEventUploadRequest:

--- a/Source/santasyncservice/SNTSantaCommandHandler+Kill.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler+Kill.h
@@ -1,0 +1,33 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <google/protobuf/arena.h>
+
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#include "commands/v1.pb.h"
+
+/// Kill command execution, shared by every command transport.
+@interface SNTSantaCommandHandler (Kill)
+
+/// Kill the requested processes via santad. Blocks until santad replies or the
+/// request times out. `identifier` is an opaque per-command id used for
+/// tracking (the NATS command UUID or the queued command id).
+- (santa::commands::v1::KillResponse*)handleKillRequest:
+                                          (const santa::commands::v1::KillRequest&)request
+                                         withIdentifier:(NSString*)identifier
+                                                onArena:(google::protobuf::Arena*)arena;
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler+Kill.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler+Kill.mm
@@ -1,0 +1,160 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
+
+#import "Source/common/SNTKillCommand.h"
+#import "Source/common/SNTXPCControlInterface.h"
+#include "Source/common/String.h"
+
+namespace pbv1 = ::santa::commands::v1;
+using santa::StringToNSString;
+
+// Semi-arbitrary number of seconds to wait for santad to finish killing processes
+static constexpr int64_t kKillResponseTimeoutSeconds = 90;
+
+namespace {
+
+void SetKillResponseError(SNTKillResponseError error, ::pbv1::KillResponse* pbResponse) {
+  switch (error) {
+    case SNTKillResponseErrorListPids:
+      pbResponse->set_error(::pbv1::KillResponse::ERROR_LIST_PIDS);
+      break;
+    case SNTKillResponseErrorInvalidRequest:
+      pbResponse->set_error(::pbv1::KillResponse::ERROR_INTERNAL);
+      break;
+    case SNTKillResponseErrorNone:
+      // Do not set the error if there was none
+      break;
+    default: pbResponse->set_error(::pbv1::KillResponse::ERROR_INTERNAL); break;
+  }
+}
+
+void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Process* pbProcess) {
+  switch (error) {
+    case SNTKilledProcessErrorUnknown:
+      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INTERNAL);
+      break;
+    case SNTKilledProcessErrorInvalidTarget:
+      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INVALID_TARGET);
+      break;
+    case SNTKilledProcessErrorNotPermitted:
+      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_OPERATION_NOT_PERMITTED);
+      break;
+    case SNTKilledProcessErrorNoSuchProcess:
+      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_NO_SUCH_PROCESS);
+      break;
+    case SNTKilledProcessErrorInvalidArgument:
+      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INVALID_ARGUMENT);
+      break;
+    case SNTKilledProcessErrorBootSessionMismatch:
+      pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_BOOT_SESSION_MISMATCH);
+      break;
+    case SNTKilledProcessErrorNone:
+      // Do not set the error if there was none
+      break;
+    default: pbProcess->set_error(::pbv1::KillResponse::KILL_ERROR_INTERNAL); break;
+  }
+}
+
+}  // namespace
+
+// Forward declaration of private interface to access private properties
+@interface SNTSantaCommandHandler ()
+@property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
+@end
+
+@implementation SNTSantaCommandHandler (Kill)
+
+- (::pbv1::KillResponse*)handleKillRequest:(const ::pbv1::KillRequest&)pbKillReq
+                            withIdentifier:(NSString*)identifier
+                                   onArena:(google::protobuf::Arena*)arena {
+  auto pbKillResponse = google::protobuf::Arena::Create<::pbv1::KillResponse>(arena);
+  SNTKillRequest* req;
+  switch (pbKillReq.process_case()) {
+    case ::pbv1::KillRequest::kRunningProcess:
+      req = [[SNTKillRequestRunningProcess alloc]
+             initWithUUID:identifier
+                      pid:pbKillReq.running_process().pid()
+               pidversion:pbKillReq.running_process().pidversion()
+          bootSessionUUID:StringToNSString(pbKillReq.running_process().boot_session_uuid())];
+      if (!req) {
+        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_RUNNING_PROCESS);
+      }
+      break;
+    case ::pbv1::KillRequest::kCdhash:
+      req = [[SNTKillRequestCDHash alloc] initWithUUID:identifier
+                                                cdHash:StringToNSString(pbKillReq.cdhash())];
+      if (!req) {
+        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_CDHASH);
+      }
+      break;
+    case ::pbv1::KillRequest::kSigningId:
+      req = [[SNTKillRequestSigningID alloc] initWithUUID:identifier
+                                                signingID:StringToNSString(pbKillReq.signing_id())];
+      if (!req) {
+        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_SIGNING_ID);
+      }
+      break;
+    case ::pbv1::KillRequest::kTeamId:
+      req = [[SNTKillRequestTeamID alloc] initWithUUID:identifier
+                                                teamID:StringToNSString(pbKillReq.team_id())];
+      if (!req) {
+        pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INVALID_TEAM_ID);
+      }
+      break;
+    default: pbKillResponse->set_error(::pbv1::KillResponse::ERROR_UNKNOWN_PROCESS_TYPE);
+  }
+
+  if (!req) {
+    return pbKillResponse;
+  }
+
+  id<SNTPushNotificationsSyncDelegate> strongSyncDelegate = self.syncDelegate;
+  if (!strongSyncDelegate) {
+    pbKillResponse->set_error(::pbv1::KillResponse::ERROR_INTERNAL);
+    return pbKillResponse;
+  }
+
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  __block SNTKillResponse* resp;
+  [[[strongSyncDelegate daemonConnection] remoteObjectProxy]
+      killProcesses:req
+              reply:^(SNTKillResponse* killResponse) {
+                resp = killResponse;
+                dispatch_semaphore_signal(sema);
+              }];
+
+  if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, kKillResponseTimeoutSeconds *
+                                                                         NSEC_PER_SEC)) != 0) {
+    pbKillResponse->set_error(::pbv1::KillResponse::ERROR_TIMEOUT);
+    return pbKillResponse;
+  }
+
+  SetKillResponseError(resp.error, pbKillResponse);
+
+  for (SNTKilledProcess* killedProc in resp.killedProcesses) {
+    auto pbProc = google::protobuf::Arena::Create<::pbv1::KillResponse::Process>(arena);
+
+    pbProc->set_pid(killedProc.pid);
+    pbProc->set_pidversion(killedProc.pidversion);
+    SetKilledProcessError(killedProc.error, pbProc);
+
+    pbKillResponse->mutable_processes()->UnsafeArenaAddAllocated(pbProc);
+  }
+
+  return pbKillResponse;
+}
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler+Kill.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler+Kill.mm
@@ -70,11 +70,6 @@ void SetKilledProcessError(SNTKilledProcessError error, ::pbv1::KillResponse::Pr
 
 }  // namespace
 
-// Forward declaration of private interface to access private properties
-@interface SNTSantaCommandHandler ()
-@property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
-@end
-
 @implementation SNTSantaCommandHandler (Kill)
 
 - (::pbv1::KillResponse*)handleKillRequest:(const ::pbv1::KillRequest&)pbKillReq

--- a/Source/santasyncservice/SNTSantaCommandHandler.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler.h
@@ -1,0 +1,43 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <google/protobuf/arena.h>
+
+#import "Source/santasyncservice/SNTPushNotifications.h"
+#include "commands/v1.pb.h"
+
+/// Executes Santa commands independently of the transport that delivered them.
+/// Both the NATS push client (request-reply) and the HTTP sync command drain
+/// call into this handler; transport concerns (envelope verification, replies,
+/// queue acknowledgment) stay with the callers.
+///
+/// Per-command execution lives in one category (and file) per command:
+/// SNTSantaCommandHandler+Kill and SNTSantaCommandHandler+EventUpload.
+@interface SNTSantaCommandHandler : NSObject
+
+- (instancetype)initWithSyncDelegate:(id<SNTPushNotificationsSyncDelegate>)syncDelegate;
+
+/// Returns YES if the named command is permitted by the AllowedSantaCommands
+/// configuration. An unset config allows all commands; an empty list blocks all.
++ (BOOL)isCommandAllowed:(NSString*)commandName;
+
+/// Execute one queued command (HTTP delivery) and block until it finishes,
+/// returning the result to post back to the server. Never returns nullptr.
+- (santa::commands::v1::CommandResult*)executeQueuedCommand:
+                                           (const santa::commands::v1::QueuedCommand&)command
+                                                    onArena:(google::protobuf::Arena*)arena;
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler.h
@@ -28,6 +28,10 @@
 /// SNTSantaCommandHandler+Kill and SNTSantaCommandHandler+EventUpload.
 @interface SNTSantaCommandHandler : NSObject
 
+/// The delegate providing the daemon connection and event-upload machinery.
+/// Held weakly; set at init.
+@property(weak, readonly) id<SNTPushNotificationsSyncDelegate> syncDelegate;
+
 - (instancetype)initWithSyncDelegate:(id<SNTPushNotificationsSyncDelegate>)syncDelegate;
 
 /// Returns YES if the named command is permitted by the AllowedSantaCommands

--- a/Source/santasyncservice/SNTSantaCommandHandler.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler.mm
@@ -1,0 +1,112 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTLogging.h"
+#include "Source/common/String.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
+
+namespace pbv1 = ::santa::commands::v1;
+using santa::NSStringToUTF8String;
+
+@interface SNTSantaCommandHandler ()
+@property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
+@end
+
+@implementation SNTSantaCommandHandler
+
+- (instancetype)initWithSyncDelegate:(id<SNTPushNotificationsSyncDelegate>)syncDelegate {
+  self = [super init];
+  if (self) {
+    _syncDelegate = syncDelegate;
+  }
+  return self;
+}
+
++ (BOOL)isCommandAllowed:(NSString*)commandName {
+  NSArray<NSString*>* allowed = [[SNTConfigurator configurator] allowedSantaCommands];
+  return !allowed || [allowed containsObject:commandName];
+}
+
+- (::pbv1::CommandResult*)executeQueuedCommand:(const ::pbv1::QueuedCommand&)command
+                                       onArena:(google::protobuf::Arena*)arena {
+  auto result = google::protobuf::Arena::Create<::pbv1::CommandResult>(arena);
+  result->set_command_id(command.command_id());
+
+  // Check if the command type is allowed by client configuration.
+  // No default case — compiler enforces all proto cases are handled (-Werror + -Wswitch)
+  NSString* commandName = nil;
+  switch (command.command_case()) {
+    case ::pbv1::QueuedCommand::kKill: commandName = @"kill"; break;
+    case ::pbv1::QueuedCommand::kEventUpload: commandName = @"event_upload"; break;
+    case ::pbv1::QueuedCommand::COMMAND_NOT_SET: break;
+  }
+
+  if (commandName && ![SNTSantaCommandHandler isCommandAllowed:commandName]) {
+    LOGW(@"SantaCommand: Command '%@' rejected - not in AllowedSantaCommands", commandName);
+    result->set_host_status(::pbv1::CommandResult::HOST_STATUS_REJECTED);
+    result->set_error_message(
+        NSStringToUTF8String([NSString stringWithFormat:@"command '%@' is not in the agent's "
+                                                        @"AllowedSantaCommands configuration",
+                                                        commandName]));
+    return result;
+  }
+
+  switch (command.command_case()) {
+    case ::pbv1::QueuedCommand::kKill: {
+      LOGI(@"SantaCommand: Executing queued KillRequest command %lld",
+           (long long)command.command_id());
+      NSString* identifier = [NSString stringWithFormat:@"%lld", (long long)command.command_id()];
+      auto* killResponse = [self handleKillRequest:command.kill()
+                                    withIdentifier:identifier
+                                           onArena:arena];
+      result->set_host_status(::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+      result->unsafe_arena_set_allocated_kill(killResponse);
+      break;
+    }
+
+    case ::pbv1::QueuedCommand::kEventUpload: {
+      LOGI(@"SantaCommand: Executing queued EventUploadRequest command %lld",
+           (long long)command.command_id());
+      // Queued commands run serially at the end of a sync, so unlike the NATS
+      // path this blocks until the upload finishes and the posted result
+      // reflects the actual outcome.
+      std::string errorMessage;
+      auto* uploadResponse = [self handleEventUploadRequestAndWait:command.event_upload()
+                                                           onArena:arena
+                                                      errorMessage:&errorMessage];
+      if (!errorMessage.empty()) {
+        result->set_error_message(errorMessage);
+      }
+      result->set_host_status(::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+      result->unsafe_arena_set_allocated_event_upload(uploadResponse);
+      break;
+    }
+
+    case ::pbv1::QueuedCommand::COMMAND_NOT_SET:
+    default:
+      LOGE(@"SantaCommand: Unknown or unset queued command type: %d",
+           static_cast<int>(command.command_case()));
+      result->set_host_status(::pbv1::CommandResult::HOST_STATUS_FAILED);
+      result->set_error_message("unknown or unset command type");
+      break;
+  }
+
+  return result;
+}
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler.mm
@@ -23,10 +23,6 @@
 namespace pbv1 = ::santa::commands::v1;
 using santa::NSStringToUTF8String;
 
-@interface SNTSantaCommandHandler ()
-@property(weak) id<SNTPushNotificationsSyncDelegate> syncDelegate;
-@end
-
 @implementation SNTSantaCommandHandler
 
 - (instancetype)initWithSyncDelegate:(id<SNTPushNotificationsSyncDelegate>)syncDelegate {

--- a/Source/santasyncservice/SNTSantaCommandHandlerTest.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandlerTest.mm
@@ -1,0 +1,285 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTConfigurator.h"
+#import "Source/santasyncservice/SNTPushNotifications.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#include "commands/v1.pb.h"
+#include "google/protobuf/arena.h"
+
+namespace pbv1 = ::santa::commands::v1;
+
+// Fake sync delegate that replies to event uploads synchronously, once per
+// path, mirroring the contract of SNTSyncManager's implementation.
+@interface SNTFakeCommandSyncDelegate : NSObject <SNTPushNotificationsSyncDelegate>
+// Per-path reply errors. NSNull (or a missing entry) replies success.
+@property(nonatomic) NSArray* eventUploadReplyErrors;
+@property(nonatomic) NSArray<NSString*>* lastEventUploadPaths;
+@property(nonatomic) NSUInteger eventUploadCallCount;
+@end
+
+@implementation SNTFakeCommandSyncDelegate
+- (void)sync {
+}
+- (void)syncSecondsFromNow:(uint64_t)seconds {
+}
+- (void)ruleSync {
+}
+- (void)ruleSyncSecondsFromNow:(uint64_t)seconds {
+}
+- (void)preflightSync {
+}
+- (void)pushNotificationSyncSecondsFromNow:(uint64_t)seconds {
+}
+- (MOLXPCConnection*)daemonConnection {
+  return nil;
+}
+- (void)eventUploadForPaths:(NSArray<NSString*>*)paths reply:(void (^)(NSError* error))reply {
+  self.eventUploadCallCount++;
+  self.lastEventUploadPaths = paths;
+  for (NSUInteger i = 0; i < paths.count; i++) {
+    NSError* err = nil;
+    if (i < self.eventUploadReplyErrors.count && ![self.eventUploadReplyErrors[i]
+                                                     isKindOfClass:[NSNull class]]) {
+      err = self.eventUploadReplyErrors[i];
+    }
+    reply(err);
+  }
+}
+@end
+
+@interface SNTSantaCommandHandlerTest : XCTestCase
+@property id mockConfigurator;
+@property SNTFakeCommandSyncDelegate* fakeSyncDelegate;
+@property SNTSantaCommandHandler* handler;
+@property google::protobuf::Arena* arena;
+@end
+
+@implementation SNTSantaCommandHandlerTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.arena = new google::protobuf::Arena();
+
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+
+  self.fakeSyncDelegate = [[SNTFakeCommandSyncDelegate alloc] init];
+  self.handler = [[SNTSantaCommandHandler alloc] initWithSyncDelegate:self.fakeSyncDelegate];
+}
+
+- (void)tearDown {
+  [self.mockConfigurator stopMocking];
+  delete self.arena;
+  self.arena = nullptr;
+  [super tearDown];
+}
+
+#pragma mark - isCommandAllowed
+
+- (void)testIsCommandAllowedUnsetConfigAllowsAll {
+  OCMStub([self.mockConfigurator allowedSantaCommands]).andReturn(nil);
+  XCTAssertTrue([SNTSantaCommandHandler isCommandAllowed:@"kill"]);
+  XCTAssertTrue([SNTSantaCommandHandler isCommandAllowed:@"event_upload"]);
+}
+
+- (void)testIsCommandAllowedEmptyConfigBlocksAll {
+  OCMStub([self.mockConfigurator allowedSantaCommands]).andReturn(@[]);
+  XCTAssertFalse([SNTSantaCommandHandler isCommandAllowed:@"kill"]);
+  XCTAssertFalse([SNTSantaCommandHandler isCommandAllowed:@"event_upload"]);
+}
+
+- (void)testIsCommandAllowedRespectsList {
+  OCMStub([self.mockConfigurator allowedSantaCommands]).andReturn(@[ @"kill" ]);
+  XCTAssertTrue([SNTSantaCommandHandler isCommandAllowed:@"kill"]);
+  XCTAssertFalse([SNTSantaCommandHandler isCommandAllowed:@"event_upload"]);
+}
+
+#pragma mark - executeQueuedCommand
+
+- (void)testExecuteQueuedCommandUnsetTypeFails {
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(42);
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->command_id(), 42);
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_FAILED);
+  XCTAssertGreaterThan(result->error_message().size(), 0u);
+  XCTAssertEqual(result->result_case(), ::pbv1::CommandResult::RESULT_NOT_SET);
+}
+
+- (void)testExecuteQueuedCommandRejectedWhenNotAllowed {
+  OCMStub([self.mockConfigurator allowedSantaCommands]).andReturn(@[ @"ping" ]);
+
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(7);
+  command.mutable_kill()->set_team_id("EQHXZ8M8AV");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->command_id(), 7);
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_REJECTED);
+  XCTAssertGreaterThan(result->error_message().size(), 0u);
+  XCTAssertEqual(result->result_case(), ::pbv1::CommandResult::RESULT_NOT_SET);
+}
+
+- (void)testExecuteQueuedCommandKillWithoutProcessCompletes {
+  // A kill request with no process target executes and reports a typed error
+  // in the payload; the command itself still completes.
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(9);
+  command.mutable_kill();
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->command_id(), 9);
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertTrue(result->has_kill());
+  XCTAssertEqual(result->kill().error(), ::pbv1::KillResponse::ERROR_UNKNOWN_PROCESS_TYPE);
+}
+
+- (void)testExecuteQueuedCommandEventUploadSuccess {
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(11);
+  command.mutable_event_upload()->add_paths("/Applications/Safari.app");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->command_id(), 11);
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertTrue(result->has_event_upload());
+  XCTAssertFalse(result->event_upload().has_error());
+  XCTAssertEqual(result->error_message().size(), 0u);
+  XCTAssertEqual(self.fakeSyncDelegate.eventUploadCallCount, 1u);
+  XCTAssertEqualObjects(self.fakeSyncDelegate.lastEventUploadPaths,
+                        @[ @"/Applications/Safari.app" ]);
+}
+
+- (void)testExecuteQueuedCommandEventUploadFailure {
+  NSError* uploadError =
+      [NSError errorWithDomain:@"com.northpolesec.santa.syncservice"
+                          code:4
+                      userInfo:@{NSLocalizedDescriptionKey : @"Failed to upload events"}];
+  self.fakeSyncDelegate.eventUploadReplyErrors = @[ uploadError ];
+
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(13);
+  command.mutable_event_upload()->add_paths("/Applications/Safari.app");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertTrue(result->has_event_upload());
+  XCTAssertEqual(result->event_upload().error(), ::pbv1::EventUploadResponse::ERROR_INTERNAL);
+  XCTAssertEqual(result->error_message(), "Failed to upload events");
+}
+
+- (void)testExecuteQueuedCommandEventUploadFirstErrorWins {
+  NSError* firstError = [NSError errorWithDomain:@"com.northpolesec.santa.syncservice"
+                                            code:2
+                                        userInfo:@{NSLocalizedDescriptionKey : @"first error"}];
+  NSError* secondError = [NSError errorWithDomain:@"com.northpolesec.santa.syncservice"
+                                             code:3
+                                         userInfo:@{NSLocalizedDescriptionKey : @"second error"}];
+  self.fakeSyncDelegate.eventUploadReplyErrors = @[ [NSNull null], firstError, secondError ];
+
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(17);
+  command.mutable_event_upload()->add_paths("/Applications/Safari.app");
+  command.mutable_event_upload()->add_paths("/Applications/Mail.app");
+  command.mutable_event_upload()->add_paths("/Applications/Notes.app");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertEqual(result->event_upload().error(), ::pbv1::EventUploadResponse::ERROR_INTERNAL);
+  XCTAssertEqual(result->error_message(), "first error");
+  XCTAssertEqual(self.fakeSyncDelegate.eventUploadCallCount, 1u);
+}
+
+- (void)testExecuteQueuedCommandEventUploadNoValidPaths {
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(19);
+  command.mutable_event_upload()->add_paths("");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertTrue(result->has_event_upload());
+  XCTAssertEqual(result->event_upload().error(), ::pbv1::EventUploadResponse::ERROR_INVALID_PATH);
+  XCTAssertEqual(self.fakeSyncDelegate.eventUploadCallCount, 0u,
+                 @"Delegate should not be invoked when validation fails");
+}
+
+#pragma mark - handleEventUploadRequest completion
+
+- (void)testHandleEventUploadCompletionInvokedOnceAfterAllPaths {
+  ::pbv1::EventUploadRequest request;
+  request.add_paths("/Applications/Safari.app");
+  request.add_paths("/Applications/Mail.app");
+
+  __block NSUInteger completionCount = 0;
+  __block NSError* completionError = nil;
+  ::pbv1::EventUploadResponse* response = [self.handler handleEventUploadRequest:request
+                                                                         onArena:self.arena
+                                                                      completion:^(NSError* error) {
+                                                                        completionCount++;
+                                                                        completionError = error;
+                                                                      }];
+
+  XCTAssertFalse(response->has_error());
+  XCTAssertEqual(completionCount, 1u, @"Completion should fire exactly once");
+  XCTAssertNil(completionError);
+}
+
+- (void)testHandleEventUploadValidationFailureDoesNotInvokeCompletion {
+  ::pbv1::EventUploadRequest request;
+
+  __block BOOL completionInvoked = NO;
+  ::pbv1::EventUploadResponse* response = [self.handler handleEventUploadRequest:request
+                                                                         onArena:self.arena
+                                                                      completion:^(NSError* error) {
+                                                                        completionInvoked = YES;
+                                                                      }];
+
+  XCTAssertEqual(response->error(), ::pbv1::EventUploadResponse::ERROR_INVALID_PATH);
+  XCTAssertFalse(completionInvoked);
+}
+
+- (void)testHandleEventUploadNoDelegate {
+  SNTSantaCommandHandler* handler = [[SNTSantaCommandHandler alloc] initWithSyncDelegate:nil];
+
+  ::pbv1::EventUploadRequest request;
+  request.add_paths("/Applications/Safari.app");
+
+  __block BOOL completionInvoked = NO;
+  ::pbv1::EventUploadResponse* response = [handler handleEventUploadRequest:request
+                                                                    onArena:self.arena
+                                                                 completion:^(NSError* error) {
+                                                                   completionInvoked = YES;
+                                                                 }];
+
+  XCTAssertEqual(response->error(), ::pbv1::EventUploadResponse::ERROR_INTERNAL);
+  XCTAssertFalse(completionInvoked);
+}
+
+@end

--- a/Source/santasyncservice/SNTSyncCommands.h
+++ b/Source/santasyncservice/SNTSyncCommands.h
@@ -1,0 +1,36 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/santasyncservice/SNTSyncStage.h"
+
+@class SNTSantaCommandHandler;
+
+/// Drains the server-side command queue at the end of a sync. Exchanges are
+/// strictly 1:1: each request posts the result of the previously executed
+/// command (none on the first exchange) and the server replies with at most
+/// one queued command; the loop runs until the server has nothing left.
+/// Long-running commands (event upload) additionally post an ack-only
+/// DELIVERED result before executing so the server reflects in-progress
+/// state; fast commands (kill) post straight to COMPLETE. Commands execute
+/// serially and nothing is persisted client-side: commands that don't run
+/// (failure, cap, crash) stay queued server-side and are delivered again on
+/// the next sync.
+@interface SNTSyncCommands : SNTSyncStage
+
+- (nullable instancetype)initWithState:(nonnull SNTSyncState*)state
+                        commandHandler:(nonnull SNTSantaCommandHandler*)commandHandler;
+
+@end

--- a/Source/santasyncservice/SNTSyncCommands.mm
+++ b/Source/santasyncservice/SNTSyncCommands.mm
@@ -123,6 +123,8 @@ static const NSUInteger kMaxCommandsPerSync = 50;
       return NO;
     }
 
+    SLOGI(@"Running command %lld...", (long long)command.command_id());
+
     // Execute the command, then post its result back. The server responds
     // with the next queued command until its queue is drained.
     pbv1::CommandResult* result = [self.commandHandler executeQueuedCommand:command onArena:&arena];

--- a/Source/santasyncservice/SNTSyncCommands.mm
+++ b/Source/santasyncservice/SNTSyncCommands.mm
@@ -14,9 +14,9 @@
 
 #import "Source/santasyncservice/SNTSyncCommands.h"
 
+#import "Source/common/SNTLogging.h"
 #include "Source/common/String.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler.h"
-#import "Source/santasyncservice/SNTSyncLogging.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 #include "commands/v1.pb.h"
 #include "google/protobuf/arena.h"
@@ -67,7 +67,7 @@ static const NSUInteger kMaxCommandsPerSync = 50;
                           intoMessage:&response
                               timeout:30];
   if (err) {
-    SLOGE(@"Failed to post delivered ack for command %lld: %@", (long long)commandId, err);
+    LOGE(@"Failed to post delivered ack for command %lld: %@", (long long)commandId, err);
     return NO;
   }
   return YES;
@@ -84,17 +84,27 @@ static const NSUInteger kMaxCommandsPerSync = 50;
   NSUInteger executed = 0;
   while (true) {
     pbv2::CommandsResponse response;
+    NSInteger statusCode = 0;
     NSError* err = [self performRequest:[self requestWithMessage:req]
                             intoMessage:&response
-                                timeout:30];
+                                timeout:30
+                             statusCode:&statusCode];
     if (err) {
-      SLOGE(@"Failed to fetch queued commands: %@", err);
+      // A 404 means this sync server predates the command-queue endpoint (e.g.
+      // Santa was upgraded ahead of the server). There is nothing to drain, so
+      // stop quietly instead of logging an error on every sync until the server
+      // catches up.
+      if (statusCode == 404) {
+        LOGD(@"Command queue endpoint unavailable (HTTP 404); server does not support commands");
+        return YES;
+      }
+      LOGE(@"Failed to fetch queued commands: %@", err);
       return NO;
     }
 
     if (!response.has_command()) {
       if (executed) {
-        SLOGI(@"Executed %lu queued command(s)", (unsigned long)executed);
+        LOGI(@"Executed %lu queued command(s)", (unsigned long)executed);
       }
       return YES;
     }
@@ -102,8 +112,8 @@ static const NSUInteger kMaxCommandsPerSync = 50;
     if (executed >= kMaxCommandsPerSync) {
       // The unexecuted command was never acknowledged, so it remains queued
       // server-side and is delivered again on the next sync.
-      SLOGW(@"Queued command limit (%lu) reached; remaining commands deferred to next sync",
-            (unsigned long)kMaxCommandsPerSync);
+      LOGW(@"Queued command limit (%lu) reached; remaining commands deferred to next sync",
+           (unsigned long)kMaxCommandsPerSync);
       return YES;
     }
 
@@ -123,7 +133,7 @@ static const NSUInteger kMaxCommandsPerSync = 50;
       return NO;
     }
 
-    SLOGI(@"Running command %lld...", (long long)command.command_id());
+    LOGI(@"Running command %lld...", (long long)command.command_id());
 
     // Execute the command, then post its result back. The server responds
     // with the next queued command until its queue is drained.

--- a/Source/santasyncservice/SNTSyncCommands.mm
+++ b/Source/santasyncservice/SNTSyncCommands.mm
@@ -1,0 +1,137 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTSyncCommands.h"
+
+#include "Source/common/String.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#import "Source/santasyncservice/SNTSyncLogging.h"
+#import "Source/santasyncservice/SNTSyncState.h"
+#include "commands/v1.pb.h"
+#include "google/protobuf/arena.h"
+#include "syncv2/v2.pb.h"
+
+using santa::NSStringToUTF8String;
+
+namespace pbv1 = ::santa::commands::v1;
+namespace pbv2 = ::santa::sync::v2;
+
+// Upper bound on commands executed in a single sync. The server delivers one
+// command per exchange and bounds its own queue depth, so this is purely a
+// guard against a misbehaving server keeping the loop alive forever.
+static const NSUInteger kMaxCommandsPerSync = 50;
+
+@interface SNTSyncCommands ()
+@property(nonatomic) SNTSantaCommandHandler* commandHandler;
+@end
+
+@implementation SNTSyncCommands
+
+- (instancetype)initWithState:(SNTSyncState*)state
+               commandHandler:(SNTSantaCommandHandler*)commandHandler {
+  self = [super initWithState:state];
+  if (self) {
+    _commandHandler = commandHandler;
+  }
+  return self;
+}
+
+- (NSURL*)stageURL {
+  NSString* stageName = [@"commands" stringByAppendingFormat:@"/%@", self.syncState.machineID];
+  return [NSURL URLWithString:stageName relativeToURL:self.syncState.syncBaseURL];
+}
+
+// Posts an ack-only DELIVERED result for `commandId` so the server reflects
+// in-progress state while the command executes. The server withholds new
+// commands while one is in flight, so the ack response is discarded.
+- (BOOL)postDeliveredAckForCommandID:(int64_t)commandId onArena:(google::protobuf::Arena*)arena {
+  auto req = google::protobuf::Arena::Create<pbv2::CommandsRequest>(arena);
+  req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
+  pbv1::CommandResult* result = req->mutable_result();
+  result->set_command_id(commandId);
+  result->set_host_status(::pbv1::CommandResult::HOST_STATUS_DELIVERED);
+
+  pbv2::CommandsResponse response;
+  NSError* err = [self performRequest:[self requestWithMessage:req]
+                          intoMessage:&response
+                              timeout:30];
+  if (err) {
+    SLOGE(@"Failed to post delivered ack for command %lld: %@", (long long)commandId, err);
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)sync {
+  google::protobuf::Arena arena;
+
+  // The first exchange carries no result; it just asks for the next queued
+  // command.
+  auto req = google::protobuf::Arena::Create<pbv2::CommandsRequest>(&arena);
+  req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
+
+  NSUInteger executed = 0;
+  while (true) {
+    pbv2::CommandsResponse response;
+    NSError* err = [self performRequest:[self requestWithMessage:req]
+                            intoMessage:&response
+                                timeout:30];
+    if (err) {
+      SLOGE(@"Failed to fetch queued commands: %@", err);
+      return NO;
+    }
+
+    if (!response.has_command()) {
+      if (executed) {
+        SLOGI(@"Executed %lu queued command(s)", (unsigned long)executed);
+      }
+      return YES;
+    }
+
+    if (executed >= kMaxCommandsPerSync) {
+      // The unexecuted command was never acknowledged, so it remains queued
+      // server-side and is delivered again on the next sync.
+      SLOGW(@"Queued command limit (%lu) reached; remaining commands deferred to next sync",
+            (unsigned long)kMaxCommandsPerSync);
+      return YES;
+    }
+
+    const pbv1::QueuedCommand& command = response.command();
+
+    // Event uploads can run for minutes, so ack DELIVERED first: the server
+    // shows the command in flight instead of untouched while the upload runs.
+    // Kill is fast and posts straight to COMPLETE (the state machine allows
+    // skipping the ack). Commands the handler will reject are not acked —
+    // DELIVERED means "will execute it". An ack failure aborts the drain like
+    // any other transport failure: the command was never executed and, unless
+    // the ack landed with only its response lost, is still queued server-side
+    // for the next sync.
+    if (command.command_case() == ::pbv1::QueuedCommand::kEventUpload &&
+        [SNTSantaCommandHandler isCommandAllowed:@"event_upload"] &&
+        ![self postDeliveredAckForCommandID:command.command_id() onArena:&arena]) {
+      return NO;
+    }
+
+    // Execute the command, then post its result back. The server responds
+    // with the next queued command until its queue is drained.
+    pbv1::CommandResult* result = [self.commandHandler executeQueuedCommand:command onArena:&arena];
+    executed++;
+
+    req = google::protobuf::Arena::Create<pbv2::CommandsRequest>(&arena);
+    req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
+    req->unsafe_arena_set_allocated_result(result);
+  }
+}
+
+@end

--- a/Source/santasyncservice/SNTSyncCommandsTest.mm
+++ b/Source/santasyncservice/SNTSyncCommandsTest.mm
@@ -1,0 +1,425 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTConfigurator.h"
+#import "Source/santasyncservice/SNTPushNotifications.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#import "Source/santasyncservice/SNTSyncCommands.h"
+#import "Source/santasyncservice/SNTSyncState.h"
+
+static NSString* const kMachineID = @"50C7E1EB-2EF5-42D4-A084-A7966FC45A95";
+
+// Fake sync delegate that replies success to every event upload path.
+@interface SNTSyncCommandsFakeSyncDelegate : NSObject <SNTPushNotificationsSyncDelegate>
+@property(nonatomic) NSMutableArray<NSString*>* uploadedPaths;
+@end
+
+@implementation SNTSyncCommandsFakeSyncDelegate
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _uploadedPaths = [NSMutableArray array];
+  }
+  return self;
+}
+- (void)sync {
+}
+- (void)syncSecondsFromNow:(uint64_t)seconds {
+}
+- (void)ruleSync {
+}
+- (void)ruleSyncSecondsFromNow:(uint64_t)seconds {
+}
+- (void)preflightSync {
+}
+- (void)pushNotificationSyncSecondsFromNow:(uint64_t)seconds {
+}
+- (MOLXPCConnection*)daemonConnection {
+  return nil;
+}
+- (void)eventUploadForPaths:(NSArray<NSString*>*)paths reply:(void (^)(NSError* error))reply {
+  [self.uploadedPaths addObjectsFromArray:paths];
+  for (NSUInteger i = 0; i < paths.count; i++) {
+    reply(nil);
+  }
+}
+@end
+
+@interface SNTSyncCommandsTest : XCTestCase
+@property SNTSyncState* syncState;
+@property id configMock;
+@property SNTSyncCommandsFakeSyncDelegate* fakeSyncDelegate;
+@property SNTSyncCommands* stage;
+@end
+
+@implementation SNTSyncCommandsTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.configMock = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.configMock configurator]).andReturn(self.configMock);
+  OCMStub([self.configMock syncEnableProtoTransfer]).andReturn(NO);
+
+  self.syncState = [[SNTSyncState alloc] init];
+  self.syncState.session = OCMClassMock([NSURLSession class]);
+  self.syncState.syncBaseURL = [NSURL URLWithString:@"https://myserver.local/"];
+  self.syncState.machineID = kMachineID;
+  self.syncState.isSyncV2 = YES;
+
+  self.fakeSyncDelegate = [[SNTSyncCommandsFakeSyncDelegate alloc] init];
+  SNTSantaCommandHandler* handler =
+      [[SNTSantaCommandHandler alloc] initWithSyncDelegate:self.fakeSyncDelegate];
+  self.stage = [[SNTSyncCommands alloc] initWithState:self.syncState commandHandler:handler];
+}
+
+- (void)tearDown {
+  [self.configMock stopMocking];
+  [super tearDown];
+}
+
+#pragma mark Test Helpers
+
+// Stub dataTaskWithRequest:completionHandler: to return `respData` for any
+// request that `validateBlock` matches. See SNTSyncTest for the pattern.
+- (void)stubRequestBody:(NSData*)respData
+               response:(NSURLResponse*)resp
+                  error:(NSError*)err
+          validateBlock:(BOOL (^)(NSURLRequest* req))validateBlock {
+  if (!respData) respData = (NSData*)[NSNull null];
+  if (!resp) resp = [self responseWithCode:200];
+  if (!err) err = (NSError*)[NSNull null];
+
+  BOOL (^validateBlockWrapper)(id value) = ^BOOL(id value) {
+    if (!validateBlock) return YES;
+    return validateBlock((NSURLRequest*)value);
+  };
+
+  OCMStub([self.syncState.session
+      dataTaskWithRequest:[OCMArg checkWithBlock:validateBlockWrapper]
+        completionHandler:([OCMArg invokeBlockWithArgs:respData, resp, err, nil])]);
+}
+
+- (NSHTTPURLResponse*)responseWithCode:(NSInteger)code {
+  return [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"a"]
+                                     statusCode:code
+                                    HTTPVersion:@"1.1"
+                                   headerFields:nil];
+}
+
+- (NSDictionary*)dictFromRequest:(NSURLRequest*)request {
+  NSData* bod = [request HTTPBody];
+  if (bod) return [NSJSONSerialization JSONObjectWithData:bod options:0 error:NULL];
+  return nil;
+}
+
+- (NSData*)dataFromDict:(NSDictionary*)dict {
+  return [NSJSONSerialization dataWithJSONObject:dict options:0 error:NULL];
+}
+
+// Returns the result dictionary from a CommandsRequest body, or nil if the
+// request carried none. Field names are the proto3 JSON (camelCase) forms.
+- (NSDictionary*)resultFromRequest:(NSURLRequest*)request {
+  return [self dictFromRequest:request][@"result"];
+}
+
+#pragma mark Tests
+
+- (void)testDrainEmptyQueue {
+  __block NSUInteger requestCount = 0;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            requestCount++;
+            return YES;
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+  XCTAssertEqual(requestCount, 1u);
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
+}
+
+- (void)testDrainSingleEventUploadCommand {
+  // First exchange: no result posted -> server returns one queued command.
+  [self
+      stubRequestBody:[self dataFromDict:@{
+        @"command" :
+            @{@"commandId" : @"7", @"eventUpload" : @{@"paths" : @[ @"/Applications/Safari.app" ]}}
+      }]
+             response:nil
+                error:nil
+        validateBlock:^BOOL(NSURLRequest* req) {
+          NSDictionary* dict = [self dictFromRequest:req];
+          if (dict[@"result"]) return NO;
+          XCTAssertEqualObjects(dict[@"machineId"], kMachineID);
+          return YES;
+        }];
+
+  // Second exchange: ack-only DELIVERED result, posted before the upload runs.
+  __block NSDictionary* deliveredResult = nil;
+  __block NSUInteger pathsUploadedAtAck = NSUIntegerMax;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (![result[@"hostStatus"] isEqual:@"HOST_STATUS_DELIVERED"]) return NO;
+            deliveredResult = result;
+            pathsUploadedAtAck = self.fakeSyncDelegate.uploadedPaths.count;
+            return YES;
+          }];
+
+  // Third exchange: the executed result is posted back -> queue is empty.
+  __block NSDictionary* postedResult = nil;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (![result[@"hostStatus"] isEqual:@"HOST_STATUS_COMPLETE"]) return NO;
+            postedResult = result;
+            return YES;
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  XCTAssertEqualObjects(self.fakeSyncDelegate.uploadedPaths, @[ @"/Applications/Safari.app" ]);
+  // The DELIVERED ack carried no payload and preceded the upload.
+  XCTAssertEqualObjects(deliveredResult[@"commandId"], @"7");
+  XCTAssertNil(deliveredResult[@"eventUpload"]);
+  XCTAssertEqual(pathsUploadedAtAck, 0u);
+  XCTAssertEqualObjects(postedResult[@"commandId"], @"7");
+  XCTAssertNotNil(postedResult[@"eventUpload"]);
+}
+
+- (void)testDrainMultipleCommandsSequentially {
+  // No result -> command 1.
+  [self
+      stubRequestBody:[self dataFromDict:@{
+        @"command" :
+            @{@"commandId" : @"1", @"eventUpload" : @{@"paths" : @[ @"/Applications/Safari.app" ]}}
+      }]
+             response:nil
+                error:nil
+        validateBlock:^BOOL(NSURLRequest* req) {
+          return [self resultFromRequest:req] == nil;
+        }];
+
+  // DELIVERED acks for both commands return no new command.
+  __block NSMutableArray<NSString*>* ackedCommandIDs = [NSMutableArray array];
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (![result[@"hostStatus"] isEqual:@"HOST_STATUS_DELIVERED"]) return NO;
+            [ackedCommandIDs addObject:result[@"commandId"]];
+            return YES;
+          }];
+
+  // COMPLETE result for command 1 -> command 2.
+  [self stubRequestBody:[self dataFromDict:@{
+          @"command" :
+              @{@"commandId" : @"2", @"eventUpload" : @{@"paths" : @[ @"/Applications/Mail.app" ]}}
+        }]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            return [result[@"hostStatus"] isEqual:@"HOST_STATUS_COMPLETE"] &&
+                   [result[@"commandId"] isEqual:@"1"];
+          }];
+
+  // COMPLETE result for command 2 -> queue drained.
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            return [result[@"hostStatus"] isEqual:@"HOST_STATUS_COMPLETE"] &&
+                   [result[@"commandId"] isEqual:@"2"];
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  NSArray* expected = @[ @"/Applications/Safari.app", @"/Applications/Mail.app" ];
+  XCTAssertEqualObjects(self.fakeSyncDelegate.uploadedPaths, expected,
+                        @"Commands should execute serially, in delivery order");
+  NSArray* expectedAcks = @[ @"1", @"2" ];
+  XCTAssertEqualObjects(ackedCommandIDs, expectedAcks,
+                        @"Each event upload should be acked DELIVERED before executing");
+}
+
+- (void)testCommandRejectedWhenNotAllowed {
+  OCMStub([self.configMock allowedSantaCommands]).andReturn(@[ @"ping" ]);
+
+  [self stubRequestBody:[self dataFromDict:@{
+          @"command" : @{@"commandId" : @"5", @"kill" : @{@"team_id" : @"EQHXZ8M8AV"}}
+        }]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            return [self resultFromRequest:req] == nil;
+          }];
+
+  __block NSDictionary* postedResult = nil;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (!result) return NO;
+            postedResult = result;
+            return YES;
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  XCTAssertEqualObjects(postedResult[@"commandId"], @"5");
+  XCTAssertEqualObjects(postedResult[@"hostStatus"], @"HOST_STATUS_REJECTED");
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
+}
+
+- (void)testServerErrorFailsStage {
+  // A non-retryable client error fails the stage. The manager treats this as
+  // best-effort, so the failure never fails the sync itself.
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:[self responseWithCode:400]
+                  error:nil
+          validateBlock:nil];
+
+  XCTAssertFalse([self.stage sync]);
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
+}
+
+- (void)testDrainStopsAtCommandCap {
+  // Server misbehaves and always returns a command. The stage must bail out
+  // after its per-sync cap rather than looping forever.
+  __block NSUInteger requestCount = 0;
+  [self
+      stubRequestBody:[self dataFromDict:@{
+        @"command" :
+            @{@"commandId" : @"1", @"eventUpload" : @{@"paths" : @[ @"/Applications/Safari.app" ]}}
+      }]
+             response:nil
+                error:nil
+        validateBlock:^BOOL(NSURLRequest* req) {
+          requestCount++;
+          return YES;
+        }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  // 50 commands executed: one initial fetch plus a DELIVERED ack and a
+  // COMPLETE post per command. The stub also returns a command in response to
+  // the acks; the stage must ignore ack response contents.
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 50u);
+  XCTAssertEqual(requestCount, 101u);
+}
+
+- (void)testEventUploadRejectedSkipsDeliveredAck {
+  // A command the handler will reject must not be acked DELIVERED first —
+  // DELIVERED means "will execute it".
+  OCMStub([self.configMock allowedSantaCommands]).andReturn(@[ @"kill" ]);
+
+  [self
+      stubRequestBody:[self dataFromDict:@{
+        @"command" :
+            @{@"commandId" : @"9", @"eventUpload" : @{@"paths" : @[ @"/Applications/Safari.app" ]}}
+      }]
+             response:nil
+                error:nil
+        validateBlock:^BOOL(NSURLRequest* req) {
+          return [self resultFromRequest:req] == nil;
+        }];
+
+  __block NSMutableArray<NSString*>* postedStatuses = [NSMutableArray array];
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (!result) return NO;
+            [postedStatuses addObject:result[@"hostStatus"]];
+            return YES;
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  XCTAssertEqualObjects(postedStatuses, @[ @"HOST_STATUS_REJECTED" ]);
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
+}
+
+- (void)testKillSkipsDeliveredAck {
+  // Kill is fast and posts straight to COMPLETE with no DELIVERED ack.
+  [self stubRequestBody:[self dataFromDict:@{@"command" : @{@"commandId" : @"3", @"kill" : @{}}}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            return [self resultFromRequest:req] == nil;
+          }];
+
+  __block NSMutableArray<NSString*>* postedStatuses = [NSMutableArray array];
+  __block NSDictionary* postedResult = nil;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (!result) return NO;
+            [postedStatuses addObject:result[@"hostStatus"]];
+            postedResult = result;
+            return YES;
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  XCTAssertEqualObjects(postedStatuses, @[ @"HOST_STATUS_COMPLETE" ]);
+  XCTAssertEqualObjects(postedResult[@"commandId"], @"3");
+  XCTAssertNotNil(postedResult[@"kill"]);
+}
+
+- (void)testDeliveredAckFailureAbortsDrain {
+  // If the DELIVERED ack cannot be posted, the command is never executed and
+  // the drain aborts; the command stays queued server-side for the next sync.
+  [self
+      stubRequestBody:[self dataFromDict:@{
+        @"command" :
+            @{@"commandId" : @"7", @"eventUpload" : @{@"paths" : @[ @"/Applications/Safari.app" ]}}
+      }]
+             response:nil
+                error:nil
+        validateBlock:^BOOL(NSURLRequest* req) {
+          return [self resultFromRequest:req] == nil;
+        }];
+
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:[self responseWithCode:400]
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            return [result[@"hostStatus"] isEqual:@"HOST_STATUS_DELIVERED"];
+          }];
+
+  XCTAssertFalse([self.stage sync]);
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
+}
+
+@end

--- a/Source/santasyncservice/SNTSyncCommandsTest.mm
+++ b/Source/santasyncservice/SNTSyncCommandsTest.mm
@@ -309,6 +309,19 @@ static NSString* const kMachineID = @"50C7E1EB-2EF5-42D4-A084-A7966FC45A95";
   XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
 }
 
+- (void)testCommandsEndpointNotFoundStopsQuietly {
+  // A 404 means the sync server predates the command-queue endpoint (Santa was
+  // upgraded ahead of the server). The stage must treat this as "nothing to
+  // drain" and succeed, so it doesn't log an error on every sync.
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:[self responseWithCode:404]
+                  error:nil
+          validateBlock:nil];
+
+  XCTAssertTrue([self.stage sync]);
+  XCTAssertEqual(self.fakeSyncDelegate.uploadedPaths.count, 0u);
+}
+
 - (void)testDrainStopsAtCommandCap {
   // Server misbehaves and always returns a command. The stage must bail out
   // after its per-sync cap rather than looping forever.

--- a/Source/santasyncservice/SNTSyncManager.mm
+++ b/Source/santasyncservice/SNTSyncManager.mm
@@ -35,6 +35,8 @@
 #import "Source/santasyncservice/SNTPushClientFCM.h"
 #import "Source/santasyncservice/SNTPushClientNATS.h"
 #import "Source/santasyncservice/SNTPushNotifications.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#import "Source/santasyncservice/SNTSyncCommands.h"
 #import "Source/santasyncservice/SNTSyncConfigBundle.h"
 #import "Source/santasyncservice/SNTSyncEventUpload.h"
 #import "Source/santasyncservice/SNTSyncLogging.h"
@@ -74,6 +76,10 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
 
 // If set, push notifications are being used.
 @property id<SNTPushNotificationsClientDelegate> pushNotifications;
+
+// Transport-agnostic command execution shared with the NATS push client. Used
+// by the end-of-sync command drain stage.
+@property(nonatomic) SNTSantaCommandHandler* commandHandler;
 
 @property NSUInteger eventBatchSize;
 
@@ -138,6 +144,8 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     _syncLimiter = dispatch_semaphore_create(kMaxEnqueuedSyncs);
     _eventUploadQueue = dispatch_queue_create("com.northpolesec.santa.syncservice.eventupload",
                                               DISPATCH_QUEUE_SERIAL);
+
+    _commandHandler = [[SNTSantaCommandHandler alloc] initWithSyncDelegate:self];
 
     _eventBatchSize = kDefaultEventBatchSize;
     _metricsQueue = dispatch_queue_create_with_target(
@@ -759,11 +767,32 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
   SNTSyncPostflight* p = [[SNTSyncPostflight alloc] initWithState:syncState];
   if ([p sync]) {
     SLOGD(@"Postflight complete");
+    [self commandsWithSyncState:syncState];
     SLOGI(@"Sync completed successfully");
     return SNTSyncStatusTypeSuccess;
   }
   SLOGE(@"Postflight failed");
   return SNTSyncStatusTypePostflightFailed;
+}
+
+// Drain any commands the server has queued for this host. Runs after a
+// successful postflight; a failure (or partial drain) must not affect the
+// sync result. Undrained commands stay queued server-side and are picked up
+// on the next sync.
+- (void)commandsWithSyncState:(SNTSyncState*)syncState {
+  // Queued commands are only supported in sync v2. Skip on v1.
+  if (!syncState.isSyncV2) {
+    return;
+  }
+
+  SLOGD(@"Commands starting");
+  SNTSyncCommands* p = [[SNTSyncCommands alloc] initWithState:syncState
+                                               commandHandler:self.commandHandler];
+  if ([p sync]) {
+    SLOGD(@"Commands complete");
+  } else {
+    SLOGE(@"Commands failed; queued commands will be retried on next sync");
+  }
 }
 
 #pragma mark internal helpers

--- a/Source/santasyncservice/SNTSyncManager.mm
+++ b/Source/santasyncservice/SNTSyncManager.mm
@@ -64,6 +64,13 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
 // fanning out into concurrent bundle-service connections and sync POSTs.
 @property(nonatomic, readonly) dispatch_queue_t eventUploadQueue;
 
+// Serial queue for the end-of-sync command drain. The drain can block for a long
+// time (event-upload commands wait for the upload to complete), so it runs off
+// the syncQueue to let the sync finish. Serial so only one drain runs at a time;
+// a redundant drain dispatched while one is running finds the server queue
+// already emptied and returns after a single fetch.
+@property(nonatomic, readonly) dispatch_queue_t commandsQueue;
+
 @property(nonatomic) MOLXPCConnection* daemonConn;
 
 @property(nonatomic) BOOL reachable;
@@ -144,6 +151,8 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     _syncLimiter = dispatch_semaphore_create(kMaxEnqueuedSyncs);
     _eventUploadQueue = dispatch_queue_create("com.northpolesec.santa.syncservice.eventupload",
                                               DISPATCH_QUEUE_SERIAL);
+    _commandsQueue =
+        dispatch_queue_create("com.northpolesec.santa.syncservice.commands", DISPATCH_QUEUE_SERIAL);
 
     _commandHandler = [[SNTSantaCommandHandler alloc] initWithSyncDelegate:self];
 
@@ -776,23 +785,30 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
 }
 
 // Drain any commands the server has queued for this host. Runs after a
-// successful postflight; a failure (or partial drain) must not affect the
-// sync result. Undrained commands stay queued server-side and are picked up
-// on the next sync.
+// successful postflight but off the syncQueue: the drain can block for a long
+// time (event-upload commands wait for the upload to finish), so it must not
+// hold up completion of the sync. A failure (or partial drain) does not affect
+// the sync result; undrained commands stay queued server-side for a later drain.
+//
+// The drain runs on the serial commandsQueue, so only one runs at a time. It is
+// fine for overlapping syncs to each dispatch here: a drain that runs after
+// another has emptied the server queue simply returns after a single fetch.
 - (void)commandsWithSyncState:(SNTSyncState*)syncState {
   // Queued commands are only supported in sync v2. Skip on v1.
   if (!syncState.isSyncV2) {
     return;
   }
 
-  SLOGD(@"Commands starting");
-  SNTSyncCommands* p = [[SNTSyncCommands alloc] initWithState:syncState
-                                               commandHandler:self.commandHandler];
-  if ([p sync]) {
-    SLOGD(@"Commands complete");
-  } else {
-    SLOGE(@"Commands failed; queued commands will be retried on next sync");
-  }
+  dispatch_async(self.commandsQueue, ^{
+    LOGD(@"Commands starting");
+    SNTSyncCommands* p = [[SNTSyncCommands alloc] initWithState:syncState
+                                                 commandHandler:self.commandHandler];
+    if ([p sync]) {
+      LOGD(@"Commands complete");
+    } else {
+      LOGE(@"Commands failed; queued commands will be retried on next sync");
+    }
+  });
 }
 
 #pragma mark internal helpers

--- a/Source/santasyncservice/SNTSyncStage.h
+++ b/Source/santasyncservice/SNTSyncStage.h
@@ -72,6 +72,20 @@
 - (nullable NSError*)performRequest:(nonnull NSURLRequest*)request
                         intoMessage:(nullable google::protobuf::Message*)message
                             timeout:(NSTimeInterval)timeout;
+
+/**
+  Like performRequest:intoMessage:timeout: but also reports the HTTP status code
+  of the final response via `statusCode`. This is 0 when no HTTP response was
+  received (e.g. a transport-level error). Lets a caller distinguish a specific
+  status — such as a 404 for an endpoint an older sync server does not implement
+  — from other failures.
+
+  @param statusCode Out param for the HTTP status code; pass NULL to ignore.
+*/
+- (nullable NSError*)performRequest:(nonnull NSURLRequest*)request
+                        intoMessage:(nullable google::protobuf::Message*)message
+                            timeout:(NSTimeInterval)timeout
+                         statusCode:(nullable NSInteger*)statusCode;
 #endif
 
 @end

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -143,6 +143,7 @@ using santa::NSStringToUTF8String;
 
 - (NSData*)dataFromRequest:(NSURLRequest*)request
                    timeout:(NSTimeInterval)timeout
+                statusCode:(NSInteger*)statusCode
                      error:(NSError**)error {
   NSHTTPURLResponse* response;
   NSError* requestError;
@@ -186,6 +187,11 @@ using santa::NSStringToUTF8String;
     }
   }
 
+  // Report the final HTTP status (0 if no HTTP response was received) so callers
+  // can special-case specific codes, e.g. a 404 for an endpoint an older server
+  // does not implement.
+  if (statusCode) *statusCode = response.statusCode;
+
   // If the final attempt resulted in an error, log the error and return nil.
   if (response.statusCode != 200) {
     long code = response.statusCode;
@@ -204,8 +210,15 @@ using santa::NSStringToUTF8String;
 - (NSError*)performRequest:(NSURLRequest*)request
                intoMessage:(google::protobuf::Message*)message
                    timeout:(NSTimeInterval)timeout {
+  return [self performRequest:request intoMessage:message timeout:timeout statusCode:NULL];
+}
+
+- (NSError*)performRequest:(NSURLRequest*)request
+               intoMessage:(google::protobuf::Message*)message
+                   timeout:(NSTimeInterval)timeout
+                statusCode:(NSInteger*)statusCode {
   NSError* error;
-  NSData* data = [self dataFromRequest:request timeout:timeout error:&error];
+  NSData* data = [self dataFromRequest:request timeout:timeout statusCode:statusCode error:&error];
   if (error) {
     SLOGE(@"Error performing request: %@", error.localizedDescription);
     return error;


### PR DESCRIPTION
Adds a new sync stage that drains Workshop's command queue after a successful postflight. Each `POST /commands/{machine_id}` exchange is strictly 1:1: the request posts the result of the previously executed command, the response carries at most one newly queued command, and the loop runs until the server is drained (capped at 50 per sync). Drain failures never fail the sync — unexecuted commands stay queued server-side and retry next sync. Nothing is persisted client-side.

Command execution is factored out of the NATS push client into a transport-agnostic `SNTSantaCommandHandler` (one file per command: `+Kill`, `+EventUpload`) that both NATS and the HTTP drain call. NATS wire behavior is unchanged; HMAC/timestamp/nonce verification stays NATS-only.

Details:
- Event uploads post an ack-only `DELIVERED` result before executing so the server shows in-flight state, then `COMPLETE` with the payload. Kill posts straight to `COMPLETE`.
- Each command logs `Running command <id>...` so a long-running command doesn't look like a hung sync.
- Bumps the protos pin for the serial `CommandsRequest`/`CommandsResponse` shapes; the new `inventory_scan` NATS variant is routed to `ERROR_UNKNOWN_REQUEST_TYPE` until implemented.
- New tests for the handler and the drain stage; existing NATS command tests pass unmodified.