### PR TITLE
santad: Separate reusable code-signing validation results from authorization-result cacheability

### DIFF
--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -21,6 +21,33 @@
 
 @class MOLCertificate;
 
+typedef NS_ENUM(NSInteger, SNTCodesignValidationState) {
+  SNTCodesignValidationStateNeedsValidation = 0,
+  SNTCodesignValidationStateSuccess,
+  SNTCodesignValidationStateUnsigned,
+  SNTCodesignValidationStateSignatureFailed,
+  SNTCodesignValidationStateSignatureUnsupported,
+  SNTCodesignValidationStateRequirementInvalid,
+  SNTCodesignValidationStateRequirementUnsupported,
+  SNTCodesignValidationStateBadObjectFormat,
+  SNTCodesignValidationStateSignatureInvalid,
+  SNTCodesignValidationStateTooBig,
+  SNTCodesignValidationStateUnsupportedDigestAlgorithm,
+  SNTCodesignValidationStateInvalidTeamIdentifier,
+  SNTCodesignValidationStateBadTeamIdentifier,
+  SNTCodesignValidationStateMultipleExecutableSegments,
+  SNTCodesignValidationStateInvalidEntitlements,
+  SNTCodesignValidationStateInvalidRuntimeVersion,
+};
+
+/// Returns a reusable state for errors determined by the executable's contents.
+/// All unrecognized or environment-dependent errors require validation again.
+SNTCodesignValidationState SNTCodesignValidationStateForError(OSStatus error);
+
+/// Returns the Security.framework error represented by a completed failure state.
+/// Returns errSecSuccess for NeedsValidation and Success.
+OSStatus SNTCodesignValidationErrorForState(SNTCodesignValidationState state);
+
 ///
 ///  Store information about executions from decision making for later logging.
 ///
@@ -58,6 +85,16 @@
 @property SNTSigningStatus signingStatus;
 @property NSDate* secureSigningTime;
 @property NSDate* signingTime;
+
+/// The reusable result of static code-signing validation for this identity.
+/// NeedsValidation means validation has not run or a prior validation attempt
+/// returned an error that must be retried. Only stable outcomes belong in this
+/// enum; do not add a Security.framework error without first establishing that
+/// it is determined by the executable's contents and cannot depend on bundle
+/// contents, filesystem access, cancellation, trust, or other mutable system
+/// state. See the errSecCS* catalog in <Security/CSCommon.h>.
+/// A successful result does not imply that the binary has a signing certificate.
+@property SNTCodesignValidationState codesignValidationState;
 
 @property NSString* quarantineURL;
 

--- a/Source/common/SNTCachedDecision.mm
+++ b/Source/common/SNTCachedDecision.mm
@@ -16,6 +16,51 @@
 
 #import "Source/common/SNTCachedDecision.h"
 
+SNTCodesignValidationState SNTCodesignValidationStateForError(OSStatus error) {
+  switch (error) {
+    case errSecCSUnsigned: return SNTCodesignValidationStateUnsigned;
+    case errSecCSSignatureFailed: return SNTCodesignValidationStateSignatureFailed;
+    case errSecCSSignatureUnsupported: return SNTCodesignValidationStateSignatureUnsupported;
+    case errSecCSReqInvalid: return SNTCodesignValidationStateRequirementInvalid;
+    case errSecCSReqUnsupported: return SNTCodesignValidationStateRequirementUnsupported;
+    case errSecCSBadObjectFormat: return SNTCodesignValidationStateBadObjectFormat;
+    case errSecCSSignatureInvalid: return SNTCodesignValidationStateSignatureInvalid;
+    case errSecCSTooBig: return SNTCodesignValidationStateTooBig;
+    case errSecCSUnsupportedDigestAlgorithm:
+      return SNTCodesignValidationStateUnsupportedDigestAlgorithm;
+    case errSecCSInvalidTeamIdentifier: return SNTCodesignValidationStateInvalidTeamIdentifier;
+    case errSecCSBadTeamIdentifier: return SNTCodesignValidationStateBadTeamIdentifier;
+    case errSecMultipleExecSegments:
+      return SNTCodesignValidationStateMultipleExecutableSegments;
+    case errSecCSInvalidEntitlements: return SNTCodesignValidationStateInvalidEntitlements;
+    case errSecCSInvalidRuntimeVersion: return SNTCodesignValidationStateInvalidRuntimeVersion;
+    default: return SNTCodesignValidationStateNeedsValidation;
+  }
+}
+
+OSStatus SNTCodesignValidationErrorForState(SNTCodesignValidationState state) {
+  switch (state) {
+    case SNTCodesignValidationStateUnsigned: return errSecCSUnsigned;
+    case SNTCodesignValidationStateSignatureFailed: return errSecCSSignatureFailed;
+    case SNTCodesignValidationStateSignatureUnsupported: return errSecCSSignatureUnsupported;
+    case SNTCodesignValidationStateRequirementInvalid: return errSecCSReqInvalid;
+    case SNTCodesignValidationStateRequirementUnsupported: return errSecCSReqUnsupported;
+    case SNTCodesignValidationStateBadObjectFormat: return errSecCSBadObjectFormat;
+    case SNTCodesignValidationStateSignatureInvalid: return errSecCSSignatureInvalid;
+    case SNTCodesignValidationStateTooBig: return errSecCSTooBig;
+    case SNTCodesignValidationStateUnsupportedDigestAlgorithm:
+      return errSecCSUnsupportedDigestAlgorithm;
+    case SNTCodesignValidationStateInvalidTeamIdentifier: return errSecCSInvalidTeamIdentifier;
+    case SNTCodesignValidationStateBadTeamIdentifier: return errSecCSBadTeamIdentifier;
+    case SNTCodesignValidationStateMultipleExecutableSegments: return errSecMultipleExecSegments;
+    case SNTCodesignValidationStateInvalidEntitlements: return errSecCSInvalidEntitlements;
+    case SNTCodesignValidationStateInvalidRuntimeVersion: return errSecCSInvalidRuntimeVersion;
+    case SNTCodesignValidationStateNeedsValidation:
+    case SNTCodesignValidationStateSuccess: return errSecSuccess;
+  }
+  return errSecCSInternalError;
+}
+
 @implementation SNTCachedDecision
 
 - (instancetype)init {
@@ -51,6 +96,7 @@
     _entitlementsFiltered = previous.entitlementsFiltered;
     _secureSigningTime = previous.secureSigningTime;
     _signingTime = previous.signingTime;
+    _codesignValidationState = previous.codesignValidationState;
   }
   return self;
 }
@@ -76,6 +122,7 @@
   copy.signingStatus = _signingStatus;
   copy.secureSigningTime = _secureSigningTime;
   copy.signingTime = _signingTime;
+  copy.codesignValidationState = _codesignValidationState;
   copy.quarantineURL = _quarantineURL;
   copy.customMsg = _customMsg;
   copy.customURL = _customURL;

--- a/Source/common/SNTCachedDecisionTest.mm
+++ b/Source/common/SNTCachedDecisionTest.mm
@@ -33,4 +33,90 @@
   XCTAssertEqual(sb.st_dev, cd.vnodeId.fsid);
 }
 
+- (void)testCachedIdentityPreservesUnsignedCodesignValidationResult {
+  SNTCachedDecision* previous = [[SNTCachedDecision alloc] init];
+  previous.sha256 = @"aabbccdd";
+  previous.codesignValidationState = SNTCodesignValidationStateUnsigned;
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] initWithCachedIdentity:previous];
+
+  XCTAssertEqual(cached.codesignValidationState, SNTCodesignValidationStateUnsigned);
+}
+
+- (void)testCachedIdentityPreservesSuccessfulAdhocValidationWithoutCertificate {
+  SNTCachedDecision* previous = [[SNTCachedDecision alloc] init];
+  previous.sha256 = @"aabbccdd";
+  previous.certSHA256 = nil;
+  previous.codesignValidationState = SNTCodesignValidationStateSuccess;
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] initWithCachedIdentity:previous];
+
+  XCTAssertEqual(cached.codesignValidationState, SNTCodesignValidationStateSuccess);
+  XCTAssertNil(cached.certSHA256);
+}
+
+- (void)testCachedIdentityPreservesNeedsValidationCodesignState {
+  SNTCachedDecision* previous = [[SNTCachedDecision alloc] init];
+  previous.sha256 = @"aabbccdd";
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] initWithCachedIdentity:previous];
+
+  XCTAssertEqual(cached.codesignValidationState, SNTCodesignValidationStateNeedsValidation);
+}
+
+- (void)testCodesignValidationErrorCatalog {
+  NSArray<NSNumber*>* reusableErrors = @[
+    @(errSecCSUnsigned),
+    @(errSecCSSignatureFailed),
+    @(errSecCSSignatureUnsupported),
+    @(errSecCSReqInvalid),
+    @(errSecCSReqUnsupported),
+    @(errSecCSBadObjectFormat),
+    @(errSecCSSignatureInvalid),
+    @(errSecCSTooBig),
+    @(errSecCSUnsupportedDigestAlgorithm),
+    @(errSecCSInvalidTeamIdentifier),
+    @(errSecCSBadTeamIdentifier),
+    @(errSecMultipleExecSegments),
+    @(errSecCSInvalidEntitlements),
+    @(errSecCSInvalidRuntimeVersion),
+  ];
+
+  for (NSNumber* error in reusableErrors) {
+    OSStatus status = (OSStatus)error.intValue;
+    SNTCodesignValidationState state = SNTCodesignValidationStateForError(status);
+    XCTAssertNotEqual(state, SNTCodesignValidationStateNeedsValidation);
+    XCTAssertEqual(SNTCodesignValidationErrorForState(state), status);
+  }
+}
+
+- (void)testMutableCodesignValidationErrorsRequireRetry {
+  NSArray<NSNumber*>* retryableErrors = @[
+    @(errSecCSSignatureNotVerifiable),
+    @(errSecCSBadDictionaryFormat),
+    @(errSecCSStaticCodeChanged),
+    @(errSecCSStaticCodeNotFound),
+    @(errSecCSDBAccess),
+    @(errSecCSInternalError),
+    @(errSecCSInfoPlistFailed),
+    @(errSecCSUnsignedNestedCode),
+    @(errSecCSBadNestedCode),
+    @(errSecCSBadMainExecutable),
+    @(errSecCSCancelled),
+    @(errSecCSInvalidAssociatedFileData),
+    @(errSecCSSignatureUntrusted),
+    @(errSecCSRevokedNotarization),
+  ];
+
+  for (NSNumber* error in retryableErrors) {
+    XCTAssertEqual(SNTCodesignValidationStateForError((OSStatus)error.intValue),
+                   SNTCodesignValidationStateNeedsValidation);
+  }
+}
+
+- (void)testUnknownCodesignValidationStateFailsClosed {
+  XCTAssertEqual(SNTCodesignValidationErrorForState((SNTCodesignValidationState)NSIntegerMax),
+                 errSecCSInternalError);
+}
+
 @end

--- a/Source/santad/CompilerAuthorizationScopeTest.mm
+++ b/Source/santad/CompilerAuthorizationScopeTest.mm
@@ -236,6 +236,14 @@ static const std::vector<std::string> kBlockedArgs = {"clang", "--link"};
                  @"the authorized context must be allowed");
   XCTAssertTrue(OCMVerifyAll(self.mockCompilerController));
 
+  es_file_t cachedFile = MakeESFile("clang", {.st_dev = 12, .st_ino = 34});
+  santa::CachedAuthResult cachedResult = _authResultCache->CheckCache(&cachedFile);
+  XCTAssertEqual(cachedResult.action, SNTActionRespondAllowNoCache);
+  XCTAssertNotNil(cachedResult.cached_decision);
+  XCTAssertEqual(cachedResult.cached_decision.codesignValidationState,
+                 SNTCodesignValidationStateSuccess,
+                 @"non-cacheable CEL policy must retain completed signature validation");
+
   // Same vnode, context the rule blocks, no cache flush in between. The rule must
   // be evaluated again rather than the earlier allow being reused. The strict mock
   // enforces that no compiler status is conferred.

--- a/Source/santad/SNTDecisionCache.mm
+++ b/Source/santad/SNTDecisionCache.mm
@@ -155,6 +155,7 @@
   NSError* err;
   MOLCodesignChecker* csc = [fi codesignCheckerWithError:&err];
   if (csc && !err) {
+    cd.codesignValidationState = SNTCodesignValidationStateSuccess;
     cd.certSHA256 = csc.leafCertificate.SHA256;
     cd.certCommonName = csc.leafCertificate.commonName;
     cd.certChain = csc.certificates;
@@ -188,6 +189,8 @@
     cd.codesigningFlags = csc.signatureFlags;
     cd.secureSigningTime = csc.secureSigningTime;
     cd.signingTime = csc.signingTime;
+  } else if (err) {
+    cd.codesignValidationState = SNTCodesignValidationStateForError((OSStatus)err.code);
   }
 
   return cd;

--- a/Source/santad/SNTDecisionCacheTest.mm
+++ b/Source/santad/SNTDecisionCacheTest.mm
@@ -44,6 +44,7 @@ SNTCachedDecision* MakeCachedDecision(struct stat sb, SNTEventState decision) {
 }
 
 @interface SNTDecisionCache (TestSupport)
+- (SNTCachedDecision*)buildDecisionForFileInfo:(SNTFileInfo*)fi;
 - (void)waitForCachePopulateQueueForTesting;
 - (NSUInteger)pendingRehydrateCountForTesting;
 - (dispatch_queue_t)cachePopulateQ;
@@ -130,6 +131,7 @@ SNTCachedDecision* MakeCachedDecision(struct stat sb, SNTEventState decision) {
   XCTAssertEqualObjects(cd.sha256, fi.SHA256);
   XCTAssertEqual(cd.decision, SNTEventStateUnknown);
   XCTAssertEqual(cd.cacheable, NO);
+  XCTAssertEqual(cd.codesignValidationState, SNTCodesignValidationStateUnsigned);
 
   // Verify it landed in the cache.
   SNTCachedDecision* cached = [dc cachedDecisionForVnode:fi.vnode];
@@ -139,6 +141,19 @@ SNTCachedDecision* MakeCachedDecision(struct stat sb, SNTEventState decision) {
 
   [dc forgetCachedDecisionForVnode:fi.vnode];
   [[NSFileManager defaultManager] removeItemAtPath:tmpPath error:nil];
+}
+
+- (void)testBuildDecisionRetriesMissingCodesignResultAndError {
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMStub([mockFileInfo SHA256]).andReturn(@"aabbccdd");
+  OCMStub([mockFileInfo vnode]).andReturn((SantaVnode){});
+  OCMStub([mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]]).andReturn(nil);
+
+  SNTCachedDecision* cd =
+      [[SNTDecisionCache sharedCache] buildDecisionForFileInfo:mockFileInfo];
+
+  XCTAssertEqual(cd.codesignValidationState, SNTCodesignValidationStateNeedsValidation);
+  [mockFileInfo stopMocking];
 }
 
 - (void)testAsyncRehydrateAndCacheDecisionForFileInfo {
@@ -227,6 +242,7 @@ SNTCachedDecision* MakeCachedDecision(struct stat sb, SNTEventState decision) {
   XCTAssertNotNil(cd.cdhash);
   XCTAssertNotNil(cd.certChain);
   XCTAssertGreaterThan(cd.certChain.count, 0u);
+  XCTAssertEqual(cd.codesignValidationState, SNTCodesignValidationStateSuccess);
 
   // launchd is a platform binary: no teamID, but signingID is retained.
   XCTAssertNil(cd.teamID);

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -648,20 +648,37 @@ static void UpdateCachedDecisionSigningInfo(
   cd.quarantineURL = fileInfo.quarantineDataURL;
 
   NSError* csInfoError;
-  if (!cd.certSHA256.length) {
+  OSStatus cachedValidationError = SNTCodesignValidationErrorForState(cd.codesignValidationState);
+  if (cachedValidationError != errSecSuccess) {
+    csInfoError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                      code:cachedValidationError
+                                  userInfo:nil];
+    cd.decisionExtra = [NSString
+        stringWithFormat:@"Signature ignored due to error: %ld", (long)csInfoError.code];
+    cd.signingStatus = (cd.signingStatus == SNTSigningStatusUnsigned ? SNTSigningStatusUnsigned
+                                                                     : SNTSigningStatusInvalid);
+  } else if (cd.codesignValidationState == SNTCodesignValidationStateNeedsValidation) {
     // Grab the code signature, if there's an error don't try to capture
     // any of the signature details.
     // TODO(mlw): MOLCodesignChecker should be updated to still grab signing information
     // even if validity check fails. Once that is done, this code can be updated to grab
     // cert information so that it can still be reported to the sync server.
     MOLCodesignChecker* csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
+    if (!csInfo && !csInfoError) {
+      csInfoError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                        code:errSecCSInternalError
+                                    userInfo:nil];
+    }
     if (csInfoError) {
+      cd.codesignValidationState =
+          SNTCodesignValidationStateForError((OSStatus)csInfoError.code);
       csInfo = nil;
       cd.decisionExtra = [NSString
           stringWithFormat:@"Signature ignored due to error: %ld", (long)csInfoError.code];
       cd.signingStatus = (cd.signingStatus == SNTSigningStatusUnsigned ? SNTSigningStatusUnsigned
                                                                        : SNTSigningStatusInvalid);
     } else {
+      cd.codesignValidationState = SNTCodesignValidationStateSuccess;
       UpdateCachedDecisionSigningInfo(cd, csInfo, platformBinaryState, entitlementsFilterCallback);
     }
   }

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -753,6 +753,98 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   XCTAssertEqualObjects(cd.signingID, @"EQHXZ8M8AV:com.apple.ls");
 }
 
+- (void)testDecisionReusesCompletedCodesignValidationWithoutCertificate {
+  NSArray<NSDictionary*>* cases = @[
+    @{
+      @"state" : @(SNTCodesignValidationStateSuccess),
+      @"codesigning_flags" : @(CS_SIGNED | CS_VALID | CS_ADHOC | CS_LINKER_SIGNED),
+    },
+    @{
+      @"state" : @(SNTCodesignValidationStateUnsigned),
+      @"codesigning_flags" : @0,
+    },
+    @{
+      @"state" : @(SNTCodesignValidationStateSignatureFailed),
+      @"codesigning_flags" : @(CS_SIGNED),
+    },
+  ];
+
+  for (NSDictionary* testCase in cases) {
+    id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+    SNTPolicyProcessor* processor =
+        [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                   entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+    id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+    OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+    processor.configurator = mockConfigurator;
+
+    id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+    OCMReject([mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]]);
+    OCMStub([mockFileInfo isMachO]).andReturn(YES);
+
+    SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+    cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+    cached.codesignValidationState =
+        (SNTCodesignValidationState)[testCase[@"state"] integerValue];
+
+    es_file_t file = MakeESFile("/tmp/rg");
+    es_process_t proc = MakeESProcess(&file);
+    proc.is_platform_binary = false;
+    proc.codesigning_flags = [testCase[@"codesigning_flags"] unsignedIntValue];
+
+    SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+    SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                             targetProcess:&proc
+                                               configState:configState
+                                        activationCallback:nil
+                                            cachedDecision:cached];
+
+    XCTAssertEqual(cd.codesignValidationState,
+                   (SNTCodesignValidationState)[testCase[@"state"] integerValue]);
+    XCTAssertEqual(cd.decision, SNTEventStateAllowUnknown);
+    OCMVerifyAll(mockFileInfo);
+    [mockConfigurator stopMocking];
+    [mockRuleTable stopMocking];
+  }
+}
+
+- (void)testDecisionCatalogsContentDerivedCodesignError {
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  processor.configurator = mockConfigurator;
+
+  NSError* error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                        code:errSecCSSignatureFailed
+                                    userInfo:nil];
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMExpect([mockFileInfo codesignCheckerWithError:[OCMArg setTo:error]]).andReturn(nil);
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+
+  es_file_t file = MakeESFile("/tmp/invalid-signature");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  proc.codesigning_flags = CS_SIGNED;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                           targetProcess:&proc
+                                             configState:configState
+                                      activationCallback:nil
+                                          cachedDecision:nil];
+
+  XCTAssertEqual(cd.codesignValidationState, SNTCodesignValidationStateSignatureFailed);
+  XCTAssertEqual(cd.decision, SNTEventStateAllowUnknown);
+  OCMVerifyAll(mockFileInfo);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
+}
+
 - (void)testCELDecisions {
   ActivationCallbackBlock activation =
       ^std::unique_ptr<::google::api::expr::runtime::BaseActivation>(bool useV2) {


### PR DESCRIPTION
Context-dependent CEL decisions still require policy evaluation on every execution, but they no longer repeat static code-signing validation for an unchanged binary. The previous reuse condition effectively depended on `certSHA256`. This is incomplete because valid ad-hoc signatures—including linker-generated signatures—normally have no certificate. A non-cacheable CEL decision therefore retained the binary identity but repeated static signature analysis on every execution.

The cached validation state now distinguishes:

- Successful validation, including ad-hoc and linker-signed binaries without certificates
- Unsigned binaries
- Deterministic signature and executable-format failures
- Results that require validation because they are unknown or may depend on mutable system state

Each deterministic failure has a typed state that maps to its exact `OSStatus`. Mutable failures, such as filesystem, cancellation, trust, database, and internal errors, are retried.

The issue was observed with frequently executed command-line tools:

- Homebrew `mise`: valid ad-hoc, linker-signed binary with no signing certificate. Static validation succeeds, but the missing certificate previously caused repeated validation after non-cacheable policy decisions.
- GitHub `rg`: valid ad-hoc, linker-signed binary with no certificate.
- Homebrew `rg`: valid ad-hoc, non-linker-signed binary with no certificate.
- Unsigned or damaged `starship` variants returned `errSecCSUnsigned` and could also repeat the same analysis.

Rough local measurements for the installed `mise` binary:

- Repeated direct static validation: approximately 1.4–1.5 seconds per invocation in the instrumented sandbox.
- Reusing the cached validation result: below measurable millisecond resolution.
- End-to-end policy comparison under the same test environment:
  - Validation repeated: approximately 1.76 seconds median.
  - Validation reused: approximately 0.04 milliseconds median.

The sandbox substantially inflated absolute validation time. Interactive shell observations were a few hundred milliseconds per invocation. The important result is the repeated work and the relative difference, not the sandbox’s absolute latency.

Added a CEL regression test which verifies that a non-cacheable authorization retains completed signature validation while still re-evaluating policy for the next execution.