### PR TITLE
Implement XSRF token invalidation on auth errors

### DIFF
--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -149,6 +149,7 @@ using santa::NSStringToUTF8String;
   NSError* requestError;
   NSData* data;
 
+  BOOL didInvalidateXSRFToken = NO;
   int maxAttempts = 5;
   for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
     if (attempt >= 2) {
@@ -169,14 +170,22 @@ using santa::NSStringToUTF8String;
     // If the original request failed because of an auth error, attempt to get a new XSRF token and
     // try again. Unfortunately some servers cause NSURLSession to return 'client cert required' or
     // 'could not parse response' when a 403 occurs and SSL cert auth is enabled.
-    if ((response.statusCode == 403 || requestError.code == NSURLErrorClientCertificateRequired ||
-         requestError.code == NSURLErrorCannotParseResponse) &&
-        [self fetchXSRFToken]) {
-      NSMutableURLRequest* mutableRequest = [request mutableCopy];
-      NSString* xsrfHeader = self.syncState.xsrfTokenHeader ?: kDefaultXSRFTokenHeader;
-      [mutableRequest setValue:self.syncState.xsrfToken forHTTPHeaderField:xsrfHeader];
-      request = mutableRequest;
-      continue;
+    if (response.statusCode == 403 || requestError.code == NSURLErrorClientCertificateRequired ||
+        requestError.code == NSURLErrorCannotParseResponse) {
+
+      // Clear the cached token so fetchXSRFToken tries again.
+      if (!didInvalidateXSRFToken) {
+        didInvalidateXSRFToken = YES;
+        self.syncState.xsrfToken = nil;
+
+        if ([self fetchXSRFToken]) {
+          NSMutableURLRequest* mutableRequest = [request mutableCopy];
+          NSString* xsrfHeader = self.syncState.xsrfTokenHeader ?: kDefaultXSRFTokenHeader;
+          [mutableRequest setValue:self.syncState.xsrfToken forHTTPHeaderField:xsrfHeader];
+          request = mutableRequest;
+          continue;
+        }
+      }
     }
 
     // Most 4xx errors indicate a client-side problem that won't resolve by retrying.


### PR DESCRIPTION
Added logic to invalidate the XSRF token on specific errors before attempting to fetch a new one.

## Summary of XSRF Token Refresh Bug Fix

(The Problem) The fetchXSRFToken method checks memory for an existing token (if (!self.syncState.xsrfToken.length)) before hitting the network. Once a token is loaded, this check prevents any subsequent network calls to refresh it during a session. When a request failed with a 403 Forbidden (or associated network quirks), the retry loop would call fetchXSRFToken. However, because the old, expired token was still stored in memory, fetchXSRFToken immediately returned NO without calling the server. As a result, the application could never recover from token expiration errors.

## What the Change Does (The Fix)

* Local State Tracking: Added a local boolean flag (didInvalidateXSRFToken) scoped exclusively to the request's execution lifecycle.
* Cache Eviction: Upon encountering an authorization error (403, SSL client certificate required, or unparsable response errors), the code explicitly clears the cached token (self.syncState.xsrfToken = nil).
* Strict One-Shot Guard: Wrapped the cache eviction and refresh logic inside an if (!didInvalidateXSRFToken) condition, flipping the boolean to YES immediately upon entry.

## Behavior Change (The Result)

* Successful Token Rotations: When an authentication failure occurs, the app now successfully bypasses the local memory cache and hits the server to pull a fresh XSRF token, allowing it to heal and finish the original transaction.
* Deterministic Single-Retry Guarantee: The logic guarantees that a token refresh will be attempted exactly once per network request sequence. If the new token still returns a 403 or the refresh itself fails, the routine immediately drops out of the refresh loop. This prevents continuing the loop and protects against unnecessary server spam.