### PR TITLE
workflows: Skip scheduled and deploy jobs outside this repo

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   preqs:
+    if: github.repository == 'northpolesec/santa'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -44,6 +44,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
+    if: github.repository == 'northpolesec/santa'
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'northpolesec/santa'
     runs-on: macos-latest
     strategy:
       matrix:


### PR DESCRIPTION
`continuous` and `sanitizers` run on a schedule, and `docs-deploy` publishes to GitHub Pages. In a fork these either consume runner time to no purpose or cannot succeed, so guard them on the repository name.

The docs `build` job is left unguarded on purpose, so documentation changes are still validated in a fork.

Verified the guard lands only on `continuous/preqs`, `sanitizers/test` and `docs-deploy/deploy`, and that all three files still parse.