### PR TITLE
pkg: Fail notarization on a non-Accepted status

### DIFF
--- a/Conf/Package/notarization_tool.sh
+++ b/Conf/Package/notarization_tool.sh
@@ -23,7 +23,12 @@ readonly CREDS=(
   --issuer "${NOTARIZATION_ISSUER_ID}"
 )
 
-readonly SUBMIT_OUTPUT=$(/usr/bin/mktemp -t notarytool-submit)
+# Assigned separately so a mktemp failure isn't masked by readonly's own status.
+SUBMIT_OUTPUT=$(/usr/bin/mktemp -t notarytool-submit) || {
+  echo "Could not create a temporary file to capture notarytool output" >&2
+  exit 1
+}
+readonly SUBMIT_OUTPUT
 trap 'rm -f "${SUBMIT_OUTPUT}"' EXIT
 
 /usr/bin/xcrun notarytool submit "${2}" --wait -v "${CREDS[@]}" 2>&1 | tee "${SUBMIT_OUTPUT}"

--- a/Conf/Package/notarization_tool.sh
+++ b/Conf/Package/notarization_tool.sh
@@ -2,7 +2,8 @@
 
 # notarytool wrapper
 
-# Expects 1 argument:
+# Expects 2 arguments:
+#   - --file
 #   - The path to the archive to submit
 
 # Expects 3 environment variables:
@@ -10,9 +11,42 @@
 #   - NOTARIZATION_KEY_ID: The key ID
 #   - NOTARIZATION_ISSUER_ID: The issuer ID of the key
 
+set -o pipefail
+
 KEY_FILE_PATH=/tmp/notarization_key.p8
 
 echo "${NOTARIZATION_KEY_P8}" | base64 --decode > "${KEY_FILE_PATH}"
 
-/usr/bin/xcrun notarytool submit "${2}" --wait -v \
-  --key "${KEY_FILE_PATH}" --key-id "${NOTARIZATION_KEY_ID}" --issuer "${NOTARIZATION_ISSUER_ID}"
+readonly CREDS=(
+  --key "${KEY_FILE_PATH}"
+  --key-id "${NOTARIZATION_KEY_ID}"
+  --issuer "${NOTARIZATION_ISSUER_ID}"
+)
+
+readonly SUBMIT_OUTPUT=$(/usr/bin/mktemp -t notarytool-submit)
+trap 'rm -f "${SUBMIT_OUTPUT}"' EXIT
+
+/usr/bin/xcrun notarytool submit "${2}" --wait -v "${CREDS[@]}" 2>&1 | tee "${SUBMIT_OUTPUT}"
+SUBMIT_RC=$?
+
+# `notarytool submit --wait` exits 0 as long as it managed to wait for a verdict,
+# including when that verdict is Invalid. Without checking the status the caller
+# proceeds to stapling, which then fails with a misleading CloudKit "Record not
+# found" -- the ticket is absent because the submission was rejected.
+STATUS=$(/usr/bin/grep -E '^ +status: ' "${SUBMIT_OUTPUT}" | /usr/bin/tail -1 | /usr/bin/awk '{print $2}')
+SUBMISSION_ID=$(/usr/bin/grep -E '^ +id: ' "${SUBMIT_OUTPUT}" | /usr/bin/tail -1 | /usr/bin/awk '{print $2}')
+
+if [[ ${SUBMIT_RC} -ne 0 || "${STATUS}" != "Accepted" ]]; then
+  echo "Notarization of $(/usr/bin/basename "${2}") failed: status=${STATUS:-unknown} rc=${SUBMIT_RC}" >&2
+
+  # The submission log carries Apple's per-issue reasons, which the submit
+  # output does not. Apple expires these after a few days, so fetch it now
+  # rather than leaving it to be chased later.
+  if [[ -n "${SUBMISSION_ID}" ]]; then
+    echo "Fetching notarization log for ${SUBMISSION_ID}" >&2
+    /usr/bin/xcrun notarytool log "${SUBMISSION_ID}" "${CREDS[@]}" >&2 ||
+      echo "Could not retrieve the notarization log for ${SUBMISSION_ID}" >&2
+  fi
+
+  exit 1
+fi


### PR DESCRIPTION
`notarytool submit --wait` exits 0 whenever it got a verdict, including `Invalid`, so a rejected submission fell through to stapling and surfaced as a CloudKit "Record not found". That's what made the failed santa-codesign release run look like an Apple-side problem rather than a rejected notarization.

Nothing in PR CI exercises notarization, so I verified the parsing against the actual notarytool output from that run — both directions. The `Santa.app` submission yields `Invalid` + its submission id (fails, fetches the log); the daemon extension submission yields `Accepted` (proceeds). The success direction is the one that matters, since a parser that misread `Accepted` would break every release.

To be clear about scope: this does not fix that release. It turns a misleading late failure into an accurate early one that prints Apple's reasons.