### PR TITLE
pkg: Verify every architecture slice before notarizing

### DIFF
--- a/Conf/Package/package_and_sign.sh
+++ b/Conf/Package/package_and_sign.sh
@@ -13,6 +13,40 @@ function die {
   exit 2
 }
 
+# Verify every architecture slice of a signed artifact.
+#
+# `codesign --verify` without --arch only checks the slice matching the host, so
+# a broken slice in a universal binary passes locally and is first caught by
+# notarization -- which reports it as "The signature of the binary is invalid"
+# with no indication of which slice or why. rules_apple 4.4.0 through at least
+# 4.5.3 omit the embedded Info.plist from the non-native slice of
+# macos_command_line_application, which produces exactly that.
+function verify_slices {
+  local artifact="${1}"
+  local binary="${artifact}"
+
+  if [[ -d "${artifact}" ]]; then
+    local exe
+    exe=$(/usr/bin/plutil -extract CFBundleExecutable raw -o - \
+      "${artifact}/Contents/Info.plist") ||
+      die "could not read CFBundleExecutable from ${artifact}"
+    binary="${artifact}/Contents/MacOS/${exe}"
+  fi
+
+  local arch
+  for arch in $(/usr/bin/lipo -archs "${binary}"); do
+    /usr/bin/codesign --verify --strict --arch "${arch}" "${artifact}" ||
+      die "invalid signature in the ${arch} slice of ${artifact}"
+
+    # An unbound Info.plist means the slice carries no plist for its signature
+    # to cover. codesign cannot add one; only the linker can.
+    if /usr/bin/codesign -d --arch "${arch}" -vvv "${binary}" 2>&1 |
+      /usr/bin/grep -q "Info.plist=not bound"; then
+      die "the ${arch} slice of ${binary} has no bound Info.plist"
+    fi
+  done
+}
+
 # RELEASE_ROOT is a required environment variable that points to the root
 # of a release tarball produced with the :release rule in Santa's
 # main BUILD file, or the root of an extracted release dir.
@@ -89,6 +123,9 @@ for ARTIFACT in "${INPUT_SANTACTL}" "${INPUT_SANTABS}" "${INPUT_SANTAMS}" "${INP
 
   echo "codesigning ${BN}"
   /usr/bin/codesign "${CODESIGN_OPTS[@]}" "${ARTIFACT}"
+
+  echo "verifying every slice of ${BN}"
+  verify_slices "${ARTIFACT}"
 done
 
 # Notarize all the bundles
@@ -202,6 +239,9 @@ if [ -n "${BUILD_LITE_PACKAGE}" ]; then
     --generate-entitlement-der \
     --options library,kill,runtime \
     "${LITE_APP}"
+
+  echo "verifying every slice of the lite Santa.app"
+  verify_slices "${LITE_APP}"
 
   # Notarize the lite app
   echo "zipping lite Santa.app"

--- a/Conf/Package/package_and_sign.sh
+++ b/Conf/Package/package_and_sign.sh
@@ -33,15 +33,24 @@ function verify_slices {
     binary="${artifact}/Contents/MacOS/${exe}"
   fi
 
-  local arch
-  for arch in $(/usr/bin/lipo -archs "${binary}"); do
+  # Capture the architectures rather than iterating the substitution directly: a
+  # failing or empty lipo would otherwise run the loop zero times and report
+  # success, which is the one thing a verification step must never do.
+  local archs
+  archs=$(/usr/bin/lipo -archs "${binary}") ||
+    die "could not read the architectures of ${binary}"
+  [[ -n "${archs}" ]] || die "lipo reported no architectures for ${binary}"
+
+  local arch details
+  for arch in ${archs}; do
     /usr/bin/codesign --verify --strict --arch "${arch}" "${artifact}" ||
       die "invalid signature in the ${arch} slice of ${artifact}"
 
     # An unbound Info.plist means the slice carries no plist for its signature
     # to cover. codesign cannot add one; only the linker can.
-    if /usr/bin/codesign -d --arch "${arch}" -vvv "${binary}" 2>&1 |
-      /usr/bin/grep -q "Info.plist=not bound"; then
+    details=$(/usr/bin/codesign -d --arch "${arch}" -vvv "${binary}" 2>&1) ||
+      die "could not inspect the ${arch} slice of ${binary}"
+    if /usr/bin/grep -q "Info.plist=not bound" <<<"${details}"; then
       die "the ${arch} slice of ${binary} has no bound Info.plist"
     fi
   done


### PR DESCRIPTION
Follow-up to #1129. `codesign --verify` without `--arch` only checks the slice matching the host, so a broken slice in a universal binary passes packaging and is first caught by Apple — reported as "The signature of the binary is invalid" with no indication of which slice or why. That's how the rules_apple 4.4.0 regression (#1130) reached notarization.

Checks each slice `lipo` reports, and additionally rejects an unbound Info.plist, which is the specific shape of that regression.

Verified both directions against real artifacts, since CI doesn't build universal binaries: against a broken build it exits 2 with `invalid signature in the x86_64 slice of .../santactl`, and against a fixed multi-arch release it passes all 8 artifacts including the app bundle and daemon extension (exercising the bundle branch that resolves `CFBundleExecutable`).