### PR TITLE
santad: Parse ProcessesWithOptions FAA rules

### DIFF
--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -2518,9 +2518,12 @@ static SNTConfigurator* sharedConfigurator = nil;
 - (NSArray*)validateFileAccessPolicy:(NSDictionary*)policy {
   NSMutableArray* errors = [NSMutableArray array];
 
+  // Always a locally managed configuration, never a sync server's rules.
+  constexpr auto kDataSource = santa::WatchItems::DataSource::kEmbeddedConfig;
+
   // First validate top-level config structure.
   NSError* error;
-  if (!santa::WatchItems::IsValidConfig(policy, &error)) {
+  if (!santa::WatchItems::IsValidConfig(policy, kDataSource, &error)) {
     [errors addObject:[NSString stringWithFormat:@"FileAccessPolicy: %@",
                                                  error.localizedDescription ?: @"Unknown error"]];
   }
@@ -2537,7 +2540,8 @@ static SNTConfigurator* sharedConfigurator = nil;
         continue;
       }
       NSError* ruleError;
-      if (!santa::WatchItems::IsValidRule(name, watchItems[name], &ruleError, policyVersion)) {
+      if (!santa::WatchItems::IsValidRule(name, watchItems[name], kDataSource, &ruleError,
+                                          policyVersion)) {
         [errors addObject:[NSString
                               stringWithFormat:@"FileAccessPolicy rule '%@' is invalid: %@", name,
                                                ruleError.localizedDescription ?: @"Unknown error"]];

--- a/Source/common/faa/WatchItemPolicy.h
+++ b/Source/common/faa/WatchItemPolicy.h
@@ -50,7 +50,8 @@ struct SharedPtrValueEqual;
 using PairPathAndType = std::pair<std::string, WatchItemPathType>;
 using SetPairPathAndType = absl::flat_hash_set<PairPathAndType>;
 // Note: This is an ordered list, not a set, because process matching is
-// first-match-wins.
+// first-match-wins. Entries parsed from `ProcessesWithOptions` are placed
+// ahead of entries parsed from `Processes` so that the former take precedence.
 using WatchItemProcessList = std::vector<WatchItemProcess>;
 using SetSharedDataWatchItemPolicy = absl::flat_hash_set<std::shared_ptr<DataWatchItemPolicy>,
                                                          SharedPtrValueHash<DataWatchItemPolicy>,
@@ -80,10 +81,27 @@ static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType =
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 
-/// The options a rule carries. Grouped into a struct so that the effective
-/// values for an event can be passed around as a unit rather than as a handful
-/// of loose parameters.
+/// The outcome of a match against a single configured process. `kInherit`
+/// defers to the rule's `rule_type` and `audit_only` options, which is the
+/// behavior of every process listed under the `Processes` key. The remaining
+/// values state their own outcome, which is how a `ProcessesWithOptions` entry
+/// can e.g. deny a process under a `PathsWithAllowedProcesses` rule.
+enum class WatchItemProcessAction {
+  kInherit,
+  kAllow,
+  kAudit,
+  kDeny,
+};
+
+static constexpr WatchItemProcessAction kWatchItemPolicyDefaultProcessAction =
+    WatchItemProcessAction::kInherit;
+
+/// The set of options a rule carries, and that a `ProcessesWithOptions` entry
+/// can override. Overrides are merged against the rule's own options while
+/// parsing the config, so every field always holds an effective value - both
+/// here and on `WatchItemPolicyBase::options`.
 struct WatchItemProcessOptions {
+  WatchItemProcessAction action = kWatchItemPolicyDefaultProcessAction;
   bool allow_read_access = kWatchItemPolicyDefaultAllowReadAccess;
   bool silent = kWatchItemPolicyDefaultEnableSilentMode;
   bool silent_tty = kWatchItemPolicyDefaultEnableSilentTTYMode;
@@ -94,8 +112,8 @@ struct WatchItemProcessOptions {
   bool operator==(const WatchItemProcessOptions& other) const {
     // Note: Matching WatchItemPolicyBase, custom_message, event_detail_url and
     // event_detail_text are not currently considered for equality purposes.
-    return allow_read_access == other.allow_read_access && silent == other.silent &&
-           silent_tty == other.silent_tty;
+    return action == other.action && allow_read_access == other.allow_read_access &&
+           silent == other.silent && silent_tty == other.silent_tty;
   }
 
   bool operator!=(const WatchItemProcessOptions& other) const { return !(*this == other); }
@@ -104,6 +122,7 @@ struct WatchItemProcessOptions {
 struct WatchItemProcess {
   static std::optional<WatchItemProcess> Create(NSString* bp, NSString* sid, NSString* tid,
                                                 NSString* cdh, NSString* ch, bool pb,
+                                                std::optional<WatchItemProcessOptions> opts,
                                                 NSError** error) {
     // Ensure at least one attribute set
     if (!bp && !sid && !tid && !cdh && !ch && !pb) {
@@ -151,19 +170,21 @@ struct WatchItemProcess {
 
     return WatchItemProcess(NSStringToUTF8String(bp ?: @""), std::move(sid_str),
                             NSStringToUTF8String(tid ?: @""), HexStringToBuf(cdh),
-                            NSStringToUTF8String(ch ?: @""), pb, wildcard_pos);
+                            NSStringToUTF8String(ch ?: @""), pb, wildcard_pos, std::move(opts));
   }
 
 #ifdef DEBUG
   // This interface is intended to only be used by tests
   WatchItemProcess(std::string bp, std::string sid, std::string tid, std::vector<uint8_t> cdh,
-                   std::string ch, bool pb)
+                   std::string ch, bool pb,
+                   std::optional<WatchItemProcessOptions> opts = std::nullopt)
       : binary_path(bp),
         signing_id(sid),
         team_id(tid),
         cdhash(std::move(cdh)),
         certificate_sha256(ch),
-        platform_binary(pb) {
+        platform_binary(pb),
+        options(std::move(opts)) {
     signing_id_wildcard_pos = signing_id.find('*');
   }
 #endif
@@ -172,7 +193,7 @@ struct WatchItemProcess {
     return binary_path == other.binary_path && signing_id == other.signing_id &&
            team_id == other.team_id && cdhash == other.cdhash &&
            certificate_sha256 == other.certificate_sha256 &&
-           platform_binary == other.platform_binary;
+           platform_binary == other.platform_binary && options == other.options;
   }
 
   bool operator!=(const WatchItemProcess& other) const { return !(*this == other); }
@@ -193,18 +214,22 @@ struct WatchItemProcess {
   std::string certificate_sha256;
   bool platform_binary;
   size_t signing_id_wildcard_pos;
+  // Only set for entries parsed from the `ProcessesWithOptions` key. Entries
+  // from `Processes` have no overrides and defer entirely to the rule.
+  std::optional<WatchItemProcessOptions> options;
 
  private:
   // This object is intended to be created via the factory method
   WatchItemProcess(std::string bp, std::string sid, std::string tid, std::vector<uint8_t> cdh,
-                   std::string ch, bool pb, size_t wc)
+                   std::string ch, bool pb, size_t wc, std::optional<WatchItemProcessOptions> opts)
       : binary_path(bp),
         signing_id(sid),
         team_id(tid),
         cdhash(std::move(cdh)),
         certificate_sha256(ch),
         platform_binary(pb),
-        signing_id_wildcard_pos(wc) {}
+        signing_id_wildcard_pos(wc),
+        options(std::move(opts)) {}
 };
 
 struct WatchItemPolicyBase {
@@ -239,8 +264,13 @@ struct WatchItemPolicyBase {
 
   std::string name;
   std::string version;  // WIP - No current way to control via config
+  // Note: audit_only and rule_type are deliberately not part of `options` -
+  // they are the two things a per-process entry cannot override, which is why
+  // WatchItemProcessAction exists.
   bool audit_only;
   WatchItemRuleType rule_type;
+  // The rule's own options, used for any event where the matched process had no
+  // overrides of its own. `action` is always kInherit here.
   WatchItemProcessOptions options;
   WatchItemProcessList processes;
   int64_t rule_id;

--- a/Source/common/faa/WatchItemPolicyTest.mm
+++ b/Source/common/faa/WatchItemPolicyTest.mm
@@ -30,6 +30,7 @@ using santa::SetSharedDataWatchItemPolicy;
 using santa::SetSharedProcessWatchItemPolicy;
 using santa::WatchItemPathType;
 using santa::WatchItemProcess;
+using santa::WatchItemProcessOptions;
 using santa::WatchItemRuleType;
 
 @interface WatchItemPolicyTest : XCTestCase
@@ -78,6 +79,44 @@ using santa::WatchItemRuleType;
     proc.cdhash = {1};
     XCTAssertNotEqual(proc, orig);
   }
+  {
+    WatchItemProcess proc = makeProc();
+    proc.options = WatchItemProcessOptions{};
+    XCTAssertNotEqual(proc, orig);
+  }
+
+  // Every field of the options struct that participates in equality
+  WatchItemProcess withDefaultOptions = makeProc();
+  withDefaultOptions.options = WatchItemProcessOptions{};
+
+  {
+    WatchItemProcess proc = makeProc();
+    WatchItemProcessOptions opts;
+    opts.action = santa::WatchItemProcessAction::kDeny;
+    proc.options = opts;
+    XCTAssertNotEqual(proc, withDefaultOptions);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    WatchItemProcessOptions opts;
+    opts.allow_read_access = !opts.allow_read_access;
+    proc.options = opts;
+    XCTAssertNotEqual(proc, withDefaultOptions);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    WatchItemProcessOptions opts;
+    opts.silent = !opts.silent;
+    proc.options = opts;
+    XCTAssertNotEqual(proc, withDefaultOptions);
+  }
+  {
+    WatchItemProcess proc = makeProc();
+    WatchItemProcessOptions opts;
+    opts.silent_tty = !opts.silent_tty;
+    proc.options = opts;
+    XCTAssertNotEqual(proc, withDefaultOptions);
+  }
 }
 
 - (void)testProcessWatchItemPolicyProcessOrder {
@@ -96,28 +135,34 @@ using santa::WatchItemRuleType;
 
 - (void)testWatchItemProcessCreate {
   // Fail when nothing is set
-  XCTAssertFalse(WatchItemProcess::Create(nil, nil, nil, nil, nil, false, nil).has_value());
+  XCTAssertFalse(
+      WatchItemProcess::Create(nil, nil, nil, nil, nil, false, std::nullopt, nil).has_value());
 
   // Both PlatformBinary and a TID cannot be set (as long as not "platform")
   XCTAssertFalse(
-      WatchItemProcess::Create(nil, nil, @"ABCDE12345", nil, nil, true, nil).has_value());
+      WatchItemProcess::Create(nil, nil, @"ABCDE12345", nil, nil, true, std::nullopt, nil)
+          .has_value());
 
   // SigningID being set requires a TID/PlatformBinary
   XCTAssertFalse(
-      WatchItemProcess::Create(nil, @"com.example", nil, nil, nil, false, nil).has_value());
+      WatchItemProcess::Create(nil, @"com.example", nil, nil, nil, false, std::nullopt, nil)
+          .has_value());
 
   // Test invalid TID prefixes for an SID
-  XCTAssertFalse(WatchItemProcess::Create(nil, @"platforms:com.example", nil, nil, nil, false, nil)
+  XCTAssertFalse(WatchItemProcess::Create(nil, @"platforms:com.example", nil, nil, nil, false,
+                                          std::nullopt, nil)
                      .has_value());
-  XCTAssertFalse(WatchItemProcess::Create(nil, @"ABCDE1234:com.example", nil, nil, nil, false, nil)
+  XCTAssertFalse(WatchItemProcess::Create(nil, @"ABCDE1234:com.example", nil, nil, nil, false,
+                                          std::nullopt, nil)
                      .has_value());
-  XCTAssertFalse(
-      WatchItemProcess::Create(nil, @"ABCDE123456:com.example", nil, nil, nil, false, nil)
-          .has_value());
+  XCTAssertFalse(WatchItemProcess::Create(nil, @"ABCDE123456:com.example", nil, nil, nil, false,
+                                          std::nullopt, nil)
+                     .has_value());
 
   {
     // If PB is set, TID:SID prefix is ignored
-    auto wip = WatchItemProcess::Create(nil, @"ABCDE12345:com.example", nil, nil, nil, true, nil);
+    auto wip = WatchItemProcess::Create(nil, @"ABCDE12345:com.example", nil, nil, nil, true,
+                                        std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertCppStringEqual(wip->signing_id, "ABCDE12345:com.example");
     XCTAssertTrue(wip->platform_binary);
@@ -125,8 +170,8 @@ using santa::WatchItemRuleType;
 
   {
     // If TID is set to platform, TID:SID prefix is ignored, marked as platform
-    auto wip =
-        WatchItemProcess::Create(nil, @"ABCDE12345:com.example", @"PLatFOrm", nil, nil, false, nil);
+    auto wip = WatchItemProcess::Create(nil, @"ABCDE12345:com.example", @"PLatFOrm", nil, nil,
+                                        false, std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertCppStringEqual(wip->signing_id, "ABCDE12345:com.example");
     XCTAssertTrue(wip->platform_binary);
@@ -135,8 +180,8 @@ using santa::WatchItemRuleType;
 
   {
     // If TID is set, TID:SID prefix is ignored
-    auto wip =
-        WatchItemProcess::Create(nil, @"platform:com.example", @"ABCDE12345", nil, nil, false, nil);
+    auto wip = WatchItemProcess::Create(nil, @"platform:com.example", @"ABCDE12345", nil, nil,
+                                        false, std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertCppStringEqual(wip->signing_id, "platform:com.example");
     XCTAssertFalse(wip->platform_binary);
@@ -145,7 +190,8 @@ using santa::WatchItemRuleType;
 
   {
     // Extract TID
-    auto wip = WatchItemProcess::Create(nil, @"ABCDE12345:x", nil, nil, nil, false, nil);
+    auto wip =
+        WatchItemProcess::Create(nil, @"ABCDE12345:x", nil, nil, nil, false, std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertCppStringEqual(wip->signing_id, "x");
     XCTAssertFalse(wip->platform_binary);
@@ -154,7 +200,8 @@ using santa::WatchItemRuleType;
 
   {
     // Extract platform TID
-    auto wip = WatchItemProcess::Create(nil, @"platFORM:*", nil, nil, nil, false, nil);
+    auto wip =
+        WatchItemProcess::Create(nil, @"platFORM:*", nil, nil, nil, false, std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertCppStringEqual(wip->signing_id, "*");
     XCTAssertTrue(wip->platform_binary);
@@ -163,7 +210,8 @@ using santa::WatchItemRuleType;
 
   {
     // Extract platform TID
-    auto wip = WatchItemProcess::Create(nil, @"platform:*", nil, nil, nil, false, nil);
+    auto wip =
+        WatchItemProcess::Create(nil, @"platform:*", nil, nil, nil, false, std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertCppStringEqual(wip->signing_id, "*");
     XCTAssertTrue(wip->platform_binary);
@@ -172,7 +220,7 @@ using santa::WatchItemRuleType;
 
   {
     // Both PlatformBinary and a TID can be set if TID is "platform"
-    auto wip = WatchItemProcess::Create(nil, nil, @"plATFOrm", nil, nil, true, nil);
+    auto wip = WatchItemProcess::Create(nil, nil, @"plATFOrm", nil, nil, true, std::nullopt, nil);
     XCTAssertTrue(wip.has_value());
     XCTAssertTrue(wip->platform_binary);
     XCTAssertCppStringEqual(wip->team_id, "");

--- a/Source/common/faa/WatchItems.h
+++ b/Source/common/faa/WatchItems.h
@@ -58,11 +58,17 @@ extern NSString* const kWatchItemConfigKeyProcessesSigningID;
 extern NSString* const kWatchItemConfigKeyProcessesTeamID;
 extern NSString* const kWatchItemConfigKeyProcessesCDHash;
 extern NSString* const kWatchItemConfigKeyProcessesPlatformBinary;
+extern NSString* const kWatchItemConfigKeyProcessesWithOptions;
+extern NSString* const kWatchItemConfigKeyProcessesAction;
 
 extern NSString* const kRuleTypePathsWithAllowedProcesses;
 extern NSString* const kRuleTypePathsWithDeniedProcesses;
 extern NSString* const kRuleTypeProcessesWithAllowedPaths;
 extern NSString* const kRuleTypeProcessesWithDeniedPaths;
+
+extern NSString* const kProcessActionAllow;
+extern NSString* const kProcessActionAudit;
+extern NSString* const kProcessActionDeny;
 
 namespace santa {
 
@@ -187,13 +193,15 @@ class WatchItems : public Timer<WatchItems>, public PassKey<WatchItems> {
   std::optional<WatchItemsState> State();
 
   /// Resolve the event detail URL/text to display, falling back to the
-  /// top-level config values when the given values are unset.
+  /// top-level config values when the given values are unset. Callers pass the
+  /// effective values for the event, which may have come from a matched
+  /// process's overrides rather than the rule itself.
   std::pair<NSString*, NSString*> EventDetailLinkInfo(std::optional<NSString*> event_detail_url,
                                                       std::optional<NSString*> event_detail_text);
 
-  static bool IsValidRule(NSString* name, NSDictionary* rule, NSError** error,
-                          NSString* policyVersion = nil);
-  static bool IsValidConfig(NSDictionary* config, NSError** error);
+  static bool IsValidRule(NSString* name, NSDictionary* rule, DataSource data_source,
+                          NSError** error, NSString* policyVersion = nil);
+  static bool IsValidConfig(NSDictionary* config, DataSource data_source, NSError** error);
 
   static NSString* DataSourceName(DataSource data_source);
 
@@ -204,9 +212,8 @@ class WatchItems : public Timer<WatchItems>, public PassKey<WatchItems> {
                                                     NSDictionary* config,
                                                     uint32_t reapply_config_frequency_secs);
 
-  NSDictionary* ReadConfig();
   NSDictionary* ReadConfigLocked() ABSL_SHARED_LOCKS_REQUIRED(lock_);
-  void ReloadConfig(NSDictionary* new_config);
+  void ReloadConfig();
   void UpdateCurrentState(DataWatchItems new_data_watch_items,
                           ProcessWatchItems new_proc_watch_items, NSDictionary* new_config,
                           uint64_t rules_loaded);

--- a/Source/common/faa/WatchItems.mm
+++ b/Source/common/faa/WatchItems.mm
@@ -66,11 +66,17 @@ NSString* const kWatchItemConfigKeyProcessesSigningID = @"SigningID";
 NSString* const kWatchItemConfigKeyProcessesTeamID = @"TeamID";
 NSString* const kWatchItemConfigKeyProcessesCDHash = @"CDHash";
 NSString* const kWatchItemConfigKeyProcessesPlatformBinary = @"PlatformBinary";
+NSString* const kWatchItemConfigKeyProcessesWithOptions = @"ProcessesWithOptions";
+NSString* const kWatchItemConfigKeyProcessesAction = @"Action";
 
 NSString* const kRuleTypePathsWithAllowedProcesses = @"pathswithallowedprocesses";
 NSString* const kRuleTypePathsWithDeniedProcesses = @"pathswithdeniedprocesses";
 NSString* const kRuleTypeProcessesWithAllowedPaths = @"processeswithallowedpaths";
 NSString* const kRuleTypeProcessesWithDeniedPaths = @"processeswithdeniedpaths";
+
+NSString* const kProcessActionAllow = @"allow";
+NSString* const kProcessActionAudit = @"audit";
+NSString* const kProcessActionDeny = @"deny";
 
 // https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/
 static constexpr NSUInteger kMaxTeamIDLength = 10;
@@ -146,6 +152,19 @@ std::optional<WatchItemRuleType> GetRuleType(NSString* rule_type) {
     return WatchItemRuleType::kProcessesWithAllowedPaths;
   } else if ([rule_type isEqualToString:kRuleTypeProcessesWithDeniedPaths]) {
     return WatchItemRuleType::kProcessesWithDeniedPaths;
+  } else {
+    return std::nullopt;
+  }
+}
+
+std::optional<WatchItemProcessAction> GetProcessAction(NSString* action) {
+  action = [action lowercaseString];
+  if ([action isEqualToString:kProcessActionAllow]) {
+    return WatchItemProcessAction::kAllow;
+  } else if ([action isEqualToString:kProcessActionAudit]) {
+    return WatchItemProcessAction::kAudit;
+  } else if ([action isEqualToString:kProcessActionDeny]) {
+    return WatchItemProcessAction::kDeny;
   } else {
     return std::nullopt;
   }
@@ -338,13 +357,18 @@ std::variant<Unit, SetPairPathAndType> VerifyConfigWatchItemPaths(NSArray<id>* p
   return path_list;
 }
 
-/// Verify and parse a rule's `Options` dictionary into the options struct.
+/// Verify and parse the option keys shared by a rule's `Options` dictionary and
+/// a `ProcessesWithOptions` entry. Any key that isn't present takes its value
+/// from `defaults`, so the result always holds effective values: pass the
+/// built-in defaults for a rule, or the rule's own options for a process entry.
 ///
 /// Note: This is the only place the empty-string conventions are applied. An
 /// empty BlockMessage or EventDetailText means "unset", while an empty
-/// EventDetailURL is meaningful - it overrides the global value in order to
+/// EventDetailURL is meaningful - it overrides the rule/global value in order to
 /// hide the button.
-std::optional<WatchItemProcessOptions> VerifyConfigOptions(NSDictionary* dict, NSError** err) {
+std::optional<WatchItemProcessOptions> VerifyConfigOptions(NSDictionary* dict,
+                                                           const WatchItemProcessOptions& defaults,
+                                                           NSError** err) {
   if (!VerifyConfigKey(dict, kWatchItemConfigKeyOptionsAllowReadAccess, [NSNumber class], err) ||
       !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsEnableSilentMode, [NSNumber class], err) ||
       !VerifyConfigKey(dict, kWatchItemConfigKeyOptionsEnableSilentTTYMode, [NSNumber class],
@@ -358,14 +382,13 @@ std::optional<WatchItemProcessOptions> VerifyConfigOptions(NSDictionary* dict, N
     return std::nullopt;
   }
 
-  WatchItemProcessOptions opts;
+  WatchItemProcessOptions opts = defaults;
 
-  opts.allow_read_access = GetBoolValue(dict, kWatchItemConfigKeyOptionsAllowReadAccess,
-                                        kWatchItemPolicyDefaultAllowReadAccess);
-  opts.silent = GetBoolValue(dict, kWatchItemConfigKeyOptionsEnableSilentMode,
-                             kWatchItemPolicyDefaultEnableSilentMode);
-  opts.silent_tty = GetBoolValue(dict, kWatchItemConfigKeyOptionsEnableSilentTTYMode,
-                                 kWatchItemPolicyDefaultEnableSilentTTYMode);
+  opts.allow_read_access =
+      GetBoolValue(dict, kWatchItemConfigKeyOptionsAllowReadAccess, defaults.allow_read_access);
+  opts.silent = GetBoolValue(dict, kWatchItemConfigKeyOptionsEnableSilentMode, defaults.silent);
+  opts.silent_tty =
+      GetBoolValue(dict, kWatchItemConfigKeyOptionsEnableSilentTTYMode, defaults.silent_tty);
 
   if (NSString* msg = dict[kWatchItemConfigKeyOptionsCustomMessage]) {
     opts.custom_message = msg.length ? std::make_optional(NSStringToUTF8String(msg)) : std::nullopt;
@@ -382,8 +405,49 @@ std::optional<WatchItemProcessOptions> VerifyConfigOptions(NSDictionary* dict, N
   return opts;
 }
 
-/// The `Processes` array can only contain dictionaries. Each dictionary can
-/// contain the attributes that describe a single process.
+/// Verify a single `ProcessesWithOptions` entry's `Action` key and its overrides
+/// of the rule's options, which are merged over `rule_options`.
+std::optional<WatchItemProcessOptions> VerifyConfigWatchItemProcessOptions(
+    NSDictionary* process, const WatchItemProcessOptions& rule_options, NSError** err) {
+  // These options only make sense for the rule as a whole. Reject them rather
+  // than silently ignoring them - reaching for AuditOnly here instead of
+  // `Action: audit` is an easy mistake, and quietly falling back to the rule's
+  // value could leave the process blocked when the intent was to audit it.
+  for (NSString* key in @[
+         kWatchItemConfigKeyOptionsAuditOnly, kWatchItemConfigKeyOptionsRuleType,
+         kWatchItemConfigKeyOptionsInvertProcessExceptions
+       ]) {
+    if (process[key]) {
+      [SNTError populateError:err
+                   withFormat:@"The '%@' option cannot be set per-process%@", key,
+                              [key isEqualToString:kWatchItemConfigKeyOptionsAuditOnly]
+                                  ? [NSString stringWithFormat:@". Use '%@' instead",
+                                                               kWatchItemConfigKeyProcessesAction]
+                                  : @""];
+      return std::nullopt;
+    }
+  }
+
+  if (!VerifyConfigKey(process, kWatchItemConfigKeyProcessesAction, [NSString class], err, false,
+                       ValidValuesValidator<WatchItemProcessAction>(GetProcessAction))) {
+    return std::nullopt;
+  }
+
+  std::optional<WatchItemProcessOptions> opts = VerifyConfigOptions(process, rule_options, err);
+  if (!opts.has_value()) {
+    return std::nullopt;
+  }
+
+  if (NSString* action = process[kWatchItemConfigKeyProcessesAction]) {
+    opts->action = GetProcessAction(action).value_or(kWatchItemPolicyDefaultProcessAction);
+  }
+
+  return opts;
+}
+
+/// The `Processes` and `ProcessesWithOptions` arrays can only contain
+/// dictionaries. Each dictionary can contain the attributes that describe a
+/// single process.
 ///
 /// <array>
 ///   <dict>
@@ -403,13 +467,30 @@ std::optional<WatchItemProcessOptions> VerifyConfigOptions(NSDictionary* dict, N
 ///     <string>EEEE</string>
 ///   </dict>
 /// </array>
-std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(NSDictionary* watch_item,
-                                                                        NSError** err) {
+///
+/// Entries of the `ProcessesWithOptions` array may additionally carry an
+/// `Action` key and overrides of the rule's options alongside the attributes
+/// above. Pass the rule's options as `rule_options` to enable (and merge)
+/// them; pass nullptr for the plain `Processes` array, whose entries always
+/// defer to the rule.
+///
+/// <array>
+///   <dict>
+///     <key>BinaryPath</key>
+///     <string>AAAA</string>
+///     <key>Action</key>
+///     <string>deny</string>
+///     <key>EnableSilentMode</key>
+///     <true/>
+///   </dict>
+/// </array>
+std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(
+    NSDictionary* watch_item, NSString* key, const WatchItemProcessOptions* rule_options,
+    NSError** err) {
   __block WatchItemProcessList proc_list;
 
   if (!VerifyConfigKeyArray(
-          watch_item, kWatchItemConfigKeyProcesses, [NSDictionary class], err,
-          ^bool(NSDictionary* process, NSError** err) {
+          watch_item, key, [NSDictionary class], err, ^bool(NSDictionary* process, NSError** err) {
             if (!VerifyConfigKey(process, kWatchItemConfigKeyProcessesBinaryPath, [NSString class],
                                  err, false, LenRangeValidator(1, PATH_MAX)) ||
                 !VerifyConfigKey(process, kWatchItemConfigKeyProcessesSigningID, [NSString class],
@@ -436,13 +517,22 @@ std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(NSDictio
               return false;
             }
 
+            std::optional<WatchItemProcessOptions> opts;
+            if (rule_options) {
+              opts = VerifyConfigWatchItemProcessOptions(process, *rule_options, err);
+              if (!opts.has_value()) {
+                return false;
+              }
+            }
+
             auto watch_item_proc = WatchItemProcess::Create(
                 process[kWatchItemConfigKeyProcessesBinaryPath],
                 process[kWatchItemConfigKeyProcessesSigningID],
                 process[kWatchItemConfigKeyProcessesTeamID],
                 process[kWatchItemConfigKeyProcessesCDHash],
                 process[kWatchItemConfigKeyProcessesCertificateSha256],
-                [process[kWatchItemConfigKeyProcessesPlatformBinary] boolValue], err);
+                [process[kWatchItemConfigKeyProcessesPlatformBinary] boolValue], std::move(opts),
+                err);
 
             if (watch_item_proc.has_value()) {
               proc_list.push_back(std::move(*watch_item_proc));
@@ -490,11 +580,26 @@ std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(NSDictio
 ///   <array>
 ///   ... See VerifyConfigWatchItemProcesses for more details ...
 ///   </array>
+///   <key>ProcessesWithOptions</key>
+///   <array>
+///   ... See VerifyConfigWatchItemProcesses for more details ...
+///   </array>
 /// </dict>
 bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy_version,
-                                NSDictionary* watch_item,
+                                NSDictionary* watch_item, WatchItems::DataSource data_source,
                                 SetSharedDataWatchItemPolicy* data_policies,
                                 SetSharedProcessWatchItemPolicy* proc_policies, NSError** err) {
+  // The only enforcement point for the sync-only keys. Rejecting the rule
+  // rather than dropping the array keeps a local config from quietly getting
+  // different access than it asked for.
+  if (data_source != WatchItems::DataSource::kDatabase &&
+      watch_item[kWatchItemConfigKeyProcessesWithOptions]) {
+    [SNTError populateError:err
+                 withFormat:@"The '%@' key is only supported for rules from Workshop",
+                            kWatchItemConfigKeyProcessesWithOptions];
+    return false;
+  }
+
   if (!VerifyConfigKey(watch_item, kWatchItemConfigKeyPaths, [NSArray class], err, true)) {
     return false;
   }
@@ -512,7 +617,8 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
 
   NSDictionary* options = watch_item[kWatchItemConfigKeyOptions];
   if (options) {
-    // Note: The keys VerifyConfigOptions handles are verified by it below.
+    // Note: The options a per-process entry can also carry are verified by
+    // VerifyConfigOptions below. Only the rule-only options are checked here.
     NSArray<NSString*>* boolOptions = @[
       kWatchItemConfigKeyOptionsAuditOnly,
       kWatchItemConfigKeyOptionsInvertProcessExceptions,
@@ -535,7 +641,8 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
     }
   }
 
-  std::optional<WatchItemProcessOptions> rule_options = VerifyConfigOptions(options, err);
+  // The rule's own options. Each ProcessesWithOptions entry is merged over these.
+  std::optional<WatchItemProcessOptions> rule_options = VerifyConfigOptions(options, {}, err);
   if (!rule_options.has_value()) {
     return false;
   }
@@ -558,12 +665,6 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
   bool audit_only =
       GetBoolValue(options, kWatchItemConfigKeyOptionsAuditOnly, kWatchItemPolicyDefaultAuditOnly);
 
-  std::variant<Unit, WatchItemProcessList> proc_list =
-      VerifyConfigWatchItemProcesses(watch_item, err);
-  if (std::holds_alternative<Unit>(proc_list)) {
-    return false;
-  }
-
   WatchItemRuleType rule_type = kWatchItemPolicyDefaultRuleType;
   if (options[kWatchItemConfigKeyOptionsRuleType]) {
     rule_type = GetRuleType(options[kWatchItemConfigKeyOptionsRuleType])
@@ -575,6 +676,25 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
     } else {
       rule_type = WatchItemRuleType::kPathsWithAllowedProcesses;
     }
+  }
+
+  // ProcessesWithOptions entries are evaluated ahead of Processes entries, so
+  // they come first in the combined list that matching iterates.
+  std::variant<Unit, WatchItemProcessList> procs_with_options = VerifyConfigWatchItemProcesses(
+      watch_item, kWatchItemConfigKeyProcessesWithOptions, &rule_options.value(), err);
+  if (std::holds_alternative<Unit>(procs_with_options)) {
+    return false;
+  }
+
+  std::variant<Unit, WatchItemProcessList> proc_list =
+      VerifyConfigWatchItemProcesses(watch_item, kWatchItemConfigKeyProcesses, nullptr, err);
+  if (std::holds_alternative<Unit>(proc_list)) {
+    return false;
+  }
+
+  WatchItemProcessList procs = std::move(std::get<WatchItemProcessList>(procs_with_options));
+  for (WatchItemProcess& proc : std::get<WatchItemProcessList>(proc_list)) {
+    procs.push_back(std::move(proc));
   }
 
   // Passing nil sets means this is a verification only.
@@ -590,8 +710,7 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
       for (const PairPathAndType& path_type_pair : std::get<SetPairPathAndType>(path_list)) {
         data_policies->insert(std::make_shared<DataWatchItemPolicy>(
             NSStringToUTF8StringView(name), policy_version, path_type_pair.first,
-            path_type_pair.second, audit_only, rule_type, *rule_options,
-            std::get<WatchItemProcessList>(proc_list), rule_id));
+            path_type_pair.second, audit_only, rule_type, *rule_options, procs, rule_id));
       }
 
       break;
@@ -600,8 +719,7 @@ bool ParseConfigSingleWatchItem(NSString* name, std::string_view fallback_policy
     case WatchItemRuleType::kProcessesWithDeniedPaths:
       proc_policies->insert(std::make_shared<ProcessWatchItemPolicy>(
           NSStringToUTF8StringView(name), policy_version, std::get<SetPairPathAndType>(path_list),
-          audit_only, rule_type, std::move(*rule_options),
-          std::move(std::get<WatchItemProcessList>(proc_list)), rule_id));
+          audit_only, rule_type, std::move(*rule_options), std::move(procs), rule_id));
 
       break;
   }
@@ -653,7 +771,8 @@ bool IsWatchItemNameValid(id key, NSError** err) {
   return true;
 }
 
-bool ParseConfig(NSDictionary* config, SetSharedDataWatchItemPolicy* data_policies,
+bool ParseConfig(NSDictionary* config, WatchItems::DataSource data_source,
+                 SetSharedDataWatchItemPolicy* data_policies,
                  SetSharedProcessWatchItemPolicy* proc_policies, uint64_t* rules_loaded,
                  NSError** err) {
   // If the top level version key exists, it must be well formatted.
@@ -703,8 +822,8 @@ bool ParseConfig(NSDictionary* config, SetSharedDataWatchItemPolicy* data_polici
       continue;
     }
 
-    if (!ParseConfigSingleWatchItem(key, policy_version, watch_items[key], data_policies,
-                                    proc_policies, err)) {
+    if (!ParseConfigSingleWatchItem(key, policy_version, watch_items[key], data_source,
+                                    data_policies, proc_policies, err)) {
       LOGE(@"Ignoring file access rule '%@': %@", key,
            (err && *err) ? (*err).localizedDescription : @"Unknown failure");
       continue;
@@ -823,16 +942,16 @@ WatchItems::WatchItems(PassKey, DataSource data_source, NSString* config_path, N
       q_(q),
       periodic_task_complete_f_(periodic_task_complete_f) {}
 
-bool WatchItems::IsValidRule(NSString* name, NSDictionary* rule, NSError** error,
-                             NSString* policyVersion) {
+bool WatchItems::IsValidRule(NSString* name, NSDictionary* rule, DataSource data_source,
+                             NSError** error, NSString* policyVersion) {
   std::string version = policyVersion ? NSStringToUTF8String(policyVersion) : "";
   return IsWatchItemNameValid(name, error) &&
-         ParseConfigSingleWatchItem(name, version, rule, nullptr, nullptr, error);
+         ParseConfigSingleWatchItem(name, version, rule, data_source, nullptr, nullptr, error);
 }
 
-bool WatchItems::IsValidConfig(NSDictionary* config, NSError** error) {
+bool WatchItems::IsValidConfig(NSDictionary* config, DataSource data_source, NSError** error) {
   uint64_t rules_loaded = 0;
-  if (!ParseConfig(config, nullptr, nullptr, &rules_loaded, error)) {
+  if (!ParseConfig(config, data_source, nullptr, nullptr, &rules_loaded, error)) {
     return false;
   }
 
@@ -941,7 +1060,17 @@ void WatchItems::UpdateCurrentState(DataWatchItems new_data_watch_items,
   }
 }
 
-void WatchItems::ReloadConfig(NSDictionary* new_config) {
+void WatchItems::ReloadConfig() {
+  NSDictionary* new_config;
+  DataSource data_source;
+  {
+    // Note: The config and its source must be read together so that parsing
+    // can't apply one source's validation rules to another's config.
+    absl::ReaderMutexLock lock(lock_);
+    new_config = embedded_config_ ?: ReadConfigLocked();
+    data_source = data_source_;
+  }
+
   DataWatchItems new_data_watch_items;
   ProcessWatchItems new_proc_watch_items;
   uint64_t rules_loaded = 0;
@@ -950,7 +1079,8 @@ void WatchItems::ReloadConfig(NSDictionary* new_config) {
     SetSharedDataWatchItemPolicy new_data_policies;
     SetSharedProcessWatchItemPolicy new_proc_policies;
     NSError* err;
-    if (!ParseConfig(new_config, &new_data_policies, &new_proc_policies, &rules_loaded, &err)) {
+    if (!ParseConfig(new_config, data_source, &new_data_policies, &new_proc_policies, &rules_loaded,
+                     &err)) {
       LOGE(@"Failed to parse watch item config: %@",
            err ? err.localizedDescription : @"Unknown failure");
       return;
@@ -964,11 +1094,6 @@ void WatchItems::ReloadConfig(NSDictionary* new_config) {
                      rules_loaded);
 }
 
-NSDictionary* WatchItems::ReadConfig() {
-  absl::ReaderMutexLock lock(lock_);
-  return ReadConfigLocked();
-}
-
 NSDictionary* WatchItems::ReadConfigLocked() {
   if (config_path_) {
     return [NSDictionary dictionaryWithContentsOfFile:config_path_];
@@ -978,7 +1103,7 @@ NSDictionary* WatchItems::ReadConfigLocked() {
 }
 
 bool WatchItems::OnTimer() {
-  ReloadConfig(embedded_config_ ?: ReadConfig());
+  ReloadConfig();
 
   if (periodic_task_complete_f_) {
     periodic_task_complete_f_();
@@ -1004,21 +1129,17 @@ void WatchItems::SetDBRules(NSDictionary* rules) {
     embedded_config_ = @{kWatchItemConfigKeyWatchItems : rules};
     data_source_ = DataSource::kDatabase;
   }
-  ReloadConfig(embedded_config_);
+  ReloadConfig();
 }
 
 void WatchItems::SetConfigPath(NSString* config_path) {
-  // Acquire the lock to set the config path and read the config, but drop
-  // the lock before reloading the config
-  NSDictionary* config;
   {
     absl::MutexLock lock(lock_);
     config_path_ = config_path;
     embedded_config_ = nil;
     data_source_ = DataSource::kDetachedConfig;
-    config = ReadConfigLocked();
   }
-  ReloadConfig(config);
+  ReloadConfig();
 }
 
 void WatchItems::SetConfig(NSDictionary* config) {
@@ -1028,7 +1149,7 @@ void WatchItems::SetConfig(NSDictionary* config) {
     embedded_config_ = config;
     data_source_ = DataSource::kEmbeddedConfig;
   }
-  ReloadConfig(embedded_config_);
+  ReloadConfig();
 }
 
 std::optional<WatchItemsState> WatchItems::State() {

--- a/Source/common/faa/WatchItemsTest.mm
+++ b/Source/common/faa/WatchItemsTest.mm
@@ -53,25 +53,27 @@ using santa::Unit;
 using santa::WatchItemPathType;
 using santa::WatchItemProcess;
 using santa::WatchItemProcessList;
-using santa::WatchItemProcessOptions;
 using santa::WatchItemsState;
 
 namespace santa {
 
-extern bool ParseConfig(NSDictionary* config, SetSharedDataWatchItemPolicy* data_policies,
+extern bool ParseConfig(NSDictionary* config, WatchItems::DataSource data_source,
+                        SetSharedDataWatchItemPolicy* data_policies,
                         SetSharedProcessWatchItemPolicy* proc_policies, uint64_t* rules_loaded,
                         NSError** err);
 extern bool IsWatchItemNameValid(id key, NSError** err);
 extern bool ParseConfigSingleWatchItem(NSString* name, std::string_view policy_version,
-                                       NSDictionary* watch_item,
+                                       NSDictionary* watch_item, WatchItems::DataSource data_source,
                                        SetSharedDataWatchItemPolicy* data_policies,
                                        SetSharedProcessWatchItemPolicy* proc_policies,
                                        NSError** err);
 extern std::variant<Unit, SetPairPathAndType> VerifyConfigWatchItemPaths(NSArray<id>* paths,
                                                                          NSError** err);
-std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(NSDictionary* watch_item,
-                                                                        NSError** err);
+extern std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(
+    NSDictionary* watch_item, NSString* key, const WatchItemProcessOptions* rule_options,
+    NSError** err);
 extern std::optional<WatchItemRuleType> GetRuleType(NSString* rule_type);
+extern std::optional<WatchItemProcessAction> GetProcessAction(NSString* action);
 extern std::vector<std::string> FindMatches(NSString* path);
 
 class WatchItemsPeer : public WatchItems {
@@ -87,7 +89,17 @@ class WatchItemsPeer : public WatchItems {
                    periodic_task_complete_f) {}
 
   using WatchItems::ForceSetIntervalForTestingUnsafe;
-  using WatchItems::ReloadConfig;
+
+  // Apply an in-memory config, leaving config_path_ alone. SetConfig would clear
+  // it, and some tests construct the peer with a path and assert on it.
+  void ReloadConfig(NSDictionary* config) {
+    {
+      absl::MutexLock lock(WatchItems::lock_);
+      WatchItems::embedded_config_ = config;
+    }
+    WatchItems::ReloadConfig();
+  }
+
   using WatchItems::SetConfig;
   using WatchItems::SetConfigPath;
 
@@ -98,14 +110,43 @@ class WatchItemsPeer : public WatchItems {
 }  // namespace santa
 
 using santa::FindMatches;
+using santa::GetProcessAction;
 using santa::GetRuleType;
 using santa::IsWatchItemNameValid;
-using santa::ParseConfig;
-using santa::ParseConfigSingleWatchItem;
+using santa::WatchItems;
+
+// Convenience wrappers so the many parser tests don't have to name a data
+// source. Rules from a sync server are the permissive case, so tests covering
+// the locally-managed restrictions name their source explicitly.
+static bool ParseConfig(NSDictionary* config, SetSharedDataWatchItemPolicy* data_policies,
+                        SetSharedProcessWatchItemPolicy* proc_policies, uint64_t* rules_loaded,
+                        NSError** err) {
+  return santa::ParseConfig(config, WatchItems::DataSource::kDatabase, data_policies, proc_policies,
+                            rules_loaded, err);
+}
+
+static bool ParseConfigSingleWatchItem(NSString* name, std::string_view policy_version,
+                                       NSDictionary* watch_item,
+                                       SetSharedDataWatchItemPolicy* data_policies,
+                                       SetSharedProcessWatchItemPolicy* proc_policies,
+                                       NSError** err) {
+  return santa::ParseConfigSingleWatchItem(name, policy_version, watch_item,
+                                           WatchItems::DataSource::kDatabase, data_policies,
+                                           proc_policies, err);
+}
 using santa::VerifyConfigWatchItemPaths;
-using santa::VerifyConfigWatchItemProcesses;
 using santa::WatchItemPolicyBase;
+using santa::WatchItemProcessAction;
+using santa::WatchItemProcessOptions;
 using santa::WatchItemsPeer;
+
+// Convenience wrapper for the common case of verifying the plain `Processes`
+// array, whose entries carry no option overrides.
+static std::variant<Unit, WatchItemProcessList> VerifyConfigWatchItemProcesses(
+    NSDictionary* watch_item, NSError** err) {
+  return santa::VerifyConfigWatchItemProcesses(watch_item, kWatchItemConfigKeyProcesses, nullptr,
+                                               err);
+}
 
 static constexpr std::string_view kBadPolicyName("__BAD_NAME__");
 static constexpr std::string_view kBadPolicyPath("__BAD_PATH__");
@@ -873,6 +914,259 @@ BlockGenResult CreatePolicyBlockGen() {
 
   XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
   XCTAssertEqual(std::get<WatchItemProcessList>(proc_list), expectedProcs);
+}
+
+- (void)testGetProcessAction {
+  XCTAssertFalse(GetProcessAction(nil).has_value());
+  XCTAssertFalse(GetProcessAction(@"").has_value());
+  XCTAssertFalse(GetProcessAction(@"inherit").has_value());
+  XCTAssertFalse(GetProcessAction(@"allowed").has_value());
+
+  XCTAssertEqual(GetProcessAction(@"allow").value(), WatchItemProcessAction::kAllow);
+  XCTAssertEqual(GetProcessAction(@"AUDIT").value(), WatchItemProcessAction::kAudit);
+  XCTAssertEqual(GetProcessAction(@"Deny").value(), WatchItemProcessAction::kDeny);
+}
+
+- (void)testVerifyConfigWatchItemProcessesWithOptions {
+  // The rule's options that unset per-process overrides must inherit.
+  WatchItemProcessOptions ruleDefaults{
+      .action = WatchItemProcessAction::kInherit,
+      .allow_read_access = true,
+      .silent = true,
+      .silent_tty = true,
+      .custom_message = std::make_optional<std::string>("rule msg"),
+      .event_detail_url = std::make_optional<NSString*>(@"https://rule.example"),
+      .event_detail_text = std::make_optional<NSString*>(@"rule text"),
+  };
+
+  auto verify = [&ruleDefaults](NSArray* entries, NSError** err) {
+    return santa::VerifyConfigWatchItemProcesses(
+        @{kWatchItemConfigKeyProcessesWithOptions : entries},
+        kWatchItemConfigKeyProcessesWithOptions, &ruleDefaults, err);
+  };
+
+  NSError* err;
+
+  // Option overrides must be well typed / within bounds
+  XCTAssertTrue(
+      std::holds_alternative<Unit>(verify(@[ @{
+                                            kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+                                            kWatchItemConfigKeyProcessesAction : @"nope",
+                                          } ],
+                                          &err)));
+  XCTAssertTrue(
+      std::holds_alternative<Unit>(verify(@[ @{
+                                            kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+                                            kWatchItemConfigKeyProcessesAction : @(1),
+                                          } ],
+                                          &err)));
+  XCTAssertTrue(
+      std::holds_alternative<Unit>(verify(@[ @{
+                                            kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+                                            kWatchItemConfigKeyOptionsEnableSilentMode : @"yes",
+                                          } ],
+                                          &err)));
+  XCTAssertTrue(std::holds_alternative<Unit>(
+      verify(@[ @{
+               kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+               kWatchItemConfigKeyOptionsCustomMessage : RepeatedString(@"A", 2049),
+             } ],
+             &err)));
+  XCTAssertTrue(std::holds_alternative<Unit>(
+      verify(@[ @{
+               kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+               kWatchItemConfigKeyOptionsEventDetailText : RepeatedString(@"A", 49),
+             } ],
+             &err)));
+
+  // Options that only make sense rule-wide are rejected, not ignored
+  for (NSString* key in @[
+         kWatchItemConfigKeyOptionsAuditOnly, kWatchItemConfigKeyOptionsRuleType,
+         kWatchItemConfigKeyOptionsInvertProcessExceptions
+       ]) {
+    XCTAssertTrue(std::holds_alternative<Unit>(
+        verify(@[ @{kWatchItemConfigKeyProcessesBinaryPath : @"pa", key : @(NO)} ], &err)));
+  }
+
+  // With no overrides set, every option is inherited from the rule
+  {
+    auto proc_list = verify(@[ @{kWatchItemConfigKeyProcessesBinaryPath : @"pa"} ], &err);
+    XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+    const WatchItemProcessList& procs = std::get<WatchItemProcessList>(proc_list);
+    XCTAssertEqual(procs.size(), 1);
+    XCTAssertTrue(procs[0].options.has_value());
+    XCTAssertEqual(procs[0].options->action, WatchItemProcessAction::kInherit);
+    XCTAssertTrue(procs[0].options->allow_read_access);
+    XCTAssertTrue(procs[0].options->silent);
+    XCTAssertTrue(procs[0].options->silent_tty);
+    XCTAssertCppStringEqual(procs[0].options->custom_message.value(), "rule msg");
+    XCTAssertEqualObjects(procs[0].options->event_detail_url.value(), @"https://rule.example");
+    XCTAssertEqualObjects(procs[0].options->event_detail_text.value(), @"rule text");
+  }
+
+  // Each set override wins over the rule's value
+  {
+    auto proc_list = verify(@[ @{
+                              kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+                              kWatchItemConfigKeyProcessesAction : @"deny",
+                              kWatchItemConfigKeyOptionsAllowReadAccess : @(NO),
+                              kWatchItemConfigKeyOptionsEnableSilentMode : @(NO),
+                              kWatchItemConfigKeyOptionsEnableSilentTTYMode : @(NO),
+                              kWatchItemConfigKeyOptionsCustomMessage : @"proc msg",
+                              kWatchItemConfigKeyOptionsEventDetailURL : @"https://proc.example",
+                              kWatchItemConfigKeyOptionsEventDetailText : @"proc text",
+                            } ],
+                            &err);
+    XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+    const WatchItemProcessList& procs = std::get<WatchItemProcessList>(proc_list);
+    XCTAssertEqual(procs.size(), 1);
+    XCTAssertCppStringEqual(procs[0].binary_path, "pa");
+    XCTAssertTrue(procs[0].options.has_value());
+    XCTAssertEqual(procs[0].options->action, WatchItemProcessAction::kDeny);
+    XCTAssertFalse(procs[0].options->allow_read_access);
+    XCTAssertFalse(procs[0].options->silent);
+    XCTAssertFalse(procs[0].options->silent_tty);
+    XCTAssertCppStringEqual(procs[0].options->custom_message.value(), "proc msg");
+    XCTAssertEqualObjects(procs[0].options->event_detail_url.value(), @"https://proc.example");
+    XCTAssertEqualObjects(procs[0].options->event_detail_text.value(), @"proc text");
+  }
+
+  // Empty strings clear the inherited message/text, but an empty URL is kept so
+  // that an entry can hide the button.
+  {
+    auto proc_list = verify(@[ @{
+                              kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+                              kWatchItemConfigKeyOptionsCustomMessage : @"",
+                              kWatchItemConfigKeyOptionsEventDetailURL : @"",
+                              kWatchItemConfigKeyOptionsEventDetailText : @"",
+                            } ],
+                            &err);
+    XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+    const WatchItemProcessList& procs = std::get<WatchItemProcessList>(proc_list);
+    XCTAssertEqual(procs.size(), 1);
+    XCTAssertFalse(procs[0].options->custom_message.has_value());
+    XCTAssertFalse(procs[0].options->event_detail_text.has_value());
+    XCTAssertTrue(procs[0].options->event_detail_url.has_value());
+    XCTAssertEqualObjects(procs[0].options->event_detail_url.value(), @"");
+  }
+
+  // Entries of the plain `Processes` array must never carry options, and the
+  // option keys are not treated as process attributes there.
+  {
+    auto proc_list = VerifyConfigWatchItemProcesses(
+        @{
+          kWatchItemConfigKeyProcesses : @[ @{
+            kWatchItemConfigKeyProcessesBinaryPath : @"pa",
+            kWatchItemConfigKeyProcessesAction : @"deny",
+          } ]
+        },
+        &err);
+    XCTAssertTrue(std::holds_alternative<WatchItemProcessList>(proc_list));
+    const WatchItemProcessList& procs = std::get<WatchItemProcessList>(proc_list);
+    XCTAssertEqual(procs.size(), 1);
+    XCTAssertFalse(procs[0].options.has_value());
+  }
+}
+
+- (void)testParseConfigSingleWatchItemProcessPrecedence {
+  SetSharedDataWatchItemPolicy data_policies;
+  SetSharedProcessWatchItemPolicy proc_policies;
+  NSError* err;
+
+  NSDictionary* singleWatchItemConfig = @{
+    kWatchItemConfigKeyPaths : @[ @"a" ],
+    kWatchItemConfigKeyOptions : @{
+      kWatchItemConfigKeyOptionsEnableSilentMode : @(NO),
+      kWatchItemConfigKeyOptionsRuleType : kRuleTypePathsWithAllowedProcesses,
+    },
+    kWatchItemConfigKeyProcesses : @[
+      @{kWatchItemConfigKeyProcessesBinaryPath : @"plain1"},
+      @{kWatchItemConfigKeyProcessesBinaryPath : @"plain2"},
+    ],
+    kWatchItemConfigKeyProcessesWithOptions : @[
+      @{
+        kWatchItemConfigKeyProcessesBinaryPath : @"withopts",
+        kWatchItemConfigKeyProcessesAction : @"deny",
+        kWatchItemConfigKeyOptionsEnableSilentMode : @(YES),
+      },
+    ],
+  };
+
+  XCTAssertTrue(ParseConfigSingleWatchItem(@"rule", kVersion, singleWatchItemConfig, &data_policies,
+                                           &proc_policies, &err));
+  XCTAssertEqual(data_policies.size(), 1);
+
+  const WatchItemProcessList& procs = (*data_policies.begin())->processes;
+  XCTAssertEqual(procs.size(), 3);
+
+  // ProcessesWithOptions entries are evaluated first, so they come first in the
+  // combined list that matching iterates.
+  XCTAssertCppStringEqual(procs[0].binary_path, "withopts");
+  XCTAssertTrue(procs[0].options.has_value());
+  XCTAssertEqual(procs[0].options->action, WatchItemProcessAction::kDeny);
+  XCTAssertTrue(procs[0].options->silent);
+
+  XCTAssertCppStringEqual(procs[1].binary_path, "plain1");
+  XCTAssertFalse(procs[1].options.has_value());
+  XCTAssertCppStringEqual(procs[2].binary_path, "plain2");
+  XCTAssertFalse(procs[2].options.has_value());
+}
+
+/// ProcessesWithOptions is a sync-only feature. A locally managed config using
+/// it must have the whole rule rejected, not have the array silently dropped.
+- (void)testProcessesWithOptionsRestrictedToSyncServer {
+  NSDictionary* watchItem = @{
+    kWatchItemConfigKeyPaths : @[ @"a" ],
+    kWatchItemConfigKeyProcessesWithOptions :
+        @[ @{kWatchItemConfigKeyProcessesBinaryPath : @"pa"} ],
+  };
+
+  for (WatchItems::DataSource dataSource :
+       {WatchItems::DataSource::kUnknown, WatchItems::DataSource::kEmbeddedConfig,
+        WatchItems::DataSource::kDetachedConfig}) {
+    SetSharedDataWatchItemPolicy data_policies;
+    SetSharedProcessWatchItemPolicy proc_policies;
+    NSError* err;
+
+    XCTAssertFalse(santa::ParseConfigSingleWatchItem(@"rule", kVersion, watchItem, dataSource,
+                                                     &data_policies, &proc_policies, &err));
+    XCTAssertEqual(data_policies.size(), 0);
+    XCTAssertEqual(proc_policies.size(), 0);
+
+    // The static validators are the entry points used by the configurator and
+    // the sync service, so they must apply the same gate.
+    XCTAssertFalse(
+        WatchItems::IsValidRule(@"rule", watchItem, dataSource, nil, @(kVersion.data())));
+  }
+
+  // The same rule from a sync server is accepted
+  {
+    SetSharedDataWatchItemPolicy data_policies;
+    SetSharedProcessWatchItemPolicy proc_policies;
+    NSError* err;
+
+    XCTAssertTrue(santa::ParseConfigSingleWatchItem(@"rule", kVersion, watchItem,
+                                                    WatchItems::DataSource::kDatabase,
+                                                    &data_policies, &proc_policies, &err));
+    XCTAssertEqual(data_policies.size(), 1);
+    XCTAssertEqual((*data_policies.begin())->processes.size(), 1);
+    XCTAssertTrue((*data_policies.begin())->processes[0].options.has_value());
+
+    XCTAssertTrue(WatchItems::IsValidRule(@"rule", watchItem, WatchItems::DataSource::kDatabase,
+                                          nil, @(kVersion.data())));
+  }
+
+  // A rule with only the plain Processes key is unaffected by the data source
+  NSDictionary* plainWatchItem = @{
+    kWatchItemConfigKeyPaths : @[ @"a" ],
+    kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesBinaryPath : @"pa"} ],
+  };
+  for (WatchItems::DataSource dataSource :
+       {WatchItems::DataSource::kEmbeddedConfig, WatchItems::DataSource::kDetachedConfig,
+        WatchItems::DataSource::kDatabase}) {
+    XCTAssertTrue(
+        WatchItems::IsValidRule(@"rule", plainWatchItem, dataSource, nil, @(kVersion.data())));
+  }
 }
 
 - (void)testIsWatchItemNameValid {

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -318,7 +318,8 @@ SNTFileAccessRule* FAARuleFromProtoFAARuleAdd(const ::pbv2::FileAccessRule::Add&
   NSString* name = StringToNSString(pbAddRule.name());
 
   NSError* err;
-  if (santa::WatchItems::IsValidRule(name, details, &err)) {
+  if (santa::WatchItems::IsValidRule(name, details, santa::WatchItems::DataSource::kDatabase,
+                                     &err)) {
     return [[SNTFileAccessRule alloc] initAddRuleWithName:name details:details];
   } else {
     return nil;


### PR DESCRIPTION
Adds the config layer for per-process rule options. Nothing evaluates them yet, and no rule can carry them until the sync service converts them, so there is no behavior change.

- Add a ProcessesWithOptions array whose entries state their own outcome via an Action key (allow/audit/deny) and can override individual rule options for just that process
- Merge each entry's overrides over the rule's own options while parsing, so a matched process always has effective values
- Order ProcessesWithOptions entries ahead of Processes entries, since matching is first-match-wins