### PR TITLE
santad: Reuse completed codesign validation across non-cacheable decisions

### DIFF
--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -59,6 +59,10 @@
 @property NSDate* secureSigningTime;
 @property NSDate* signingTime;
 
+/// The OSStatus returned by static code signature validation for this identity,
+/// or nil if validation has not run yet.
+@property NSNumber* codesignValidationStatus;
+
 @property NSString* quarantineURL;
 
 @property NSString* customMsg;

--- a/Source/common/SNTCachedDecision.mm
+++ b/Source/common/SNTCachedDecision.mm
@@ -51,6 +51,7 @@
     _entitlementsFiltered = previous.entitlementsFiltered;
     _secureSigningTime = previous.secureSigningTime;
     _signingTime = previous.signingTime;
+    _codesignValidationStatus = previous.codesignValidationStatus;
   }
   return self;
 }
@@ -76,6 +77,7 @@
   copy.signingStatus = _signingStatus;
   copy.secureSigningTime = _secureSigningTime;
   copy.signingTime = _signingTime;
+  copy.codesignValidationStatus = _codesignValidationStatus;
   copy.quarantineURL = _quarantineURL;
   copy.customMsg = _customMsg;
   copy.customURL = _customURL;

--- a/Source/common/SNTCachedDecisionTest.mm
+++ b/Source/common/SNTCachedDecisionTest.mm
@@ -12,6 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+#import <Security/Security.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTCachedDecision.h"
@@ -31,6 +32,48 @@
 
   XCTAssertEqual(sb.st_ino, cd.vnodeId.fileid);
   XCTAssertEqual(sb.st_dev, cd.vnodeId.fsid);
+}
+
+- (void)testCachedIdentityCarriesSuccessfulValidationWithoutCertificate {
+  SNTCachedDecision* previous = [[SNTCachedDecision alloc] init];
+  previous.sha256 = @"aabbccdd";
+  // Ad-hoc and linker-signed binaries validate successfully with no
+  // certificate. This is the case a certSHA256 check cannot distinguish from
+  // "validation has not run yet".
+  previous.codesignValidationStatus = @(errSecSuccess);
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] initWithCachedIdentity:previous];
+
+  XCTAssertEqualObjects(cached.codesignValidationStatus, @(errSecSuccess));
+  XCTAssertNil(cached.certSHA256);
+}
+
+- (void)testCachedIdentityCarriesValidationFailure {
+  SNTCachedDecision* previous = [[SNTCachedDecision alloc] init];
+  previous.sha256 = @"aabbccdd";
+  previous.codesignValidationStatus = @(errSecCSUnsigned);
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] initWithCachedIdentity:previous];
+
+  XCTAssertEqualObjects(cached.codesignValidationStatus, @(errSecCSUnsigned));
+}
+
+- (void)testCachedIdentityLeavesValidationStatusNilWhenNeverValidated {
+  SNTCachedDecision* previous = [[SNTCachedDecision alloc] init];
+  previous.sha256 = @"aabbccdd";
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] initWithCachedIdentity:previous];
+
+  XCTAssertNil(cached.codesignValidationStatus);
+}
+
+- (void)testCopyCarriesValidationStatus {
+  SNTCachedDecision* cd = [[SNTCachedDecision alloc] init];
+  cd.codesignValidationStatus = @(errSecCSUnsigned);
+
+  SNTCachedDecision* copy = [cd copy];
+
+  XCTAssertEqualObjects(copy.codesignValidationStatus, @(errSecCSUnsigned));
 }
 
 @end

--- a/Source/santad/CompilerAuthorizationScopeTest.mm
+++ b/Source/santad/CompilerAuthorizationScopeTest.mm
@@ -97,6 +97,7 @@ static const std::vector<std::string> kBlockedArgs = {"clang", "--link"};
 @implementation CompilerAuthorizationScopeTest {
   std::shared_ptr<AuthResultCache> _authResultCache;
   std::shared_ptr<MockEndpointSecurityAPI> _mockESApi;
+  int _staticValidationCount;
 }
 
 - (void)setUp {
@@ -125,6 +126,9 @@ static const std::vector<std::string> kBlockedArgs = {"clang", "--link"};
   OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
   OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
   OCMStub([self.mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]])
+      .andDo(^(NSInvocation* inv) {
+        self->_staticValidationCount++;
+      })
       .andReturn(self.mockCodesignChecker);
 
   self.mockRuleDatabase = OCMClassMock([SNTRuleTable class]);
@@ -236,11 +240,25 @@ static const std::vector<std::string> kBlockedArgs = {"clang", "--link"};
                  @"the authorized context must be allowed");
   XCTAssertTrue(OCMVerifyAll(self.mockCompilerController));
 
+  // The non-cacheable entry must retain the completed validation. The mock
+  // checker has no leaf certificate, so certSHA256 is nil — the shape that
+  // previously forced a full re-validation on the next execution.
+  es_file_t cachedFile = MakeESFile("clang", {.st_dev = 12, .st_ino = 34});
+  santa::CachedAuthResult cachedResult = _authResultCache->CheckCache(&cachedFile);
+  XCTAssertEqual(cachedResult.action, SNTActionRespondAllowNoCache);
+  XCTAssertNotNil(cachedResult.cached_decision);
+  XCTAssertNil(cachedResult.cached_decision.certSHA256);
+  XCTAssertEqualObjects(cachedResult.cached_decision.codesignValidationStatus, @(errSecSuccess),
+                        @"non-cacheable CEL policy must retain completed signature validation");
+  int validationsAfterFirstExec = _staticValidationCount;
+
   // Same vnode, context the rule blocks, no cache flush in between. The rule must
   // be evaluated again rather than the earlier allow being reused. The strict mock
   // enforces that no compiler status is conferred.
   XCTAssertEqual([self runExecWithArgs:kBlockedArgs dev:12 ino:34], ES_AUTH_RESULT_DENY,
                  @"a primed vnode must not settle a blocked context");
+  XCTAssertEqual(_staticValidationCount, validationsAfterFirstExec,
+                 @"a primed vnode must not repeat static signature validation");
 }
 
 // Priming one vnode must not change the answer for a different one.

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -621,6 +621,14 @@ static void UpdateCachedDecisionSigningInfo(
   cd.signingTime = csInfo.signingTime;
 }
 
+// Applies the effects of a failed static code signature validation.
+static void ApplyCodesignValidationFailure(SNTCachedDecision* cd, OSStatus status) {
+  cd.decisionExtra =
+      [NSString stringWithFormat:@"Signature ignored due to error: %ld", (long)status];
+  cd.signingStatus = (cd.signingStatus == SNTSigningStatusUnsigned ? SNTSigningStatusUnsigned
+                                                                   : SNTSigningStatusInvalid);
+}
+
 - (nonnull SNTCachedDecision*)
            decisionForFileInfo:(nonnull SNTFileInfo*)fileInfo
                    configState:(nonnull SNTConfigState*)configState
@@ -647,21 +655,33 @@ static void UpdateCachedDecisionSigningInfo(
   cd.decisionClientMode = configState.clientMode;
   cd.quarantineURL = fileInfo.quarantineDataURL;
 
-  NSError* csInfoError;
-  if (!cd.certSHA256.length) {
+  // Static validation is expensive, so it runs at most once per identity — but
+  // only outcomes that cannot change while the identity is valid are recorded.
+  OSStatus csStatus;
+  if (cd.codesignValidationStatus) {
+    csStatus = (OSStatus)cd.codesignValidationStatus.intValue;
+    if (csStatus != errSecSuccess) {
+      ApplyCodesignValidationFailure(cd, csStatus);
+    }
+  } else {
     // Grab the code signature, if there's an error don't try to capture
     // any of the signature details.
     // TODO(mlw): MOLCodesignChecker should be updated to still grab signing information
     // even if validity check fails. Once that is done, this code can be updated to grab
     // cert information so that it can still be reported to the sync server.
+    NSError* csInfoError;
     MOLCodesignChecker* csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
+    csStatus = csInfoError ? (OSStatus)csInfoError.code : errSecSuccess;
     if (csInfoError) {
-      csInfo = nil;
-      cd.decisionExtra = [NSString
-          stringWithFormat:@"Signature ignored due to error: %ld", (long)csInfoError.code];
-      cd.signingStatus = (cd.signingStatus == SNTSigningStatusUnsigned ? SNTSigningStatusUnsigned
-                                                                       : SNTSigningStatusInvalid);
+      // Record an unsigned verdict only when the kernel agrees the executable itself
+      // carries no signature, so the recorded state describes this vnode. Other
+      // failures are left unrecorded and re-derived on the next execution.
+      if (csStatus == errSecCSUnsigned && cd.signingStatus == SNTSigningStatusUnsigned) {
+        cd.codesignValidationStatus = @(errSecCSUnsigned);
+      }
+      ApplyCodesignValidationFailure(cd, csStatus);
     } else {
+      cd.codesignValidationStatus = @(errSecSuccess);
       UpdateCachedDecisionSigningInfo(cd, csInfo, platformBinaryState, entitlementsFilterCallback);
     }
   }
@@ -677,10 +697,10 @@ static void UpdateCachedDecisionSigningInfo(
     }
   }
 
-  if ([self.configurator enableBadSignatureProtection] && csInfoError &&
-      csInfoError.code != errSecCSUnsigned) {
+  if ([self.configurator enableBadSignatureProtection] && csStatus != errSecSuccess &&
+      csStatus != errSecCSUnsigned) {
     cd.decisionExtra =
-        [NSString stringWithFormat:@"Blocked due to signature error: %ld", (long)csInfoError.code];
+        [NSString stringWithFormat:@"Blocked due to signature error: %ld", (long)csStatus];
     cd.decision = SNTEventStateBlockCertificate;
     return cd;
   }

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1006,6 +1006,60 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   [mockRuleTable stopMocking];
 }
 
+- (void)testDecisionRevalidatesWhenCachedStatusAbsent {
+  // The recorded status gates the skip, not the mere presence of a cached
+  // decision: a failure that was deliberately not recorded must be re-derived on
+  // the next execution.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  processor.configurator = mockConfigurator;
+
+  NSError* csError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                         code:errSecCSSignatureFailed
+                                     userInfo:nil];
+  __block int validations = 0;
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMStub([mockFileInfo codesignCheckerWithError:[OCMArg setTo:csError]])
+      .andDo(^(NSInvocation* inv) {
+        validations++;
+      })
+      .andReturn(nil);
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+  OCMStub([mockFileInfo SHA256])
+      .andReturn(@"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e");
+
+  es_file_t file = MakeESFile("/tmp/invalid-signature");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  proc.codesigning_flags = CS_SIGNED;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  SNTCachedDecision* first = [processor decisionForFileInfo:mockFileInfo
+                                              targetProcess:&proc
+                                                configState:configState
+                                         activationCallback:nil
+                                             cachedDecision:nil];
+
+  XCTAssertNil(first.codesignValidationStatus);
+  XCTAssertEqual(validations, 1);
+
+  SNTCachedDecision* second = [processor decisionForFileInfo:mockFileInfo
+                                               targetProcess:&proc
+                                                 configState:configState
+                                          activationCallback:nil
+                                              cachedDecision:first];
+
+  XCTAssertEqual(validations, 2, @"an unrecorded failure must be re-derived");
+  XCTAssertNil(second.codesignValidationStatus);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
+}
+
 - (void)testCELDecisions {
   ActivationCallbackBlock activation =
       ^std::unique_ptr<::google::api::expr::runtime::BaseActivation>(bool useV2) {

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -751,6 +751,259 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
 
   XCTAssertEqualObjects(cd.teamID, @"EQHXZ8M8AV");
   XCTAssertEqualObjects(cd.signingID, @"EQHXZ8M8AV:com.apple.ls");
+  // /bin/ls validates cleanly, so the fresh path must record the success. This
+  // is the sole production write of the property the whole feature consumes.
+  XCTAssertEqualObjects(cd.codesignValidationStatus, @(errSecSuccess));
+}
+
+- (void)testDecisionReusesCompletedCodesignValidation {
+  // Each case is a validation that already completed and produced no
+  // certificate, so certSHA256 cannot distinguish it from "never validated".
+  NSArray<NSDictionary*>* cases = @[
+    @{
+      // Ad-hoc, linker-signed: valid signature, no certificate.
+      @"status" : @(errSecSuccess),
+      @"codesigning_flags" : @(CS_SIGNED | CS_VALID | CS_ADHOC | CS_LINKER_SIGNED),
+      @"expected_signing_status" : @(SNTSigningStatusAdhoc),
+      @"expected_extra" : [NSNull null],
+    },
+    @{
+      @"status" : @(errSecCSUnsigned),
+      @"codesigning_flags" : @0,
+      @"expected_signing_status" : @(SNTSigningStatusUnsigned),
+      @"expected_extra" : [NSString
+          stringWithFormat:@"Signature ignored due to error: %ld", (long)errSecCSUnsigned],
+    },
+  ];
+
+  for (NSDictionary* testCase in cases) {
+    id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+    SNTPolicyProcessor* processor =
+        [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                   entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+    id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+    OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+    processor.configurator = mockConfigurator;
+
+    id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+    // The assertion that matters: static validation must not run again.
+    OCMReject([mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]]);
+    OCMStub([mockFileInfo isMachO]).andReturn(YES);
+
+    SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+    cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+    cached.codesignValidationStatus = testCase[@"status"];
+
+    es_file_t file = MakeESFile("/tmp/rg");
+    es_process_t proc = MakeESProcess(&file);
+    proc.is_platform_binary = false;
+    proc.codesigning_flags = [testCase[@"codesigning_flags"] unsignedIntValue];
+    SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+    SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                             targetProcess:&proc
+                                               configState:configState
+                                        activationCallback:nil
+                                            cachedDecision:cached];
+
+    XCTAssertEqualObjects(cd.codesignValidationStatus, testCase[@"status"]);
+    XCTAssertEqual(cd.signingStatus,
+                   (SNTSigningStatus)[testCase[@"expected_signing_status"] integerValue]);
+    XCTAssertEqual(cd.decision, SNTEventStateAllowUnknown);
+
+    id expectedExtra = testCase[@"expected_extra"];
+    if (expectedExtra == [NSNull null]) {
+      XCTAssertNil(cd.decisionExtra);
+    } else {
+      XCTAssertEqualObjects(cd.decisionExtra, expectedExtra);
+    }
+
+    OCMVerifyAll(mockFileInfo);
+    [mockFileInfo stopMocking];
+    [mockConfigurator stopMocking];
+    [mockRuleTable stopMocking];
+  }
+}
+
+- (void)testDecisionBlocksFreshCodesignValidationFailure {
+  // A signature failure is not recorded, so it must be re-derived on every
+  // execution. Also the only coverage of the fresh failure path.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  OCMStub([mockConfigurator enableBadSignatureProtection]).andReturn(YES);
+  processor.configurator = mockConfigurator;
+
+  NSError* csError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                         code:errSecCSSignatureFailed
+                                     userInfo:nil];
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMExpect([mockFileInfo codesignCheckerWithError:[OCMArg setTo:csError]]).andReturn(nil);
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+  OCMStub([mockFileInfo SHA256])
+      .andReturn(@"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e");
+
+  es_file_t file = MakeESFile("/tmp/invalid-signature");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  proc.codesigning_flags = CS_SIGNED;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                           targetProcess:&proc
+                                             configState:configState
+                                      activationCallback:nil
+                                          cachedDecision:nil];
+
+  XCTAssertEqual(cd.decision, SNTEventStateBlockCertificate);
+  XCTAssertEqual(cd.signingStatus, SNTSigningStatusInvalid);
+  XCTAssertEqualObjects(cd.decisionExtra,
+                        ([NSString stringWithFormat:@"Blocked due to signature error: %ld",
+                                                    (long)errSecCSSignatureFailed]));
+  // The failure must NOT be recorded: the next execution has to re-derive it.
+  XCTAssertNil(cd.codesignValidationStatus);
+  OCMVerifyAll(mockFileInfo);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
+}
+
+- (void)testDecisionDoesNotBlockReusedUnsignedValidation {
+  // errSecCSUnsigned is carved out of bad signature protection: an unsigned
+  // binary is not a signature failure. Without that carve-out the setting
+  // would block every unsigned binary on the endpoint.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  OCMStub([mockConfigurator enableBadSignatureProtection]).andReturn(YES);
+  processor.configurator = mockConfigurator;
+
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMReject([mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]]);
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+  cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+  cached.codesignValidationStatus = @(errSecCSUnsigned);
+
+  es_file_t file = MakeESFile("/tmp/unsigned-tool");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  proc.codesigning_flags = 0;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                           targetProcess:&proc
+                                             configState:configState
+                                      activationCallback:nil
+                                          cachedDecision:cached];
+
+  XCTAssertEqual(cd.decision, SNTEventStateAllowUnknown);
+  XCTAssertEqual(cd.signingStatus, SNTSigningStatusUnsigned);
+  // The failure replay must still happen even though the block does not. These
+  // two are easy to conflate when editing that region, so both are pinned.
+  XCTAssertEqualObjects(
+      cd.decisionExtra,
+      ([NSString stringWithFormat:@"Signature ignored due to error: %ld", (long)errSecCSUnsigned]));
+  OCMVerifyAll(mockFileInfo);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
+}
+
+- (void)testDecisionRecordsFreshUnsignedValidation {
+  // errSecCSUnsigned is reusable, so a fresh unsigned verdict must be recorded
+  // for the next execution to skip.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  processor.configurator = mockConfigurator;
+
+  NSError* csError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                         code:errSecCSUnsigned
+                                     userInfo:nil];
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMExpect([mockFileInfo codesignCheckerWithError:[OCMArg setTo:csError]]).andReturn(nil);
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+  OCMStub([mockFileInfo SHA256])
+      .andReturn(@"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e");
+
+  es_file_t file = MakeESFile("/tmp/unsigned-tool");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  proc.codesigning_flags = 0;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                           targetProcess:&proc
+                                             configState:configState
+                                      activationCallback:nil
+                                          cachedDecision:nil];
+
+  XCTAssertEqualObjects(cd.codesignValidationStatus, @(errSecCSUnsigned));
+  XCTAssertEqual(cd.decision, SNTEventStateAllowUnknown);
+  XCTAssertEqual(cd.signingStatus, SNTSigningStatusUnsigned);
+  OCMVerifyAll(mockFileInfo);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
+}
+
+- (void)testDecisionDoesNotRecordUnsignedVerdictWhenKernelSaysSigned {
+  // errSecCSUnsigned is only reusable when the kernel agrees the executable
+  // itself carries no signature. When the running image is signed the two
+  // sources disagree, so the verdict must not be recorded and the next
+  // execution has to re-derive it.
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  processor.configurator = mockConfigurator;
+
+  NSError* csError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                         code:errSecCSUnsigned
+                                     userInfo:nil];
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  OCMExpect([mockFileInfo codesignCheckerWithError:[OCMArg setTo:csError]]).andReturn(nil);
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+  OCMStub([mockFileInfo SHA256])
+      .andReturn(@"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e");
+
+  es_file_t file = MakeESFile("/tmp/signed-tool");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  // The kernel loaded a valid signature for this executable, contradicting the
+  // static unsigned verdict.
+  proc.codesigning_flags = CS_SIGNED | CS_VALID;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                           targetProcess:&proc
+                                             configState:configState
+                                      activationCallback:nil
+                                          cachedDecision:nil];
+
+  XCTAssertNil(cd.codesignValidationStatus);
+  // The failure effects still apply; only the recording is withheld.
+  XCTAssertEqual(cd.signingStatus, SNTSigningStatusInvalid);
+  XCTAssertEqualObjects(
+      cd.decisionExtra,
+      ([NSString stringWithFormat:@"Signature ignored due to error: %ld", (long)errSecCSUnsigned]));
+  OCMVerifyAll(mockFileInfo);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
 }
 
 - (void)testCELDecisions {


### PR DESCRIPTION
`SNTPolicyProcessor` decided whether to run static code signature validation by checking for an empty `certSHA256`, which is always empty for ad-hoc and linker-signed binaries. Non-cacheable CEL decisions therefore repeated full validation on every execution of the same binary — measured at ~250ms per exec for a 54MB ad-hoc binary, ~13ms for a 6MB one, with no per-file memoization below us to soften it. That cost lands on the exec authorization path.

`SNTCachedDecision` now records the `OSStatus` validation returned; the guard keys on that, and failure effects are replayed from it so a reused failure behaves identically to a fresh one. Skipping validation on reuse loses nothing: every field `UpdateCachedDecisionSigningInfo` writes is already carried by `initWithCachedIdentity:`.

Only outcomes that cannot change while the identity is valid are recorded — a success, or an unsigned verdict that static validation and the kernel's `codesigning_flags` agree describes this executable. Any other failure is re-derived on the next execution, so a failure that may depend on state outside this vnode cannot pin the identity.
