### PR TITLE
MOLCodesignChecker: Fix the initWithSecStaticCodeRef: initializers

### DIFF
--- a/Source/common/MOLCodesignChecker.h
+++ b/Source/common/MOLCodesignChecker.h
@@ -116,18 +116,18 @@
 /**
   Designated initializer
 
-  @note Takes ownership of `codeRef`.
+  @note Retains `codeRef`; the caller keeps ownership of its own reference.
 
   @param codeRef A `SecStaticCodeRef` or `SecCodeRef` representing a binary.
   @param error NSError to be filled in if validation fails for any reason.
-  @return An initialized `MOLCodesignChecker`
+  @return An initialized `MOLCodesignChecker`, or nil if `codeRef` is not a code object.
 */
 - (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef error:(NSError**)error;
 
 /**
   Initialize with a SecStaticCodeRef (or SecCodeRef);
 
-  @note Takes ownership of `codeRef`.
+  @note Retains `codeRef`; the caller keeps ownership of its own reference.
 
   @param codeRef A `SecStaticCodeRef` or `SecCodeRef` representing a binary.
   @return An initialized `MOLCodesignChecker` or nil if validation failed.

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -80,6 +80,12 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 @property SecCSFlags staticSigningFlags;
 
 - (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef
+                              binaryPath:(NSString*)binaryPath
+                          fileDescriptor:(int)fileDescriptor
+                      staticSigningFlags:(SecCSFlags)staticSigningFlags
+                                   error:(NSError**)error;
+
+- (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef
                       staticSigningFlags:(SecCSFlags)staticSigningFlags
                                    error:(NSError**)error;
 
@@ -100,30 +106,51 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 - (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef
                       staticSigningFlags:(SecCSFlags)staticSigningFlags
                                    error:(NSError**)error {
+  return [self initWithSecStaticCodeRef:codeRef
+                             binaryPath:nil
+                         fileDescriptor:-1
+                     staticSigningFlags:staticSigningFlags
+                                  error:error];
+}
+
+- (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef
+                              binaryPath:(NSString*)binaryPath
+                          fileDescriptor:(int)fileDescriptor
+                      staticSigningFlags:(SecCSFlags)staticSigningFlags
+                                   error:(NSError**)error {
   self = [super init];
 
   if (self) {
+    // Security dereferences the ref without type checking it first, so a ref that isn't code
+    // can't be wrapped: every accessor here would crash inside Security.
+    BOOL isStaticCode = codeRef && CFGetTypeID(codeRef) == SecStaticCodeGetTypeID();
+    BOOL isCode = codeRef && CFGetTypeID(codeRef) == SecCodeGetTypeID();
+    if (!isStaticCode && !isCode) {
+      if (error) {
+        *error = [self errorWithCode:errSecUnimplemented description:@"Invalid code ref type"];
+      }
+      return nil;
+    }
+
+    // Assign before anything else: the checks below reach code that reads self.codeRef.
+    _codeRef = codeRef;
+    CFRetain(_codeRef);
+    _binaryPath = binaryPath;
+    _binaryFileDescriptor = fileDescriptor;
     _staticSigningFlags = staticSigningFlags;
 
     auto [status, scopedError] = ScopedCFError::AssumeFrom(^OSStatus(CFErrorRef* out) {
-      if (CFGetTypeID(codeRef) == SecStaticCodeGetTypeID()) {
+      if (isStaticCode) {
         return SecStaticCodeCheckValidityWithErrors(codeRef, staticSigningFlags, NULL, out);
-      } else if (CFGetTypeID(codeRef) == SecCodeGetTypeID()) {
-        return SecCodeCheckValidityWithErrors((SecCodeRef)codeRef, kSigningFlags, NULL, out);
-      } else {
-        OSStatus status = errSecUnimplemented;
-        *out = (CFErrorRef)CFBridgingRetain([self errorWithCode:status
-                                                    description:@"Invalid code ref type"]);
-        return status;
       }
+      return SecCodeCheckValidityWithErrors((SecCodeRef)codeRef, kSigningFlags, NULL, out);
     });
 
     // For static code checks perform additional checks across all slices
-    if (CFGetTypeID(codeRef) == SecStaticCodeGetTypeID()) {
+    if (isStaticCode) {
       // Ensure signing is consistent for all architectures.
       // Any issues found here take precedence over already found issues.
-      if (!_binaryPath) _binaryPath = [self binaryPathForCodeRef:self.codeRef];
-      NSArray* infos = [self universalSigningInformationForBinaryPath:_binaryPath
+      NSArray* infos = [self universalSigningInformationForBinaryPath:self.binaryPath
                                                        fileDescriptor:_binaryFileDescriptor];
       if (infos) _universalSigningInformation = infos;
       if (infos && ![self allSigningInformationMatches:infos]) {
@@ -152,8 +179,6 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
     if (status != errSecSuccess) {
       if (error) *error = err ?: [self errorWithCode:status];
     }
-    _codeRef = codeRef;
-    CFRetain(_codeRef);
   }
   return self;
 }
@@ -209,10 +234,11 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
     return nil;
   }
 
-  _binaryPath = binaryPath;
-  _binaryFileDescriptor = (fileDescriptor != -1) ? fileDescriptor : -1;
-
-  self = [self initWithSecStaticCodeRef:codeRef staticSigningFlags:staticSigningFlags error:error];
+  self = [self initWithSecStaticCodeRef:codeRef
+                             binaryPath:binaryPath
+                         fileDescriptor:fileDescriptor
+                     staticSigningFlags:staticSigningFlags
+                                  error:error];
   if (codeRef) CFRelease(codeRef);  // it was retained above
   return self;
 }
@@ -319,10 +345,13 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 }
 
 - (NSString*)binaryPathForCodeRef:(SecStaticCodeRef)codeRef {
-  CFURLRef path;
+  CFURLRef path = NULL;
   OSStatus status = SecCodeCopyPath(codeRef, kSecCSDefaultFlags, &path);
+  if (status != errSecSuccess) {
+    if (path) CFRelease(path);
+    return nil;
+  }
   NSURL* pathURL = CFBridgingRelease(path);
-  if (status != errSecSuccess) return nil;
   return [pathURL path];
 }
 
@@ -550,6 +579,7 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 }
 
 - (NSDictionary*)architectureAndOffsetsForUniversalBinaryPath:(NSString*)path {
+  if (!path) return nil;
   int fd = open(path.UTF8String, O_RDONLY | O_CLOEXEC);
   if (fd == -1) return nil;
   NSDictionary* offsets = [self architectureAndOffsetsForFileDescriptor:fd];

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -87,6 +87,7 @@
   XCTAssertEqual(SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:path],
                                              kSecCSDefaultFlags, &codeRef),
                  errSecSuccess);
+  if (!codeRef) return;
 
   NSError* error;
   MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithSecStaticCodeRef:codeRef
@@ -113,6 +114,7 @@
   XCTAssertEqual(SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:path],
                                              kSecCSDefaultFlags, &codeRef),
                  errSecSuccess);
+  if (!codeRef) return;
 
   error = nil;
   MOLCodesignChecker* byCodeRef = [[MOLCodesignChecker alloc] initWithSecStaticCodeRef:codeRef

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -79,6 +79,69 @@
   XCTAssertNotNil(error);
 }
 
+- (void)testInitWithSecStaticCodeRef {
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"signed-with-teamid" ofType:@""];
+
+  SecStaticCodeRef codeRef = NULL;
+  XCTAssertEqual(SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:path],
+                                             kSecCSDefaultFlags, &codeRef),
+                 errSecSuccess);
+
+  NSError* error;
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithSecStaticCodeRef:codeRef
+                                                                           error:&error];
+  // The checker retains codeRef, so the caller's reference is theirs to drop.
+  CFRelease(codeRef);
+
+  XCTAssertNotNil(sut);
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(sut.binaryPath, path);
+  XCTAssertEqualObjects(sut.cdhash, @"23cbe7039ac34bf26f0b1ccc22ff96d6f0d80b72");
+}
+
+- (void)testInitWithSecStaticCodeRefUniversalSigningInformation {
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* path = [bundle pathForResource:@"yikes-universal_signed" ofType:@""];
+
+  NSError* error;
+  MOLCodesignChecker* byPath = [[MOLCodesignChecker alloc] initWithBinaryPath:path error:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(byPath.universalSigningInformation);
+
+  SecStaticCodeRef codeRef = NULL;
+  XCTAssertEqual(SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:path],
+                                             kSecCSDefaultFlags, &codeRef),
+                 errSecSuccess);
+
+  error = nil;
+  MOLCodesignChecker* byCodeRef = [[MOLCodesignChecker alloc] initWithSecStaticCodeRef:codeRef
+                                                                                 error:&error];
+  CFRelease(codeRef);
+
+  XCTAssertNil(error);
+  XCTAssertNotNil(byCodeRef.universalSigningInformation);
+  XCTAssertEqualObjects(
+      [self architecturesFromSigningInformation:byCodeRef.universalSigningInformation],
+      [self architecturesFromSigningInformation:byPath.universalSigningInformation]);
+}
+
+- (void)testInitWithSecStaticCodeRefOfWrongType {
+  NSError* error;
+  MOLCodesignChecker* sut =
+      [[MOLCodesignChecker alloc] initWithSecStaticCodeRef:(SecStaticCodeRef)CFSTR("not a code ref")
+                                                     error:&error];
+  XCTAssertNil(sut);
+  XCTAssertEqual(error.code, errSecUnimplemented);
+}
+
+- (void)testInitWithNullSecStaticCodeRef {
+  NSError* error;
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithSecStaticCodeRef:NULL error:&error];
+  XCTAssertNil(sut);
+  XCTAssertEqual(error.code, errSecUnimplemented);
+}
+
 - (void)testInitWithPID {
   MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithPID:1];
   XCTAssertNotNil(sut);
@@ -270,6 +333,15 @@
   [wantedEntitlements enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL* stop) {
     XCTAssertEqualObjects(sut.entitlements[key], value);
   }];
+}
+
+/// Sorted architecture names from a `universalSigningInformation` array.
+- (NSArray*)architecturesFromSigningInformation:(NSArray*)signingInformation {
+  NSMutableArray* archs = [NSMutableArray arrayWithCapacity:signingInformation.count];
+  for (NSDictionary* arch in signingInformation) {
+    [archs addObject:arch.allKeys.firstObject];
+  }
+  return [archs sortedArrayUsingSelector:@selector(compare:)];
 }
 
 @end


### PR DESCRIPTION
The `initWithSecStaticCodeRef:` initializers have no in-tree callers and are broken for external ones: `_codeRef` is read before it is assigned, so the universal-binary check passes NULL to `binaryPathForCodeRef:`, which releases an uninitialized `CFURLRef` out-param; `_binaryFileDescriptor` defaults to 0, so that same check reads the fat header from stdin (silently skips, hangs on a tty, or reports a valid binary as inconsistently signed depending on what stdin is); and a ref that isn't a code object is detected but still handed to Security, which dereferences it without a type check. Ref, path and fd now come in through one designated initializer and are assigned up front, an invalid ref returns nil, and `binaryPathForCodeRef:` bridges the out-param only on success. Each of the new tests crashed the test runner before the fix.