### PR TITLE
docs: Document binary_upload and package_inventory commands

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -1184,7 +1184,8 @@ extern NSString* _Nonnull const kStateTempAdminTargetUIDKey;
 
 ///
 ///  If set, only the listed command types will be accepted from the sync server.
-///  Command names are lowercase strings matching proto field names: "kill", "ping", "eventupload".
+///  Command names are lowercase strings matching proto field names: "kill", "ping",
+///  "event_upload", "binary_upload", "package_inventory".
 ///  When unset (nil), all commands are allowed.
 ///
 ///  This is a forced config key (MDM only) — not settable via sync server.

--- a/docs/src/lib/santaconfig.ts
+++ b/docs/src/lib/santaconfig.ts
@@ -138,7 +138,9 @@ export const SantaConfigKeyGroups: SantaConfigGroups = {
       possibleValues: [
         { value: "kill" },
         { value: "ping" },
-        { value: "eventupload" },
+        { value: "event_upload" },
+        { value: "binary_upload", versionAdded: "2026.7" },
+        { value: "package_inventory", versionAdded: "2026.7" },
       ],
       versionAdded: "2026.3",
     },


### PR DESCRIPTION
Adds `binary_upload` and `package_inventory` (both `versionAdded: 2026.7`) to the documented values for `AllowedSantaCommands` in the config reference, and corrects `eventupload` to `event_upload`.

`SNTSantaCommandHandler.isCommandAllowed:` does an exact, case-sensitive `containsObject:` against the names from `CommandName()` — `kill`, `ping`, `event_upload`, `binary_upload`, `package_inventory` — so there is no alias handling and the old `eventupload` value would have silently blocked event uploads for anyone who copied it out of the docs or config generator into an MDM profile. The same stale list in the `allowedSantaCommands` doc comment in `SNTConfigurator.h` is corrected too.

Note: `BinaryUploadFilterExpressions` is still marked `2026.5`; if that key ships alongside these commands it should be bumped to `2026.7` as well.