### PR TITLE
santad: Group FAA rule options into a struct

### DIFF
--- a/Source/common/faa/WatchItemPolicy.h
+++ b/Source/common/faa/WatchItemPolicy.h
@@ -49,7 +49,9 @@ struct SharedPtrValueEqual;
 // Helper type aliases
 using PairPathAndType = std::pair<std::string, WatchItemPathType>;
 using SetPairPathAndType = absl::flat_hash_set<PairPathAndType>;
-using SetWatchItemProcess = absl::flat_hash_set<WatchItemProcess>;
+// Note: This is an ordered list, not a set, because process matching is
+// first-match-wins.
+using WatchItemProcessList = std::vector<WatchItemProcess>;
 using SetSharedDataWatchItemPolicy = absl::flat_hash_set<std::shared_ptr<DataWatchItemPolicy>,
                                                          SharedPtrValueHash<DataWatchItemPolicy>,
                                                          SharedPtrValueEqual<DataWatchItemPolicy>>;
@@ -77,6 +79,27 @@ static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType =
     WatchItemRuleType::kPathsWithAllowedProcesses;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
+
+/// The options a rule carries. Grouped into a struct so that the effective
+/// values for an event can be passed around as a unit rather than as a handful
+/// of loose parameters.
+struct WatchItemProcessOptions {
+  bool allow_read_access = kWatchItemPolicyDefaultAllowReadAccess;
+  bool silent = kWatchItemPolicyDefaultEnableSilentMode;
+  bool silent_tty = kWatchItemPolicyDefaultEnableSilentTTYMode;
+  std::optional<std::string> custom_message;
+  std::optional<NSString*> event_detail_url;
+  std::optional<NSString*> event_detail_text;
+
+  bool operator==(const WatchItemProcessOptions& other) const {
+    // Note: Matching WatchItemPolicyBase, custom_message, event_detail_url and
+    // event_detail_text are not currently considered for equality purposes.
+    return allow_read_access == other.allow_read_access && silent == other.silent &&
+           silent_tty == other.silent_tty;
+  }
+
+  bool operator!=(const WatchItemProcessOptions& other) const { return !(*this == other); }
+};
 
 struct WatchItemProcess {
   static std::optional<WatchItemProcess> Create(NSString* bp, NSString* sid, NSString* tid,
@@ -163,12 +186,6 @@ struct WatchItemProcess {
   }
 #endif
 
-  template <typename H>
-  friend H AbslHashValue(H h, const WatchItemProcess& p) {
-    return H::combine(std::move(h), p.binary_path, p.signing_id, p.team_id, p.cdhash,
-                      p.certificate_sha256, p.platform_binary);
-  }
-
   std::string binary_path;
   const std::string signing_id;
   std::string team_id;
@@ -192,37 +209,25 @@ struct WatchItemProcess {
 
 struct WatchItemPolicyBase {
   WatchItemPolicyBase(std::string_view n, std::string_view v,
-                      bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                       bool ao = kWatchItemPolicyDefaultAuditOnly,
                       WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
-                      bool esm = kWatchItemPolicyDefaultEnableSilentMode,
-                      bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
-                      std::string_view cm = "", NSString* edu = nil, NSString* edt = nil,
-                      SetWatchItemProcess procs = {}, int64_t rid = 0)
+                      WatchItemProcessOptions opts = {}, WatchItemProcessList procs = {},
+                      int64_t rid = 0)
       : name(n),
         version(v),
-        allow_read_access(ara),
         audit_only(ao),
         rule_type(rt),
-        silent(esm),
-        silent_tty(estm),
-        custom_message(cm.length() == 0 ? std::nullopt : std::make_optional<std::string>(cm)),
-        // Note: Empty string considered valid for event_detail_url to allow rules
-        // overriding global setting in order to hide the button.
-        event_detail_url(edu == nil ? std::nullopt : std::make_optional<NSString*>(edu)),
-        event_detail_text(edt.length == 0 ? std::nullopt : std::make_optional<NSString*>(edt)),
+        options(std::move(opts)),
         processes(std::move(procs)),
         rule_id(rid) {}
 
   virtual ~WatchItemPolicyBase() = default;
 
   virtual bool operator==(const WatchItemPolicyBase& other) const {
-    // Note: custom_message, event_detail_url, and event_detail_text are not currently considered
-    // for equality purposes
-    return name == other.name && version == other.version &&
-           allow_read_access == other.allow_read_access && audit_only == other.audit_only &&
-           rule_type == other.rule_type && silent == other.silent &&
-           silent_tty == other.silent_tty && processes == other.processes;
+    // Note: WatchItemProcessOptions::operator== does not consider custom_message,
+    // event_detail_url or event_detail_text.
+    return name == other.name && version == other.version && audit_only == other.audit_only &&
+           rule_type == other.rule_type && options == other.options && processes == other.processes;
   }
 
   virtual bool operator!=(const WatchItemPolicyBase& other) const { return !(*this == other); }
@@ -234,29 +239,21 @@ struct WatchItemPolicyBase {
 
   std::string name;
   std::string version;  // WIP - No current way to control via config
-  bool allow_read_access;
   bool audit_only;
   WatchItemRuleType rule_type;
-  bool silent;
-  bool silent_tty;
-  std::optional<std::string> custom_message;
-  std::optional<NSString*> event_detail_url;
-  std::optional<NSString*> event_detail_text;
-  SetWatchItemProcess processes;
+  WatchItemProcessOptions options;
+  WatchItemProcessList processes;
   int64_t rule_id;
 };
 
 struct DataWatchItemPolicy : public WatchItemPolicyBase {
   DataWatchItemPolicy(std::string_view n, std::string_view v, std::string_view p,
                       WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
-                      bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                       bool ao = kWatchItemPolicyDefaultAuditOnly,
                       WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
-                      bool esm = kWatchItemPolicyDefaultEnableSilentMode,
-                      bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
-                      std::string_view cm = "", NSString* edu = nil, NSString* edt = nil,
-                      SetWatchItemProcess procs = {}, int64_t rid = 0)
-      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt, std::move(procs), rid),
+                      WatchItemProcessOptions opts = {}, WatchItemProcessList procs = {},
+                      int64_t rid = 0)
+      : WatchItemPolicyBase(n, v, ao, rt, std::move(opts), std::move(procs), rid),
         path(p),
         path_type(pt) {}
 
@@ -279,14 +276,11 @@ struct DataWatchItemPolicy : public WatchItemPolicyBase {
 
 struct ProcessWatchItemPolicy : public WatchItemPolicyBase {
   ProcessWatchItemPolicy(std::string_view n, std::string_view v, SetPairPathAndType pt,
-                         bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                          bool ao = kWatchItemPolicyDefaultAuditOnly,
                          WatchItemRuleType rt = kWatchItemPolicyDefaultRuleType,
-                         bool esm = kWatchItemPolicyDefaultEnableSilentMode,
-                         bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
-                         std::string_view cm = "", NSString* edu = nil, NSString* edt = nil,
-                         SetWatchItemProcess procs = {}, int64_t rid = 0)
-      : WatchItemPolicyBase(n, v, ara, ao, rt, esm, estm, cm, edu, edt, std::move(procs), rid),
+                         WatchItemProcessOptions opts = {}, WatchItemProcessList procs = {},
+                         int64_t rid = 0)
+      : WatchItemPolicyBase(n, v, ao, rt, std::move(opts), std::move(procs), rid),
         path_type_pairs(std::move(pt)),
         tree(std::make_unique<santa::PrefixTree<santa::Unit>>()) {
     // Build tree

--- a/Source/common/faa/WatchItemPolicyTest.mm
+++ b/Source/common/faa/WatchItemPolicyTest.mm
@@ -38,47 +38,60 @@ using santa::WatchItemRuleType;
 @implementation WatchItemPolicyTest
 
 - (void)testProcessWatchItemPolicy {
-  // Make sure the hash function for a WatchItemProcess covers all members
-  WatchItemProcess proc("proc_path_1", "com.example.proc", "PROCTEAMID", {}, "", false);
+  // Make sure the equality operator for a WatchItemProcess covers all members.
+  // Note: WatchItemProcess isn't assignable (it has a const member), so each
+  // case starts from a fresh copy.
+  auto makeProc = [] {
+    return WatchItemProcess("proc_path_1", "com.example.proc", "PROCTEAMID", {}, "", false);
+  };
+  WatchItemProcess orig = makeProc();
+
+  XCTAssertEqual(makeProc(), orig);
+
+  {
+    WatchItemProcess proc = makeProc();
+    proc.UnsafeUpdateSigningId("abc");
+    XCTAssertNotEqual(proc, orig);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    proc.binary_path = "abc";
+    XCTAssertNotEqual(proc, orig);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    proc.team_id = "abc";
+    XCTAssertNotEqual(proc, orig);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    proc.platform_binary = true;
+    XCTAssertNotEqual(proc, orig);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    proc.certificate_sha256 = "abc";
+    XCTAssertNotEqual(proc, orig);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    proc.cdhash = {1};
+    XCTAssertNotEqual(proc, orig);
+  }
+}
+
+- (void)testProcessWatchItemPolicyProcessOrder {
+  // The processes list is ordered - matching is first-match-wins.
+  WatchItemProcess first("first", "", "", {}, "", false);
+  WatchItemProcess second("second", "", "", {}, "", false);
 
   ProcessWatchItemPolicy pwip(
       "name", "ver", SetPairPathAndType{PairPathAndType{"path1", WatchItemPathType::kLiteral}},
-      true, true, santa::WatchItemRuleType::kProcessesWithAllowedPaths, false, false, "", nil, nil,
-      {proc});
+      true, santa::WatchItemRuleType::kProcessesWithAllowedPaths, {}, {first, second});
 
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
-  XCTAssertEqual(pwip.processes.size(), 1);
-
-  proc.UnsafeUpdateSigningId("abc");
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
   XCTAssertEqual(pwip.processes.size(), 2);
-
-  proc.binary_path = "abc";
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
-  XCTAssertEqual(pwip.processes.size(), 3);
-
-  proc.team_id = "abc";
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
-  XCTAssertEqual(pwip.processes.size(), 4);
-
-  proc.platform_binary = true;
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
-  XCTAssertEqual(pwip.processes.size(), 5);
-
-  proc.certificate_sha256 = "abc";
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
-  XCTAssertEqual(pwip.processes.size(), 6);
-
-  proc.cdhash = {1};
-  pwip.processes.insert(proc);
-  pwip.processes.insert(proc);
-  XCTAssertEqual(pwip.processes.size(), 7);
+  XCTAssertEqual(pwip.processes[0], first);
+  XCTAssertEqual(pwip.processes[1], second);
 }
 
 - (void)testWatchItemProcessCreate {
@@ -172,15 +185,15 @@ using santa::WatchItemRuleType;
 
   auto sharedDataPolicy1 =
       std::make_shared<DataWatchItemPolicy>("name", "v1", "/foo", WatchItemPathType::kLiteral, true,
-                                            true, WatchItemRuleType::kPathsWithAllowedProcesses);
+                                            WatchItemRuleType::kPathsWithAllowedProcesses);
 
   auto sharedDataPolicy2 =
       std::make_shared<DataWatchItemPolicy>("name", "v1", "/foo", WatchItemPathType::kLiteral, true,
-                                            true, WatchItemRuleType::kPathsWithAllowedProcesses);
+                                            WatchItemRuleType::kPathsWithAllowedProcesses);
 
   auto sharedDataPolicy3 =
       std::make_shared<DataWatchItemPolicy>("name", "v1", "/bar", WatchItemPathType::kLiteral, true,
-                                            true, WatchItemRuleType::kPathsWithAllowedProcesses);
+                                            WatchItemRuleType::kPathsWithAllowedProcesses);
 
   // Underlying pointers should be different
   XCTAssertNotEqual(sharedDataPolicy1, sharedDataPolicy2);
@@ -212,15 +225,15 @@ using santa::WatchItemRuleType;
   SetSharedProcessWatchItemPolicy procSet;
 
   auto sharedProcPolicy1 = std::make_shared<ProcessWatchItemPolicy>(
-      "name", "v1", SetPairPathAndType{{"/foo", WatchItemPathType::kLiteral}}, true, true,
+      "name", "v1", SetPairPathAndType{{"/foo", WatchItemPathType::kLiteral}}, true,
       WatchItemRuleType::kProcessesWithDeniedPaths);
 
   auto sharedProcPolicy2 = std::make_shared<ProcessWatchItemPolicy>(
-      "name", "v1", SetPairPathAndType{{"/foo", WatchItemPathType::kLiteral}}, true, true,
+      "name", "v1", SetPairPathAndType{{"/foo", WatchItemPathType::kLiteral}}, true,
       WatchItemRuleType::kProcessesWithDeniedPaths);
 
   auto sharedProcPolicy3 = std::make_shared<ProcessWatchItemPolicy>(
-      "name", "v1", SetPairPathAndType{{"/bar", WatchItemPathType::kLiteral}}, true, true,
+      "name", "v1", SetPairPathAndType{{"/bar", WatchItemPathType::kLiteral}}, true,
       WatchItemRuleType::kProcessesWithDeniedPaths);
 
   // Underlying pointers should be different

--- a/Source/common/faa/WatchItems.h
+++ b/Source/common/faa/WatchItems.h
@@ -186,8 +186,10 @@ class WatchItems : public Timer<WatchItems>, public PassKey<WatchItems> {
 
   std::optional<WatchItemsState> State();
 
-  std::pair<NSString*, NSString*> EventDetailLinkInfo(
-      const std::shared_ptr<WatchItemPolicyBase>& watch_item);
+  /// Resolve the event detail URL/text to display, falling back to the
+  /// top-level config values when the given values are unset.
+  std::pair<NSString*, NSString*> EventDetailLinkInfo(std::optional<NSString*> event_detail_url,
+                                                      std::optional<NSString*> event_detail_text);
 
   static bool IsValidRule(NSString* name, NSDictionary* rule, NSError** error,
                           NSString* policyVersion = nil);

--- a/Source/common/faa/WatchItems.mm
+++ b/Source/common/faa/WatchItems.mm
@@ -338,6 +338,50 @@ std::variant<Unit, SetPairPathAndType> VerifyConfigWatchItemPaths(NSArray<id>* p
   return path_list;
 }
 
+/// Verify and parse a rule's `Options` dictionary into the options struct.
+///
+/// Note: This is the only place the empty-string conventions are applied. An
+/// empty BlockMessage or EventDetailText means "unset", while an empty
+/// EventDetailURL is meaningful - it overrides the global value in order to
+/// hide the button.
+std::optional<WatchItemProcessOptions> VerifyConfigOptions(NSDictionary* dict, NSError** err) {
+  if (!VerifyConfigKey(dict, kWatchItemConfigKeyOptionsAllowReadAccess, [NSNumber class], err) ||
+      !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsEnableSilentMode, [NSNumber class], err) ||
+      !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsEnableSilentTTYMode, [NSNumber class],
+                       err) ||
+      !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsCustomMessage, [NSString class], err, false,
+                       LenRangeValidator(0, kWatchItemConfigOptionCustomMessageMaxLength)) ||
+      !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsEventDetailURL, [NSString class], err, false,
+                       LenRangeValidator(0, kWatchItemConfigEventDetailURLMaxLength)) ||
+      !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsEventDetailText, [NSString class], err,
+                       false, LenRangeValidator(0, kWatchItemConfigEventDetailTextMaxLength))) {
+    return std::nullopt;
+  }
+
+  WatchItemProcessOptions opts;
+
+  opts.allow_read_access = GetBoolValue(dict, kWatchItemConfigKeyOptionsAllowReadAccess,
+                                        kWatchItemPolicyDefaultAllowReadAccess);
+  opts.silent = GetBoolValue(dict, kWatchItemConfigKeyOptionsEnableSilentMode,
+                             kWatchItemPolicyDefaultEnableSilentMode);
+  opts.silent_tty = GetBoolValue(dict, kWatchItemConfigKeyOptionsEnableSilentTTYMode,
+                                 kWatchItemPolicyDefaultEnableSilentTTYMode);
+
+  if (NSString* msg = dict[kWatchItemConfigKeyOptionsCustomMessage]) {
+    opts.custom_message = msg.length ? std::make_optional(NSStringToUTF8String(msg)) : std::nullopt;
+  }
+
+  if (NSString* url = dict[kWatchItemConfigKeyOptionsEventDetailURL]) {
+    opts.event_detail_url = url;
+  }
+
+  if (NSString* text = dict[kWatchItemConfigKeyOptionsEventDetailText]) {
+    opts.event_detail_text = text.length ? std::make_optional<NSString*>(text) : std::nullopt;
+  }
+
+  return opts;
+}
+
 /// The `Processes` array can only contain dictionaries. Each dictionary can
 /// contain the attributes that describe a single process.
 ///
@@ -359,9 +403,9 @@ std::variant<Unit, SetPairPathAndType> VerifyConfigWatchItemPaths(NSArray<id>* p
 ///     <string>EEEE</string>
 ///   </dict>
 /// </array>
-std::variant<Unit, SetWatchItemProcess> VerifyConfigWatchItemProcesses(NSDictionary* watch_item,
-                                                                       NSError** err) {
-  __block SetWatchItemProcess proc_list;
+std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(NSDictionary* watch_item,
+                                                                        NSError** err) {
+  __block WatchItemProcessList proc_list;
 
   if (!VerifyConfigKeyArray(
           watch_item, kWatchItemConfigKeyProcesses, [NSDictionary class], err,
@@ -401,7 +445,7 @@ std::variant<Unit, SetWatchItemProcess> VerifyConfigWatchItemProcesses(NSDiction
                 [process[kWatchItemConfigKeyProcessesPlatformBinary] boolValue], err);
 
             if (watch_item_proc.has_value()) {
-              proc_list.insert(std::move(*watch_item_proc));
+              proc_list.push_back(std::move(*watch_item_proc));
               return true;
             } else {
               return false;
@@ -468,12 +512,10 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
 
   NSDictionary* options = watch_item[kWatchItemConfigKeyOptions];
   if (options) {
+    // Note: The keys VerifyConfigOptions handles are verified by it below.
     NSArray<NSString*>* boolOptions = @[
-      kWatchItemConfigKeyOptionsAllowReadAccess,
       kWatchItemConfigKeyOptionsAuditOnly,
       kWatchItemConfigKeyOptionsInvertProcessExceptions,
-      kWatchItemConfigKeyOptionsEnableSilentMode,
-      kWatchItemConfigKeyOptionsEnableSilentTTYMode,
     ];
 
     for (NSString* key in boolOptions) {
@@ -487,26 +529,15 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
       return false;
     }
 
-    if (!VerifyConfigKey(options, kWatchItemConfigKeyOptionsCustomMessage, [NSString class], err,
-                         false,
-                         LenRangeValidator(0, kWatchItemConfigOptionCustomMessageMaxLength))) {
-      return false;
-    }
-
-    if (!VerifyConfigKey(options, kWatchItemConfigKeyOptionsEventDetailURL, [NSString class], err,
-                         false, LenRangeValidator(0, kWatchItemConfigEventDetailURLMaxLength))) {
-      return false;
-    }
-
-    if (!VerifyConfigKey(options, kWatchItemConfigKeyOptionsEventDetailText, [NSString class], err,
-                         false, LenRangeValidator(0, kWatchItemConfigEventDetailTextMaxLength))) {
-      return false;
-    }
-
     if (!VerifyConfigKey(options, kWatchItemConfigKeyOptionsRuleId, [NSNumber class], err, false,
                          NonNegativeValidator())) {
       return false;
     }
+  }
+
+  std::optional<WatchItemProcessOptions> rule_options = VerifyConfigOptions(options, err);
+  if (!rule_options.has_value()) {
+    return false;
   }
 
   std::string policy_version;
@@ -524,16 +555,10 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
     return false;
   }
 
-  bool allow_read_access = GetBoolValue(options, kWatchItemConfigKeyOptionsAllowReadAccess,
-                                        kWatchItemPolicyDefaultAllowReadAccess);
   bool audit_only =
       GetBoolValue(options, kWatchItemConfigKeyOptionsAuditOnly, kWatchItemPolicyDefaultAuditOnly);
-  bool enable_silent_mode = GetBoolValue(options, kWatchItemConfigKeyOptionsEnableSilentMode,
-                                         kWatchItemPolicyDefaultEnableSilentMode);
-  bool enable_silent_tty_mode = GetBoolValue(options, kWatchItemConfigKeyOptionsEnableSilentTTYMode,
-                                             kWatchItemPolicyDefaultEnableSilentTTYMode);
 
-  std::variant<Unit, SetWatchItemProcess> proc_list =
+  std::variant<Unit, WatchItemProcessList> proc_list =
       VerifyConfigWatchItemProcesses(watch_item, err);
   if (std::holds_alternative<Unit>(proc_list)) {
     return false;
@@ -565,12 +590,8 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
       for (const PairPathAndType& path_type_pair : std::get<SetPairPathAndType>(path_list)) {
         data_policies->insert(std::make_shared<DataWatchItemPolicy>(
             NSStringToUTF8StringView(name), policy_version, path_type_pair.first,
-            path_type_pair.second, allow_read_access, audit_only, rule_type, enable_silent_mode,
-            enable_silent_tty_mode,
-            NSStringToUTF8StringView(options[kWatchItemConfigKeyOptionsCustomMessage]),
-            options[kWatchItemConfigKeyOptionsEventDetailURL],
-            options[kWatchItemConfigKeyOptionsEventDetailText],
-            std::get<SetWatchItemProcess>(proc_list), rule_id));
+            path_type_pair.second, audit_only, rule_type, *rule_options,
+            std::get<WatchItemProcessList>(proc_list), rule_id));
       }
 
       break;
@@ -579,11 +600,8 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
     case WatchItemRuleType::kProcessesWithDeniedPaths:
       proc_policies->insert(std::make_shared<ProcessWatchItemPolicy>(
           NSStringToUTF8StringView(name), policy_version, std::get<SetPairPathAndType>(path_list),
-          allow_read_access, audit_only, rule_type, enable_silent_mode, enable_silent_tty_mode,
-          NSStringToUTF8StringView(options[kWatchItemConfigKeyOptionsCustomMessage]),
-          options[kWatchItemConfigKeyOptionsEventDetailURL],
-          options[kWatchItemConfigKeyOptionsEventDetailText],
-          std::get<SetWatchItemProcess>(proc_list), rule_id));
+          audit_only, rule_type, std::move(*rule_options),
+          std::move(std::get<WatchItemProcessList>(proc_list)), rule_id));
 
       break;
   }
@@ -1032,17 +1050,10 @@ std::optional<WatchItemsState> WatchItems::State() {
 }
 
 std::pair<NSString*, NSString*> WatchItems::EventDetailLinkInfo(
-    const std::shared_ptr<WatchItemPolicyBase>& watch_item) {
+    std::optional<NSString*> event_detail_url, std::optional<NSString*> event_detail_text) {
   absl::ReaderMutexLock lock(lock_);
-  if (!watch_item) {
-    return {policy_event_detail_url_, policy_event_detail_text_};
-  }
-
-  NSString* url = watch_item->event_detail_url.has_value() ? watch_item->event_detail_url.value()
-                                                           : policy_event_detail_url_;
-
-  NSString* text = watch_item->event_detail_text.has_value() ? watch_item->event_detail_text.value()
-                                                             : policy_event_detail_text_;
+  NSString* url = event_detail_url.value_or(policy_event_detail_url_);
+  NSString* text = event_detail_text.value_or(policy_event_detail_text_);
 
   // Ensure empty strings are repplaced with nil
   if (!url.length) {

--- a/Source/common/faa/WatchItemsTest.mm
+++ b/Source/common/faa/WatchItemsTest.mm
@@ -49,10 +49,11 @@ using santa::ProcessWatchItemPolicy;
 using santa::SetPairPathAndType;
 using santa::SetSharedDataWatchItemPolicy;
 using santa::SetSharedProcessWatchItemPolicy;
-using santa::SetWatchItemProcess;
 using santa::Unit;
 using santa::WatchItemPathType;
 using santa::WatchItemProcess;
+using santa::WatchItemProcessList;
+using santa::WatchItemProcessOptions;
 using santa::WatchItemsState;
 
 namespace santa {
@@ -68,8 +69,8 @@ extern bool ParseConfigSingleWatchItem(NSString* name, std::string_view policy_v
                                        NSError** err);
 extern std::variant<Unit, SetPairPathAndType> VerifyConfigWatchItemPaths(NSArray<id>* paths,
                                                                          NSError** err);
-std::variant<Unit, SetWatchItemProcess> VerifyConfigWatchItemProcesses(NSDictionary* watch_item,
-                                                                       NSError** err);
+std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(NSDictionary* watch_item,
+                                                                        NSError** err);
 extern std::optional<WatchItemRuleType> GetRuleType(NSString* rule_type);
 extern std::vector<std::string> FindMatches(NSString* path);
 
@@ -549,13 +550,13 @@ BlockGenResult CreatePolicyBlockGen() {
 }
 
 - (void)testVerifyConfigWatchItemProcesses {
-  std::variant<Unit, SetWatchItemProcess> proc_list;
+  std::variant<Unit, WatchItemProcessList> proc_list;
   NSError* err;
 
   // Non-existent process list parses successfully, but has no items
   proc_list = VerifyConfigWatchItemProcesses(@{}, &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 0);
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 0);
 
   // Process list fails to parse if contains non-array type
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @""}, &err);
@@ -565,7 +566,7 @@ BlockGenResult CreatePolicyBlockGen() {
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @{}}, &err);
   XCTAssertTrue(std::holds_alternative<Unit>(proc_list));
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @[]}, &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
 
   // Test a process dictionary with no valid attributes set
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @[ @{} ]}, &err);
@@ -583,9 +584,9 @@ BlockGenResult CreatePolicyBlockGen() {
   proc_list = VerifyConfigWatchItemProcesses(
       @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesBinaryPath : @"mypath"} ]},
       &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("mypath", "", "", {}, "", false));
 
   // Test SigningID length limits
@@ -612,11 +613,11 @@ BlockGenResult CreatePolicyBlockGen() {
     } ],
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "com.northpolesec.test", "ABCDE12345", {}, "", false));
-  XCTAssertEqual((*std::get<SetWatchItemProcess>(proc_list).begin()).signing_id_wildcard_pos,
+  XCTAssertEqual((*std::get<WatchItemProcessList>(proc_list).begin()).signing_id_wildcard_pos,
                  std::string::npos);
 
   // Test SigningID prefix but PlatformBinary or TeamID are not set
@@ -657,11 +658,11 @@ BlockGenResult CreatePolicyBlockGen() {
     } ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "com.northpolesec.*", "", {}, "", true));
-  XCTAssertNotEqual((*std::get<SetWatchItemProcess>(proc_list).begin()).signing_id_wildcard_pos,
+  XCTAssertNotEqual((*std::get<WatchItemProcessList>(proc_list).begin()).signing_id_wildcard_pos,
                     std::string::npos);
 
   // Test SigningID prefix with TeamID set
@@ -672,11 +673,11 @@ BlockGenResult CreatePolicyBlockGen() {
     } ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "com.*.test", "myvalidtid", {}, "", false));
-  XCTAssertNotEqual((*std::get<SetWatchItemProcess>(proc_list).begin()).signing_id_wildcard_pos,
+  XCTAssertNotEqual((*std::get<WatchItemProcessList>(proc_list).begin()).signing_id_wildcard_pos,
                     std::string::npos);
 
   // Test SigningID with TeamID prefix
@@ -685,11 +686,11 @@ BlockGenResult CreatePolicyBlockGen() {
         @[ @{kWatchItemConfigKeyProcessesSigningID : @"ABCDE12345:com.northpolesec.*"} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "com.northpolesec.*", "ABCDE12345", {}, "", false));
-  XCTAssertNotEqual((*std::get<SetWatchItemProcess>(proc_list).begin()).signing_id_wildcard_pos,
+  XCTAssertNotEqual((*std::get<WatchItemProcessList>(proc_list).begin()).signing_id_wildcard_pos,
                     std::string::npos);
 
   // Test SigningID with invalid TeamID prefix length (long)
@@ -714,11 +715,11 @@ BlockGenResult CreatePolicyBlockGen() {
         @[ @{kWatchItemConfigKeyProcessesSigningID : @"platform:com.northpolesec.*"} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "com.northpolesec.*", "", {}, "", true));
-  XCTAssertNotEqual((*std::get<SetWatchItemProcess>(proc_list).begin()).signing_id_wildcard_pos,
+  XCTAssertNotEqual((*std::get<WatchItemProcessList>(proc_list).begin()).signing_id_wildcard_pos,
                     std::string::npos);
 
   // Test SigningID with multiple wildcards and TeamID set
@@ -729,11 +730,11 @@ BlockGenResult CreatePolicyBlockGen() {
     } ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "com.*.*test", "myvalidtid", {}, "", false));
-  XCTAssertNotEqual((*std::get<SetWatchItemProcess>(proc_list).begin()).signing_id_wildcard_pos,
+  XCTAssertNotEqual((*std::get<WatchItemProcessList>(proc_list).begin()).signing_id_wildcard_pos,
                     std::string::npos);
 
   // Test TeamID length limits
@@ -754,18 +755,18 @@ BlockGenResult CreatePolicyBlockGen() {
   proc_list = VerifyConfigWatchItemProcesses(
       @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesTeamID : @"myvalidtid"} ]},
       &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "", "myvalidtid", {}, "", false));
 
   // Test valid TeamID - "platform"
   proc_list = VerifyConfigWatchItemProcesses(
       @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesTeamID : @"pLaTfOrM"} ]},
       &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "", "", {}, "", true));
 
   // Test CDHash length limits
@@ -790,9 +791,9 @@ BlockGenResult CreatePolicyBlockGen() {
   std::fill(cdhashBytes.begin(), cdhashBytes.end(), 0xAA);
   proc_list = VerifyConfigWatchItemProcesses(
       @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesCDHash : cdhash} ]}, &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "", "", cdhashBytes, "", false));
 
   // Test Cert Hash length limits
@@ -821,9 +822,9 @@ BlockGenResult CreatePolicyBlockGen() {
     kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesCertificateSha256 : certHash} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "", "", {}, [certHash UTF8String], false));
 
   // Test valid invalid PlatformBinary type
@@ -836,9 +837,9 @@ BlockGenResult CreatePolicyBlockGen() {
   proc_list = VerifyConfigWatchItemProcesses(
       @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesPlatformBinary : @(YES)} ]},
       &err);
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 1);
-  XCTAssertEqual(*std::get<SetWatchItemProcess>(proc_list).begin(),
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(*std::get<WatchItemProcessList>(proc_list).begin(),
                  WatchItemProcess("", "", "", {}, "", true));
 
   // Test valid multiple attributes, multiple procs
@@ -864,19 +865,14 @@ BlockGenResult CreatePolicyBlockGen() {
   },
                                              &err);
 
-  SetWatchItemProcess expectedProcs{
+  WatchItemProcessList expectedProcs{
       WatchItemProcess("mypath1", "com.northpolesec.test1", "validtid_1", cdhashBytes,
                        [certHash UTF8String], false),
       WatchItemProcess("mypath2", "com.northpolesec.test2", "validtid_2", cdhashBytes,
                        [certHash UTF8String], false)};
 
-  XCTAssertTrue(std::holds_alternative<SetWatchItemProcess>(proc_list));
-  XCTAssertEqual(std::get<SetWatchItemProcess>(proc_list).size(), 2);
-
-  // Ensure each of the procs in the set is in the set of expected procs
-  for (const auto& p : std::get<SetWatchItemProcess>(proc_list)) {
-    XCTAssertEqual(expectedProcs.count(p), 1);
-  }
+  XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+  XCTAssertEqual(std::get<WatchItemProcessList>(proc_list), expectedProcs);
 }
 
 - (void)testIsWatchItemNameValid {
@@ -1220,8 +1216,7 @@ BlockGenResult CreatePolicyBlockGen() {
   XCTAssertEqual(
       **data_policies.begin(),
       DataWatchItemPolicy("rule", kVersion, "a", kWatchItemPolicyDefaultPathType,
-                          kWatchItemPolicyDefaultAllowReadAccess, kWatchItemPolicyDefaultAuditOnly,
-                          kWatchItemPolicyDefaultRuleType));
+                          kWatchItemPolicyDefaultAuditOnly, kWatchItemPolicyDefaultRuleType));
 }
 
 - (void)testParseConfigSingleWatchItemPolicies {
@@ -1232,7 +1227,7 @@ BlockGenResult CreatePolicyBlockGen() {
   // Data FAA - Test multiple paths, options, and processes
   data_policies.clear();
   proc_policies.clear();
-  SetWatchItemProcess procs = {
+  WatchItemProcessList procs = {
       WatchItemProcess("pa", "", "", {}, "", false),
       WatchItemProcess("pb", "", "", {}, "", false),
   };
@@ -1259,13 +1254,18 @@ BlockGenResult CreatePolicyBlockGen() {
   XCTAssertTrue(ParseConfigSingleWatchItem(@"rule", kVersion, singleWatchItemConfig, &data_policies,
                                            &proc_policies, &err));
 
+  // Matches the Options dictionary above
+  WatchItemProcessOptions expectedOptions;
+  expectedOptions.allow_read_access = true;
+  expectedOptions.silent = true;
+
   SetSharedDataWatchItemPolicy expectedDataPolicies = {
       std::make_shared<DataWatchItemPolicy>(
-          "rule", kVersion, "a", kWatchItemPolicyDefaultPathType, true, false,
-          santa::WatchItemRuleType::kPathsWithDeniedProcesses, true, false, "", nil, nil, procs),
+          "rule", kVersion, "a", kWatchItemPolicyDefaultPathType, false,
+          santa::WatchItemRuleType::kPathsWithDeniedProcesses, expectedOptions, procs),
       std::make_shared<DataWatchItemPolicy>(
-          "rule", kVersion, "b", WatchItemPathType::kPrefix, true, false,
-          santa::WatchItemRuleType::kPathsWithDeniedProcesses, true, false, "", nil, nil, procs)};
+          "rule", kVersion, "b", WatchItemPathType::kPrefix, false,
+          santa::WatchItemRuleType::kPathsWithDeniedProcesses, expectedOptions, procs)};
 
   XCTAssertEqual(proc_policies.size(), 0);
   XCTAssertEqual(data_policies.size(), 2);
@@ -1288,9 +1288,8 @@ BlockGenResult CreatePolicyBlockGen() {
   XCTAssertTrue(**proc_policies.begin() ==
                 ProcessWatchItemPolicy(
                     "rule", kVersion,
-                    {{"a", WatchItemPathType::kLiteral}, {"b", WatchItemPathType::kPrefix}}, true,
-                    false, santa::WatchItemRuleType::kProcessesWithDeniedPaths, true, false, "",
-                    nil, nil, procs));
+                    {{"a", WatchItemPathType::kLiteral}, {"b", WatchItemPathType::kPrefix}}, false,
+                    santa::WatchItemRuleType::kProcessesWithDeniedPaths, expectedOptions, procs));
 }
 
 - (void)testState {

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -72,9 +72,10 @@ class FAAPolicyProcessor {
   using CheckIfPolicyMatchesBlock = bool (^)(const santa::WatchItemPolicyBase& base_policy,
                                              const Message::PathTarget& target, const Message& msg);
   using URLTextPair = std::pair<NSString*, NSString*>;
-  /// A block that generates custom URL and Text pairs from a given policy.
-  using GenerateEventDetailLinkBlock =
-      URLTextPair (^)(const std::shared_ptr<WatchItemPolicyBase>& watch_item);
+  /// A block that resolves the given event detail URL and text, filling in
+  /// global defaults for any value that is unset.
+  using GenerateEventDetailLinkBlock = URLTextPair (^)(std::optional<NSString*> event_detail_url,
+                                                       std::optional<NSString*> event_detail_text);
 
   using ReadsCacheKey = std::tuple<pid_t, int, FAAClientType>;
   using StoreAccessEventBlock = void (^)(SNTStoredFileAccessEvent*, bool);
@@ -161,7 +162,7 @@ class FAAPolicyProcessor {
       CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock);
 
   virtual bool PolicyAllowsReadsForTarget(const Message& msg, const Message::PathTarget& target,
-                                          std::shared_ptr<WatchItemPolicyBase> policy);
+                                          bool allow_read_access);
 
   /// Return true if the TTY was previously messaged for the given
   /// process/policy pair. Otherwise false.

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -86,13 +86,12 @@ bool ShouldLogDecision(FileAccessPolicyDecision decision) {
   }
 }
 
-static inline bool ShouldShowUIForPolicy(const std::shared_ptr<WatchItemPolicyBase>& policy) {
-  return !policy->silent;
+static inline bool ShouldShowUI(const WatchItemProcessOptions& options) {
+  return !options.silent;
 }
 
-static inline bool ShouldMessageTTYForPolicy(const std::shared_ptr<WatchItemPolicyBase>& policy,
-                                             const Message& msg) {
-  if (policy->silent_tty || !TTYWriter::CanWrite(msg->process)) {
+static inline bool ShouldMessageTTY(const WatchItemProcessOptions& options, const Message& msg) {
+  if (options.silent_tty || !TTYWriter::CanWrite(msg->process)) {
     return false;
   }
   return true;
@@ -305,11 +304,11 @@ SNTCachedDecision* FAAPolicyProcessor::GetCachedDecision(const struct stat& stat
   return [decision_cache_ cachedDecisionForFile:stat_buf];
 }
 
-bool FAAPolicyProcessor::PolicyAllowsReadsForTarget(
-    const Message& msg, const Message::PathTarget& target,
-    const std::shared_ptr<WatchItemPolicyBase> policy) {
+bool FAAPolicyProcessor::PolicyAllowsReadsForTarget(const Message& msg,
+                                                    const Message::PathTarget& target,
+                                                    bool allow_read_access) {
   // All special cases currently require the option "allow_read_access" is set
-  if (!policy->allow_read_access) {
+  if (!allow_read_access) {
     return false;
   }
 
@@ -371,7 +370,7 @@ FileAccessPolicyDecision FAAPolicyProcessor::ApplyPolicy(
   // layer. If the policy would generally allow access to the resource,
   // producing the full kAllow result would potentially result in better
   // system performance.
-  if (PolicyAllowsReadsForTarget(msg, target, policy)) {
+  if (PolicyAllowsReadsForTarget(msg, target, policy->options.allow_read_access)) {
     return FileAccessPolicyDecision::kAllowedReadAccess;
   }
 
@@ -452,9 +451,10 @@ void FAAPolicyProcessor::LogTTY(SNTStoredFileAccessEvent* event, URLTextPair lin
     return;
   }
 
-  NSAttributedString* attrStr = [SNTBlockMessage
-      attributedBlockMessageForFileAccessEvent:event
-                                 customMessage:OptionalStringToNSString(policy.custom_message)];
+  NSAttributedString* attrStr =
+      [SNTBlockMessage attributedBlockMessageForFileAccessEvent:event
+                                                  customMessage:OptionalStringToNSString(
+                                                                    policy.options.custom_message)];
 
   NSMutableString* blockMsg = [NSMutableString stringWithCapacity:1024];
   // Escape sequences `\033[1m` and `\033[0m` begin/end bold lettering
@@ -547,7 +547,8 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
 
     URLTextPair link_info;
     if (generate_event_detail_link_block_) {
-      link_info = generate_event_detail_link_block_(policy);
+      link_info = generate_event_detail_link_block_(policy->options.event_detail_url,
+                                                    policy->options.event_detail_text);
     }
 
     if (store_access_event_block_) {
@@ -555,12 +556,12 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
     }
 
     if (IsBlockDecision(decision)) {
-      if (ShouldShowUIForPolicy(policy)) {
-        file_access_denied_block(event, OptionalStringToNSString(policy->custom_message),
+      if (ShouldShowUI(policy->options)) {
+        file_access_denied_block(event, OptionalStringToNSString(policy->options.custom_message),
                                  link_info.first, link_info.second);
       }
 
-      if (ShouldMessageTTYForPolicy(policy, msg)) {
+      if (ShouldMessageTTY(policy->options, msg)) {
         LogTTY(event, link_info, msg, *policy);
       }
     }
@@ -597,7 +598,8 @@ FAAPolicyProcessor::ESResult FAAPolicyProcessor::ProcessMessage(
     if (decision != FileAccessPolicyDecision::kNoPolicy &&
         decision != FileAccessPolicyDecision::kDeniedInvalidSignature && !path_target.truncated &&
         path_target.is_readable && path_target.unsafe_file &&
-        target_policy_pair.second.has_value() && (*target_policy_pair.second)->allow_read_access) {
+        target_policy_pair.second.has_value() &&
+        (*target_policy_pair.second)->options.allow_read_access) {
       reads_cache_.Set(MakeReadsCacheKey(msg->process->audit_token, client_type),
                        std::pair<dev_t, ino_t>({path_target.unsafe_file->stat.st_dev,
                                                 path_target.unsafe_file->stat.st_ino}));

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -210,8 +210,8 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
   EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
       .WillRepeatedly([&faaPolicyProcessor](const Message& msg, const Message::PathTarget& target,
-                                            std::shared_ptr<santa::WatchItemPolicyBase> policy) {
-        return faaPolicyProcessor.PolicyAllowsReadsForTargetWrapper(msg, target, policy);
+                                            bool allow_read_access) {
+        return faaPolicyProcessor.PolicyAllowsReadsForTargetWrapper(msg, target, allow_read_access);
       });
 
   {
@@ -219,26 +219,32 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
     // Write-only policy, Write operation
     {
-      policy->allow_read_access = true;
+      policy->options.allow_read_access = true;
       esMsg.event.open.fflag = FWRITE | FREAD;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), false);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     false);
     }
 
     // Write-only policy, Read operation
     {
-      policy->allow_read_access = true;
+      policy->options.allow_read_access = true;
       esMsg.event.open.fflag = FREAD;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), true);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     true);
     }
 
     // Read/Write policy, Read operation
     {
-      policy->allow_read_access = false;
+      policy->options.allow_read_access = false;
       esMsg.event.open.fflag = FREAD;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), false);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     false);
     }
   }
 
@@ -247,18 +253,22 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
     // Write-only policy, target readable
     {
-      policy->allow_read_access = true;
+      policy->options.allow_read_access = true;
       target.is_readable = true;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), true);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     true);
     }
 
     // Write-only policy, target not readable
     {
-      policy->allow_read_access = true;
+      policy->options.allow_read_access = true;
       target.is_readable = false;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), false);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     false);
     }
   }
 
@@ -267,18 +277,22 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
     // Write-only policy, target readable
     {
-      policy->allow_read_access = true;
+      policy->options.allow_read_access = true;
       target.is_readable = true;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), true);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     true);
     }
 
     // Write-only policy, target not readable
     {
-      policy->allow_read_access = true;
+      policy->options.allow_read_access = true;
       target.is_readable = false;
       Message msg(mockESApi, &esMsg);
-      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), false);
+      XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(
+                         msg, target, policy->options.allow_read_access),
+                     false);
     }
   }
 
@@ -291,7 +305,9 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   for (const auto& event : eventTypes) {
     esMsg.event_type = event;
     Message msg(mockESApi, &esMsg);
-    XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target, policy), false);
+    XCTAssertEqual(faaPolicyProcessor.PolicyAllowsReadsForTarget(msg, target,
+                                                                 policy->options.allow_read_access),
+                   false);
   }
 }
 
@@ -328,7 +344,7 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   }
 
   auto policy = std::make_shared<WatchItemPolicyBase>("foo_policy", "ver", "/foo");
-  policy->processes.insert(policyProc);
+  policy->processes.push_back(policyProc);
   auto optionalPolicy = std::make_optional<std::shared_ptr<WatchItemPolicyBase>>(policy);
 
   // Signed but invalid instigating processes are automatically

--- a/Source/santad/EventProviders/MockFAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/MockFAAPolicyProcessor.h
@@ -51,8 +51,7 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
   MOCK_METHOD(SNTCachedDecision*, GetCachedDecision, (const struct stat& stat_buf), (override));
   MOCK_METHOD(NSString*, GetCertificateHash, (const es_file_t* es_file), (override));
   MOCK_METHOD(bool, PolicyAllowsReadsForTarget,
-              (const Message& msg, const Message::PathTarget& target,
-               std::shared_ptr<WatchItemPolicyBase> policy),
+              (const Message& msg, const Message::PathTarget& target, bool allow_read_access),
               (override));
   MOCK_METHOD(FileAccessPolicyDecision, ApplyPolicy,
               (const Message& msg, const Message::PathTarget& target,
@@ -68,8 +67,8 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
   }
 
   bool PolicyAllowsReadsForTargetWrapper(const Message& msg, const Message::PathTarget& target,
-                                         std::shared_ptr<WatchItemPolicyBase> policy) {
-    return FAAPolicyProcessor::PolicyAllowsReadsForTarget(msg, target, policy);
+                                         bool allow_read_access) {
+    return FAAPolicyProcessor::PolicyAllowsReadsForTarget(msg, target, allow_read_access);
   }
 
   FileAccessPolicyDecision ApplyPolicyWrapper(

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
@@ -116,8 +116,8 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
   WatchItemProcess proc("proc_path_1", "com.example.proc", "PROCTEAMID", {}, "", false);
   auto pwip = std::make_shared<ProcessWatchItemPolicy>(
       "name", "ver", SetPairPathAndType{PairPathAndType{"path1", WatchItemPathType::kLiteral}},
-      true, true, santa::WatchItemRuleType::kProcessesWithAllowedPaths, false, false, "", nil, nil,
-      santa::SetWatchItemProcess{proc});
+      true, santa::WatchItemRuleType::kProcessesWithAllowedPaths, santa::WatchItemProcessOptions{},
+      santa::WatchItemProcessList{proc});
 
   // Test iter block will call the given CheckPolicyBlock and capture the return
   __block bool checkPolicyBlockResult;

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -205,9 +205,9 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
   auto faaPolicyProcessor = std::make_shared<santa::FAAPolicyProcessor>(
       [SNTDecisionCache sharedCache], enricher, logger, tty_writer, metrics,
       configurator.fileAccessGlobalLogsPerSec, configurator.fileAccessGlobalWindowSizeSec,
-      ^santa::FAAPolicyProcessor::URLTextPair(
-          const std::shared_ptr<santa::WatchItemPolicyBase>& policy) {
-        return watch_items->EventDetailLinkInfo(policy);
+      ^santa::FAAPolicyProcessor::URLTextPair(std::optional<NSString*> event_detail_url,
+                                              std::optional<NSString*> event_detail_text) {
+        return watch_items->EventDetailLinkInfo(event_detail_url, event_detail_text);
       },
       ^(SNTStoredFileAccessEvent* event, bool sendImmediately) {
         // Only store FAA events if a sync server is configured.


### PR DESCRIPTION
Preparation for per-process rule options. No behavior change.

- Group the rule's AllowReadAccess, EnableSilentMode, EnableSilentTTYMode, BlockMessage, EventDetailURL and EventDetailText into WatchItemProcessOptions so the effective values for an event can be passed around as a unit
- Parse those keys in one place (VerifyConfigOptions) instead of splitting the work between the parser and WatchItemPolicyBase's constructor
- Store a rule's processes in an ordered list rather than a hash set. Matching was already a linear scan, and ordering becomes meaningful in a follow-up
- Take the values they actually need in PolicyAllowsReadsForTarget and EventDetailLinkInfo rather than the whole policy