### PR TITLE
santad: Don't present UI during signature invalidation

### DIFF
--- a/Source/common/CodeSigningIdentifierUtils.h
+++ b/Source/common/CodeSigningIdentifierUtils.h
@@ -37,7 +37,15 @@ static inline bool CdhashStrictlyEnforced(uint32_t csFlags) {
 // invalidity even if we allow the execution to proceed. Native
 // arm64 code must be signed, while unsigned x86_64 code may execute on Intel or
 // under Rosetta, so CS_KILL without CS_VALID is only terminal for arm64.
-bool KernelWillKillForInvalidSignature(uint32_t csFlags, cpu_type_t imageCPUType);
+//
+// Note that treating CS_KILL without CS_VALID on arm64 as invalid is technically
+// incorrect: to the kernel at least, such a binary is considered unsigned. This
+// is a deliberate trade-off. All arm64 binaries must be signed, so the kernel
+// would refuse to execute a genuinely unsigned one anyway, and creating an
+// unsigned arm64 binary is difficult in the first place. The far more common
+// case is a binary that is signed but damaged, so reporting invalid is the more
+// useful answer.
+bool KernelWillKillForCodeSigning(uint32_t csFlags, cpu_type_t imageCPUType);
 
 extern const NSUInteger kTeamIDLength;
 extern NSString* const kPlatformTeamID;

--- a/Source/common/CodeSigningIdentifierUtils.h
+++ b/Source/common/CodeSigningIdentifierUtils.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 #include <Kernel/kern/cs_blobs.h>
+#include <mach/machine.h>
 
 #include <cstdint>
 #include <string_view>
@@ -31,6 +32,12 @@ namespace santa {
 static inline bool CdhashStrictlyEnforced(uint32_t csFlags) {
   return (csFlags & CS_VALID) && (csFlags & (CS_HARD | CS_KILL));
 }
+
+// Returns true when the kernel will kill the process for code-signing
+// invalidity even if we allow the execution to proceed. Native
+// arm64 code must be signed, while unsigned x86_64 code may execute on Intel or
+// under Rosetta, so CS_KILL without CS_VALID is only terminal for arm64.
+bool KernelWillKillForInvalidSignature(uint32_t csFlags, cpu_type_t imageCPUType);
 
 extern const NSUInteger kTeamIDLength;
 extern NSString* const kPlatformTeamID;

--- a/Source/common/CodeSigningIdentifierUtils.mm
+++ b/Source/common/CodeSigningIdentifierUtils.mm
@@ -24,7 +24,7 @@ const NSUInteger kTeamIDLength = 10;
 NSString* const kPlatformTeamID = @"platform";
 NSString* const kPlatformTeamIDPrefix = @"platform:";
 
-bool KernelWillKillForInvalidSignature(uint32_t csFlags, cpu_type_t imageCPUType) {
+bool KernelWillKillForCodeSigning(uint32_t csFlags, cpu_type_t imageCPUType) {
   if (csFlags & CS_KILLED) return true;
 
   return imageCPUType == CPU_TYPE_ARM64 && (csFlags & CS_KILL) && !(csFlags & CS_VALID);

--- a/Source/common/CodeSigningIdentifierUtils.mm
+++ b/Source/common/CodeSigningIdentifierUtils.mm
@@ -24,6 +24,12 @@ const NSUInteger kTeamIDLength = 10;
 NSString* const kPlatformTeamID = @"platform";
 NSString* const kPlatformTeamIDPrefix = @"platform:";
 
+bool KernelWillKillForInvalidSignature(uint32_t csFlags, cpu_type_t imageCPUType) {
+  if (csFlags & CS_KILLED) return true;
+
+  return imageCPUType == CPU_TYPE_ARM64 && (csFlags & CS_KILL) && !(csFlags & CS_VALID);
+}
+
 namespace {
 
 bool IsAsciiAlnum(char c) {

--- a/Source/common/CodeSigningIdentifierUtilsTest.mm
+++ b/Source/common/CodeSigningIdentifierUtilsTest.mm
@@ -24,14 +24,14 @@
 
 @implementation CodeSigningIdentifierUtilsTest
 
-- (void)testKernelWillKillForInvalidSignature {
-  XCTAssertTrue(santa::KernelWillKillForInvalidSignature(CS_KILLED, CPU_TYPE_ANY));
-  XCTAssertTrue(santa::KernelWillKillForInvalidSignature(CS_KILL, CPU_TYPE_ARM64));
-  XCTAssertTrue(santa::KernelWillKillForInvalidSignature(CS_SIGNED | CS_KILL, CPU_TYPE_ARM64));
+- (void)testKernelWillKillForCodeSigning {
+  XCTAssertTrue(santa::KernelWillKillForCodeSigning(CS_KILLED, CPU_TYPE_ANY));
+  XCTAssertTrue(santa::KernelWillKillForCodeSigning(CS_KILL, CPU_TYPE_ARM64));
+  XCTAssertTrue(santa::KernelWillKillForCodeSigning(CS_SIGNED | CS_KILL, CPU_TYPE_ARM64));
 
-  XCTAssertFalse(santa::KernelWillKillForInvalidSignature(CS_VALID | CS_KILL, CPU_TYPE_ARM64));
-  XCTAssertFalse(santa::KernelWillKillForInvalidSignature(CS_KILL, CPU_TYPE_X86_64));
-  XCTAssertFalse(santa::KernelWillKillForInvalidSignature(CS_KILL, CPU_TYPE_ANY));
+  XCTAssertFalse(santa::KernelWillKillForCodeSigning(CS_VALID | CS_KILL, CPU_TYPE_ARM64));
+  XCTAssertFalse(santa::KernelWillKillForCodeSigning(CS_KILL, CPU_TYPE_X86_64));
+  XCTAssertFalse(santa::KernelWillKillForCodeSigning(CS_KILL, CPU_TYPE_ANY));
 }
 
 #pragma mark - IsValidTeamID Tests

--- a/Source/common/CodeSigningIdentifierUtilsTest.mm
+++ b/Source/common/CodeSigningIdentifierUtilsTest.mm
@@ -24,6 +24,16 @@
 
 @implementation CodeSigningIdentifierUtilsTest
 
+- (void)testKernelWillKillForInvalidSignature {
+  XCTAssertTrue(santa::KernelWillKillForInvalidSignature(CS_KILLED, CPU_TYPE_ANY));
+  XCTAssertTrue(santa::KernelWillKillForInvalidSignature(CS_KILL, CPU_TYPE_ARM64));
+  XCTAssertTrue(santa::KernelWillKillForInvalidSignature(CS_SIGNED | CS_KILL, CPU_TYPE_ARM64));
+
+  XCTAssertFalse(santa::KernelWillKillForInvalidSignature(CS_VALID | CS_KILL, CPU_TYPE_ARM64));
+  XCTAssertFalse(santa::KernelWillKillForInvalidSignature(CS_KILL, CPU_TYPE_X86_64));
+  XCTAssertFalse(santa::KernelWillKillForInvalidSignature(CS_KILL, CPU_TYPE_ANY));
+}
+
 #pragma mark - IsValidTeamID Tests
 
 - (void)testIsValidTeamID {

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -455,7 +455,7 @@ static BOOL DecisionIsCompiler(SNTEventState decision) {
   // cannot succeed no matter what Santa decides. The policy still applies and
   // the block is still logged and uploaded, but no UI is shown: the user would
   // otherwise blame Santa for a kill it didn't cause.
-  if (santa::KernelWillKillForInvalidSignature(targetProc->codesigning_flags, imageCPUType) &&
+  if (santa::KernelWillKillForCodeSigning(targetProc->codesigning_flags, imageCPUType) &&
       (cd.decision & SNTEventStateAllow) == 0) {
     cd.silentBlockGUI = YES;
     cd.silentBlockTTY = YES;
@@ -467,7 +467,7 @@ static BOOL DecisionIsCompiler(SNTEventState decision) {
     LOGW(@"Denying %@ but suppressing block UI: the kernel will kill this process for code "
          @"signature invalidity (codesigning_flags=0x%x). The exec would have failed regardless of "
          @"Santa's decision.",
-         @(targetProc->executable->path.data), targetProc->codesigning_flags);
+         santa::StringTokenToNSString(targetProc->executable->path), targetProc->codesigning_flags);
   }
 
   // Formulate an initial action from the decision.

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -368,8 +368,10 @@ static BOOL DecisionIsCompiler(SNTEventState decision) {
           : santa::CreateCELActivationBlock(esMsg, [binInfo codesignCheckerWithError:NULL],
                                             _processTree);
 
+  cpu_type_t imageCPUType = esMsg->version >= 6 ? esMsg->event.exec.image_cputype : CPU_TYPE_ANY;
   SNTCachedDecision* cd = [self.policyProcessor decisionForFileInfo:binInfo
                                                       targetProcess:targetProc
+                                                       imageCPUType:imageCPUType
                                                         configState:configState
                                                  activationCallback:activationBlock
                                                      cachedDecision:existingDecision];
@@ -447,6 +449,25 @@ static BOOL DecisionIsCompiler(SNTEventState decision) {
                          audit_token_to_pidversion(targetProc->audit_token)),
           true);
     }
+  }
+
+  // When the kernel kills the target for code signature invalidity, this exec
+  // cannot succeed no matter what Santa decides. The policy still applies and
+  // the block is still logged and uploaded, but no UI is shown: the user would
+  // otherwise blame Santa for a kill it didn't cause.
+  if (santa::KernelWillKillForInvalidSignature(targetProc->codesigning_flags, imageCPUType) &&
+      (cd.decision & SNTEventStateAllow) == 0) {
+    cd.silentBlockGUI = YES;
+    cd.silentBlockTTY = YES;
+    cd.holdAndAsk = NO;
+    NSString* extra = @"Kernel will kill the process for code signature invalidity; "
+                      @"suppressing block UI";
+    cd.decisionExtra =
+        cd.decisionExtra ? [NSString stringWithFormat:@"%@; %@", cd.decisionExtra, extra] : extra;
+    LOGW(@"Denying %@ but suppressing block UI: the kernel will kill this process for code "
+         @"signature invalidity (codesigning_flags=0x%x). The exec would have failed regardless of "
+         @"Santa's decision.",
+         @(targetProc->executable->path.data), targetProc->codesigning_flags);
   }
 
   // Formulate an initial action from the decision.

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -1006,6 +1006,7 @@ static SNTSandboxExecRequest* MakeSandboxRequest(uint64_t dev, uint64_t ino, con
 
   OCMStub([mockPolicyProcessor decisionForFileInfo:OCMOCK_ANY
                                      targetProcess:&procExec
+                                      imageCPUType:0
                                        configState:OCMOCK_ANY
                                 activationCallback:OCMOCK_ANY
                                     cachedDecision:OCMOCK_ANY])
@@ -1073,6 +1074,130 @@ static SNTSandboxExecRequest* MakeSandboxRequest(uint64_t dev, uint64_t ino, con
                        expectedControl:santa::ProcessControl::Kill];
 }
 
+// When the kernel kills the process for code signature invalidity, a block must
+// still be applied and logged but no UI shown, and there's nothing to hold for
+// approval.
+- (void)validateBlockWithCodesigningFlags:(uint32_t)csFlags
+                             imageCPUType:(cpu_type_t)imageCPUType
+                           expectedAction:(SNTAction)expectedAction
+                                  wantGUI:(BOOL)wantGUI {
+  OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
+  OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
+  OCMStub([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
+
+  id mockNotifierQueue = OCMClassMock([SNTNotificationQueue class]);
+  __block BOOL guiShown = NO;
+  OCMStub([mockNotifierQueue addEvent:OCMOCK_ANY
+                    withCustomMessage:OCMOCK_ANY
+                            customURL:OCMOCK_ANY
+                eventDetailButtonText:OCMOCK_ANY
+                          configState:OCMOCK_ANY
+                             andReply:OCMOCK_ANY])
+      .andDo(^(NSInvocation* invocation) {
+        guiShown = YES;
+      });
+
+  id mockPolicyProcessor = OCMClassMock([SNTPolicyProcessor class]);
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.decision = SNTEventStateBlockSigningID;
+  cd.holdAndAsk = YES;
+  cd.decisionClientMode = SNTClientModeLockdown;
+
+  es_file_t file = MakeESFile("foo");
+  es_process_t proc = MakeESProcess(&file);
+  es_file_t fileExec = MakeESFile("bar", {.st_dev = 12, .st_ino = 34});
+  es_process_t procExec = MakeESProcess(&fileExec);
+  procExec.is_platform_binary = false;
+  procExec.codesigning_flags = csFlags;
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, &proc);
+  esMsg.event.exec.target = &procExec;
+  esMsg.event.exec.image_cputype = imageCPUType;
+
+  OCMStub([mockPolicyProcessor decisionForFileInfo:OCMOCK_ANY
+                                     targetProcess:&procExec
+                                      imageCPUType:imageCPUType
+                                       configState:OCMOCK_ANY
+                                activationCallback:OCMOCK_ANY
+                                    cachedDecision:OCMOCK_ANY])
+      .ignoringNonObjectArgs()
+      .andReturn(cd);
+
+  LogExecutionBlock loggerBlock = ^(Message esMsg) {
+  };
+  santa::ProcessControlBlock processControl = ^bool(pid_t pid, santa::ProcessControl control) {
+    return true;
+  };
+
+  std::shared_ptr<santa::santad::process_tree::ProcessTree> processTree;
+  SNTExecutionController* controller = [[SNTExecutionController alloc]
+        initWithRuleTable:self.mockRuleDatabase
+               eventTable:self.mockEventDatabase
+            notifierQueue:mockNotifierQueue
+               syncdQueue:nil
+                   logger:loggerBlock
+                ttyWriter:santa::TTYWriter::Create(true)
+          policyProcessor:mockPolicyProcessor
+      processControlBlock:processControl
+              processTree:processTree
+      sandboxExpectations:std::make_shared<santa::SandboxExpectations>()];
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+
+  __block SNTAction resultAction = SNTActionUnset;
+  {
+    Message msg(mockESApi, &esMsg);
+    [controller validateExecEvent:msg
+                   cachedDecision:nil
+                       postAction:^bool(SNTAction action, SNTCachedDecision* cd) {
+                         resultAction = action;
+                         return true;
+                       }];
+  }
+
+  XCTAssertEqual(resultAction, expectedAction);
+  XCTAssertEqual(guiShown, wantGUI);
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+  [mockNotifierQueue stopMocking];
+  [mockPolicyProcessor stopMocking];
+}
+
+- (void)testBlockWithCSKilledIsSilent {
+  [self validateBlockWithCodesigningFlags:CS_KILLED
+                             imageCPUType:CPU_TYPE_ANY
+                           expectedAction:SNTActionRespondDeny
+                                  wantGUI:NO];
+}
+
+// CS_KILL without CS_VALID is terminal for native arm64, where signing is
+// required, but not for x86_64, where unsigned code may execute.
+- (void)testBlockWithCSKillOnlyUsesTargetArchitecture {
+  [self validateBlockWithCodesigningFlags:CS_KILL
+                             imageCPUType:CPU_TYPE_ARM64
+                           expectedAction:SNTActionRespondDeny
+                                  wantGUI:NO];
+  [self validateBlockWithCodesigningFlags:CS_KILL
+                             imageCPUType:CPU_TYPE_X86_64
+                           expectedAction:SNTActionRespondHold
+                                  wantGUI:YES];
+}
+
+- (void)testBlockWithValidSignatureShowsGUI {
+  [self validateBlockWithCodesigningFlags:CS_SIGNED | CS_VALID | CS_KILL
+                             imageCPUType:CPU_TYPE_ARM64
+                           expectedAction:SNTActionRespondHold
+                                  wantGUI:YES];
+}
+
+// Invalid signature but the kernel is not set to kill for it.
+- (void)testBlockWithInvalidAndNoCSKillShowsGUI {
+  [self validateBlockWithCodesigningFlags:CS_SIGNED
+                             imageCPUType:CPU_TYPE_ARM64
+                           expectedAction:SNTActionRespondHold
+                                  wantGUI:YES];
+}
+
 // Test that successful TouchID auth populates the cache, and subsequent executions
 // of the same binary skip the TouchID prompt (cache hit scenario)
 - (void)testTouchIDCacheHitSkipsPrompt {
@@ -1117,6 +1242,7 @@ static SNTSandboxExecRequest* MakeSandboxRequest(uint64_t dev, uint64_t ino, con
 
   OCMStub([mockPolicyProcessor decisionForFileInfo:OCMOCK_ANY
                                      targetProcess:&procExec
+                                      imageCPUType:0
                                        configState:OCMOCK_ANY
                                 activationCallback:OCMOCK_ANY
                                     cachedDecision:OCMOCK_ANY])

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -61,6 +61,7 @@ using ActivationCallbackBlock =
 ///
 - (nonnull SNTCachedDecision*)decisionForFileInfo:(nonnull SNTFileInfo*)fileInfo
                                     targetProcess:(nonnull const es_process_t*)targetProc
+                                     imageCPUType:(cpu_type_t)imageCPUType
                                       configState:(nonnull SNTConfigState*)configState
                                activationCallback:
                                    (nullable ActivationCallbackBlock)activationCallback

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -784,7 +784,7 @@ static void UpdateCachedDecisionSigningInfo(
         uint32_t csFlags = targetProc->codesigning_flags;
         // CS_KILLED, and CS_KILL without CS_VALID on native arm64, identify
         // images the kernel rejected even if CS_SIGNED has already been cleared.
-        if (santa::KernelWillKillForInvalidSignature(csFlags, imageCPUType)) {
+        if (santa::KernelWillKillForCodeSigning(csFlags, imageCPUType)) {
           return SNTSigningStatusInvalid;
         } else if ((csFlags & CS_SIGNED) == 0) {
           return SNTSigningStatusUnsigned;

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -719,6 +719,7 @@ static void UpdateCachedDecisionSigningInfo(
 
 - (nonnull SNTCachedDecision*)decisionForFileInfo:(nonnull SNTFileInfo*)fileInfo
                                     targetProcess:(nonnull const es_process_t*)targetProc
+                                     imageCPUType:(cpu_type_t)imageCPUType
                                       configState:(nonnull SNTConfigState*)configState
                                activationCallback:
                                    (nullable ActivationCallbackBlock)activationCallback
@@ -781,7 +782,11 @@ static void UpdateCachedDecisionSigningInfo(
       platformBinaryState:pbs
       signingStatusCallback:^SNTSigningStatus {
         uint32_t csFlags = targetProc->codesigning_flags;
-        if ((csFlags & CS_SIGNED) == 0) {
+        // CS_KILLED, and CS_KILL without CS_VALID on native arm64, identify
+        // images the kernel rejected even if CS_SIGNED has already been cleared.
+        if (santa::KernelWillKillForInvalidSignature(csFlags, imageCPUType)) {
+          return SNTSigningStatusInvalid;
+        } else if ((csFlags & CS_SIGNED) == 0) {
           return SNTSigningStatusUnsigned;
         } else if ((csFlags & CS_VALID) == 0) {
           return SNTSigningStatusInvalid;

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -745,12 +745,63 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 
   SNTCachedDecision* cd = [processor decisionForFileInfo:fi
                                            targetProcess:&proc
+                                            imageCPUType:CPU_TYPE_ARM64
                                              configState:configState
                                       activationCallback:nil
                                           cachedDecision:nil];
 
   XCTAssertEqualObjects(cd.teamID, @"EQHXZ8M8AV");
   XCTAssertEqualObjects(cd.signingID, @"EQHXZ8M8AV:com.apple.ls");
+}
+
+- (SNTSigningStatus)signingStatusForCodesigningFlags:(uint32_t)csFlags
+                                        imageCPUType:(cpu_type_t)imageCPUType {
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+
+  SNTFileInfo* fi = [[SNTFileInfo alloc] initWithPath:@"/bin/ls"];
+  XCTAssertNotNil(fi);
+
+  es_file_t file = MakeESFile("/bin/ls");
+  es_process_t proc = MakeESProcess(&file);
+  proc.codesigning_flags = csFlags;
+
+  SNTConfigState* configState =
+      [[SNTConfigState alloc] initWithConfig:[SNTConfigurator configurator]];
+
+  return [processor decisionForFileInfo:fi
+                          targetProcess:&proc
+                           imageCPUType:imageCPUType
+                            configState:configState
+                     activationCallback:nil
+                         cachedDecision:nil]
+      .signingStatus;
+}
+
+// CS_KILLED is invalid on every architecture. A CS_KILL-only image is invalid
+// for native arm64, where signing is required, but remains unsigned on x86_64.
+- (void)testSigningStatusFromCodesigningFlags {
+  XCTAssertEqual([self signingStatusForCodesigningFlags:0 imageCPUType:CPU_TYPE_ARM64],
+                 SNTSigningStatusUnsigned);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_KILLED imageCPUType:CPU_TYPE_ANY],
+                 SNTSigningStatusInvalid);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_KILL imageCPUType:CPU_TYPE_ARM64],
+                 SNTSigningStatusInvalid);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_KILL imageCPUType:CPU_TYPE_X86_64],
+                 SNTSigningStatusUnsigned);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_SIGNED imageCPUType:CPU_TYPE_ANY],
+                 SNTSigningStatusInvalid);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_SIGNED | CS_VALID | CS_ADHOC
+                                           imageCPUType:CPU_TYPE_ANY],
+                 SNTSigningStatusAdhoc);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_SIGNED | CS_VALID | CS_DEV_CODE
+                                           imageCPUType:CPU_TYPE_ANY],
+                 SNTSigningStatusDevelopment);
+  XCTAssertEqual([self signingStatusForCodesigningFlags:CS_SIGNED | CS_VALID
+                                           imageCPUType:CPU_TYPE_ANY],
+                 SNTSigningStatusProduction);
 }
 
 - (void)testCELDecisions {
@@ -1690,6 +1741,7 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 
   return [processor decisionForFileInfo:fi
                           targetProcess:&proc
+                           imageCPUType:CPU_TYPE_ARM64
                             configState:configState
                      activationCallback:nil
                          cachedDecision:nil];


### PR DESCRIPTION
On arm64 - where all binaries must be signed - a process with CS_KILL but not CS_VALID is going to be killed immediately. A process that has CS_KILLED set will also. These cases can occur when Santa is evaluating execution of a binary that was being written at the time of execution. Instead of blocking the execution and presenting UI and having Santa be blamed for an execution that would have failed anyway, suppress the UI in this case.