### PR TITLE
build: Hold rules_apple at 4.3.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ bazel_dep(name = "apple_support", version = "2.8.0")
 bazel_dep(name = "cel-cpp", version = "0.15.0")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "protobuf", version = "35.1")
-bazel_dep(name = "rules_apple", version = "4.5.3")
+bazel_dep(name = "rules_apple", version = "4.3.3")
 bazel_dep(name = "rules_cc", version = "0.2.22")
 bazel_dep(name = "rules_fuzzing", version = "0.8.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")
@@ -13,6 +13,18 @@ bazel_dep(name = "rules_swift", version = "3.6.1")
 bazel_dep(name = "xxhash", version = "0.8.3.bcr.1")
 bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
 bazel_dep(name = "boringssl", version = "0.20260803.0")
+
+# rules_apple is held at 4.3.3 because 4.4.0 stopped embedding the Info.plist in
+# the non-native arch slice of macos_command_line_application, leaving that slice
+# with `Info.plist=not bound`. codesign cannot repair it after the fact, so
+# notarization rejects the universal binaries with "The signature of the binary
+# is invalid". The override is needed as well as the version above: MVS takes the
+# highest version declared anywhere in the graph, and santanetd -- injected into
+# release builds -- declares its own.
+single_version_override(
+    module_name = "rules_apple",
+    version = "4.3.3",
+)
 
 # North Pole Protos
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")


### PR DESCRIPTION
Fixes the "Package & Sign" failure on santa-codesign releases. rules_apple 4.4.0 stopped embedding the Info.plist in the non-native arch slice of `macos_command_line_application`, leaving it `Info.plist=not bound`. codesign can't repair that (only the linker embeds it), so packaging's re-sign leaves it broken and Apple rejects the app with "The signature of the binary is invalid" — which then surfaced as a misleading CloudKit "Record not found" during stapling.

Bisected: 4.3.3 clean, 4.4.0 / 4.5.0 / 4.5.1 / 4.5.2 / 4.5.3 all broken. Only affects the non-host slice, so it shows up solely in universal release builds — nothing in PR CI or a local arm64 build would catch it.

Verified with the pin: `mod graph` resolves 4.3.3 on every path, 139/139 tests pass, and a multi-arch `-c opt //:release` produces binaries where every slice passes `codesign --verify --strict --arch` with a bound Info.plist.

Note for later: 4.4.0 is also the release that added Bazel 9 support, so this needs an upstream fix before the Bazel 9 bump can happen.