### PR TITLE
workflows: Reduce scheduled macOS runner minutes

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,20 +1,85 @@
 # Continuous Testing
 #
-# Run 50 times per day, split over two runs to keep individual run times
-# lower so as not to hit action timeout conditions.
+# Nightly flake hunt: runs the unit test suite 25 times under
+# --test_strategy=exclusive.
+#
+# macOS runner minutes bill at 10x, so this does not run unconditionally. A
+# cheap Linux "gate" job checks whether main received a commit recently; the
+# expensive macOS job runs only when it did, or on manual dispatch.
 name: continuous
 on:
   schedule:
     - cron: "0 10 * * *" # Every day at 10:00 UTC
-    - cron: "30 23 * * *" # Every day at 23:30 UTC
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
+# No `concurrency` group: at one cron per day only a manual dispatch can double
+# up, and serialising that would make an on-demand run wait out the nightly.
+
 jobs:
-  preqs:
-    if: github.repository == 'northpolesec/santa'
-    runs-on: macos-latest
+  gate:
+    name: "Gate on recent merge"
+    # Only scheduled runs need gating. Manual dispatch skips this job entirely
+    # and forces the hunt to run (see the flake-hunt job's `if`).
+    if: github.event_name == 'schedule' && github.repository == 'northpolesec/santa'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      # Run only if HEAD landed within 36h (129600s). Wider than the 24h cron
+      # cadence on purpose: GitHub fires scheduled runs late, so a 25h window
+      # would drop commits that landed shortly before their slot.
+      - name: Check for a recent commit
+        id: check
+        run: |
+          if [ $(( $(date +%s) - $(git log -1 --format=%ct) )) -lt 129600 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  flake-hunt:
+    name: "Flake hunt"
+    needs: gate
+    # Run on a scheduled trigger only when the gate found a recent merge, or on
+    # any manual dispatch. `!cancelled()` is required: on manual dispatch the
+    # gate job is skipped, and a job that `needs` a skipped job is skipped too
+    # by default unless its `if` uses a status function to opt back in.
+    if: ${{ !cancelled() && github.repository == 'northpolesec/santa' && (needs.gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch') }}
+    runs-on: macos-latest
+    # Hang backstop, not a target; runs are ~3.5h with a 4.7h worst case.
+    timeout-minutes: 330
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      # Read-only use of the same GCS cache PR CI populates: this build passes no
+      # --config, so its action keys match ci.yml's. Uploads stay off so the
+      # nightly can't poison the shared bucket, and test results are never
+      # cached regardless (-t- below). Auth is best effort — ci.yml only
+      # exercises this provider on pull_request, so if it rejects scheduled runs
+      # the build falls back to no cache instead of failing.
+      - name: Auth to GCP
+        continue-on-error: true
+        id: auth
+        uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # ratchet:google-github-actions/auth@v3
+        with:
+          workload_identity_provider: "projects/131531281042/locations/global/workloadIdentityPools/github/providers/github"
+          project_id: "santa-build-cache"
+
+      - name: Configure remote cache
+        run: |
+          if [[ "${{ steps.auth.outcome }}" == "success" ]]; then
+            echo "REMOTE_CACHE_FLAGS=--remote_cache=https://storage.googleapis.com/santa-build-cache --google_default_credentials --remote_upload_local_results=false" >> "$GITHUB_ENV"
+          else
+            echo "REMOTE_CACHE_FLAGS=" >> "$GITHUB_ENV"
+          fi
 
       # Note: Using Bazel flags documented here to reduce memory footprint:
       # https://bazel.build/advanced/performance/memory
@@ -30,6 +95,7 @@ jobs:
       - name: Check for flaky tests
         run: |
           bazel test \
+            ${REMOTE_CACHE_FLAGS} \
             --test_strategy=exclusive \
             --test_output=errors \
             --runs_per_test 25 \

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -58,6 +58,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # Read-only use of the same GCS cache PR CI populates: this build passes no
       # --config, so its action keys match ci.yml's. Uploads stay off so the

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: macos-latest
     # Hang backstop. TSAN is the long pole at ~1.7h; the others are ~25m.
     timeout-minutes: 180
+    permissions:
+      contents: read
     strategy:
       # One sanitizer failing shouldn't cancel the others mid-run.
       fail-fast: false
@@ -66,6 +68,8 @@ jobs:
             runs: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
       # Deliberately no build cache, unlike continuous.yml: -fsanitize=* is a
       # global --copt, so the whole closure is rebuilt instrumented and shares no
       # action keys with the fastbuild entries PR CI populates.

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,18 +1,74 @@
+# Sanitizers
+#
+# Runs the unit test suite under ASAN, TSAN, and UBSAN. TSAN is repeated because
+# data races are nondeterministic; ASAN/UBSAN faults are deterministic, so one
+# run per test is enough.
+#
+# macOS runner minutes bill at 10x, so this does not run unconditionally. A
+# cheap Linux "gate" job checks whether main received a commit recently; the
+# expensive macOS matrix runs only when it did, or on manual dispatch.
 name: sanitizers
 on:
   schedule:
-    - cron: '0 15 * * *'
-  workflow_dispatch:
+    - cron: '0 15 * * *' # 15:00 UTC; staggered clear of continuous.yml (10:00)
+  workflow_dispatch: # Allows manual runs from the Actions tab (skips the gate)
+
+# No `concurrency` group; see the note in continuous.yml.
 
 jobs:
-  test:
-    if: github.repository == 'northpolesec/santa'
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        sanitizer: [asan, tsan, ubsan]
+  gate:
+    name: "Gate on recent merge"
+    # Only scheduled runs need gating. Manual dispatch skips this job entirely
+    # and forces the sanitizers to run (see the sanitizers job's `if`).
+    if: github.event_name == 'schedule' && github.repository == 'northpolesec/santa'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      # Run only if HEAD landed within 36h (129600s). Wider than the 24h cron
+      # cadence because GitHub fires scheduled runs late. Keep in sync with
+      # continuous.yml.
+      - name: Check for a recent commit
+        id: check
+        run: |
+          if [ $(( $(date +%s) - $(git log -1 --format=%ct) )) -lt 129600 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  sanitizers:
+    name: "${{ matrix.sanitizer }}"
+    needs: gate
+    # Run on a scheduled trigger only when the gate found a recent merge, or on
+    # any manual dispatch. `!cancelled()` is required: on manual dispatch the
+    # gate job is skipped, and a job that `needs` a skipped job is skipped too
+    # by default unless its `if` uses a status function to opt back in.
+    if: ${{ !cancelled() && github.repository == 'northpolesec/santa' && (needs.gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch') }}
+    runs-on: macos-latest
+    # Hang backstop. TSAN is the long pole at ~1.7h; the others are ~25m.
+    timeout-minutes: 180
+    strategy:
+      # One sanitizer failing shouldn't cancel the others mid-run.
+      fail-fast: false
+      matrix:
+        include:
+          - sanitizer: asan
+            runs: 1
+          - sanitizer: ubsan
+            runs: 1
+          - sanitizer: tsan
+            runs: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      # Deliberately no build cache, unlike continuous.yml: -fsanitize=* is a
+      # global --copt, so the whole closure is rebuilt instrumented and shares no
+      # action keys with the fastbuild entries PR CI populates.
       - name: ${{ matrix.sanitizer }}
         run: |
           CLANG_VERSION=$(clang --version | head -n 1 | cut -d' ' -f 4)
@@ -21,11 +77,11 @@ jobs:
           bazel test --config=${{ matrix.sanitizer }} \
             --test_strategy=exclusive --test_output=all \
             --test_env=DYLD_INSERT_LIBRARIES=${DYLIB_PATH} \
-            --runs_per_test 5 -t- :unit_tests \
+            --runs_per_test ${{ matrix.runs }} -t- :unit_tests \
             --define=SANTA_BUILD_TYPE=adhoc
       - name: Upload logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # ratchet:actions/upload-artifact@v7.0.0
         if: failure()
         with:
-          name: logs
+          name: logs-${{ matrix.sanitizer }}
           path: /tmp/san_out*


### PR DESCRIPTION
`continuous` and `sanitizers` were 83% of this repo's Actions usage last month (~206k of ~248k minutes, macOS weighted 10x). PR CI was 17%.

| Workflow | Now | Projected |
|---|---|---|
| continuous | 138,080 | ~41,900 |
| sanitizers | 68,360 | ~33,000 |
| ci | 41,157 | unchanged |
| **Total** | **247,806** | **~116,300** |

**continuous:** one cron/day instead of two; gate on a recent merge to `main`; read from the GCS cache PR CI already populates (~20m cold build → ~7m, uploads off, `-t-` means test results are never cached); add `timeout-minutes`; rename job from `preqs`. `--runs_per_test` stays at 25 — iterations are cheaper per sample than whole runs, since the build is fixed overhead.

**sanitizers:** ASAN/UBSAN drop to 1 run per test, as repeat runs only help TSAN, which keeps 5; gate on a recent merge; `fail-fast: false`, since one sanitizer failing was cancelling the others mid-run; per-sanitizer artifact names, as all three uploaded to `logs` and conflicted; add `timeout-minutes`; rename job from `test`. No build cache: `-fsanitize=*` is a global `--copt`, so nothing shares action keys with PR CI's fastbuild entries.

Gate window is 36h rather than santanetd's 25h — GitHub fires scheduled runs late (p90 64m, worst ~2h), and 25h would drop a commit that landed shortly before its slot. No `concurrency` group: at one cron/day only manual dispatch could double up, and serialising that would make an on-demand run wait out the nightly.

Worth checking the `Auth to GCP` step on the first scheduled run — `ci.yml` only exercises that provider on `pull_request`. Auth is `continue-on-error` with a no-cache fallback, so a rejection won't break the nightly but would silently forfeit the cache savings.
