### PR TITLE
Remove the Foundation dependency from ScopedTypeRef.h

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -180,10 +180,23 @@ santa_unit_test(
 
 # This target shouldn't be used directly.
 # Use a more specific scoped type instead.
-objc_library(
+cc_library(
     name = "ScopedTypeRef",
     hdrs = ["ScopedTypeRef.h"],
     visibility = ["//Source/common:__pkg__"],
+)
+
+# ScopedTypeRef.h is intentionally free of Objective-C and Foundation deps so it
+# can be used from pure C++ TUs. This library compiles as C++ (not
+# Objective-C++) to keep it so.
+cc_library(
+    name = "ScopedTypeRefPureCXX",
+    testonly = 1,
+    srcs = ["ScopedTypeRefPureCXX.cc"],
+    visibility = ["//Source/common:__pkg__"],
+    deps = [
+        ":ScopedTypeRef",
+    ],
 )
 
 objc_library(
@@ -202,6 +215,7 @@ santa_unit_test(
     ],
     deps = [
         ":ScopedCFTypeRef",
+        ":ScopedTypeRefPureCXX",
     ],
 )
 

--- a/Source/common/ScopedTypeRef.h
+++ b/Source/common/ScopedTypeRef.h
@@ -16,11 +16,9 @@
 #ifndef SANTA_COMMON_SCOPEDTYPEREF_H
 #define SANTA_COMMON_SCOPEDTYPEREF_H
 
-#include <CoreFoundation/CoreFoundation.h>
-#import <Foundation/Foundation.h>
 #include <assert.h>
 
-#include <functional>
+#include <type_traits>
 #include <utility>
 
 namespace santa {
@@ -111,24 +109,35 @@ class ScopedTypeRef {
 
   ElementT Unsafe() const { return object_; }
 
+#ifdef __OBJC__
+  // Objective-C bridging helpers. Both `id` and the __bridge casts are
+  // compiler builtins in Objective-C mode, so these need no Foundation import.
+  // They are conditional so that this header remains usable from pure C++
+  // translation units, where __bridge isn't valid syntax.
+
   template <typename T>
   T Bridge() const {
     return (__bridge T)object_;
   }
 
+// The casts below transfer ownership, which is meaningless without ARC. Leave
+// them undeclared there rather than silently miscounting references.
+#if __has_feature(objc_arc)
   template <typename T>
     requires std::is_pointer_v<T> && std::is_convertible_v<id, T>
   T BridgeRelease() {
-    T tmp = CFBridgingRelease(object_);
+    T tmp = (__bridge_transfer T)object_;
     object_ = InvalidV;
     return tmp;
   }
 
   static ScopedTypeRef<ElementT, InvalidV, RetainFunc, ReleaseFunc>
   BridgeRetain(id nsobj) {
-    ElementT obj = (ElementT)(CFBridgingRetain(nsobj));
+    ElementT obj = (ElementT)((__bridge_retained void*)nsobj);
     return Assume(obj);
   }
+#endif  // __has_feature(objc_arc)
+#endif  // __OBJC__
 
   // This is to be used only to take ownership of objects that are created by
   // pass-by-pointer create functions. The object must not already be valid.

--- a/Source/common/ScopedTypeRefPureCXX.cc
+++ b/Source/common/ScopedTypeRefPureCXX.cc
@@ -1,0 +1,75 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+/// ScopedTypeRef.h is deliberately free of Objective-C and Foundation
+/// dependencies so that it can be included from pure C++ translation units.
+/// This file is compiled as C++ rather than Objective-C++ to keep it that way:
+/// if either dependency comes back unguarded, this stops compiling.
+///
+/// Nothing consumes the symbols defined here. This is built as a dependency of
+/// ScopedCFTypeRefTest, which is where the behavior of ScopedTypeRef is
+/// actually covered.
+
+#include <type_traits>
+#include <utility>
+
+#include "Source/common/ScopedTypeRef.h"
+
+namespace {
+
+struct FakeObject {
+  int refcount = 1;
+};
+
+void FakeRetain(FakeObject* obj) { obj->refcount++; }
+
+void FakeRelease(FakeObject* obj) { obj->refcount--; }
+
+using ScopedFake =
+    santa::ScopedTypeRef<FakeObject*, nullptr, FakeRetain, FakeRelease>;
+
+static_assert(std::is_copy_constructible_v<ScopedFake>);
+static_assert(std::is_copy_assignable_v<ScopedFake>);
+static_assert(std::is_move_constructible_v<ScopedFake>);
+static_assert(std::is_move_assignable_v<ScopedFake>);
+
+}  // namespace
+
+// Template members are only instantiated where they're used, so touch each one
+// to get it parsed. Never called; declared with external linkage so that it
+// isn't flagged as unused.
+bool SantaScopedTypeRefPureCXXCompileCheck() {
+  FakeObject obj;
+
+  ScopedFake def;
+  ScopedFake assumed = ScopedFake::Assume(&obj);
+  ScopedFake retained = ScopedFake::Retain(&obj);
+  ScopedFake copied = assumed;
+  ScopedFake moved = std::move(copied);
+
+  copied = assumed;
+  moved = std::move(retained);
+
+  auto [ret, from_out] = ScopedFake::AssumeFrom([&obj](FakeObject** out) {
+    *out = &obj;
+    return 0;
+  });
+
+  ScopedFake into;
+  *into.InitializeInto() = &obj;
+
+  return static_cast<bool>(def) || static_cast<bool>(assumed) ||
+         static_cast<bool>(copied) || static_cast<bool>(moved) ||
+         static_cast<bool>(from_out) || into.Unsafe() != nullptr || ret != 0;
+}


### PR DESCRIPTION
`CFBridgingRetain` and `CFBridgingRelease` were the only Foundation symbols `ScopedTypeRef.h` used, and both are `NS_INLINE` wrappers around the `__bridge_retained`/`__bridge_transfer` casts it now performs directly, so codegen in ARC translation units is unchanged. `id` and the `__bridge` casts are compiler builtins needing no import. The CoreFoundation include was vestigial (the class never names a CF type) and `<functional>` was unused, so both are gone; `<type_traits>` is now included directly rather than arriving transitively. This also drops Foundation from `ScopedCFTypeRef.h`, `ScopedIOObjectRef.h`, and `ScopedMachPort.h`, which only inherited it. No call sites change.

The bridging members sit behind `#ifdef __OBJC__` since `__bridge` isn't valid C++ syntax even in an uninstantiated template. The two ownership-transferring ones are additionally behind `__has_feature(objc_arc)`: outside ARC those casts compile to a warned no-op, so a non-ARC consumer now gets a compile error instead of silently miscounted references. That path is inert today — nothing in the tree uses `non_arc_srcs`.

`ScopedTypeRefPureCXX.cc` compiles the header as C++ as a dependency of `ScopedCFTypeRefTest`, so a reintroduced Foundation import fails the build rather than going unnoticed; verified by temporarily re-adding one. `:ScopedTypeRef` becomes a `cc_library`, which is now what it is. All 711 `//Source/...` targets build clean, confirming nothing was relying on the removed transitive includes, and `:unit_tests` passes 139/139.