### PR TITLE
logging: Log under a com.northpolesec.santa subsystem

### DIFF
--- a/Source/common/SNTLogging.h
+++ b/Source/common/SNTLogging.h
@@ -20,10 +20,52 @@
 #include <os/log.h>
 #include <sys/cdefs.h>
 
+// Every Santa component logs under a single subsystem, which lets the whole
+// product be configured with one logging configuration profile. This is the
+// reason not to use OS_LOG_DEFAULT: os_log(5) states that "behavior involving
+// the OS_LOG_DEFAULT constant is not affected by configuration profiles", so
+// logging through it cannot have its level, persistence, or message size limit
+// changed for Santa alone - only system-wide.
+#ifndef SNT_LOG_SUBSYSTEM
+#define SNT_LOG_SUBSYSTEM "com.northpolesec.santa"
+#endif
+
+// Categories subdivide the subsystem and are the unit that configuration
+// profiles address. A target that needs its own category can define this in its
+// copts; everything else shares the default. Note that the process name is
+// already recorded on every log message, so there is no need to spend a
+// category distinguishing Santa's components from each other.
+#ifndef SNT_LOG_CATEGORY
+#define SNT_LOG_CATEGORY "santa"
+#endif
+
+namespace santa {
+
+// The handle used by the LOG* macros below. The logging system interns handles,
+// so all translation units including this header share a single object per
+// (subsystem, category) pair.
+static inline os_log_t LogHandle() {
+  // C++11 onward guarantees thread-safe initialization of function-local
+  // statics, so this needs no explicit synchronization.
+  static os_log_t handle = os_log_create(SNT_LOG_SUBSYSTEM, SNT_LOG_CATEGORY);
+  return handle;
+}
+
+// Creates a handle for an explicit category within Santa's subsystem, for the
+// uncommon call site that should not log under its target's default category.
+// os_log_create costs roughly 40ns even when the category already exists, so
+// callers on a hot path must cache the result rather than calling this per
+// message.
+static inline os_log_t LogHandleForCategory(const char* category) {
+  return os_log_create(SNT_LOG_SUBSYSTEM, category);
+}
+
+}  // namespace santa
+
 __BEGIN_DECLS
 
-#define SNT_LOG_WITH_TYPE(type, fmt, ...)              \
-  os_log_with_type(OS_LOG_DEFAULT, type, "%{public}s", \
+#define SNT_LOG_WITH_TYPE(type, fmt, ...)                  \
+  os_log_with_type(santa::LogHandle(), type, "%{public}s", \
                    [[NSString stringWithFormat:fmt, ##__VA_ARGS__] UTF8String])
 
 #define SNT_PRINT_LOG(file, fmt, ...) \

--- a/Source/gui/Info.plist
+++ b/Source/gui/Info.plist
@@ -52,5 +52,19 @@
 	<string>North Pole Security, Inc.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>OSLogPreferences</key>
+	<dict>
+		<key>com.northpolesec.santa</key>
+		<dict>
+			<key>DEFAULT-OPTIONS</key>
+			<dict>
+				<key>Level</key>
+				<dict>
+					<key>Persist</key>
+					<string>Info</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -982,6 +982,7 @@ objc_library(
     hdrs = ["Logs/EndpointSecurity/Writers/Syslog.h"],
     deps = [
         ":EndpointSecurityWriter",
+        "//Source/common:SNTLogging",
     ],
 )
 

--- a/Source/santad/Info.plist
+++ b/Source/santad/Info.plist
@@ -25,5 +25,19 @@
 	<true />
 	<key>CFBundleExecutable</key>
 	<string>com.northpolesec.santa.daemon</string>
+	<key>OSLogPreferences</key>
+	<dict>
+		<key>com.northpolesec.santa</key>
+		<dict>
+			<key>DEFAULT-OPTIONS</key>
+			<dict>
+				<key>Level</key>
+				<dict>
+					<key>Persist</key>
+					<string>Info</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Source/santad/Logs/EndpointSecurity/Writers/Syslog.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Syslog.mm
@@ -17,6 +17,8 @@
 
 #include <os/log.h>
 
+#include "Source/common/SNTLogging.h"
+
 namespace santa {
 
 // Max length of data that should be displayed in a single line.
@@ -29,7 +31,13 @@ std::shared_ptr<Syslog> Syslog::Create() {
 }
 
 void Syslog::Write(std::vector<uint8_t>&& bytes) {
-  os_log(OS_LOG_DEFAULT, "%{public}.*s", (int)std::min(kMaxLineLength, bytes.size()), bytes.data());
+  // Telemetry uses its own category so that it can be configured separately
+  // from Santa's diagnostic logging. It is by far the highest volume thing
+  // Santa writes to the system log, and it is the only category that would
+  // benefit from Enable-Oversize-Messages, which raises the per-message limit
+  // that kMaxLineLength truncates to.
+  static os_log_t telemetryLog = LogHandleForCategory("telemetry");
+  os_log(telemetryLog, "%{public}.*s", (int)std::min(kMaxLineLength, bytes.size()), bytes.data());
 }
 
 void Syslog::Flush() {


### PR DESCRIPTION
`SNTLogging` logged through `OS_LOG_DEFAULT`, which `os_log(5)` exempts from logging configuration profiles, so Santa's log levels and persistence could only be changed system-wide. `LOGI` never reached disk, and `LOGD` only existed while someone was already streaming.

Logs now go through a `com.northpolesec.santa` subsystem handle. No call sites change. Telemetry gets its own category so it can be configured apart from diagnostic logging. Both bundle `Info.plist`s set `Persist: Info` so `LOGI` survives to disk; `Enable` is left to inherit, so `log stream --level debug` still works as before.

Cost is ~5ns per disabled log call. All 384 `objc_library` targets under `//Source/...` build; logger, writer and metrics tests pass.
