### PR TITLE
Rank transitive rules below every configured rule type

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -106,8 +106,9 @@
 
 ///
 ///  @return Rule for given identifiers.
-///          Currently: binary, signingID, certificate or teamID (in that order).
-///          The first matching rule found is returned.
+///          Precedence: CDHash, binary, signingID, certificate, teamID, with
+///          transitive binary rules ranked after all of them.
+///          The highest-precedence matching rule is returned.
 ///
 - (SNTRule*)executionRuleForIdentifiers:(struct RuleIdentifiers)identifiers;
 

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -579,34 +579,40 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 
   // Now query the database.
   //
-  // The intended order of precedence is CDHash > Binaries > Signing IDs > Certificates > Team IDs.
-  // The UNION ALL structure lets SQLite evaluate each sub-select independently (potentially
-  // short-circuiting via LIMIT 1), while ORDER BY type ASC guarantees the highest-priority
-  // rule is returned regardless of query planner behavior.
+  // The intended order of precedence is
+  // CDHash > Binaries > Signing IDs > Certificates > Team IDs > transitive Binaries.
   //
-  // There is a test for this in SNTRuleTableTests in case SQLite behavior changes in the future.
+  // Transitive rules sort last because they are not a statement of policy: they are written
+  // locally by SNTCompilerController for whatever a compiler happened to produce, which makes
+  // them an allowance of last resort that must not shadow a rule an admin actually configured.
   //
+  // The UNION ALL structure lets SQLite evaluate each sub-select independently, while
+  // ORDER BY prio ASC guarantees the highest-priority rule is returned regardless of query
+  // planner behavior. `prio` is a constant per sub-select rather than an expression over `state`
+  // so that the compound query stays naturally ordered: SQLite then plans this as a streaming
+  // MERGE over indexed lookups. An equivalent `ORDER BY CASE WHEN state=... END` is opaque to the
+  // planner and costs a temp B-tree sort on every lookup.
+  //
+  // clang-format off
   [self inDatabase:^(FMDatabase* db) {
-    FMResultSet* rs =
-        [db executeQuery:@"SELECT * FROM ("
-                         @"  SELECT * FROM execution_rules WHERE identifier=? AND type=500 "
-                         @"  UNION ALL "
-                         @"  SELECT * FROM execution_rules WHERE identifier=? AND type=1000 "
-                         @"  UNION ALL "
-                         @"  SELECT * FROM execution_rules WHERE identifier=? AND type=2000 "
-                         @"  UNION ALL "
-                         @"  SELECT * FROM execution_rules WHERE identifier=? AND type=3000 "
-                         @"  UNION ALL "
-                         @"  SELECT * FROM execution_rules WHERE identifier=? AND type=4000"
-                         @") ORDER BY type ASC LIMIT 1",
-                         identifiers.cdhash, identifiers.binarySHA256, identifiers.signingID,
-                         identifiers.certificateSHA256, identifiers.teamID];
+    FMResultSet* rs = [db executeQuery:@"SELECT * FROM ("
+                                      @"            SELECT 1 AS prio, * FROM execution_rules WHERE identifier=? AND type=500  "
+                                      @"  UNION ALL SELECT 2 AS prio, * FROM execution_rules WHERE identifier=? AND type=1000 AND state<>? "
+                                      @"  UNION ALL SELECT 3 AS prio, * FROM execution_rules WHERE identifier=? AND type=2000 "
+                                      @"  UNION ALL SELECT 4 AS prio, * FROM execution_rules WHERE identifier=? AND type=3000 "
+                                      @"  UNION ALL SELECT 5 AS prio, * FROM execution_rules WHERE identifier=? AND type=4000 "
+                                      @"  UNION ALL SELECT 6 AS prio, * FROM execution_rules WHERE identifier=? AND type=1000 AND state=?"
+                                      @") ORDER BY prio ASC LIMIT 1",
+                                      identifiers.cdhash, identifiers.binarySHA256,
+                                      @(SNTRuleStateAllowTransitive), identifiers.signingID,
+                                      identifiers.certificateSHA256, identifiers.teamID,
+                                      identifiers.binarySHA256, @(SNTRuleStateAllowTransitive)];
     if ([rs next]) {
       rule = [self executionRuleFromResultSet:rs];
     }
     [rs close];
   }];
-
+  // clang-format on
   return rule;
 }
 
@@ -966,9 +972,9 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   [self inTransaction:^(FMDatabase* db, BOOL* rollback) {
     for (SNTRule* rule in rules) {
       if (rule.state != SNTRuleStateAllow) {
-        // If the rule is a CEL rule, block rule, silent block rule, or a compiler rule check if it
-        // already exists in the database. If it is a CEL rule also check the expression is the
-        // same.
+        // If the rule is a CEL rule, block rule, silent block rule, or a compiler rule check if
+        // it already exists in the database. If it is a CEL rule also check the expression is
+        // the same.
         //
         // If it does not then flush the cache. To ensure that the new rule is honored.
         if ([db longForQuery:
@@ -985,11 +991,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
         // Skip certificate and TeamID rules as they cannot be compiler rules.
         if (rule.type == SNTRuleTypeCertificate || rule.type == SNTRuleTypeTeamID) continue;
 
-        if ([db longForQuery:
-                    @"SELECT COUNT(*) FROM execution_rules WHERE identifier=? AND type IN (?, ?, ?)"
-                    @" AND state=? LIMIT 1",
-                    rule.identifier, @(SNTRuleTypeCDHash), @(SNTRuleTypeBinary),
-                    @(SNTRuleTypeSigningID), @(SNTRuleStateAllowCompiler)] > 0) {
+        if ([db longForQuery:@"SELECT COUNT(*) FROM execution_rules WHERE identifier=? AND type "
+                             @"IN (?, ?, ?)"
+                             @" AND state=? LIMIT 1",
+                             rule.identifier, @(SNTRuleTypeCDHash), @(SNTRuleTypeBinary),
+                             @(SNTRuleTypeSigningID), @(SNTRuleStateAllowCompiler)] > 0) {
           flushDecisionCache = YES;
           return;
         }
@@ -1084,8 +1090,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   }
 
   // Column order: 0=name, 1=rule_id, 2=rule_blob. Both `name` (field 1) and `rule_id` (field 2)
-  // of the NetworkFlowRule.Add proto are already part of rule_blob, so the hash need only fold in
-  // the blob bytes; ordering by name ASC makes it deterministic.
+  // of the NetworkFlowRule.Add proto are already part of rule_blob, so the hash need only fold
+  // in the blob bytes; ordering by name ASC makes it deterministic.
   santa::Xxhash128 h;
   FMResultSet* rs = [db executeQuery:@"SELECT name, rule_id, rule_blob FROM network_flow_rules "
                                      @"ORDER BY name ASC"];
@@ -1255,7 +1261,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 
 - (NSString*)networkFlowRulesHashSerialized:(FMDatabase*)db {
   // Shares the single scan/filter used to materialize the ruleset, so this hash and the
-  // snapshot's hash can never drift apart. See -networkFlowRulesHashSerializedInDB:collectInto:.
+  // snapshot's hash can never drift apart. See
+  // -networkFlowRulesHashSerializedInDB:collectInto:.
   return [self networkFlowRulesHashSerializedInDB:db collectInto:nil];
 }
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -114,6 +114,15 @@
   return r;
 }
 
+- (SNTRule*)_exampleSigningIDCompilerRule {
+  SNTRule* r = [[SNTRule alloc] init];
+  r.identifier = @"ABCDEFGHIJ:signingID";
+  r.state = SNTRuleStateAllowCompiler;
+  r.type = SNTRuleTypeSigningID;
+  r.customMsg = @"A signingID compiler rule";
+  return r;
+}
+
 - (SNTRule*)_exampleCertRule {
   SNTRule* r = [[SNTRule alloc] init];
   r.identifier = @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258";
@@ -589,6 +598,284 @@
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID, @"Implicit rule ordering failed (TeamID)");
+}
+
+// A transitive rule is not a statement of policy -- SNTCompilerController writes one for
+// whatever a compiler produced -- so it must lose to every configured rule type, including the
+// Binary slot it nominally occupies.
+//
+// The writer cannot be relied on to prevent the overlap: its existing-rule guard looks up only
+// .binarySHA256, so a Signing ID / Certificate / Team ID rule covering the same executable is
+// invisible to it and the transitive rule is written regardless.
+- (void)testFetchRuleOrderingTransitiveLosesToEveryConfiguredType {
+  NSArray<NSError*>* err;
+  [self.sut addExecutionRules:@[
+    [self _exampleTransitiveRule],
+    [self _exampleCDHashRule],
+    [self _exampleSigningIDRuleIsPlatform:NO],
+    [self _exampleCertRule],
+    [self _exampleTeamIDRule],
+  ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:&err];
+  XCTAssertNil(err);
+
+  // Only sqlite's behavior is under test here. Ensure static rules are ignored.
+  [self.sut updateStaticRules:nil];
+
+  NSString* transitiveID = [self _exampleTransitiveRule].identifier;
+
+  // Each case pairs the transitive Binary rule with exactly one configured rule. The configured
+  // rule must win every time, even Team ID -- the lowest-priority type there is.
+  NSArray<NSDictionary*>* cases = @[
+    @{
+      @"name" : @"CDHash",
+      @"ids" : [[SNTRuleIdentifiers alloc]
+          initWithRuleIdentifiers:(struct RuleIdentifiers){
+                                      .cdhash = @"dbe8c39801f93e05fc7bc53a02af5b4d3cfc670a",
+                                      .binarySHA256 = transitiveID,
+                                  }],
+      @"wantType" : @(SNTRuleTypeCDHash),
+      @"wantID" : @"dbe8c39801f93e05fc7bc53a02af5b4d3cfc670a",
+    },
+    @{
+      @"name" : @"SigningID",
+      @"ids" : [[SNTRuleIdentifiers alloc]
+          initWithRuleIdentifiers:(struct RuleIdentifiers){
+                                      .binarySHA256 = transitiveID,
+                                      .signingID = @"ABCDEFGHIJ:signingID",
+                                  }],
+      @"wantType" : @(SNTRuleTypeSigningID),
+      @"wantID" : @"ABCDEFGHIJ:signingID",
+    },
+    @{
+      @"name" : @"Certificate",
+      @"ids" : [[SNTRuleIdentifiers alloc]
+          initWithRuleIdentifiers:
+              (struct RuleIdentifiers){
+                  .binarySHA256 = transitiveID,
+                  .certificateSHA256 =
+                      @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+              }],
+      @"wantType" : @(SNTRuleTypeCertificate),
+      @"wantID" : @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+    },
+    @{
+      @"name" : @"TeamID",
+      @"ids" : [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:(struct RuleIdentifiers){
+                                                                       .binarySHA256 = transitiveID,
+                                                                       .teamID = @"ABCDEFGHIJ",
+                                                                   }],
+      @"wantType" : @(SNTRuleTypeTeamID),
+      @"wantID" : @"ABCDEFGHIJ",
+    },
+  ];
+
+  for (NSDictionary* testCase in cases) {
+    SNTRule* r =
+        [self.sut executionRuleForIdentifiers:[(SNTRuleIdentifiers*)testCase[@"ids"] toStruct]];
+    XCTAssertNotNil(r, @"%@: no rule returned", testCase[@"name"]);
+    XCTAssertEqual(r.type, (SNTRuleType)[testCase[@"wantType"] integerValue],
+                   @"%@ rule must outrank a transitive Binary rule", testCase[@"name"]);
+    XCTAssertEqualObjects(r.identifier, testCase[@"wantID"], @"%@: wrong rule returned",
+                          testCase[@"name"]);
+    XCTAssertNotEqual(r.state, SNTRuleStateAllowTransitive, @"%@: transitive rule was not demoted",
+                      testCase[@"name"]);
+  }
+
+  // Demotion must not mean "unreachable". With nothing else matching, the transitive rule is
+  // still the answer -- that is the whole point of transitive allowlisting.
+  SNTRule* r = [self.sut executionRuleForIdentifiers:(struct RuleIdentifiers){
+                                                         .cdhash = @"unknown",
+                                                         .binarySHA256 = transitiveID,
+                                                         .signingID = @"unknown",
+                                                         .certificateSHA256 = @"unknown",
+                                                         .teamID = @"unknown",
+                                                     }];
+  XCTAssertNotNil(r);
+  XCTAssertEqualObjects(r.identifier, transitiveID);
+  XCTAssertEqual(r.type, SNTRuleTypeBinary);
+  XCTAssertEqual(r.state, SNTRuleStateAllowTransitive,
+                 @"a transitive rule must still match when nothing else does");
+}
+
+// The GOTOOLCHAIN=auto case from https://github.com/northpolesec/santa/issues/1123. A compiler
+// unpacked by another compiler gets a transitive Binary rule written for it. If that rule
+// outranks the Signing ID ALLOWLIST_COMPILER rule covering the same executable, the new compiler
+// silently stops being treated as a compiler and everything it builds is blocked.
+- (void)testFetchRuleOrderingTransitiveDoesNotShadowCompilerRule {
+  NSArray<NSError*>* err;
+  [self.sut addExecutionRules:@[
+    [self _exampleSigningIDCompilerRule],
+    [self _exampleTransitiveRule],
+  ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:&err];
+  XCTAssertNil(err);
+  [self.sut updateStaticRules:nil];
+
+  SNTRule* r = [self.sut
+      executionRuleForIdentifiers:(struct RuleIdentifiers){
+                                      .binarySHA256 = [self _exampleTransitiveRule].identifier,
+                                      .signingID = @"ABCDEFGHIJ:signingID",
+                                  }];
+  XCTAssertNotNil(r);
+  XCTAssertEqual(r.type, SNTRuleTypeSigningID);
+  XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ:signingID");
+  XCTAssertEqual(r.state, SNTRuleStateAllowCompiler,
+                 @"a transitive rule must not downgrade a compiler rule to a transitive allow");
+}
+
+// The configured rule must win regardless of its state, not just when it is a compiler rule.
+// Covers Signing ID, Certificate and Team ID, whose state is asserted to survive the lookup
+// unchanged -- none of these types could win under the pre-fix Binary-typed ordering.
+- (void)testFetchRuleOrderingConfiguredRuleStateIsPreserved {
+  NSArray<NSError*>* err;
+  // _exampleCertRule shares its state with the other fixtures, so a distinctly-stated
+  // Certificate rule is built here rather than reused -- without it a regression that demoted
+  // transitive below SigningID/TeamID but not below Certificate would slip through.
+  SNTRule* certRule = [[SNTRule alloc] init];
+  certRule.identifier = @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258";
+  certRule.state = SNTRuleStateBlock;
+  certRule.type = SNTRuleTypeCertificate;
+
+  [self.sut addExecutionRules:@[
+    [self _exampleTransitiveRule],
+    [self _exampleSigningIDRuleIsPlatform:NO],
+    certRule,
+    [self _exampleTeamIDRule],
+  ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:&err];
+  XCTAssertNil(err);
+  [self.sut updateStaticRules:nil];
+
+  NSString* transitiveID = [self _exampleTransitiveRule].identifier;
+
+  NSArray<NSDictionary*>* cases = @[
+    @{
+      @"name" : @"SigningID",
+      @"ids" : [[SNTRuleIdentifiers alloc]
+          initWithRuleIdentifiers:(struct RuleIdentifiers){
+                                      .binarySHA256 = transitiveID,
+                                      .signingID = @"ABCDEFGHIJ:signingID",
+                                  }],
+      @"wantType" : @(SNTRuleTypeSigningID),
+    },
+    @{
+      @"name" : @"Certificate",
+      @"ids" : [[SNTRuleIdentifiers alloc]
+          initWithRuleIdentifiers:
+              (struct RuleIdentifiers){
+                  .binarySHA256 = transitiveID,
+                  .certificateSHA256 =
+                      @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+              }],
+      @"wantType" : @(SNTRuleTypeCertificate),
+    },
+    @{
+      @"name" : @"TeamID",
+      @"ids" : [[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:(struct RuleIdentifiers){
+                                                                       .binarySHA256 = transitiveID,
+                                                                       .teamID = @"ABCDEFGHIJ",
+                                                                   }],
+      @"wantType" : @(SNTRuleTypeTeamID),
+    },
+  ];
+
+  for (NSDictionary* testCase in cases) {
+    SNTRule* r =
+        [self.sut executionRuleForIdentifiers:[(SNTRuleIdentifiers*)testCase[@"ids"] toStruct]];
+    XCTAssertNotNil(r, @"%@: no rule returned", testCase[@"name"]);
+    XCTAssertEqual(r.state, SNTRuleStateBlock, @"%@ rule state must survive the lookup",
+                   testCase[@"name"]);
+    XCTAssertEqual(r.type, (SNTRuleType)[testCase[@"wantType"] integerValue],
+                   @"%@: wrong rule type returned", testCase[@"name"]);
+  }
+}
+
+// Guard against over-correcting the above by demoting the whole Binary slot. Only the transitive
+// state is demoted; an ordinary Binary rule keeps outranking Signing ID / Certificate / Team ID.
+- (void)testFetchRuleOrderingNonTransitiveBinaryStillOutranksSigningID {
+  NSArray<NSError*>* err;
+  [self.sut addExecutionRules:@[
+    [self _exampleBinaryRule],
+    [self _exampleSigningIDRuleIsPlatform:NO],
+    [self _exampleCertRule],
+    [self _exampleTeamIDRule],
+  ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:&err];
+  XCTAssertNil(err);
+  [self.sut updateStaticRules:nil];
+
+  SNTRule* r = [self.sut
+      executionRuleForIdentifiers:
+          (struct RuleIdentifiers){
+              .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+              .signingID = @"ABCDEFGHIJ:signingID",
+              .certificateSHA256 =
+                  @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+              .teamID = @"ABCDEFGHIJ",
+          }];
+  XCTAssertNotNil(r);
+  XCTAssertEqual(r.type, SNTRuleTypeBinary,
+                 @"only the transitive state is demoted, not the Binary type");
+  XCTAssertEqualObjects(r.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+}
+
+// executionRuleForIdentifiers: sorts on a literal aliased `prio` inside a subquery whose inner
+// selects use `*`. If execution_rules ever gains its own `prio` column, that column lands in the
+// subquery output alongside the alias and `ORDER BY prio` has two candidates -- SQLite takes the
+// first, so the alias is selected before the `*` to stay ahead of it. This test fails if such a
+// column is ever added, so the ambiguity has to be dealt with deliberately rather than silently
+// re-sorting rule precedence by unrelated row data.
+- (void)testExecutionRulesHasNoColumnNamedPrio {
+  __block NSMutableArray<NSString*>* columns = [NSMutableArray array];
+  [self.sut inDatabase:^(FMDatabase* db) {
+    FMResultSet* rs = [db executeQuery:@"PRAGMA table_info(execution_rules)"];
+    while ([rs next]) {
+      [columns addObject:[rs stringForColumn:@"name"]];
+    }
+    [rs close];
+  }];
+
+  XCTAssertGreaterThan(columns.count, 0, @"could not read execution_rules schema");
+  XCTAssertFalse([columns containsObject:@"prio"],
+                 @"execution_rules gained a column named 'prio', which collides with the sort "
+                 @"alias in executionRuleForIdentifiers:. Rename one of them.");
+}
+
+// The transitive demotion is scoped to type=1000 because SNTCompilerController is the only writer
+// of transitive rules and always writes type Binary. This asserts the half of that invariant the
+// rule table can see: a transitive rule at another type would NOT be demoted, so if a new writer
+// ever introduces one, this test documents what breaks.
+- (void)testTransitiveDemotionIsScopedToBinaryType {
+  NSArray<NSError*>* err;
+  SNTRule* transitiveSigningID = [[SNTRule alloc] init];
+  transitiveSigningID.identifier = @"ABCDEFGHIJ:signingID";
+  transitiveSigningID.state = SNTRuleStateAllowTransitive;
+  transitiveSigningID.type = SNTRuleTypeSigningID;
+
+  [self.sut addExecutionRules:@[ transitiveSigningID, [self _exampleTeamIDRule] ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:&err];
+  XCTAssertNil(err);
+  [self.sut updateStaticRules:nil];
+
+  SNTRule* r = [self.sut executionRuleForIdentifiers:(struct RuleIdentifiers){
+                                                         .signingID = @"ABCDEFGHIJ:signingID",
+                                                         .teamID = @"ABCDEFGHIJ",
+                                                     }];
+  XCTAssertNotNil(r);
+  // Characterization, not an endorsement: a transitive rule stored at a non-Binary type keeps
+  // that type's precedence. Reaching this state requires a new writer of transitive rules, since
+  // no policy string parses to SNTRuleStateAllowTransitive. If that ever happens, extend the
+  // state split in executionRuleForIdentifiers: to the affected type.
+  XCTAssertEqual(r.type, SNTRuleTypeSigningID);
+  XCTAssertEqual(r.state, SNTRuleStateAllowTransitive,
+                 @"demotion is type-scoped; a non-Binary transitive rule is not demoted");
 }
 
 - (void)testBadDatabase {

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -601,6 +601,106 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
       expectedDecision:SNTEventStateAllowSigningID];
 }
 
+// Decision-level coverage for https://github.com/northpolesec/santa/issues/1123, driven through
+// a real SNTRuleTable so the actual lookup SQL is exercised. Every other test in this file mocks
+// the rule table or calls -decision:forRule:... directly, so none of them can catch a precedence
+// regression.
+//
+// Scenario: a Go toolchain is unpacked by an existing compiler. The compiler controller writes a
+// transitive Binary rule for the new `go`, which is also covered by a Signing ID
+// ALLOWLIST_COMPILER rule. Adding that transitive rule must not change the decision -- if the
+// Binary-typed transitive rule outranks the Signing ID rule, `go` silently stops being a compiler
+// and everything it builds is blocked.
+- (void)testDecisionTransitiveRuleDoesNotShadowSigningIDCompilerRule {
+  static NSString* const kSHA256 =
+      @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+  static NSString* const kTeamID = @"TEAMID1234";
+  static NSString* const kSigningID = @"TEAMID1234:com.example.go";
+
+  // Same assertion with and without the transitive rule present. The pair is the property:
+  // writing a transitive rule must be decision-neutral when a compiler rule already covers it.
+  for (NSNumber* withTransitiveRule in @[ @NO, @YES ]) {
+    FMDatabaseQueue* dbq = [[FMDatabaseQueue alloc] init];
+    SNTRuleTable* ruleTable = [[SNTRuleTable alloc] initWithDatabaseQueue:dbq];
+
+    // Partial mock so executionRuleForIdentifiers: runs for real. Only the lazy critical-binary
+    // scan is stubbed out -- it spins up an ES client and codesigns system paths, neither of
+    // which this test needs.
+    id partialRuleTable = OCMPartialMock(ruleTable);
+    OCMStub([partialRuleTable criticalSystemBinaries]).andReturn(@{});
+
+    NSMutableArray<SNTRule*>* rules = [NSMutableArray array];
+    SNTRule* compilerRule = [[SNTRule alloc] initWithDictionary:@{
+      @"rule_type" : @"SIGNINGID",
+      @"identifier" : kSigningID,
+      @"policy" : @"ALLOWLIST_COMPILER",
+    }
+                                                          error:nil];
+    XCTAssertNotNil(compilerRule, @"invalid test rule dictionary");
+    [rules addObject:compilerRule];
+
+    if (withTransitiveRule.boolValue) {
+      [rules addObject:[[SNTRule alloc] initWithIdentifier:kSHA256
+                                                     state:SNTRuleStateAllowTransitive
+                                                      type:SNTRuleTypeBinary]];
+    }
+
+    NSArray<NSError*>* errs;
+    XCTAssertTrue([ruleTable addExecutionRules:rules ruleCleanup:SNTRuleCleanupNone errors:&errs]);
+    XCTAssertNil(errs);
+    // Only the database query is under test; keep static rules out of it.
+    [ruleTable updateStaticRules:nil];
+
+    id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+    OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
+    OCMStub([mockConfigurator enableTransitiveRules]).andReturn(YES);
+
+    SNTPolicyProcessor* processor =
+        [[SNTPolicyProcessor alloc] initWithRuleTable:partialRuleTable
+                                   entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+    processor.configurator = mockConfigurator;
+
+    id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+    OCMStub([mockFileInfo isMachO]).andReturn(YES);
+    OCMStub([mockFileInfo SHA256]).andReturn(kSHA256);
+    // Signature validation is passed in as already-completed, so the identifiers the lookup sees
+    // are exactly the ones set below rather than whatever a real codesign check would produce.
+    OCMReject([mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]]);
+
+    SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+    cached.sha256 = kSHA256;
+    cached.signingID = kSigningID;
+    cached.teamID = kTeamID;
+    cached.codesignValidationStatus = @(errSecSuccess);
+
+    es_file_t file = MakeESFile("/tmp/go");
+    es_process_t proc = MakeESProcess(&file);
+    proc.is_platform_binary = false;
+    // CS_SIGNED|CS_VALID without ADHOC or DEV_CODE yields SNTSigningStatusProduction, which is
+    // what allows Signing ID rules to be considered at all.
+    proc.codesigning_flags = CS_SIGNED | CS_VALID;
+
+    SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+    SNTCachedDecision* cd = [processor decisionForFileInfo:mockFileInfo
+                                             targetProcess:&proc
+                                              imageCPUType:CPU_TYPE_ARM64
+                                               configState:configState
+                                        activationCallback:nil
+                                            cachedDecision:cached];
+
+    NSString* ctx = withTransitiveRule.boolValue ? @"with transitive rule" : @"baseline";
+    XCTAssertEqual(cd.decision, SNTEventStateAllowCompilerSigningID,
+                   @"%@: the SigningID compiler rule must win", ctx);
+    XCTAssertNotEqual(cd.decision, SNTEventStateAllowTransitive,
+                      @"%@: a transitive rule must not shadow the compiler rule", ctx);
+
+    [partialRuleTable stopMocking];
+    [mockConfigurator stopMocking];
+    [mockFileInfo stopMocking];
+  }
+}
+
 // Transitive allowlist rules
 - (void)testDecisionForTransitiveAllowlistRuleMatches {
   SNTRule* rule = [[SNTRule alloc]

--- a/Testing/OneOffs/RuleQueryBench.mm
+++ b/Testing/OneOffs/RuleQueryBench.mm
@@ -568,8 +568,9 @@ static BOOL QueryUnionAllOrderBy(FMDatabase* db, const LookupIdentifiers& ids) {
 // Demotes transitive rules below every other type by splitting the Binary sub-select on `state`
 // and sorting on a constant `prio` per sub-select. Because each prio is a literal, the compound
 // query is still naturally ordered and SQLite plans it as a streaming MERGE over indexed lookups
-// -- so LIMIT 1 short-circuits and sub-selects after the first match never execute. Costs one
-// extra index seek on (binarySHA256, 1000), but only on lookups that get far enough to run it.
+// with no temp B-tree sort. LIMIT 1 is not an early-out: the MERGE steps every branch to find the
+// first ordered row, so the extra index seek on (binarySHA256, 1000) is paid on every lookup --
+// see the note in the file header.
 static BOOL QueryUnionAllPrio(FMDatabase* db, const LookupIdentifiers& ids) {
   FMResultSet* rs = [db executeQuery:@"SELECT * FROM ("
                                      @"  SELECT 1 AS prio, * FROM execution_rules "

--- a/Testing/OneOffs/RuleQueryBench.mm
+++ b/Testing/OneOffs/RuleQueryBench.mm
@@ -21,14 +21,37 @@ Generate a test database:
 
 Run benchmarks with hyperfine:
   BENCH=bazel-bin/Testing/OneOffs/rule_query_bench
-  STRATEGIES=implicit,orderby,separate,unionall,unionallorderby
-  LOOKUPS=cdhash,teamid,miss,multimatch,mixed
+  STRATEGIES=none,implicit,orderby,separate,unionall,unionallorderby,unionallprio,unionallcase
+  LOOKUPS=cdhash,teamid,miss,multimatch,transitive,shadowed,mixed
   /opt/homebrew/bin/hyperfine --warmup 10 \
       --parameter-list strategy $STRATEGIES \
       --parameter-list lookup $LOOKUPS \
       "$BENCH -i 10000 -t {strategy} -l {lookup} -d /tmp/rule_bench.db"
 
+IMPORTANT -- how to turn a run into a per-query number:
+
+Each run measures whole-process time, which includes both a fixed cost (process launch, opening
+the DB) and a PER-ITERATION cost that is not the query (generating one random identifier set per
+iteration). Subtract the `none` strategy at the SAME `-i`, which pays both of those and runs no
+query:
+
+    per_query = (T(strategy, N) - T(none, N)) / N
+
+Do NOT use an `-i 1` run as the baseline. Identifier generation scales with `-i`, so an `-i 1`
+baseline removes almost none of it and what is left lands in the "per-query" figure instead.
+That mistake inflated the numbers recorded on SNT-391 by roughly 4x.
+
+Comparing two strategies at the same `-i` is also safe without any baseline, since the non-query
+cost is identical and cancels in the difference.
+
+Between-invocation drift on a loaded machine is ~0.3us/query, larger than the within-invocation
+standard error hyperfine reports. Deltas below ~0.5us/query need several independent hyperfine
+invocations pooled before they mean anything, and nothing else should be running.
+
 Strategies:
+  none            - Runs no query. Establishes the non-query cost (process launch, opening the
+                    DB, and the per-iteration identifier generation) for a given -i. Subtract it
+                    from another strategy at the same -i to recover the true per-query cost.
   implicit        - OR clauses + LIMIT 1, no ORDER BY. Relies on SQLite's query planner
                     evaluating OR clauses left-to-right -- empirically correct but not
                     guaranteed. A query planner change could silently break precedence.
@@ -44,16 +67,43 @@ Strategies:
   unionallorderby - UNION ALL of five selects wrapped in a subquery with ORDER BY type ASC
                     + LIMIT 1. Guaranteed correct by ORDER BY, and the UNION ALL structure
                     gives SQLite more optimization freedom than the flat OR approach.
+                    This was the production strategy before transitive rules were demoted.
+  unionallprio    - unionallorderby, but the Binary sub-select is split on `state` and the sort
+                    key is a constant `prio` per sub-select, so transitive Binary rules rank
+                    below every other type instead of ranking as Binary. Keeps the naturally
+                    ordered compound query (streaming MERGE, no temp B-tree) at the cost of one
+                    extra index seek on (binarySHA256, 1000), paid on EVERY lookup -- see the
+                    note below on LIMIT 1.
                     This is the strategy used in production (see SNTRuleTable.mm).
+  unionallcase    - Same demotion via ORDER BY CASE WHEN state=... over the original five
+                    sub-selects. Avoids the extra seek, but the sort key is opaque to the
+                    planner, so SQLite materializes the union and adds a temp B-tree sort.
+
+The last two exist because a transitive Binary rule must not outrank a configured Signing ID /
+Certificate / Team ID rule for the same executable -- see issue #1123, where a Go toolchain
+unpacked by another compiler stopped being treated as a compiler.
+
+LIMIT 1 is not an early-out. Under the MERGE (UNION ALL) plan SQLite steps every branch to
+determine which sorts first, so all of them do their index seek regardless of whether a
+higher-priority branch matched. Verified with a counting SQL function in the last branch: it is
+invoked even when the prio-1 CDHash branch matches. Consequently the strategies differ by a
+roughly CONSTANT amount across lookup types -- there is no "cheap" lookup that skips the extra
+work, and measured deltas being flat across lookup types is the expected result, not a bug in the
+measurement.
 
 Lookup types:
-  cdhash      - Hit on CDHash rule (highest priority, best case for short-circuit)
+  cdhash      - Hit on CDHash rule (highest priority)
   binary      - Hit on Binary rule
   signingid   - Hit on SigningID rule
   certificate - Hit on Certificate rule
-  teamid      - Hit on TeamID rule (lowest priority, worst case for short-circuit)
+  teamid      - Hit on TeamID rule (lowest priority)
   multimatch  - Hits on SigningID + Certificate + TeamID simultaneously (tests ordering correctness)
-  miss        - No matching rule exists
+  transitive  - Hit on a transitive Binary rule and nothing else. Exercises the extra sub-select
+                actually producing the winning row.
+  shadowed    - Hit on both a transitive Binary rule and a SigningID rule (the issue #1123 case).
+                unionall/unionallorderby return the transitive rule here; unionallprio and
+                unionallcase return the SigningID rule.
+  miss        - No matching rule exists.
   mixed       - Uniform random mix of all the above
 
 Note: Miss identifiers are randomly generated per-iteration to avoid B-tree page cache
@@ -82,6 +132,14 @@ static const int kRuleTypeCertificate = 3000;
 static const int kRuleTypeTeamID = 4000;
 
 static const int kRuleStateAllow = 1;
+static const int kRuleStateAllowTransitive = 6;
+
+// Fraction of generated Binary rules given state=AllowTransitive. Transitive rules are written
+// locally by the compiler controller, so on a developer machine they make up a large share of the
+// Binary rules. `state` is not part of execution_rules_unique, so varying this changes only row
+// composition, never row count or index shape -- results stay comparable to runs that predate the
+// transitive strategies.
+static const double kTransitiveBinaryFraction = 0.5;
 
 static const uint32_t kSeed = 0xBEEFCAFE;
 
@@ -105,14 +163,32 @@ static NSString* const kMultiCertificate =
     @"1111111111111111111111111111111111111111111111111111111111111111";
 static NSString* const kMultiTeamID = @"MULTITEST1";
 
+#pragma mark - Known identifiers for transitive rule testing
+
+// A Binary rule with state=AllowTransitive and nothing else matching. Every sub-select must be
+// evaluated before this is found, so this is the worst case for the prio strategy's extra
+// Binary sub-select.
+static NSString* const kTransitiveBinary =
+    @"2222222222222222222222222222222222222222222222222222222222222222";
+
+// The GOTOOLCHAIN=auto case from issue #1123: a binary carrying both a locally-written transitive
+// Binary rule and a configured SigningID rule. `unionall`/`unionallorderby` rank the transitive
+// rule by its Binary type and return it; `unionallprio`/`unionallcase` return the SigningID rule.
+static NSString* const kShadowedBinary =
+    @"3333333333333333333333333333333333333333333333333333333333333333";
+static NSString* const kShadowedSigningID = @"SHADOWTEST:com.example.benchmark.shadowed";
+
 #pragma mark - Enums and config
 
 enum class Strategy {
+  kNone,
   kImplicit,
   kOrderBy,
   kSeparate,
   kUnionAll,
   kUnionAllOrderBy,
+  kUnionAllPrio,
+  kUnionAllCase,
 };
 
 enum class LookupType {
@@ -122,6 +198,8 @@ enum class LookupType {
   kCertificate,
   kTeamID,
   kMultiMatch,
+  kTransitive,
+  kShadowed,
   kMiss,
   kMixed,
 };
@@ -145,14 +223,25 @@ struct LookupIdentifiers {
 
 #pragma mark - Random data generation
 
+// Fills a stack buffer and creates the NSString once. An earlier version appended one
+// -appendFormat: per character, which cost ~36us per lookup set -- an order of magnitude more
+// than the queries under test, diluting every strategy comparison into the noise.
 static NSString* RandomHex(int length, std::mt19937& gen) {
   static const char hex[] = "0123456789abcdef";
   std::uniform_int_distribution<> dist(0, 15);
-  NSMutableString* s = [NSMutableString stringWithCapacity:length];
-  for (int i = 0; i < length; i++) {
-    [s appendFormat:@"%c", hex[dist(gen)]];
+  char buf[128];
+  // Abort rather than clamp. Silently returning a shorter identifier would populate the
+  // database with wrong-length identifiers and raise the collision rate under INSERT OR
+  // IGNORE, quietly changing the row counts the benchmark is characterizing.
+  if (length < 0 || length > (int)sizeof(buf)) {
+    std::cerr << "Error: RandomHex length " << length << " out of range (max " << sizeof(buf) << ")"
+              << std::endl;
+    abort();
   }
-  return s;
+  for (int i = 0; i < length; i++) {
+    buf[i] = hex[dist(gen)];
+  }
+  return [[NSString alloc] initWithBytes:buf length:length encoding:NSASCIIStringEncoding];
 }
 
 static NSString* RandomTeamID(std::mt19937& gen) {
@@ -167,8 +256,24 @@ static NSString* RandomTeamID(std::mt19937& gen) {
 }
 
 static NSString* RandomSigningID(std::mt19937& gen) {
-  return
-      [NSString stringWithFormat:@"%@:com.example.bench.%@", RandomTeamID(gen), RandomHex(8, gen)];
+  static const char teamChars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  static const char hex[] = "0123456789abcdef";
+  static const char kInfix[] = ":com.example.bench.";
+  std::uniform_int_distribution<> teamDist(0, (int)strlen(teamChars) - 1);
+  std::uniform_int_distribution<> hexDist(0, 15);
+
+  // "<10 team chars>:com.example.bench.<8 hex>", assembled in one pass.
+  char buf[10 + sizeof(kInfix) - 1 + 8];
+  char* p = buf;
+  for (int i = 0; i < 10; i++) {
+    *p++ = teamChars[teamDist(gen)];
+  }
+  memcpy(p, kInfix, sizeof(kInfix) - 1);
+  p += sizeof(kInfix) - 1;
+  for (int i = 0; i < 8; i++) {
+    *p++ = hex[hexDist(gen)];
+  }
+  return [[NSString alloc] initWithBytes:buf length:sizeof(buf) encoding:NSASCIIStringEncoding];
 }
 
 // Generate a full set of random identifiers that will not match any known rules.
@@ -236,6 +341,16 @@ static void GenerateDatabase(const Config& config) {
   [db executeUpdate:@"INSERT INTO execution_rules (identifier, state, type) VALUES (?, ?, ?)",
                     kMultiTeamID, @(kRuleStateAllow), @(kRuleTypeTeamID)];
 
+  // Insert transitive known rules: one standalone, and one shadowing a SigningID rule.
+  [db executeUpdate:@"INSERT INTO execution_rules (identifier, state, type) VALUES (?, ?, ?)",
+                    kTransitiveBinary, @(kRuleStateAllowTransitive), @(kRuleTypeBinary)];
+  [db executeUpdate:@"INSERT INTO execution_rules (identifier, state, type) VALUES (?, ?, ?)",
+                    kShadowedBinary, @(kRuleStateAllowTransitive), @(kRuleTypeBinary)];
+  [db executeUpdate:@"INSERT INTO execution_rules (identifier, state, type) VALUES (?, ?, ?)",
+                    kShadowedSigningID, @(kRuleStateAllow), @(kRuleTypeSigningID)];
+
+  std::bernoulli_distribution transitiveDist(kTransitiveBinaryFraction);
+
   // Insert random rules
   for (int i = 0; i < config.generateCount; i++) {
     int typeIdx = typeDist(gen);
@@ -251,9 +366,13 @@ static void GenerateDatabase(const Config& config) {
       default: __builtin_unreachable();
     }
 
+    // Only Binary rules can be transitive.
+    int state = (type == kRuleTypeBinary && transitiveDist(gen)) ? kRuleStateAllowTransitive
+                                                                 : kRuleStateAllow;
+
     [db executeUpdate:
             @"INSERT OR IGNORE INTO execution_rules (identifier, state, type) VALUES (?, ?, ?)",
-            identifier, @(kRuleStateAllow), @(type)];
+            identifier, @(state), @(type)];
 
     if (i > 0 && i % 50000 == 0) {
       [db commit];
@@ -289,6 +408,11 @@ static void GenerateDatabase(const Config& config) {
   [rs close];
   std::cout << "  Total: " << total << std::endl;
 
+  std::cout << "  (of which transitive: " <<
+      [db longForQuery:@"SELECT COUNT(*) FROM execution_rules WHERE state=?",
+                       @(kRuleStateAllowTransitive)]
+            << ")" << std::endl;
+
   [db close];
 }
 
@@ -310,6 +434,11 @@ static LookupIdentifiers BuildLookup(LookupType type, std::mt19937& gen) {
       ids.certificateSHA256 = kMultiCertificate;
       ids.teamID = kMultiTeamID;
       break;
+    case LookupType::kTransitive: ids.binarySHA256 = kTransitiveBinary; break;
+    case LookupType::kShadowed:
+      ids.binarySHA256 = kShadowedBinary;
+      ids.signingID = kShadowedSigningID;
+      break;
     case LookupType::kMiss: break;
     case LookupType::kMixed: break;  // handled by caller
   }
@@ -317,6 +446,13 @@ static LookupIdentifiers BuildLookup(LookupType type, std::mt19937& gen) {
 }
 
 #pragma mark - Query strategies
+
+// Runs no query at all. Establishes the harness floor for a given -i: process launch, building
+// the lookup vector, and opening the DB. Subtract it from another strategy at the same -i to get
+// that strategy's true per-query cost, instead of a number diluted by harness overhead.
+static BOOL QueryNone(FMDatabase* db, const LookupIdentifiers& ids) {
+  return NO;
+}
 
 static BOOL QueryImplicit(FMDatabase* db, const LookupIdentifiers& ids) {
   FMResultSet* rs = [db executeQuery:@"SELECT * FROM execution_rules WHERE "
@@ -429,6 +565,63 @@ static BOOL QueryUnionAllOrderBy(FMDatabase* db, const LookupIdentifiers& ids) {
   return found;
 }
 
+// Demotes transitive rules below every other type by splitting the Binary sub-select on `state`
+// and sorting on a constant `prio` per sub-select. Because each prio is a literal, the compound
+// query is still naturally ordered and SQLite plans it as a streaming MERGE over indexed lookups
+// -- so LIMIT 1 short-circuits and sub-selects after the first match never execute. Costs one
+// extra index seek on (binarySHA256, 1000), but only on lookups that get far enough to run it.
+static BOOL QueryUnionAllPrio(FMDatabase* db, const LookupIdentifiers& ids) {
+  FMResultSet* rs = [db executeQuery:@"SELECT * FROM ("
+                                     @"  SELECT 1 AS prio, * FROM execution_rules "
+                                     @"    WHERE identifier=? AND type=500 "
+                                     @"  UNION ALL "
+                                     @"  SELECT 2 AS prio, * FROM execution_rules "
+                                     @"    WHERE identifier=? AND type=1000 AND state<>? "
+                                     @"  UNION ALL "
+                                     @"  SELECT 3 AS prio, * FROM execution_rules "
+                                     @"    WHERE identifier=? AND type=2000 "
+                                     @"  UNION ALL "
+                                     @"  SELECT 4 AS prio, * FROM execution_rules "
+                                     @"    WHERE identifier=? AND type=3000 "
+                                     @"  UNION ALL "
+                                     @"  SELECT 5 AS prio, * FROM execution_rules "
+                                     @"    WHERE identifier=? AND type=4000 "
+                                     @"  UNION ALL "
+                                     @"  SELECT 6 AS prio, * FROM execution_rules "
+                                     @"    WHERE identifier=? AND type=1000 AND state=?"
+                                     @") ORDER BY prio ASC LIMIT 1",
+                                     ids.cdhash, ids.binarySHA256, @(kRuleStateAllowTransitive),
+                                     ids.signingID, ids.certificateSHA256, ids.teamID,
+                                     ids.binarySHA256, @(kRuleStateAllowTransitive)];
+  BOOL found = [rs next];
+  [rs close];
+  return found;
+}
+
+// Same demotion expressed as a CASE over `state` in the ORDER BY, keeping the original five
+// sub-selects. Avoids the extra index seek, but the sort key is opaque to the planner: SQLite can
+// no longer prove the compound query is ordered, so it materializes the union as a co-routine and
+// adds a temp B-tree sort. Included to measure which trade wins.
+static BOOL QueryUnionAllCase(FMDatabase* db, const LookupIdentifiers& ids) {
+  FMResultSet* rs =
+      [db executeQuery:@"SELECT * FROM ("
+                       @"SELECT * FROM execution_rules WHERE identifier=? AND type=500 "
+                       @"UNION ALL "
+                       @"SELECT * FROM execution_rules WHERE identifier=? AND type=1000 "
+                       @"UNION ALL "
+                       @"SELECT * FROM execution_rules WHERE identifier=? AND type=2000 "
+                       @"UNION ALL "
+                       @"SELECT * FROM execution_rules WHERE identifier=? AND type=3000 "
+                       @"UNION ALL "
+                       @"SELECT * FROM execution_rules WHERE identifier=? AND type=4000"
+                       @") ORDER BY (CASE WHEN state=? THEN 1000000 ELSE type END) ASC LIMIT 1",
+                       ids.cdhash, ids.binarySHA256, ids.signingID, ids.certificateSHA256,
+                       ids.teamID, @(kRuleStateAllowTransitive)];
+  BOOL found = [rs next];
+  [rs close];
+  return found;
+}
+
 #pragma mark - Benchmark runner
 
 static void RunBenchmark(const Config& config) {
@@ -449,12 +642,12 @@ static void RunBenchmark(const Config& config) {
   std::mt19937 gen(kSeed);
 
   if (config.lookup == LookupType::kMixed) {
-    std::uniform_int_distribution<> dist(0, 6);
     LookupType allTypes[] = {
-        LookupType::kCDHash,      LookupType::kBinary, LookupType::kSigningID,
-        LookupType::kCertificate, LookupType::kTeamID, LookupType::kMultiMatch,
-        LookupType::kMiss,
+        LookupType::kCDHash,      LookupType::kBinary,   LookupType::kSigningID,
+        LookupType::kCertificate, LookupType::kTeamID,   LookupType::kMultiMatch,
+        LookupType::kTransitive,  LookupType::kShadowed, LookupType::kMiss,
     };
+    std::uniform_int_distribution<> dist(0, (int)(sizeof(allTypes) / sizeof(allTypes[0])) - 1);
     for (int i = 0; i < config.iterations; i++) {
       lookups.push_back(BuildLookup(allTypes[dist(gen)], gen));
     }
@@ -467,11 +660,14 @@ static void RunBenchmark(const Config& config) {
   // Select strategy
   BOOL (*queryFn)(FMDatabase*, const LookupIdentifiers&) = nullptr;
   switch (config.strategy) {
+    case Strategy::kNone: queryFn = QueryNone; break;
     case Strategy::kImplicit: queryFn = QueryImplicit; break;
     case Strategy::kOrderBy: queryFn = QueryOrderBy; break;
     case Strategy::kSeparate: queryFn = QuerySeparate; break;
     case Strategy::kUnionAll: queryFn = QueryUnionAll; break;
     case Strategy::kUnionAllOrderBy: queryFn = QueryUnionAllOrderBy; break;
+    case Strategy::kUnionAllPrio: queryFn = QueryUnionAllPrio; break;
+    case Strategy::kUnionAllCase: queryFn = QueryUnionAllCase; break;
   }
 
   int hits = 0;
@@ -492,11 +688,14 @@ static void RunBenchmark(const Config& config) {
 #pragma mark - CLI
 
 static std::optional<Strategy> ParseStrategy(const char* s) {
+  if (strcmp(s, "none") == 0) return Strategy::kNone;
   if (strcmp(s, "implicit") == 0) return Strategy::kImplicit;
   if (strcmp(s, "orderby") == 0) return Strategy::kOrderBy;
   if (strcmp(s, "separate") == 0) return Strategy::kSeparate;
   if (strcmp(s, "unionall") == 0) return Strategy::kUnionAll;
   if (strcmp(s, "unionallorderby") == 0) return Strategy::kUnionAllOrderBy;
+  if (strcmp(s, "unionallprio") == 0) return Strategy::kUnionAllPrio;
+  if (strcmp(s, "unionallcase") == 0) return Strategy::kUnionAllCase;
   return std::nullopt;
 }
 
@@ -507,6 +706,8 @@ static std::optional<LookupType> ParseLookup(const char* s) {
   if (strcmp(s, "certificate") == 0) return LookupType::kCertificate;
   if (strcmp(s, "teamid") == 0) return LookupType::kTeamID;
   if (strcmp(s, "multimatch") == 0) return LookupType::kMultiMatch;
+  if (strcmp(s, "transitive") == 0) return LookupType::kTransitive;
+  if (strcmp(s, "shadowed") == 0) return LookupType::kShadowed;
   if (strcmp(s, "miss") == 0) return LookupType::kMiss;
   if (strcmp(s, "mixed") == 0) return LookupType::kMixed;
   return std::nullopt;
@@ -517,10 +718,12 @@ static void PrintUsage() {
             << "Options:\n"
             << "  -g <count>     Generate database with <count> random rules, then exit\n"
             << "  -i <count>     Number of lookup iterations (default: 1000)\n"
-            << "  -t <strategy>  Query strategy: implicit, orderby, separate, unionall,\n"
-            << "                 unionallorderby (default: implicit)\n"
+            << "  -t <strategy>  Query strategy: none, implicit, orderby, separate, unionall,\n"
+            << "                 unionallorderby, unionallprio, unionallcase\n"
+            << "                 (default: implicit)\n"
             << "  -l <lookup>    Lookup type: cdhash, binary, signingid, certificate,\n"
-            << "                   teamid, multimatch, miss, mixed (default: mixed)\n"
+            << "                   teamid, multimatch, transitive, shadowed, miss, mixed\n"
+            << "                   (default: mixed)\n"
             << "  -d <path>      Database path (default: /tmp/rule_bench.db)\n"
             << "  -v             Verbose output\n"
             << "  -h             Show this help\n";


### PR DESCRIPTION
Fixes #1123.

A transitive rule is written for whatever a compiler produced, so it should not take precedence over an explicitly configured rule. Ranking it by its Binary type let it outrank a Signing ID / Certificate / Team ID rule for the same executable, downgrading an `ALLOWLIST_COMPILER` rule to a plain transitive allow — a Go toolchain fetched by `GOTOOLCHAIN=auto` stopped being treated as a compiler, and its output was no longer transitively allowed.

`executionRuleForIdentifiers:` now splits the Binary sub-select on `state` and sorts on a constant `prio` per sub-select. Keeping `prio` a literal rather than a `CASE` over `state` leaves the compound query naturally ordered, so the plan stays a streaming `MERGE` over indexed lookups instead of adding a temp B-tree sort.

Sorting at lookup time rather than declining to write the rule also repairs databases that already contain such a rule, and holds regardless of which rule was added first.

## Benchmarks

`Testing/OneOffs/RuleQueryBench.mm` gains `unionallprio` (this change), `unionallcase` (the `CASE` alternative), and `none` (a no-query baseline), plus `transitive` / `shadowed` lookup types.

Per-query cost with the `none` baseline subtracted at the same `-i`, 100k-rule database:

| strategy | mixed | miss |
|---|---|---|
| `unionallorderby` (before) | 9.02 us | 9.30 us |
| `unionallprio` (this change) | 10.03 us | 9.93 us |
| `unionallcase` (rejected) | 13.12 us | 12.85 us |

The added cost does not grow with database size:

| db rules | mean delta |
|---|---|
| 10,000 | +0.77 .. +0.82 us |
| 100,000 | +0.69 .. +0.78 us |
| 1,000,000 | +0.58 .. +0.59 us |

Roughly +0.8 us per uncached rule lookup, about half the cost of the `ORDER BY` change in #916. The extra sub-select re-seeks a key the Binary sub-select already sought, so its pages stay warm regardless of B-tree depth.

Two harness notes, both of which affected previously recorded numbers:

- `RandomHex` / `RandomSigningID` built identifiers with one `-appendFormat:` per character, ~24 us per iteration. Now single-pass into a stack buffer. RNG draw order is unchanged, so generated databases are identical.
- An `-i 1` run is not a valid baseline: identifier generation scales with `-i`, so most of it lands in the "per-query" figure. Use the `none` strategy at the same `-i` instead.

## Tests

- `SNTRuleTableTest` — precedence against each configured type, compiler-rule preservation, configured state preserved, a guard that ordinary Binary rules still outrank Signing ID, a canary for a future `prio` column, and characterization of the demotion being scoped to the Binary type.
- `SNTPolicyProcessorTest` — decision-level coverage through a real `SNTRuleTable`, asserting `SNTEventStateAllowCompilerSigningID` with and without the transitive rule present. Every other test in that file mocks the rule table, so none of them exercise lookup precedence.

All new tests were confirmed to fail against the previous query. `//Source/santad/...` and `//Source/common/...` pass (108 targets).
