### PR TITLE
santasyncservice: run binary uploads from the HTTP command queue

### DIFF
--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -26,18 +26,21 @@ objc_library(
     name = "SNTSantaCommandHandler",
     srcs = [
         "SNTSantaCommandHandler.mm",
+        "SNTSantaCommandHandler+BinaryUpload.mm",
         "SNTSantaCommandHandler+EventUpload.mm",
         "SNTSantaCommandHandler+Kill.mm",
         "SNTSantaCommandHandler+PackageInventory.mm",
     ],
     hdrs = [
         "SNTSantaCommandHandler.h",
+        "SNTSantaCommandHandler+BinaryUpload.h",
         "SNTSantaCommandHandler+EventUpload.h",
         "SNTSantaCommandHandler+Kill.h",
         "SNTSantaCommandHandler+PackageInventory.h",
     ],
     deps = [
         ":SNTPushNotifications",
+        "//Source/common:MOLXPCConnection",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTKillCommand",
         "//Source/common:SNTLogging",
@@ -619,7 +622,9 @@ santa_unit_test(
     deps = [
         ":SNTPushNotifications",
         ":SNTSantaCommandHandler",
+        "//Source/common:MOLXPCConnection",
         "//Source/common:SNTConfigurator",
+        "//Source/common:SNTXPCControlInterface",
         "@OCMock",
         "@northpolesec_protos//commands:v1_cc_proto",
         "@protobuf",

--- a/Source/santasyncservice/SNTPushClientNATS+Commands.mm
+++ b/Source/santasyncservice/SNTPushClientNATS+Commands.mm
@@ -20,8 +20,8 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
 #import "Source/common/SNTLogging.h"
-#import "Source/common/SNTXPCControlInterface.h"
 #include "Source/common/String.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler.h"
@@ -212,48 +212,25 @@ bool VerifyCommandRequestTimestamp(const ::pbv1::SantaCommandRequest& command) {
                                             completion:nil];
 }
 
-// Handle BinaryUploadRequest command (async). Forwards the request to santad over
+// Handle BinaryUploadRequest command (async). Execution lives in the
+// transport-agnostic command handler, which forwards the request to santad over
 // XPC; santad opens the file and launches sleigh. The response is published from
-// the XPC reply block so the shared command queue is never blocked for the upload.
+// the completion block so the shared command queue is never blocked for the
+// upload.
 - (void)handleBinaryUploadRequest:(const ::pbv1::BinaryUploadRequest&)binaryUploadRequest
                        replyTopic:(NSString*)replyTopic {
-  id<SNTPushNotificationsSyncDelegate> strongSyncDelegate = self.syncDelegate;
-  if (!strongSyncDelegate) {
-    LOGE(@"NATS: BinaryUploadRequest failed - no sync delegate");
-    ::pbv1::SantaCommandResponse response;
-    auto* uploadResponse = response.mutable_binary_upload();
-    uploadResponse->set_disposition(::pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
-    uploadResponse->set_message("santasyncservice has no sync delegate");
-    [self publishResponse:response toReplyTopic:replyTopic];
-    return;
-  }
-
-  std::string serializedRequest;
-  binaryUploadRequest.SerializeToString(&serializedRequest);
-  NSData* requestData = [NSData dataWithBytes:serializedRequest.data()
-                                       length:serializedRequest.size()];
-
   __weak __typeof(self) weakSelf = self;
-  [[[strongSyncDelegate daemonConnection] remoteObjectProxy]
-      uploadBinary:requestData
-             reply:^(NSData* responseData) {
-               __typeof(self) strongSelf = weakSelf;
-               if (!strongSelf) {
-                 return;
-               }
-               ::pbv1::SantaCommandResponse response;
-               ::pbv1::BinaryUploadResponse uploadResponse;
-               if (responseData &&
-                   uploadResponse.ParseFromArray(responseData.bytes, (int)responseData.length)) {
-                 *response.mutable_binary_upload() = uploadResponse;
-               } else {
-                 LOGE(@"NATS: BinaryUploadRequest got no parseable response from santad");
-                 ::pbv1::BinaryUploadResponse* bu = response.mutable_binary_upload();
-                 bu->set_disposition(::pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
-                 bu->set_message("no parseable response from santad");
-               }
-               [strongSelf publishResponse:response toReplyTopic:replyTopic];
-             }];
+  [self.commandHandler
+      handleBinaryUploadRequest:binaryUploadRequest
+                     completion:^(const ::pbv1::BinaryUploadResponse& uploadResponse) {
+                       __typeof(self) strongSelf = weakSelf;
+                       if (!strongSelf) {
+                         return;
+                       }
+                       ::pbv1::SantaCommandResponse response;
+                       *response.mutable_binary_upload() = uploadResponse;
+                       [strongSelf publishResponse:response toReplyTopic:replyTopic];
+                     }];
 }
 
 // Backwards-compatible overload for callers that don't publish asynchronously

--- a/Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.h
@@ -1,0 +1,45 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#include <google/protobuf/arena.h>
+
+#import "Source/santasyncservice/SNTSantaCommandHandler.h"
+#include "commands/v1.pb.h"
+
+/// Binary upload command execution, shared by every command transport. The
+/// upload itself happens in santad: this forwards the request over XPC, santad
+/// opens the file as root and launches Sleigh to POST it to the presigned URL
+/// carried in the request.
+@interface SNTSantaCommandHandler (BinaryUpload)
+
+/// Start a binary upload. Returns immediately; `completion` is invoked exactly
+/// once with the response to report, either from the XPC reply or synchronously
+/// with DISPOSITION_INTERNAL_ERROR when the request could not be handed to
+/// santad at all. `completion` must not be nil.
+- (void)handleBinaryUploadRequest:(const santa::commands::v1::BinaryUploadRequest&)request
+                       completion:
+                           (void (^)(const santa::commands::v1::BinaryUploadResponse& response))
+                               completion;
+
+/// Blocking variant used for queued (HTTP) command delivery: hands the request
+/// to santad and waits for the upload to finish. Bounded by an internal
+/// deadline comfortably longer than santad's own, so a santad that never
+/// replies can't wedge the sync drain. Never returns nullptr.
+- (santa::commands::v1::BinaryUploadResponse*)
+    handleBinaryUploadRequestAndWait:(const santa::commands::v1::BinaryUploadRequest&)request
+                             onArena:(google::protobuf::Arena*)arena;
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.mm
@@ -1,0 +1,96 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.h"
+
+#include <memory>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTXPCControlInterface.h"
+
+namespace pbv1 = ::santa::commands::v1;
+
+// Semi-arbitrary bound on how long to wait for santad to finish an upload.
+// santad SIGKILLs Sleigh 6 minutes into a launch and serializes launches, so a
+// request can sit behind one in-flight upload before its own deadline even
+// starts. This covers that with margin, while still guaranteeing the serial
+// sync drain can't wedge forever if santad dies mid-request: MOLXPCConnection
+// hands out a proxy whose error handler invalidates the connection without
+// invoking the reply block, so a lost reply is simply never delivered.
+static constexpr int64_t kBinaryUploadResponseTimeoutSeconds = 15 * 60;
+
+@implementation SNTSantaCommandHandler (BinaryUpload)
+
+- (void)handleBinaryUploadRequest:(const pbv1::BinaryUploadRequest&)request
+                       completion:(void (^)(const pbv1::BinaryUploadResponse& response))completion {
+  id<SNTDaemonControlXPC> daemon = [[self.syncDelegate daemonConnection] remoteObjectProxy];
+  if (!daemon) {
+    LOGE(@"SantaCommand: BinaryUploadRequest failed - no connection to santad");
+    pbv1::BinaryUploadResponse response;
+    response.set_disposition(pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
+    response.set_message("santasyncservice has no connection to santad");
+    completion(response);
+    return;
+  }
+
+  std::string serializedRequest;
+  request.SerializeToString(&serializedRequest);
+
+  [daemon
+      uploadBinary:[NSData dataWithBytes:serializedRequest.data() length:serializedRequest.size()]
+             reply:^(NSData* responseData) {
+               pbv1::BinaryUploadResponse response;
+               if (!responseData ||
+                   !response.ParseFromArray(responseData.bytes, (int)responseData.length)) {
+                 LOGE(@"SantaCommand: BinaryUploadRequest got no parseable response from "
+                      @"santad");
+                 response.Clear();
+                 response.set_disposition(pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
+                 response.set_message("no parseable response from santad");
+               }
+               completion(response);
+             }];
+}
+
+- (pbv1::BinaryUploadResponse*)handleBinaryUploadRequestAndWait:
+                                   (const pbv1::BinaryUploadRequest&)request
+                                                        onArena:(google::protobuf::Arena*)arena {
+  auto pbResponse = google::protobuf::Arena::Create<pbv1::BinaryUploadResponse>(arena);
+
+  // Held by the completion block so a reply that lands after the wait below
+  // gives up still writes to live memory. Only read once the semaphore has been
+  // signalled, so the timeout path never races that write.
+  auto received = std::make_shared<pbv1::BinaryUploadResponse>();
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  [self handleBinaryUploadRequest:request
+                       completion:^(const pbv1::BinaryUploadResponse& response) {
+                         *received = response;
+                         dispatch_semaphore_signal(sema);
+                       }];
+
+  if (dispatch_semaphore_wait(
+          sema, dispatch_time(DISPATCH_TIME_NOW,
+                              kBinaryUploadResponseTimeoutSeconds * NSEC_PER_SEC)) != 0) {
+    LOGE(@"SantaCommand: BinaryUploadRequest timed out waiting for santad");
+    pbResponse->set_disposition(pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
+    pbResponse->set_message("timed out waiting for santad to finish the upload");
+    return pbResponse;
+  }
+
+  *pbResponse = *received;
+  return pbResponse;
+}
+
+@end

--- a/Source/santasyncservice/SNTSantaCommandHandler.h
+++ b/Source/santasyncservice/SNTSantaCommandHandler.h
@@ -19,11 +19,6 @@
 #import "Source/santasyncservice/SNTPushNotifications.h"
 #include "commands/v1.pb.h"
 
-/// Canonical AllowedSantaCommands names, shared across transports so the command
-/// handler's allowlist mapping and the sync drain's checks cannot drift apart.
-extern NSString* const kSantaCommandNameEventUpload;
-extern NSString* const kSantaCommandNamePackageInventory;
-
 /// Executes Santa commands independently of the transport that delivered them.
 /// Both the NATS push client (request-reply) and the HTTP sync command drain
 /// call into this handler; transport concerns (envelope verification, replies,
@@ -42,6 +37,11 @@ extern NSString* const kSantaCommandNamePackageInventory;
 /// Returns YES if the named command is permitted by the AllowedSantaCommands
 /// configuration. An unset config allows all commands; an empty list blocks all.
 + (BOOL)isCommandAllowed:(NSString*)commandName;
+
+/// Returns YES if the caller should post an ack-only DELIVERED result before
+/// executing this queued command, i.e. it is long-running enough that the
+/// server should see it in flight, and it will actually be executed.
++ (BOOL)shouldPostDeliveredAckForCommand:(const santa::commands::v1::QueuedCommand&)command;
 
 /// Execute one queued command (HTTP delivery) and block until it finishes,
 /// returning the result to post back to the server. Never returns nullptr.

--- a/Source/santasyncservice/SNTSantaCommandHandler.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler.mm
@@ -17,6 +17,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
 #include "Source/common/String.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+PackageInventory.h"
@@ -24,8 +25,23 @@
 namespace pbv1 = ::santa::commands::v1;
 using santa::NSStringToUTF8String;
 
-NSString* const kSantaCommandNameEventUpload = @"event_upload";
-NSString* const kSantaCommandNamePackageInventory = @"package_inventory";
+namespace {
+
+// The AllowedSantaCommands name for a queued command, or nil for command types
+// this agent doesn't implement (those are reported as FAILED rather than gated).
+// No default case — compiler enforces all proto cases are handled
+// (-Werror + -Wswitch)
+NSString* CommandName(const ::pbv1::QueuedCommand& command) {
+  switch (command.command_case()) {
+    case ::pbv1::QueuedCommand::kKill: return @"kill";
+    case ::pbv1::QueuedCommand::kEventUpload: return @"event_upload";
+    case ::pbv1::QueuedCommand::kBinaryUpload: return @"binary_upload";
+    case ::pbv1::QueuedCommand::kPackageInventory: return @"package_inventory";
+    case ::pbv1::QueuedCommand::COMMAND_NOT_SET: return nil;
+  }
+}
+
+}  // namespace
 
 @implementation SNTSantaCommandHandler
 
@@ -42,27 +58,30 @@ NSString* const kSantaCommandNamePackageInventory = @"package_inventory";
   return !allowed || [allowed containsObject:commandName];
 }
 
++ (BOOL)shouldPostDeliveredAckForCommand:(const ::pbv1::QueuedCommand&)command {
+  // Uploads and package-inventory scans can run for minutes; acking first lets
+  // the server show them in flight instead of untouched while they run.
+  // Everything else is fast enough to post straight to COMPLETE.
+  switch (command.command_case()) {
+    case ::pbv1::QueuedCommand::kEventUpload:
+    case ::pbv1::QueuedCommand::kBinaryUpload:
+    case ::pbv1::QueuedCommand::kPackageInventory: break;
+    default: return NO;
+  }
+
+  // DELIVERED means "will execute it", so don't ack a command that is about to
+  // be rejected or reported as unimplemented.
+  NSString* commandName = CommandName(command);
+  return commandName && [self isCommandAllowed:commandName];
+}
+
 - (::pbv1::CommandResult*)executeQueuedCommand:(const ::pbv1::QueuedCommand&)command
                                        onArena:(google::protobuf::Arena*)arena {
   auto result = google::protobuf::Arena::Create<::pbv1::CommandResult>(arena);
   result->set_command_id(command.command_id());
 
   // Check if the command type is allowed by client configuration.
-  // No default case — compiler enforces all proto cases are handled (-Werror + -Wswitch)
-  NSString* commandName = nil;
-  switch (command.command_case()) {
-    case ::pbv1::QueuedCommand::kKill: commandName = @"kill"; break;
-    case ::pbv1::QueuedCommand::kEventUpload: commandName = kSantaCommandNameEventUpload; break;
-    case ::pbv1::QueuedCommand::kPackageInventory:
-      commandName = kSantaCommandNamePackageInventory;
-      break;
-    // binary_upload over the queued-command path is not implemented (binary upload
-    // is delivered via the NATS command path); leaving the name unset routes it to
-    // the FAILED default in the dispatch switch below.
-    case ::pbv1::QueuedCommand::kBinaryUpload: break;
-    case ::pbv1::QueuedCommand::COMMAND_NOT_SET: break;
-  }
-
+  NSString* commandName = CommandName(command);
   if (commandName && ![SNTSantaCommandHandler isCommandAllowed:commandName]) {
     LOGW(@"SantaCommand: Command '%@' rejected - not in AllowedSantaCommands", commandName);
     result->set_host_status(::pbv1::CommandResult::HOST_STATUS_REJECTED);
@@ -101,6 +120,18 @@ NSString* const kSantaCommandNamePackageInventory = @"package_inventory";
       }
       result->set_host_status(::pbv1::CommandResult::HOST_STATUS_COMPLETE);
       result->unsafe_arena_set_allocated_event_upload(uploadResponse);
+      break;
+    }
+
+    case ::pbv1::QueuedCommand::kBinaryUpload: {
+      LOGI(@"SantaCommand: Executing queued BinaryUploadRequest command %lld",
+           (long long)command.command_id());
+      // Like event upload, this blocks until santad reports the upload's
+      // outcome so the posted result reflects what actually happened.
+      auto* uploadResponse = [self handleBinaryUploadRequestAndWait:command.binary_upload()
+                                                            onArena:arena];
+      result->set_host_status(::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+      result->unsafe_arena_set_allocated_binary_upload(uploadResponse);
       break;
     }
 

--- a/Source/santasyncservice/SNTSantaCommandHandler.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandler.mm
@@ -27,8 +27,8 @@ using santa::NSStringToUTF8String;
 
 namespace {
 
-// The AllowedSantaCommands name for a queued command, or nil for command types
-// this agent doesn't implement (those are reported as FAILED rather than gated).
+// The AllowedSantaCommands name for a queued command, or nil when no command is
+// set (that case is reported as FAILED rather than gated by the allowlist).
 // No default case — compiler enforces all proto cases are handled
 // (-Werror + -Wswitch)
 NSString* CommandName(const ::pbv1::QueuedCommand& command) {
@@ -70,7 +70,7 @@ NSString* CommandName(const ::pbv1::QueuedCommand& command) {
   }
 
   // DELIVERED means "will execute it", so don't ack a command that is about to
-  // be rejected or reported as unimplemented.
+  // be rejected by the allowlist.
   NSString* commandName = CommandName(command);
   return commandName && [self isCommandAllowed:commandName];
 }

--- a/Source/santasyncservice/SNTSantaCommandHandlerTest.mm
+++ b/Source/santasyncservice/SNTSantaCommandHandlerTest.mm
@@ -16,8 +16,11 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTXPCControlInterface.h"
 #import "Source/santasyncservice/SNTPushNotifications.h"
+#import "Source/santasyncservice/SNTSantaCommandHandler+BinaryUpload.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+EventUpload.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+Kill.h"
 #import "Source/santasyncservice/SNTSantaCommandHandler+PackageInventory.h"
@@ -34,6 +37,9 @@ namespace pbv1 = ::santa::commands::v1;
 @property(nonatomic) NSArray* eventUploadReplyErrors;
 @property(nonatomic) NSArray<NSString*>* lastEventUploadPaths;
 @property(nonatomic) NSUInteger eventUploadCallCount;
+// Connection handed to commands that talk to santad. Nil (the default) stands
+// in for a santasyncservice that isn't connected to the daemon.
+@property(nonatomic) MOLXPCConnection* daemonConnection;
 @end
 
 @implementation SNTFakeCommandSyncDelegate
@@ -48,9 +54,6 @@ namespace pbv1 = ::santa::commands::v1;
 - (void)preflightSync {
 }
 - (void)pushNotificationSyncSecondsFromNow:(uint64_t)seconds {
-}
-- (MOLXPCConnection*)daemonConnection {
-  return nil;
 }
 - (void)eventUploadForPaths:(NSArray<NSString*>*)paths reply:(void (^)(NSError* error))reply {
   self.eventUploadCallCount++;
@@ -68,9 +71,12 @@ namespace pbv1 = ::santa::commands::v1;
 
 @interface SNTSantaCommandHandlerTest : XCTestCase
 @property id mockConfigurator;
+@property id mockDaemonConnection;
 @property SNTFakeCommandSyncDelegate* fakeSyncDelegate;
 @property SNTSantaCommandHandler* handler;
 @property google::protobuf::Arena* arena;
+@property NSData* lastBinaryUploadRequestData;
+@property NSUInteger binaryUploadCallCount;
 @end
 
 @implementation SNTSantaCommandHandlerTest
@@ -89,9 +95,42 @@ namespace pbv1 = ::santa::commands::v1;
 
 - (void)tearDown {
   [self.mockConfigurator stopMocking];
+  [self.mockDaemonConnection stopMocking];
   delete self.arena;
   self.arena = nullptr;
   [super tearDown];
+}
+
+#pragma mark - Test Helpers
+
+// Connects the fake sync delegate to a mock santad that replies to
+// uploadBinary: with `replyData`, recording what it was handed.
+- (void)stubDaemonBinaryUploadReplyData:(NSData*)replyData {
+  id mockProxy = OCMProtocolMock(@protocol(SNTDaemonControlXPC));
+  OCMStub([mockProxy uploadBinary:OCMOCK_ANY reply:OCMOCK_ANY]).andDo(^(NSInvocation* invocation) {
+    __unsafe_unretained NSData* requestData = nil;
+    [invocation getArgument:&requestData atIndex:2];
+    __unsafe_unretained void (^reply)(NSData*) = nil;
+    [invocation getArgument:&reply atIndex:3];
+    self.lastBinaryUploadRequestData = requestData;
+    self.binaryUploadCallCount++;
+    reply(replyData);
+  });
+
+  self.mockDaemonConnection = OCMClassMock([MOLXPCConnection class]);
+  OCMStub([self.mockDaemonConnection remoteObjectProxy]).andReturn(mockProxy);
+  self.fakeSyncDelegate.daemonConnection = self.mockDaemonConnection;
+}
+
+- (NSData*)serializedBinaryUploadResponseWithDisposition:
+               (pbv1::BinaryUploadResponse::Disposition)disposition
+                                          sha256Computed:(const std::string&)sha256 {
+  pbv1::BinaryUploadResponse response;
+  response.set_disposition(disposition);
+  response.set_sha256_computed(sha256);
+  std::string serialized;
+  response.SerializeToString(&serialized);
+  return [NSData dataWithBytes:serialized.data() length:serialized.size()];
 }
 
 #pragma mark - isCommandAllowed
@@ -259,6 +298,135 @@ namespace pbv1 = ::santa::commands::v1;
   XCTAssertEqual(result->event_upload().error(), ::pbv1::EventUploadResponse::ERROR_INVALID_PATH);
   XCTAssertEqual(self.fakeSyncDelegate.eventUploadCallCount, 0u,
                  @"Delegate should not be invoked when validation fails");
+}
+
+- (void)testExecuteQueuedCommandBinaryUploadForwardsRequestAndReportsResponse {
+  [self
+      stubDaemonBinaryUploadReplyData:[self
+                                          serializedBinaryUploadResponseWithDisposition:
+                                              pbv1::BinaryUploadResponse::DISPOSITION_COMPLETED
+                                                                         sha256Computed:"abc123"]];
+
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(21);
+  auto* upload = command.mutable_binary_upload();
+  upload->set_path("/bin/ls");
+  (*upload->mutable_signed_post()->mutable_form_values())["key"] = "objects/abc";
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->command_id(), 21);
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertTrue(result->has_binary_upload());
+  XCTAssertEqual(result->binary_upload().disposition(),
+                 ::pbv1::BinaryUploadResponse::DISPOSITION_COMPLETED);
+  XCTAssertEqual(result->binary_upload().sha256_computed(), "abc123");
+
+  // santad received the request as sent, presigned POST included.
+  XCTAssertEqual(self.binaryUploadCallCount, 1u);
+  ::pbv1::BinaryUploadRequest forwarded;
+  XCTAssertTrue(forwarded.ParseFromArray(self.lastBinaryUploadRequestData.bytes,
+                                         (int)self.lastBinaryUploadRequestData.length));
+  XCTAssertEqual(forwarded.path(), "/bin/ls");
+  XCTAssertEqual(forwarded.signed_post().form_values().at("key"), "objects/abc");
+}
+
+- (void)testExecuteQueuedCommandBinaryUploadUnparseableReply {
+  [self stubDaemonBinaryUploadReplyData:nil];
+
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(23);
+  command.mutable_binary_upload()->set_path("/bin/ls");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertEqual(result->binary_upload().disposition(),
+                 ::pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
+  XCTAssertGreaterThan(result->binary_upload().message().size(), 0u);
+}
+
+- (void)testExecuteQueuedCommandBinaryUploadNoDaemonConnection {
+  // The fake sync delegate has no daemon connection, so the request can't be
+  // handed off; the command still completes, reporting the failure.
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(29);
+  command.mutable_binary_upload()->set_path("/bin/ls");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_COMPLETE);
+  XCTAssertEqual(result->binary_upload().disposition(),
+                 ::pbv1::BinaryUploadResponse::DISPOSITION_INTERNAL_ERROR);
+  XCTAssertGreaterThan(result->binary_upload().message().size(), 0u);
+}
+
+- (void)testExecuteQueuedCommandBinaryUploadRejectedWhenNotAllowed {
+  OCMStub([self.mockConfigurator allowedSantaCommands]).andReturn(@[ @"kill" ]);
+  [self
+      stubDaemonBinaryUploadReplyData:[self
+                                          serializedBinaryUploadResponseWithDisposition:
+                                              pbv1::BinaryUploadResponse::DISPOSITION_COMPLETED
+                                                                         sha256Computed:"abc123"]];
+
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(31);
+  command.mutable_binary_upload()->set_path("/bin/ls");
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_REJECTED);
+  XCTAssertEqual(result->result_case(), ::pbv1::CommandResult::RESULT_NOT_SET);
+  XCTAssertEqual(self.binaryUploadCallCount, 0u, @"Rejected commands should not reach santad");
+}
+
+- (void)testExecuteQueuedCommandUnsetFails {
+  ::pbv1::QueuedCommand command;
+  command.set_command_id(37);
+
+  ::pbv1::CommandResult* result = [self.handler executeQueuedCommand:command onArena:self.arena];
+
+  XCTAssertEqual(result->command_id(), 37);
+  XCTAssertEqual(result->host_status(), ::pbv1::CommandResult::HOST_STATUS_FAILED);
+  XCTAssertGreaterThan(result->error_message().size(), 0u);
+  XCTAssertEqual(result->result_case(), ::pbv1::CommandResult::RESULT_NOT_SET);
+}
+
+#pragma mark - shouldPostDeliveredAckForCommand
+
+- (void)testShouldPostDeliveredAckOnlyForLongRunningCommands {
+  ::pbv1::QueuedCommand eventUpload;
+  eventUpload.mutable_event_upload()->add_paths("/Applications/Safari.app");
+  XCTAssertTrue([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:eventUpload]);
+
+  ::pbv1::QueuedCommand binaryUpload;
+  binaryUpload.mutable_binary_upload()->set_path("/bin/ls");
+  XCTAssertTrue([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:binaryUpload]);
+
+  ::pbv1::QueuedCommand kill;
+  kill.mutable_kill()->set_team_id("EQHXZ8M8AV");
+  XCTAssertFalse([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:kill],
+                 @"Kill is fast enough to post straight to COMPLETE");
+
+  ::pbv1::QueuedCommand packageInventory;
+  packageInventory.mutable_package_inventory();
+  XCTAssertTrue([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:packageInventory]);
+
+  ::pbv1::QueuedCommand unset;
+  XCTAssertFalse([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:unset]);
+}
+
+- (void)testShouldNotPostDeliveredAckForDisallowedCommand {
+  OCMStub([self.mockConfigurator allowedSantaCommands]).andReturn(@[ @"event_upload" ]);
+
+  ::pbv1::QueuedCommand eventUpload;
+  eventUpload.mutable_event_upload()->add_paths("/Applications/Safari.app");
+  XCTAssertTrue([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:eventUpload]);
+
+  ::pbv1::QueuedCommand binaryUpload;
+  binaryUpload.mutable_binary_upload()->set_path("/bin/ls");
+  XCTAssertFalse([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:binaryUpload],
+                 @"DELIVERED means 'will execute it'");
 }
 
 #pragma mark - handleEventUploadRequest completion

--- a/Source/santasyncservice/SNTSyncCommands.mm
+++ b/Source/santasyncservice/SNTSyncCommands.mm
@@ -119,20 +119,17 @@ static const NSUInteger kMaxCommandsPerSync = 50;
 
     const pbv1::QueuedCommand& command = response.command();
 
-    // Event uploads and package-inventory scans can run for minutes, so ack
+    // Uploads and package-inventory scans can run for minutes, so they ack
     // DELIVERED first: the server shows the command in flight instead of
     // untouched while it runs. Kill is fast and posts straight to COMPLETE (the
-    // state machine allows skipping the ack). Commands the handler will reject
-    // are not acked — DELIVERED means "will execute it". An ack failure aborts
-    // the drain like any other transport failure: the command was never executed
-    // and, unless the ack landed with only its response lost, is still queued
-    // server-side for the next sync.
-    BOOL longRunning =
-        (command.command_case() == ::pbv1::QueuedCommand::kEventUpload &&
-         [SNTSantaCommandHandler isCommandAllowed:kSantaCommandNameEventUpload]) ||
-        (command.command_case() == ::pbv1::QueuedCommand::kPackageInventory &&
-         [SNTSantaCommandHandler isCommandAllowed:kSantaCommandNamePackageInventory]);
-    if (longRunning && ![self postDeliveredAckForCommandID:command.command_id() onArena:&arena]) {
+    // state machine allows skipping the ack), as do commands the handler will
+    // reject — DELIVERED means "will execute it". The handler owns which
+    // commands qualify. An ack failure aborts the drain like any other
+    // transport failure: the command was never executed and, unless the ack
+    // landed with only its response lost, is still queued server-side for the
+    // next sync.
+    if ([SNTSantaCommandHandler shouldPostDeliveredAckForCommand:command] &&
+        ![self postDeliveredAckForCommandID:command.command_id() onArena:&arena]) {
       return NO;
     }
 

--- a/Source/santasyncservice/SNTSyncCommandsTest.mm
+++ b/Source/santasyncservice/SNTSyncCommandsTest.mm
@@ -209,6 +209,58 @@ static NSString* const kMachineID = @"50C7E1EB-2EF5-42D4-A084-A7966FC45A95";
   XCTAssertNotNil(postedResult[@"eventUpload"]);
 }
 
+- (void)testDrainSingleBinaryUploadCommand {
+  // First exchange: no result posted -> server returns one queued command.
+  [self
+      stubRequestBody:[self dataFromDict:@{
+        @"command" : @{
+          @"commandId" : @"9",
+          @"binaryUpload" :
+              @{@"path" : @"/bin/ls",
+                @"signed_post" : @{@"url" : @"https://bucket.example/upload"}}
+        }
+      }]
+             response:nil
+                error:nil
+        validateBlock:^BOOL(NSURLRequest* req) {
+          return [self resultFromRequest:req] == nil;
+        }];
+
+  // Second exchange: ack-only DELIVERED result, posted before the upload runs.
+  __block NSDictionary* deliveredResult = nil;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (![result[@"hostStatus"] isEqual:@"HOST_STATUS_DELIVERED"]) return NO;
+            deliveredResult = result;
+            return YES;
+          }];
+
+  // Third exchange: the executed result is posted back -> queue is empty. This
+  // fake has no daemon connection, so the upload can't be handed to santad and
+  // the typed payload reports that; the command itself still completes.
+  __block NSDictionary* postedResult = nil;
+  [self stubRequestBody:[self dataFromDict:@{}]
+               response:nil
+                  error:nil
+          validateBlock:^BOOL(NSURLRequest* req) {
+            NSDictionary* result = [self resultFromRequest:req];
+            if (![result[@"hostStatus"] isEqual:@"HOST_STATUS_COMPLETE"]) return NO;
+            postedResult = result;
+            return YES;
+          }];
+
+  XCTAssertTrue([self.stage sync]);
+
+  XCTAssertEqualObjects(deliveredResult[@"commandId"], @"9");
+  XCTAssertNil(deliveredResult[@"binaryUpload"]);
+  XCTAssertEqualObjects(postedResult[@"commandId"], @"9");
+  XCTAssertEqualObjects(postedResult[@"binaryUpload"][@"disposition"],
+                        @"DISPOSITION_INTERNAL_ERROR");
+}
+
 - (void)testDrainMultipleCommandsSequentially {
   // No result -> command 1.
   [self


### PR DESCRIPTION
Bumps the protos pin to pick up the additive `binary_upload`/`inventory_scan` oneof fields on `QueuedCommand` and `CommandResult`, and wires binary upload into the sync-pull command drain. Execution moves out of the NATS client into a shared `SNTSantaCommandHandler+BinaryUpload` (one file per command, like `+Kill` and `+EventUpload`) exposing an async variant — NATS publishes from the completion block, keeping its message queue unblocked — and a blocking variant for the drain, bounded at 15 minutes so a santad that dies without replying can't wedge the serial sync queue, with late replies writing to a `shared_ptr` owned by the block rather than the arena message.

Binary uploads ack `DELIVERED` before executing like event uploads do, so the server sees them in flight; the per-variant name mapping now lives in one place behind `+shouldPostDeliveredAckForCommand:`, and `inventory_scan` is routed to `HOST_STATUS_FAILED` until implemented, mirroring how NATS answers it with `ERROR_UNKNOWN_REQUEST_TYPE`. One NATS behavior change: a sync delegate present but disconnected from santad used to drop the request silently and never publish a reply, and now reports `DISPOSITION_INTERNAL_ERROR`.

`bazel test :unit_tests` passes 138/138, including new coverage for the request round-tripping to santad with the presigned POST intact, unparseable/absent replies, allow-list rejection never reaching santad, the ack predicate matrix, and a full HTTP drain asserting the `DELIVERED` → `COMPLETE` sequence. A real upload was not exercised end to end — that needs a live sync server plus santad, so the daemon-side path remains covered only by the existing `SNTBinaryUploadControllerTest`.

A part of WS-1271