### PR TITLE
santactl: report build metadata from the embed label

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1411,6 +1411,19 @@ genrule(
     cmd = """
     STABLE_GIT_COMMIT=$$(awk '/STABLE_GIT_COMMIT/ { print $$2 }' bazel-out/stable-status.txt)
     defaults write $${PWD}/$(@) SNTCommitHash -string $${STABLE_GIT_COMMIT:-unset}
+
+    # The embed label may carry SemVer build metadata after "+". Record the
+    # recognized values so they can be reported with the version.
+    BUILD_EMBED_LABEL=$$(awk '/BUILD_EMBED_LABEL/ { print $$2 }' bazel-out/stable-status.txt)
+    case "$${BUILD_EMBED_LABEL}" in
+      *+*)
+        case ".$${BUILD_EMBED_LABEL##*+}." in
+          *.unpublished.*)
+            defaults write $${PWD}/$(@) SNTBuildMetadata -string unpublished
+            ;;
+        esac
+        ;;
+    esac
     """,
     local = True,
     message = "Generating CommitHash.plist",

--- a/Source/santactl/Commands/SNTCommandVersion.mm
+++ b/Source/santactl/Commands/SNTCommandVersion.mm
@@ -157,8 +157,15 @@ REGISTER_COMMAND_NAME(@"version")
     commitHash = [commitHash substringToIndex:8];
   }
 
+  // Optional build metadata recorded at build time.
+  NSString* buildMetadata = dict[@"SNTBuildMetadata"];
+  NSString* commitDescription =
+      buildMetadata.length > 0
+          ? [NSString stringWithFormat:@"%@ commit %@", buildMetadata, commitHash]
+          : [NSString stringWithFormat:@"commit %@", commitHash];
+
   return [NSString
-      stringWithFormat:@"%@ (build %@, commit %@)", productVersion, buildVersion, commitHash];
+      stringWithFormat:@"%@ (build %@, %@)", productVersion, buildVersion, commitDescription];
 }
 
 - (NSString*)santadVersion {


### PR DESCRIPTION
`--embed_label` can carry SemVer build metadata after `+`, but nothing surfaces it — `apple_bundle_version` uses numeric capture groups and drops it.

- `Source/common/BUILD`: the `CommitHash` genrule already reads `bazel-out/stable-status.txt`, and `BUILD_EMBED_LABEL` is in the same file, so it reads one more line and writes recognized metadata as `SNTBuildMetadata`. Written only when present, so dev builds and metadata-free labels produce an unchanged plist. All five bundles listing `//Source/common:CommitHash` pick it up.
- `SNTCommandVersion.mm`: `composeVersionsFromDict` renders `2026.7 (build 219, <metadata> commit a5d822e7)` when present, unchanged otherwise. Table and `--json` share the function.

Testing: built `//Source/common:CommitHash` under three labels (metadata, bare commit suffix, no label) and checked `plutil -p` — key present only in the first. Compiled `composeVersionsFromDict` against Foundation over the real plist values. `bazel build //Source/santactl:SNTCommandVersion` is clean and `./Testing/lint.sh` exits 0.

Draft: not yet run end to end from a signed build.