### PR TITLE
santad: leave Temporary Monitor Mode when client mode changes

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -39,6 +39,13 @@
 @property(readonly, nonatomic) SNTClientMode clientMode;
 
 ///
+///  The client mode as set by policy (sync state, then config state), ignoring
+///  any active Temporary Monitor Mode override. `clientMode` returns Monitor
+///  while a session is active; this returns what the mode would be without it.
+///
+@property(readonly, nonatomic) SNTClientMode clientModeIgnoringTemporaryMonitorMode;
+
+///
 ///  Set the operating mode as received from a sync server.
 ///
 - (void)setSyncServerClientMode:(SNTClientMode)newMode;

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -959,7 +959,10 @@ static SNTConfigurator* sharedConfigurator = nil;
   if ([self inTemporaryMonitorMode]) {
     return SNTClientModeMonitor;
   }
+  return [self clientModeIgnoringTemporaryMonitorMode];
+}
 
+- (SNTClientMode)clientModeIgnoringTemporaryMonitorMode {
   SNTClientMode cm = static_cast<SNTClientMode>([self.syncState[kClientModeKey] integerValue]);
   if (cm == SNTClientModeMonitor || cm == SNTClientModeLockdown || cm == SNTClientModeStandalone) {
     return cm;

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -549,6 +549,12 @@ static SNTConfigurator* sharedConfigurator = nil;
       setByAddingObject:NSStringFromSelector(@selector(inTemporaryMonitorMode))];
 }
 
++ (NSSet*)keyPathsForValuesAffectingClientModeIgnoringTemporaryMonitorMode {
+  // Deliberately excludes inTemporaryMonitorMode: this accessor reports the base
+  // (policy) mode, which an active session must not affect.
+  return [self syncAndConfigStateSet];
+}
+
 + (NSSet*)keyPathsForValuesAffectingAllowedPathRegex {
   return [self syncAndConfigStateSet];
 }

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -676,4 +676,26 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   XCTAssertNotNil([cfg savedDemotedAdmins]);
 }
 
+- (void)testClientModeIgnoringTemporaryMonitorMode {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/cm-ignoring-tmm.plist", self.testDir];
+  SNTConfigurator* sut = [self configuratorWithEmptySyncStateAtPath:plistPath];
+  [sut setSyncServerClientMode:SNTClientModeLockdown];
+
+  XCTAssertEqual(sut.clientMode, SNTClientModeLockdown);
+  XCTAssertEqual(sut.clientModeIgnoringTemporaryMonitorMode, SNTClientModeLockdown);
+
+  [sut setInTemporaryMonitorMode:YES];
+
+  // The masked getter reports Monitor during a session; the unmasked accessor
+  // still reports the underlying Lockdown policy.
+  XCTAssertEqual(sut.clientMode, SNTClientModeMonitor);
+  XCTAssertEqual(sut.clientModeIgnoringTemporaryMonitorMode, SNTClientModeLockdown);
+
+  [sut setInTemporaryMonitorMode:NO];
+  [sut setSyncServerClientMode:SNTClientModeMonitor];
+  XCTAssertEqual(sut.clientModeIgnoringTemporaryMonitorMode, SNTClientModeMonitor);
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
 @end

--- a/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
+++ b/Source/common/SNTStoredTemporaryMonitorModeAuditEvent.h
@@ -54,6 +54,13 @@ typedef NS_ENUM(NSInteger, SNTTemporaryMonitorModeLeaveReason) {
   // on restart); defined for symmetry with the shared TimedSyncSession restart
   // path. Reported as REASON_UNSPECIFIED upstream.
   SNTTemporaryMonitorModeLeaveReasonUnspecified,
+
+  // The base (policy) client mode changed to something other than Lockdown,
+  // making an active temporary Monitor Mode session redundant. Ends the session
+  // without revoking eligibility. Appended after the values above (rather than
+  // inserted) so their raw ordinals stay stable across upgrades: the reason is
+  // persisted as an integer in the on-disk events database.
+  SNTTemporaryMonitorModeLeaveReasonClientModeChanged,
 };
 
 // Represents a temporary Monitor Mode audit event stored in the events database.

--- a/Source/gui/SNTStatusItemManager.mm
+++ b/Source/gui/SNTStatusItemManager.mm
@@ -762,6 +762,17 @@ static NSString* const kNotificationSilencesKey = @"SilencedNotifications";
   state.menuItem.hidden = !(available || active);
   state.refreshItem.hidden = !(available || active);
 
+  // The greyed "Mode:" header tracks the TMM item's visibility (see
+  // refreshMonitorModeHeaderWithClientMode:), but only the poll / menu-open paths
+  // refresh it — the daemon-pushed leave+availability path does not. When a synced
+  // base-mode change ends the session the item hides here; propagate that hiding so
+  // an already-open menu does not keep showing a stale "Mode: Temporary Monitor".
+  // Showing the header and its title stay with the poll path (which knows the mode),
+  // so the un-hide direction is intentionally left untouched.
+  if (state == self.tmmState && state.menuItem.hidden) {
+    self.monitorModeMenuItem.hidden = YES;
+  }
+
   [self updateTimedModeSeparatorVisibility];
 }
 

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -735,6 +735,16 @@ static NSString* TAMUsernameForUID(uid_t uid) {
     _temporaryMonitorMode->NewModeTransitionReceived(val);
   }];
 
+  // A synced client-mode change can make an active Temporary Monitor Mode session
+  // redundant (base mode is now Monitor) or overridden (Standalone). While TMM
+  // masks the effective clientMode to Monitor, that change is invisible to the
+  // clientMode KVO and may arrive with no mode transition, so reconcile explicitly
+  // here against the just-committed base mode. Gated on the bundle carrying a
+  // client mode so it does not push availability on every sync.
+  [result clientMode:^(SNTClientMode m) {
+    _temporaryMonitorMode->ReconcileWithClientMode();
+  }];
+
   // Same post-batch ordering as modeTransition: enforce revoke and re-notify GUI
   // availability against just-committed state.
   [result temporaryAdminPolicy:^(SNTTemporaryAdminPolicy* val) {

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -580,10 +580,17 @@ static NSString* TAMUsernameForUID(uid_t uid) {
   // and rules-newly-added cases.
   NSData* oldCELData = [SNTCELFallbackRule serializeArray:[configurator celFallbackRules]];
 
+  // A clean sync that clears synced state drops any previously synced client
+  // mode, which can change the base (policy) client mode without the bundle
+  // carrying a clientMode field. Track it so Temporary Monitor Mode is still
+  // reconciled after the batch in that case.
+  __block BOOL syncStateCleared = NO;
+
   BOOL committed = [configurator performSyncStateBatch:^{
     [result clearSyncStateBeforeApply:^(BOOL clear) {
       if (clear) {
         [configurator clearSyncState];
+        syncStateCleared = YES;
       }
     }];
 
@@ -735,15 +742,21 @@ static NSString* TAMUsernameForUID(uid_t uid) {
     _temporaryMonitorMode->NewModeTransitionReceived(val);
   }];
 
-  // A synced client-mode change can make an active Temporary Monitor Mode session
+  // A synced client-mode change -- or a clean sync that cleared a previously
+  // synced client mode -- can make an active Temporary Monitor Mode session
   // redundant (base mode is now Monitor) or overridden (Standalone). While TMM
   // masks the effective clientMode to Monitor, that change is invisible to the
-  // clientMode KVO and may arrive with no mode transition, so reconcile explicitly
-  // here against the just-committed base mode. Gated on the bundle carrying a
-  // client mode so it does not push availability on every sync.
+  // clientMode KVO and may arrive with no mode transition, so reconcile
+  // explicitly here against the just-committed base mode. Triggered only when the
+  // bundle carries a client mode or a clean sync cleared synced state, so
+  // unrelated syncs do not reconcile.
+  __block BOOL reconcileClientMode = syncStateCleared;
   [result clientMode:^(SNTClientMode m) {
-    _temporaryMonitorMode->ReconcileWithClientMode();
+    reconcileClientMode = YES;
   }];
+  if (reconcileClientMode) {
+    _temporaryMonitorMode->ReconcileWithClientMode();
+  }
 
   // Same post-batch ordering as modeTransition: enforce revoke and re-notify GUI
   // availability against just-committed state.

--- a/Source/santad/TemporaryMonitorMode.h
+++ b/Source/santad/TemporaryMonitorMode.h
@@ -52,6 +52,13 @@ class TemporaryMonitorMode : public TimedSyncSession, public PassKey<TemporaryMo
   // existing session; always re-notify the GUI of availability.
   void NewModeTransitionReceived(SNTModeTransition* mode_transition);
 
+  // Reconcile an active session against the current base (policy) client mode.
+  // When the base mode is no longer Lockdown, an active session is redundant
+  // (Monitor) or overridden (Standalone), so end it — without writing a revoke
+  // policy, so eligibility survives a later return to Lockdown. Always re-notify
+  // the GUI of availability. Call after a sync commits a client-mode change.
+  void ReconcileWithClientMode();
+
   friend class TemporaryMonitorModePeer;
 
  protected:

--- a/Source/santad/TemporaryMonitorMode.mm
+++ b/Source/santad/TemporaryMonitorMode.mm
@@ -95,6 +95,23 @@ void TemporaryMonitorMode::NewModeTransitionReceived(SNTModeTransition* mode_tra
       temporaryMonitorModePolicyAvailable:Available()];
 }
 
+void TemporaryMonitorMode::ReconcileWithClientMode() {
+  // A synced base client-mode change to anything other than Lockdown makes an
+  // active session redundant/overridden. Ending via End() (not Revoke()) leaves
+  // the on-demand policy intact so the machine can re-enter if it returns to
+  // Lockdown. End() is a no-op when no session is active, which also clears a
+  // stale "available" for the no-session case. The availability push is
+  // idempotent with NewModeTransitionReceived's push earlier this sync.
+  if ([configurator_ clientModeIgnoringTemporaryMonitorMode] != SNTClientModeLockdown) {
+    if (End(SNTTemporaryMonitorModeLeaveReasonClientModeChanged)) {
+      LOGI(@"Temporary Monitor Mode session ended: client mode is no longer Lockdown.");
+    }
+  }
+
+  [[notification_queue_.notifierConnection remoteObjectProxy]
+      temporaryMonitorModePolicyAvailable:Available()];
+}
+
 #pragma mark Hooks
 
 bool TemporaryMonitorMode::ApplyEffect(NSError** err) {
@@ -117,9 +134,11 @@ bool TemporaryMonitorMode::ReapplyEffectOnRestart() {
 }
 
 bool TemporaryMonitorMode::ExtraPreconditions() {
-  SNTClientMode clientMode = [configurator_ clientMode];
-  return clientMode == SNTClientModeLockdown ||
-         (clientMode == SNTClientModeMonitor && [configurator_ inTemporaryMonitorMode]);
+  // Temporary Monitor Mode only makes sense while the base (policy) client mode
+  // is Lockdown: from Monitor it is redundant, from Standalone it is overridden.
+  // Read the base mode rather than [configurator_ clientMode], which reports
+  // Monitor while a session is active and would mask a base-mode change.
+  return [configurator_ clientModeIgnoringTemporaryMonitorMode] == SNTClientModeLockdown;
 }
 
 NSString* TemporaryMonitorMode::StateKey() {

--- a/Source/santad/TemporaryMonitorModeTest.mm
+++ b/Source/santad/TemporaryMonitorModeTest.mm
@@ -177,6 +177,10 @@ uint64_t MakeDeadline(uint64_t want) {
       .andReturn([[SNTModeTransition alloc] initOnDemandMinutes:maxMinutes defaultDuration:def]);
   OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
   OCMStub([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
+  // ExtraPreconditions reads the unmasked base mode; keep it Lockdown so the
+  // feature is available (clientMode above is masked to Monitor during a session).
+  OCMStub([self.mockConfigurator clientModeIgnoringTemporaryMonitorMode])
+      .andReturn(SNTClientModeLockdown);
   OCMStub([self.mockConfigurator syncBaseURL])
       .andReturn([NSURL URLWithString:@"https://foo.workshop.cloud"]);
   OCMStub([self.mockNotQueue
@@ -383,6 +387,84 @@ uint64_t MakeDeadline(uint64_t want) {
   XCTAssertEqual(((SNTStoredTemporaryMonitorModeEnterAuditEvent*)events[1]).reason,
                  SNTTemporaryMonitorModeEnterReasonOnDemandRefresh);
   XCTAssertEqualObjects(events[0].uuid, events[1].uuid);
+}
+
+- (void)testReconcileEndsSessionWhenBaseModeLeavesLockdown {
+  __block SNTClientMode baseMode = SNTClientModeLockdown;
+  OCMStub([self.mockConfigurator modeTransition])
+      .andReturn([[SNTModeTransition alloc] initOnDemandMinutes:60 defaultDuration:5]);
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
+  OCMStub([self.mockConfigurator clientModeIgnoringTemporaryMonitorMode])
+      .andDo(^(NSInvocation* inv) {
+        [inv setReturnValue:&baseMode];
+      });
+  OCMStub([self.mockConfigurator syncBaseURL])
+      .andReturn([NSURL URLWithString:@"https://foo.workshop.cloud"]);
+  OCMStub([self.mockNotQueue
+      authorizeTemporaryMonitorMode:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(YES), nil])]);
+
+  NSMutableArray<SNTStoredTemporaryMonitorModeAuditEvent*>* events = [NSMutableArray array];
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>(
+      (SNTConfigurator*)self.mockConfigurator, (SNTNotificationQueue*)self.mockNotQueue,
+      ^(SNTStoredTemporaryMonitorModeAuditEvent* e) {
+        [events addObject:e];
+      });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+  XCTAssertTrue(tmm->SecondsRemaining().has_value());
+  XCTAssertTrue(tmm->Available());
+
+  // Arm the rejection BEFORE the action: OCMReject only traps invocations made
+  // after it is registered. Ending because the mode changed must NOT write a
+  // revoke policy (eligibility is preserved for a later return to Lockdown).
+  OCMReject([self.mockConfigurator
+      setSyncServerModeTransition:[OCMArg checkWithBlock:^BOOL(SNTModeTransition* mt) {
+        return mt.type == SNTModeTransitionTypeRevoke;
+      }]]);
+
+  // Admin flips the machine to real Monitor Mode; the sync commits it with no
+  // revoke transition. Reconcile must end the now-redundant session.
+  baseMode = SNTClientModeMonitor;
+  tmm->ReconcileWithClientMode();
+
+  OCMVerify([self.mockConfigurator setInTemporaryMonitorMode:NO]);
+  XCTAssertFalse(tmm->SecondsRemaining().has_value());
+  XCTAssertFalse(tmm->Available());
+
+  XCTAssertTrue(
+      [events.lastObject isKindOfClass:[SNTStoredTemporaryMonitorModeLeaveAuditEvent class]]);
+  XCTAssertEqual(((SNTStoredTemporaryMonitorModeLeaveAuditEvent*)events.lastObject).reason,
+                 SNTTemporaryMonitorModeLeaveReasonClientModeChanged);
+}
+
+- (void)testReconcileLeavesSessionUntouchedWhileLockdown {
+  __block SNTClientMode baseMode = SNTClientModeLockdown;
+  OCMStub([self.mockConfigurator modeTransition])
+      .andReturn([[SNTModeTransition alloc] initOnDemandMinutes:60 defaultDuration:5]);
+  OCMStub([self.mockConfigurator isSyncV2Enabled]).andReturn(YES);
+  OCMStub([self.mockConfigurator clientModeIgnoringTemporaryMonitorMode])
+      .andDo(^(NSInvocation* inv) {
+        [inv setReturnValue:&baseMode];
+      });
+  OCMStub([self.mockConfigurator syncBaseURL])
+      .andReturn([NSURL URLWithString:@"https://foo.workshop.cloud"]);
+  OCMStub([self.mockNotQueue
+      authorizeTemporaryMonitorMode:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(YES), nil])]);
+
+  auto tmm = std::make_shared<TemporaryMonitorModePeer>((SNTConfigurator*)self.mockConfigurator,
+                                                        (SNTNotificationQueue*)self.mockNotQueue,
+                                                        ^(SNTStoredTemporaryMonitorModeAuditEvent*){
+                                                        });
+
+  NSError* err = nil;
+  XCTAssertEqual(tmm->RequestMinutes(@5, &err), 5u);
+
+  // A sync arrives but the base mode is still Lockdown: the session must survive.
+  tmm->ReconcileWithClientMode();
+
+  XCTAssertTrue(tmm->SecondsRemaining().has_value());
+  XCTAssertTrue(tmm->Available());
 }
 
 @end

--- a/Source/santad/TimedSyncSession.h
+++ b/Source/santad/TimedSyncSession.h
@@ -73,6 +73,11 @@ class TimedSyncSession : public Timer<TimedSyncSession> {
   // was active.
   bool Cancel();
 
+  // End an active session for a feature-specific reason WITHOUT writing a revoke
+  // policy (the feature stays eligible for immediate re-entry). Returns true if a
+  // session was active. Generalizes Cancel(), which is End(LeaveReasonCancelled()).
+  bool End(NSInteger leave_reason);
+
   // Revoke an active session and write the revoke policy. `leave_reason` is the
   // subclass's leave-reason enum value used for the audit event. Returns true if
   // a session was active.

--- a/Source/santad/TimedSyncSession.mm
+++ b/Source/santad/TimedSyncSession.mm
@@ -408,6 +408,11 @@ bool TimedSyncSession::EndForReasonLocked(NSInteger leave_reason) {
   return false;
 }
 
+bool TimedSyncSession::End(NSInteger leave_reason) {
+  absl::MutexLock lock(lock_);
+  return EndForReasonLocked(leave_reason);
+}
+
 bool TimedSyncSession::Cancel() {
   absl::MutexLock lock(lock_);
   return EndForReasonLocked(LeaveReasonCancelled());

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -551,6 +551,11 @@ void MessageForTemporaryMonitorModeLeaveAuditEvent(
     case SNTTemporaryMonitorModeLeaveReasonReboot:
       pbLeave->set_reason(::pbv2::TemporaryMonitorModeLeave::REASON_REBOOT);
       break;
+    case SNTTemporaryMonitorModeLeaveReasonClientModeChanged:
+      // The syncv2 TemporaryMonitorModeLeave proto has no dedicated reason for a
+      // client-mode change yet; report UNSPECIFIED until one is added upstream.
+      pbLeave->set_reason(::pbv2::TemporaryMonitorModeLeave::REASON_UNSPECIFIED);
+      break;
     default: pbLeave->set_reason(::pbv2::TemporaryMonitorModeLeave::REASON_UNSPECIFIED); break;
   }
 }


### PR DESCRIPTION
Fixes SNT-422

- End an active TMM session when a sync flips the base client mode out of Lockdown, preserving eligibility (no revoke policy) so it can re-enter later.
