### PR TITLE
Revert "santactl: report build metadata from the embed label"

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -1411,19 +1411,6 @@ genrule(
     cmd = """
     STABLE_GIT_COMMIT=$$(awk '/STABLE_GIT_COMMIT/ { print $$2 }' bazel-out/stable-status.txt)
     defaults write $${PWD}/$(@) SNTCommitHash -string $${STABLE_GIT_COMMIT:-unset}
-
-    # The embed label may carry SemVer build metadata after "+". Record the
-    # recognized values so they can be reported with the version.
-    BUILD_EMBED_LABEL=$$(awk '/BUILD_EMBED_LABEL/ { print $$2 }' bazel-out/stable-status.txt)
-    case "$${BUILD_EMBED_LABEL}" in
-      *+*)
-        case ".$${BUILD_EMBED_LABEL##*+}." in
-          *.unpublished.*)
-            defaults write $${PWD}/$(@) SNTBuildMetadata -string unpublished
-            ;;
-        esac
-        ;;
-    esac
     """,
     local = True,
     message = "Generating CommitHash.plist",

--- a/Source/santactl/Commands/SNTCommandVersion.mm
+++ b/Source/santactl/Commands/SNTCommandVersion.mm
@@ -157,15 +157,8 @@ REGISTER_COMMAND_NAME(@"version")
     commitHash = [commitHash substringToIndex:8];
   }
 
-  // Optional build metadata recorded at build time.
-  NSString* buildMetadata = dict[@"SNTBuildMetadata"];
-  NSString* commitDescription =
-      buildMetadata.length > 0
-          ? [NSString stringWithFormat:@"%@ commit %@", buildMetadata, commitHash]
-          : [NSString stringWithFormat:@"commit %@", commitHash];
-
   return [NSString
-      stringWithFormat:@"%@ (build %@, %@)", productVersion, buildVersion, commitDescription];
+      stringWithFormat:@"%@ (build %@, commit %@)", productVersion, buildVersion, commitHash];
 }
 
 - (NSString*)santadVersion {


### PR DESCRIPTION
Reverts #1102. The metadata reported there was added before the release build process was settled; that information is tracked in the build artifacts instead, so there is no need to carry it in the version string.

- `CommitHash.plist` again contains only `SNTCommitHash`.
- `santactl version` returns to `<version> (build N, commit <sha>)` in all cases.

Testing: rebuilt `//Source/common:CommitHash` both with and without an embed label carrying build metadata — only `SNTCommitHash` is written in either case. `bazel build //Source/santactl:SNTCommandVersion` is clean and `./Testing/lint.sh` exits 0.