### PR TITLE
Clear synced state when SyncBaseURL is removed or changed

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -912,6 +912,20 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 - (nullable NSArray<NSDictionary*>*)savedDemotedAdmins;
 
 ///
+///  Records the sync server most recently seen in `SyncBaseURL`, so that a change made while the
+///  daemon was not running is still recognisable on the next launch. Stored whole rather than by
+///  host, so that tenants sharing a host stay distinguishable.
+///
+///  Returns NO if the record could not be written to disk.
+///
+- (BOOL)persistLastSyncServerURL:(nullable NSURL*)syncServerURL;
+
+///
+///  Returns the sync server recorded by `persistLastSyncServerURL:`, or nil if none is recorded.
+///
+- (nullable NSURL*)savedLastSyncServerURL;
+
+///
 ///  State-file key under which Temporary Admin Mode persists its session state
 ///  (an active session, or a deadline-0 demote-retry residue after a failed
 ///  teardown), and the field within it naming the session's target uid.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -1235,9 +1235,15 @@ extern NSString* _Nonnull const kStateTempAdminTargetUIDKey;
 #endif
 
 ///
-///  Whether any state produced by a sync server is currently held. `SyncTypeRequired` does not
-///  count: it is this client's own bookkeeping rather than anything a server put there, so a state
-///  holding nothing else is indistinguishable from never having synced at all.
+///  Whether any state produced by a sync server is currently held, in memory or on disk.
+///  `SyncTypeRequired` does not count: it is this client's own bookkeeping rather than anything a
+///  server put there, so state holding nothing else is indistinguishable from never having synced.
+///
+///  Consults the sync state file when memory holds nothing, so this may touch disk. That fallback
+///  is the point: the file is only read into memory when a sync server is configured, so a daemon
+///  that started after `SyncBaseURL` was removed would otherwise report no synced state while the
+///  departed server's settings sat on disk. A file that cannot be parsed reads as no state; it
+///  carries no policy either, since the same parse failure leaves the effective state empty.
 ///
 @property(readonly, nonatomic) BOOL hasSyncedSettings;
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -1219,9 +1219,27 @@ extern NSString* _Nonnull const kStateTempAdminTargetUIDKey;
 #endif
 
 ///
+///  Whether any state produced by a sync server is currently held. `SyncTypeRequired` does not
+///  count: it is this client's own bookkeeping rather than anything a server put there, so a state
+///  holding nothing else is indistinguishable from never having synced at all.
+///
+@property(readonly, nonatomic) BOOL hasSyncedSettings;
+
+///
 ///  Clear the sync server configuration from the effective configuration.
 ///
 - (void)clearSyncState;
+
+///
+///  Clear the sync server configuration and record, in the same transition, that the next sync
+///  must be a `syncType` one. Returns NO if the new state did not reach disk.
+///
+///  Exists because the two halves cannot be expressed as `clearSyncState` followed by
+///  `setSyncTypeRequired:`. The caller runs precisely because `SyncBaseURL` went away, and the
+///  ordinary sync-state write path is gated on a configured sync server, so the second half would
+///  be silently dropped and the requirement would live only in this process's memory.
+///
+- (BOOL)clearSyncStateRequiringSyncType:(SNTSyncType)syncType;
 
 ///
 ///  Buffer a series of sync-state mutations into a single atomic commit.

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -2162,7 +2162,16 @@ static SNTConfigurator* sharedConfigurator = nil;
   if (!self.syncStateAccessAuthorizerBlock()) {
     return NO;
   }
+  return [self writeSyncStateToDisk];
+}
 
+///
+///  Saves the current effective syncState to disk without consulting
+///  `syncStateAccessAuthorizerBlock`. Only for callers that have a documented
+///  reason to skip that gate; everything on the ordinary sync-server write path
+///  must go through `saveSyncStateToDisk` instead.
+///
+- (BOOL)writeSyncStateToDisk {
   NSMutableDictionary* syncState = self.syncState.mutableCopy;
 
   // An empty sync state and a missing plist mean the same thing, so keep only the one that says
@@ -2185,6 +2194,16 @@ static SNTConfigurator* sharedConfigurator = nil;
   return YES;
 }
 
+- (BOOL)hasSyncedSettings {
+  NSDictionary* syncState = self.syncState;
+  for (NSString* key in syncState) {
+    if (![key isEqualToString:kSyncTypeRequired]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 - (void)clearSyncState {
   // Intentionally not gated on `syncStateAccessAuthorizerBlock`: the authorizer
   // requires `syncBaseURL != nil`, but the SNTSyncdQueue caller invokes this
@@ -2204,6 +2223,38 @@ static SNTConfigurator* sharedConfigurator = nil;
   } else {
     dispatch_sync(dispatch_get_main_queue(), block);
   }
+}
+
+- (BOOL)clearSyncStateRequiringSyncType:(SNTSyncType)syncType {
+  // One transition rather than `clearSyncState` plus `setSyncTypeRequired:`. That pairing cannot
+  // work here: `setSyncTypeRequired:` writes through `saveSyncStateToDisk`, whose authorizer
+  // requires `syncBaseURL != nil`, and the caller runs precisely *because* the URL went away. The
+  // write would be refused and the requirement would survive only in this process's memory, so a
+  // restarted daemon would fall back to `syncTypeRequired`'s empty-state default, which lapses to
+  // Normal the moment postflight writes any other key.
+  //
+  // Skipping the authorizer is the same exemption `clearSyncState` takes, for the same reason.
+  // Writing to `syncStateFilePath` still requires root, which santad has.
+  __block BOOL committed = NO;
+  void (^block)(void) = ^{
+    NSMutableDictionary* syncState = [NSMutableDictionary dictionaryWithObject:@(syncType)
+                                                                        forKey:kSyncTypeRequired];
+    if (self.batchedSyncState) {
+      [self.batchedSyncState removeAllObjects];
+      [self.batchedSyncState addEntriesFromDictionary:syncState];
+      // Durability is the enclosing batch's to report, not ours.
+      committed = YES;
+      return;
+    }
+    self.syncState = syncState;
+    committed = [self writeSyncStateToDisk];
+  };
+  if ([NSThread isMainThread]) {
+    block();
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), block);
+  }
+  return committed;
 }
 
 - (NSArray*)entitlementsPrefixFilter {

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -117,6 +117,7 @@ NSString* const kStateTempAdminModeKey = @"TempAdmin";
 NSString* const kStateTempAdminTargetUIDKey = @"TargetUID";
 static NSString* const kStateDemotedAdminsKey = @"DemotedAdmins";
 static NSString* const kStateLastBootUUIDKey = @"LastBootUUID";
+static NSString* const kStateLastSyncServerURLKey = @"LastSyncServerURL";
 
 /// User defaults key for user override of the menu item enabled setting.
 NSString* const kEnableMenuItemUserOverride = @"EnableMenuItemUserOverride";
@@ -1017,6 +1018,18 @@ static SNTConfigurator* sharedConfigurator = nil;
   return self.state[kStateDemotedAdminsKey];
 }
 
+- (BOOL)persistLastSyncServerURL:(NSURL*)syncServerURL {
+  @synchronized(self) {
+    return [self updateStateSynchronizedKey:kStateLastSyncServerURLKey
+                                      value:syncServerURL.absoluteString];
+  }
+}
+
+- (NSURL*)savedLastSyncServerURL {
+  NSString* urlString = self.state[kStateLastSyncServerURLKey];
+  return urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
+}
+
 - (void)updateLastBootUUID:(NSString*)bootUUID {
   @synchronized(self) {
     [self updateStateSynchronizedKey:kStateLastBootUUIDKey value:bootUUID];
@@ -1432,7 +1445,9 @@ static SNTConfigurator* sharedConfigurator = nil;
 
 - (SNTSyncType)syncTypeRequired {
   if (self.syncState.count == 0) {
-    return SNTSyncTypeCleanAll;
+    // Without synced state the client can't vouch for its rules. Clean, not CleanAll, so the
+    // server keeps the final say and can still escalate.
+    return SNTSyncTypeClean;
   }
   return (SNTSyncType)[self.syncState[kSyncTypeRequired] integerValue];
 }
@@ -2121,6 +2136,24 @@ static SNTConfigurator* sharedConfigurator = nil;
 }
 
 ///
+///  Removes the sync state plist, returning whether it is now gone. A missing file is the
+///  expected case on a host that never synced and counts as success; anything else means synced
+///  state survived on disk and would be read back on the next launch, so it must not fail
+///  silently.
+///
+- (BOOL)removeSyncStateFile {
+  NSError* error;
+  if ([[NSFileManager defaultManager] removeItemAtPath:self.syncStateFilePath error:&error]) {
+    return YES;
+  }
+  if ([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSFileNoSuchFileError) {
+    return YES;
+  }
+  LOGE(@"Failed to remove sync state at %@: %@", self.syncStateFilePath, error);
+  return NO;
+}
+
+///
 ///  Saves the current effective syncState to disk. Returns YES if the write
 ///  succeeded; NO if the authorizer denied the operation or the underlying
 ///  file write failed.
@@ -2131,6 +2164,15 @@ static SNTConfigurator* sharedConfigurator = nil;
   }
 
   NSMutableDictionary* syncState = self.syncState.mutableCopy;
+
+  // An empty sync state and a missing plist mean the same thing, so keep only the one that says
+  // so. Sync-state writes are unconditional, so without this a no-op commit (e.g. a preflight
+  // whose config bundle carries nothing) leaves an empty plist behind, which reads as though the
+  // host holds synced state when it holds none.
+  if (syncState.count == 0) {
+    return [self removeSyncStateFile];
+  }
+
   syncState[kAllowedPathRegexKey] = [syncState[kAllowedPathRegexKey] pattern];
   syncState[kBlockedPathRegexKey] = [syncState[kBlockedPathRegexKey] pattern];
   if (![syncState writeToFile:self.syncStateFilePath atomically:YES]) {
@@ -2155,7 +2197,7 @@ static SNTConfigurator* sharedConfigurator = nil;
       return;
     }
     self.syncState = [NSMutableDictionary dictionary];
-    [[NSFileManager defaultManager] removeItemAtPath:self.syncStateFilePath error:NULL];
+    [self removeSyncStateFile];
   };
   if ([NSThread isMainThread]) {
     block();
@@ -2246,6 +2288,10 @@ static SNTConfigurator* sharedConfigurator = nil;
   if ([state[kStateLastBootUUIDKey] isKindOfClass:[NSString class]]) {
     _lastBootUUID = state[kStateLastBootUUIDKey];
     newState[kStateLastBootUUIDKey] = _lastBootUUID;
+  }
+
+  if ([state[kStateLastSyncServerURLKey] isKindOfClass:[NSString class]]) {
+    newState[kStateLastSyncServerURLKey] = state[kStateLastSyncServerURLKey];
   }
 
   return newState;

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -2205,14 +2205,28 @@ static SNTConfigurator* sharedConfigurator = nil;
   return YES;
 }
 
-- (BOOL)hasSyncedSettings {
-  NSDictionary* syncState = self.syncState;
+/// Whether `syncState` holds anything a sync server put there. `SyncTypeRequired` is this
+/// client's own bookkeeping, so a dictionary holding nothing else counts as empty.
+static BOOL HoldsSyncedSettings(NSDictionary* syncState) {
   for (NSString* key in syncState) {
     if (![key isEqualToString:kSyncTypeRequired]) {
       return YES;
     }
   }
   return NO;
+}
+
+- (BOOL)hasSyncedSettings {
+  if (HoldsSyncedSettings(self.syncState)) {
+    return YES;
+  }
+
+  // In-memory state is not the whole story. `readSyncStateFromDisk` is gated on a configured sync
+  // server, so a daemon that started *after* SyncBaseURL was removed holds nothing while the
+  // departed server's settings are still on disk -- which is exactly when they most need dropping,
+  // and the ordinary way a fleet retires a sync server. Read the file directly rather than through
+  // the authorizer, the same exemption `clearSyncState` takes and for the same reason.
+  return HoldsSyncedSettings([NSDictionary dictionaryWithContentsOfFile:self.syncStateFilePath]);
 }
 
 - (void)clearSyncState {

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -444,6 +444,110 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
 }
 
+/// Unlike the other helpers here, this models the *production* sync-state authorizer, which is
+/// `syncBaseURL != nil && geteuid() == 0`. Tests that pin behaviour around a departing sync server
+/// have to use it: an authorizer that always says yes hides the very gate they are about.
+- (SNTConfigurator*)configuratorWithSyncStateAtPath:(NSString*)plistPath
+                               syncServerConfigured:(BOOL (^)(void))syncServerConfigured {
+  return [[SNTConfigurator alloc] initWithSyncStateFile:plistPath
+      stateFile:@"/does/not/need/to/exist"
+      syncStateAccessAuthorizer:^BOOL {
+        return syncServerConfigured();
+      }
+      stateAccessAuthorizer:^BOOL {
+        return NO;
+      }];
+}
+
+// The clean-sync requirement recorded when SyncBaseURL goes away has to reach disk. It cannot be
+// written through the ordinary path -- that path is gated on a configured sync server, and there
+// isn't one any more, which is the whole reason this is happening. If the write is dropped the
+// requirement lives only in the running daemon's memory, and a restart falls back to
+// `syncTypeRequired`'s empty-state default, which lapses to Normal the moment postflight writes
+// any other key (see testExplicitCleanSyncTypeSurvivesUnacknowledgedSync for that mechanism).
+- (void)testCleanSyncRequirementRecordedOnSyncBaseURLRemovalIsDurable {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/removal-clean.plist", self.testDir];
+  __block BOOL syncServerConfigured = YES;
+  SNTConfigurator* cfg = [self configuratorWithSyncStateAtPath:plistPath
+                                          syncServerConfigured:^BOOL {
+                                            return syncServerConfigured;
+                                          }];
+
+  // A host that has been syncing: settings on disk, no clean sync pending.
+  [cfg setSyncTypeRequired:SNTSyncTypeNormal];
+  cfg.fullSyncLastSuccess = [NSDate now];
+  XCTAssertTrue([self.fileMgr fileExistsAtPath:plistPath], @"Sanity: synced state must be on disk");
+
+  // SyncBaseURL is removed and the grace period elapses.
+  syncServerConfigured = NO;
+  XCTAssertTrue([cfg clearSyncStateRequiringSyncType:SNTSyncTypeClean],
+                @"The requirement must be recorded even though no sync server is configured");
+
+  // A sync server is configured again and the daemon restarts, so everything is re-read from disk.
+  syncServerConfigured = YES;
+  SNTConfigurator* restarted = [self configuratorWithSyncStateAtPath:plistPath
+                                                syncServerConfigured:^BOOL {
+                                                  return syncServerConfigured;
+                                                }];
+
+  XCTAssertNil(restarted.fullSyncLastSuccess, @"The departed server's state must not come back");
+  XCTAssertEqual(restarted.syncTypeRequired, SNTSyncTypeClean);
+
+  // The decisive case: a server that declines the clean sync still writes other keys at postflight,
+  // which is what makes the empty-state default lapse. The recorded requirement must outlast it.
+  restarted.fullSyncLastSuccess = [NSDate now];
+  XCTAssertEqual(restarted.syncTypeRequired, SNTSyncTypeClean,
+                 @"The client must keep asking until a server actually performs the clean sync");
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
+// Nothing calls it inside a batch today, but the branch that handles one is what stops a future
+// caller from clobbering `syncState` and writing to disk mid-transaction, the way an unguarded
+// implementation would. `clearSyncState` guards the same way for the same reason.
+- (void)testClearSyncStateRequiringSyncTypeComposesWithABatch {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/reset-in-batch.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  cfg.fullSyncLastSuccess = [NSDate now];
+
+  XCTAssertTrue([cfg performSyncStateBatch:^{
+    XCTAssertTrue([cfg clearSyncStateRequiringSyncType:SNTSyncTypeClean]);
+    // Still inside the transaction, so nothing has been published yet.
+    XCTAssertNotNil(cfg.fullSyncLastSuccess);
+  }]);
+
+  XCTAssertNil(cfg.fullSyncLastSuccess, @"The batch must commit the clear");
+  XCTAssertEqual(cfg.syncTypeRequired, SNTSyncTypeClean);
+  XCTAssertFalse(cfg.hasSyncedSettings);
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
+// `SyncTypeRequired` is this client's own bookkeeping, not something a server sent, so a state
+// holding nothing else has to read as "never synced". SNTRuleTable records one when it creates the
+// database, before any sync has happened, so counting it would make every host look like it holds
+// a departed server's settings.
+- (void)testHasSyncedSettingsIgnoresTheSyncTypeRequirement {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/has-synced-settings.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  XCTAssertFalse(cfg.hasSyncedSettings, @"A host that has never synced holds no settings");
+
+  // Stands in for SNTRuleTable creating the rule database on a host with no sync server.
+  [cfg setSyncTypeRequired:SNTSyncTypeCleanAll];
+  XCTAssertFalse(cfg.hasSyncedSettings, @"The sync-type requirement alone is not a synced setting");
+
+  [cfg setSyncServerClientMode:SNTClientModeLockdown];
+  XCTAssertTrue(cfg.hasSyncedSettings);
+
+  XCTAssertTrue([cfg clearSyncStateRequiringSyncType:SNTSyncTypeClean]);
+  XCTAssertFalse(cfg.hasSyncedSettings,
+                 @"Clearing leaves only the requirement, so there is nothing left to clear again");
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
 // Sync-state writes are unconditional, so a no-op batch (e.g. a preflight whose config bundle
 // carries nothing) would otherwise leave an empty plist behind. An empty plist and a missing one
 // mean the same thing, so keep only the one that says so.

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -373,6 +373,143 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   }
 }
 
+/// Unlike configuratorWithEmptySyncStateAtPath:, this permits state-file access, which is what
+/// the persisted last-sync-server record lives in.
+- (SNTConfigurator*)configuratorWithStateFileAtPath:(NSString*)stateFilePath {
+  return [[SNTConfigurator alloc] initWithSyncStateFile:@"/does/not/need/to/exist"
+      stateFile:stateFilePath
+      syncStateAccessAuthorizer:^{
+        return NO;
+      }
+      stateAccessAuthorizer:^BOOL {
+        return YES;
+      }];
+}
+
+// The record has to outlive the daemon: a SyncBaseURL edited while santad was not running is the
+// most common way a sync server changes, and in-memory tracking alone never sees it.
+- (void)testLastSyncServerURLSurvivesARestart {
+  NSString* statePath = [NSString stringWithFormat:@"%@/last-sync-server.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithStateFileAtPath:statePath];
+
+  XCTAssertNil(cfg.savedLastSyncServerURL, @"Nothing is recorded before a sync server is seen");
+
+  XCTAssertTrue([cfg persistLastSyncServerURL:[NSURL URLWithString:@"https://a.example.com/"]]);
+  XCTAssertEqualObjects(cfg.savedLastSyncServerURL.absoluteString, @"https://a.example.com/");
+
+  // A second configurator over the same file stands in for the next launch.
+  SNTConfigurator* restarted = [self configuratorWithStateFileAtPath:statePath];
+  XCTAssertEqualObjects(restarted.savedLastSyncServerURL.absoluteString, @"https://a.example.com/",
+                        @"The recorded sync server must be readable after a restart");
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:statePath error:nil]);
+}
+
+// Stored whole rather than by host, so that two tenants served from one host are distinguishable.
+- (void)testLastSyncServerURLDistinguishesPathsOnTheSameHost {
+  NSString* statePath = [NSString stringWithFormat:@"%@/last-sync-server-path.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithStateFileAtPath:statePath];
+
+  [cfg persistLastSyncServerURL:[NSURL URLWithString:@"https://sync.example.com/tenant-a/"]];
+
+  XCTAssertNotEqualObjects(cfg.savedLastSyncServerURL,
+                           [NSURL URLWithString:@"https://sync.example.com/tenant-b/"]);
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:statePath error:nil]);
+}
+
+- (void)testSyncTypeRequiredDefaultsToCleanWhenNoSyncStateExists {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/sync-type-default.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  // Clean, not CleanAll: SNTSyncPreflight escalates a CLEAN response to CleanAll only when the
+  // client asked for CleanAll, so this leaves the server the final say.
+  XCTAssertEqual(cfg.syncTypeRequired, SNTSyncTypeClean);
+}
+
+// A clean sync stays required until a server actually performs one. Postflight stamps
+// FullSyncLastSuccess on every successful sync but only writes SyncTypeRequired when the server
+// acknowledged the clean sync, so an explicitly recorded requirement must survive that write.
+- (void)testExplicitCleanSyncTypeSurvivesUnacknowledgedSync {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/sync-type-sticky.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  [cfg setSyncTypeRequired:SNTSyncTypeClean];
+  cfg.fullSyncLastSuccess = [NSDate now];
+
+  XCTAssertEqual(cfg.syncTypeRequired, SNTSyncTypeClean,
+                 @"A recorded clean-sync requirement must not lapse after a sync the server "
+                 @"declined to perform cleanly");
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
+// Sync-state writes are unconditional, so a no-op batch (e.g. a preflight whose config bundle
+// carries nothing) would otherwise leave an empty plist behind. An empty plist and a missing one
+// mean the same thing, so keep only the one that says so.
+- (void)testSavingEmptySyncStateRemovesThePlistRatherThanWritingAnEmptyOne {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/empty-state.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  [cfg setSyncTypeRequired:SNTSyncTypeClean];
+  XCTAssertTrue([self.fileMgr fileExistsAtPath:plistPath],
+                @"Sanity: a populated sync state must be written to disk");
+
+  // Mirrors a no-op batch committing an empty dictionary.
+  XCTAssertTrue([cfg performSyncStateBatch:^{
+    [cfg clearSyncState];
+  }]);
+
+  XCTAssertFalse([self.fileMgr fileExistsAtPath:plistPath],
+                 @"An empty sync state must remove the plist, not write an empty one");
+}
+
+// Committing an empty state means removing the plist, so a removal that fails has not achieved
+// durability any more than a failed write would have. Callers gate post-commit side effects on
+// the returned flag, so it must not claim success.
+- (void)testSavingEmptySyncStateReportsFailureWhenThePlistCannotBeRemoved {
+  if (geteuid() == 0) {
+    XCTSkip(@"Running as root defeats the directory permissions this test relies on");
+  }
+
+  NSString* lockedDir = [NSString stringWithFormat:@"%@/locked", self.testDir];
+  XCTAssertTrue([self.fileMgr createDirectoryAtPath:lockedDir
+                        withIntermediateDirectories:YES
+                                         attributes:nil
+                                              error:nil]);
+  NSString* plistPath = [lockedDir stringByAppendingPathComponent:@"sync-state.plist"];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  [cfg setSyncTypeRequired:SNTSyncTypeClean];
+  XCTAssertTrue([self.fileMgr fileExistsAtPath:plistPath], @"Sanity: the plist must exist");
+
+  // A directory without write permission cannot have entries unlinked from it.
+  XCTAssertTrue([self.fileMgr setAttributes:@{NSFilePosixPermissions : @0500}
+                               ofItemAtPath:lockedDir
+                                      error:nil]);
+  BOOL committed = [cfg performSyncStateBatch:^{
+    [cfg clearSyncState];
+  }];
+  XCTAssertTrue([self.fileMgr setAttributes:@{NSFilePosixPermissions : @0700}
+                               ofItemAtPath:lockedDir
+                                      error:nil]);
+
+  XCTAssertFalse(committed, @"A plist that could not be removed must not report a durable commit");
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:lockedDir error:nil]);
+}
+
+- (void)testSyncTypeRequiredReturnsCleanAfterSyncStateIsCleared {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/sync-type-cleared.plist", self.testDir];
+  SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];
+
+  [cfg setSyncTypeRequired:SNTSyncTypeNormal];
+  XCTAssertEqual(cfg.syncTypeRequired, SNTSyncTypeNormal);
+
+  [cfg clearSyncState];
+  XCTAssertEqual(cfg.syncTypeRequired, SNTSyncTypeClean);
+}
+
 - (void)testPerformSyncStateBatchCommitsAsSingleKVOFire {
   NSString* plistPath = [NSString stringWithFormat:@"%@/batch-kvo.plist", self.testDir];
   SNTConfigurator* cfg = [self configuratorWithEmptySyncStateAtPath:plistPath];

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -502,6 +502,54 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
 }
 
+// The sync state file is only read when a sync server is configured, so a daemon that starts
+// *after* SyncBaseURL was removed holds nothing in memory while the departed server's settings are
+// still sitting on disk. Deciding from memory alone strands that file forever, and a later launch
+// with a sync server configured would read a departed server's policy straight back in. This is
+// the "removed while santad was not running" case, which is the ordinary way a fleet drops a sync
+// server.
+- (void)testSyncedSettingsAreFoundOnDiskWhenNoSyncServerIsConfigured {
+  NSString* plistPath = [NSString stringWithFormat:@"%@/removed-while-down.plist", self.testDir];
+  __block BOOL syncServerConfigured = YES;
+  BOOL (^authorizer)(void) = ^BOOL {
+    return syncServerConfigured;
+  };
+
+  SNTConfigurator* synced = [self configuratorWithSyncStateAtPath:plistPath
+                                             syncServerConfigured:authorizer];
+  [synced setSyncServerClientMode:SNTClientModeLockdown];
+  XCTAssertTrue([self.fileMgr fileExistsAtPath:plistPath],
+                @"Sanity: a synced setting must be on disk");
+
+  // SyncBaseURL is removed while santad is down, then santad starts.
+  syncServerConfigured = NO;
+  SNTConfigurator* restarted = [self configuratorWithSyncStateAtPath:plistPath
+                                                syncServerConfigured:authorizer];
+  XCTAssertEqual(restarted.syncState.count, 0u,
+                 @"Sanity: the file is not read into memory without a sync server");
+  XCTAssertTrue(restarted.hasSyncedSettings,
+                @"A departed server's settings still on disk must be recognised as droppable");
+
+  XCTAssertTrue([restarted clearSyncStateRequiringSyncType:SNTSyncTypeClean]);
+
+  // The next launch finds only the recorded requirement, which is not a synced setting, so it has
+  // nothing to redo.
+  SNTConfigurator* afterClear = [self configuratorWithSyncStateAtPath:plistPath
+                                                 syncServerConfigured:authorizer];
+  XCTAssertFalse(afterClear.hasSyncedSettings, @"Only the recorded clean-sync requirement is left");
+
+  // The harm this prevents: with a sync server configured again the file *is* read, and it must no
+  // longer carry the departed server's policy -- only the requirement that the next sync be clean.
+  syncServerConfigured = YES;
+  SNTConfigurator* nextServer = [self configuratorWithSyncStateAtPath:plistPath
+                                                 syncServerConfigured:authorizer];
+  XCTAssertEqual(nextServer.syncState.count, 1u,
+                 @"A departed server's settings must not be read back by the next launch");
+  XCTAssertEqual(nextServer.syncTypeRequired, SNTSyncTypeClean);
+
+  XCTAssertTrue([self.fileMgr removeItemAtPath:plistPath error:nil]);
+}
+
 // Nothing calls it inside a batch today, but the branch that handles one is what stops a future
 // caller from clobbering `syncState` and writing to disk mid-transaction, the way an unguarded
 // implementation would. `clearSyncState` guards the same way for the same reason.

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -392,6 +392,15 @@ santa_unit_test(
 )
 
 santa_unit_test(
+    name = "SNTCommandRuleTest",
+    srcs = ["Commands/SNTCommandRuleTest.mm"],
+    visibility = ["//:santa_package_group"],
+    deps = [
+        ":SNTCommandRule",
+    ],
+)
+
+santa_unit_test(
     name = "SNTCommandTest",
     srcs = ["SNTCommandTest.mm"],
     deps = [
@@ -409,6 +418,7 @@ test_suite(
         ":SNTCommandDoctorTest",
         ":SNTCommandFileInfoTest",
         ":SNTCommandMetricsTest",
+        ":SNTCommandRuleTest",
         ":SNTCommandTest",
     ],
     visibility = ["//:santa_package_group"],

--- a/Source/santactl/Commands/SNTCommandRule.mm
+++ b/Source/santactl/Commands/SNTCommandRule.mm
@@ -162,20 +162,28 @@ REGISTER_COMMAND_NAME(@"rule")
           @"\n");
 }
 
-- (void)runWithArguments:(NSArray*)arguments {
-  SNTConfigurator* config = [SNTConfigurator configurator];
-  if ((config.syncBaseURL || config.staticRules.count) &&
-      ![arguments containsObject:@"--check"]
-#ifdef DEBUG
-      // DEBUG builds add a --force flag to allow manually adding/removing rules during testing.
-      && ![arguments containsObject:@"--force"]) {
-#else
-  ) {
-#endif
-    TEE_LOGE(@"(SyncBaseURL/StaticRules is set, rules are managed centrally.)");
-    exit(1);
+/// Whether a manual rule change must be refused because policy belongs to something other than
+/// the operator. Clearing the database stays available when only StaticRules is set: static rules
+/// override just the identifiers they name, so a database that could never be cleared would
+/// strand a host on a departed sync server's policy with no supported way out. A configured
+/// SyncBaseURL refuses everything -- the sync server owns the database, and a clean sync is how
+/// to reset it.
+///
+/// Decided from parsed options rather than from raw arguments: an option value can look exactly
+/// like a flag (`--comment --clean` makes "--clean" a comment), so only the parser knows what the
+/// command actually does. Exposed for testing.
+BOOL SNTCommandRuleChangesAreRefused(NSURL* syncBaseURL, NSUInteger staticRuleCount, BOOL check,
+                                     BOOL importRules, SNTRuleCleanup cleanupType) {
+  // --check only reads, so it is never refused.
+  if (check) {
+    return NO;
   }
 
+  BOOL cleanupOnly = !importRules && cleanupType != SNTRuleCleanupNone;
+  return syncBaseURL != nil || (staticRuleCount > 0 && !cleanupOnly);
+}
+
+- (void)runWithArguments:(NSArray*)arguments {
   NSString* identifier;
   SNTRuleState state = SNTRuleStateUnknown;
   SNTRuleType type = SNTRuleTypeBinary;
@@ -189,6 +197,9 @@ REGISTER_COMMAND_NAME(@"rule")
   BOOL exportRules = NO;
   BOOL exportFileAccessRules = NO;
   BOOL faaLookup = NO;
+#ifdef DEBUG
+  BOOL force = NO;
+#endif
 
   // Parse arguments
   for (NSUInteger i = 0; i < arguments.count; ++i) {
@@ -256,7 +267,7 @@ REGISTER_COMMAND_NAME(@"rule")
       comment = arguments[i];
 #ifdef DEBUG
     } else if ([arg caseInsensitiveCompare:@"--force"] == NSOrderedSame) {
-      // Don't do anything special.
+      force = YES;
 #endif
     } else if ([arg caseInsensitiveCompare:@"--import"] == NSOrderedSame) {
       if (exportRules) {
@@ -299,6 +310,19 @@ REGISTER_COMMAND_NAME(@"rule")
     } else {
       [self printErrorUsageAndExit:[@"Unknown argument: " stringByAppendingString:arg]];
     }
+  }
+
+  // Placed after parsing so the decision reflects what the command will actually do.
+  SNTConfigurator* config = [SNTConfigurator configurator];
+  BOOL refused = SNTCommandRuleChangesAreRefused(config.syncBaseURL, config.staticRules.count,
+                                                 check, importRules, cleanupType);
+#ifdef DEBUG
+  // DEBUG builds add a --force flag to allow manually adding/removing rules during testing.
+  refused = refused && !force;
+#endif
+  if (refused) {
+    TEE_LOGE(@"(SyncBaseURL/StaticRules is set, rules are managed centrally.)");
+    exit(1);
   }
 
   if (check) {

--- a/Source/santactl/Commands/SNTCommandRuleTest.mm
+++ b/Source/santactl/Commands/SNTCommandRuleTest.mm
@@ -45,22 +45,12 @@ static NSURL* SyncURL(void) {
   XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, NO, SNTRuleCleanupNone));
 }
 
-// --import adds rules, so combining it with a cleanup flag is not a cleanup-only operation.
-- (void)testImportIsRefusedWithStaticRulesEvenAlongsideCleanup {
+// --import adds rules, so it is refused on its own, and combining it with a cleanup flag does not
+// make it a cleanup-only operation.
+- (void)testImportIsRefusedWithStaticRules {
+  XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, YES, SNTRuleCleanupNone));
   XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, YES, SNTRuleCleanupNonTransitive));
   XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, YES, SNTRuleCleanupAll));
-}
-
-// Regression: a cleanup flag appearing in argv does not mean a cleanup was requested. In
-//
-//     santactl rule --allow --identifier <sha256> --comment --clean
-//
-// the parser consumes "--clean" as the value of --comment, leaving cleanupType unset and the
-// command an ordinary rule addition. Deciding from parsed options rather than from raw arguments
-// is what keeps that from reading as a cleanup and slipping past this gate.
-- (void)testCleanupFlagConsumedAsAnotherOptionsValueIsNotTreatedAsCleanup {
-  XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, NO, SNTRuleCleanupNone),
-                @"A rule addition must be refused no matter what its option values contain");
 }
 
 #pragma mark - SyncBaseURL

--- a/Source/santactl/Commands/SNTCommandRuleTest.mm
+++ b/Source/santactl/Commands/SNTCommandRuleTest.mm
@@ -1,0 +1,101 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTCommonEnums.h"
+
+// Defined in SNTCommandRule.mm.
+extern BOOL SNTCommandRuleChangesAreRefused(NSURL* syncBaseURL, NSUInteger staticRuleCount,
+                                            BOOL check, BOOL importRules,
+                                            SNTRuleCleanup cleanupType);
+
+@interface SNTCommandRuleTest : XCTestCase
+@end
+
+@implementation SNTCommandRuleTest
+
+static NSURL* SyncURL(void) {
+  return [NSURL URLWithString:@"https://sync.example.com/"];
+}
+
+#pragma mark - StaticRules only
+
+// Static rules only override the identifiers they name, so the rest of the database must stay
+// clearable or a host moving to profile-only management is stuck with a former sync server's
+// rules.
+- (void)testClearingIsAllowedWithStaticRules {
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(nil, 1, NO, NO, SNTRuleCleanupNonTransitive));
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(nil, 1, NO, NO, SNTRuleCleanupAll));
+}
+
+- (void)testAddingIsRefusedWithStaticRules {
+  XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, NO, SNTRuleCleanupNone));
+}
+
+// --import adds rules, so combining it with a cleanup flag is not a cleanup-only operation.
+- (void)testImportIsRefusedWithStaticRulesEvenAlongsideCleanup {
+  XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, YES, SNTRuleCleanupNonTransitive));
+  XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, YES, SNTRuleCleanupAll));
+}
+
+// Regression: a cleanup flag appearing in argv does not mean a cleanup was requested. In
+//
+//     santactl rule --allow --identifier <sha256> --comment --clean
+//
+// the parser consumes "--clean" as the value of --comment, leaving cleanupType unset and the
+// command an ordinary rule addition. Deciding from parsed options rather than from raw arguments
+// is what keeps that from reading as a cleanup and slipping past this gate.
+- (void)testCleanupFlagConsumedAsAnotherOptionsValueIsNotTreatedAsCleanup {
+  XCTAssertTrue(SNTCommandRuleChangesAreRefused(nil, 1, NO, NO, SNTRuleCleanupNone),
+                @"A rule addition must be refused no matter what its option values contain");
+}
+
+#pragma mark - SyncBaseURL
+
+// The sync server owns the database, so nothing but a read-only check gets past this gate.
+- (void)testEverythingIsRefusedWhileASyncServerIsConfigured {
+  const SNTRuleCleanup cleanups[] = {SNTRuleCleanupNone, SNTRuleCleanupNonTransitive,
+                                     SNTRuleCleanupAll};
+  for (size_t i = 0; i < sizeof(cleanups) / sizeof(cleanups[0]); ++i) {
+    for (int importRules = 0; importRules < 2; ++importRules) {
+      for (NSUInteger staticCount = 0; staticCount < 2; ++staticCount) {
+        XCTAssertTrue(
+            SNTCommandRuleChangesAreRefused(SyncURL(), staticCount, NO, importRules, cleanups[i]),
+            @"cleanup=%d import=%d static=%lu", (int)cleanups[i], importRules,
+            (unsigned long)staticCount);
+      }
+    }
+  }
+}
+
+#pragma mark - Exceptions
+
+// --check only reads: it is mutually exclusive with every mutating option and returns before the
+// rule database is touched, so it is never refused.
+- (void)testCheckIsAlwaysAllowed {
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(SyncURL(), 1, YES, NO, SNTRuleCleanupNone));
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(nil, 1, YES, NO, SNTRuleCleanupNone));
+}
+
+#pragma mark - Unmanaged
+
+- (void)testNothingIsRefusedWhenNothingElseManagesPolicy {
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(nil, 0, NO, NO, SNTRuleCleanupNone));
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(nil, 0, NO, NO, SNTRuleCleanupAll));
+  XCTAssertFalse(SNTCommandRuleChangesAreRefused(nil, 0, NO, YES, SNTRuleCleanupNone));
+}
+
+@end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -328,6 +328,22 @@ static NSString* TAMUsernameForUID(uid_t uid) {
   reply(ruleCounts);
 }
 
+/// Whether a rule change originating from santactl must be refused because policy is managed
+/// elsewhere. Always compiled so it can be tested; enforcement is release-only.
+///
+/// `addingRules` distinguishes adding rules from clearing them, because the two differ once
+/// StaticRules is in play: static rules only override the identifiers they name, so a rule
+/// database that cannot be cleared would strand a host on a departed sync server's policy with no
+/// supported way out. A configured SyncBaseURL refuses both -- the sync server owns the database,
+/// and a clean sync is the supported way to reset it.
+- (BOOL)shouldRejectManualRuleChangeAddingRules:(BOOL)addingRules {
+  SNTConfigurator* config = [SNTConfigurator configurator];
+  if (config.syncBaseURL) {
+    return YES;
+  }
+  return config.staticRules.count > 0 && addingRules;
+}
+
 - (void)databaseRuleAddExecutionRules:(NSArray<SNTRule*>*)executionRules
                       fileAccessRules:(NSArray<SNTFileAccessRule*>*)fileAccessRules
                      networkFlowRules:(NSArray<SNTNetworkFlowRule*>*)networkFlowRules
@@ -336,8 +352,10 @@ static NSString* TAMUsernameForUID(uid_t uid) {
                                source:(SNTRuleAddSource)source
                                 reply:(void (^)(BOOL, NSArray<NSError*>* error))reply {
 #ifndef DEBUG
-  SNTConfigurator* config = [SNTConfigurator configurator];
-  if (source == SNTRuleAddSourceSantactl && (config.syncBaseURL || config.staticRules.count > 0)) {
+  BOOL addingRules = executionRules.count > 0 || fileAccessRules.count > 0 ||
+                     networkFlowRules.count > 0 || signals.count > 0;
+  if (source == SNTRuleAddSourceSantactl &&
+      [self shouldRejectManualRuleChangeAddingRules:addingRules]) {
     NSError* error;
     [SNTError populateError:&error
                    withCode:SNTErrorCodeManualRulesDisabled

--- a/Source/santad/SNTDaemonControlControllerTest.mm
+++ b/Source/santad/SNTDaemonControlControllerTest.mm
@@ -12,6 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+#import "Source/common/SNTConfigurator.h"
 #import "Source/santad/SNTDaemonControlController.h"
 
 #import <Foundation/Foundation.h>
@@ -46,6 +47,7 @@ static NSString* const kBinarySHA256 =
 @end
 
 @interface SNTDaemonControlController (Testing)
+- (BOOL)shouldRejectManualRuleChangeAddingRules:(BOOL)addingRules;
 @property(readonly) dispatch_queue_t binaryUploadQ;
 @property(readonly) dispatch_queue_t packageInventoryQ;
 @end
@@ -383,6 +385,50 @@ static NSString* const kBinarySHA256 =
   }];
 
   XCTAssertEqual(got.networkFlow, 7);
+}
+
+// ---- Manual (santactl) rule change gate ------------------------------
+//
+// Enforcement itself is release-only (#ifndef DEBUG), so these cover the decision directly.
+
+- (void)testManualRuleChangesAreRefusedWhileASyncServerOwnsTheRuleDatabase {
+  id cfg = OCMClassMock([SNTConfigurator class]);
+  OCMStub([cfg configurator]).andReturn(cfg);
+  OCMStub([cfg syncBaseURL]).andReturn([NSURL URLWithString:@"https://example.com/"]);
+
+  XCTAssertTrue([self.sut shouldRejectManualRuleChangeAddingRules:YES],
+                @"A sync server owns the rule database, so manual additions must be refused");
+  XCTAssertTrue([self.sut shouldRejectManualRuleChangeAddingRules:NO],
+                @"Clearing is the sync server's job too: a clean sync is the supported reset");
+
+  [cfg stopMocking];
+}
+
+- (void)testManualRuleClearingIsAllowedWithStaticRulesButAddingIsNot {
+  id cfg = OCMClassMock([SNTConfigurator class]);
+  OCMStub([cfg configurator]).andReturn(cfg);
+  OCMStub([cfg syncBaseURL]).andReturn(nil);
+  OCMStub([cfg staticRules]).andReturn(@[ @{@"identifier" : @"abc"} ]);
+
+  XCTAssertTrue([self.sut shouldRejectManualRuleChangeAddingRules:YES],
+                @"Static rules are managed policy, so manual additions must still be refused");
+  XCTAssertFalse([self.sut shouldRejectManualRuleChangeAddingRules:NO],
+                 @"Clearing must stay possible, or a host moving to profile-only management is "
+                 @"stuck with a departed sync server's rules");
+
+  [cfg stopMocking];
+}
+
+- (void)testManualRuleChangesAreAllowedWhenNothingElseManagesPolicy {
+  id cfg = OCMClassMock([SNTConfigurator class]);
+  OCMStub([cfg configurator]).andReturn(cfg);
+  OCMStub([cfg syncBaseURL]).andReturn(nil);
+  OCMStub([cfg staticRules]).andReturn(@[]);
+
+  XCTAssertFalse([self.sut shouldRejectManualRuleChangeAddingRules:YES]);
+  XCTAssertFalse([self.sut shouldRejectManualRuleChangeAddingRules:NO]);
+
+  [cfg stopMocking];
 }
 
 @end

--- a/Source/santad/SNTSyncdQueue.h
+++ b/Source/santad/SNTSyncdQueue.h
@@ -24,7 +24,7 @@
 
 @interface SNTSyncdQueue : NSObject
 
-- (instancetype)initWithCacheSize:(uint64_t)cacheSize;
+- (instancetype)initWithCacheSize:(uint64_t)cacheSize NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)reassessSyncServiceConnection;

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -26,11 +26,27 @@
 #include "Source/common/SantaCache.h"
 #include "Source/common/String.h"
 
+// How long a removed SyncBaseURL must stay removed before synced state is dropped. Gives
+// com.apple.ManagedClient time to settle if it is flapping.
+static constexpr NSTimeInterval kDefaultClearSyncStateGracePeriod = 600;
+
 @interface SNTSyncdQueue ()
 @property dispatch_queue_t syncdQueue;
 @property MOLXPCConnection* syncConnection;
 @property dispatch_source_t timer;
 @property NSURL* previousSyncBaseURL;
+
+/// Last non-nil SyncBaseURL seen. Unlike `previousSyncBaseURL` this survives the URL going away,
+/// so a server swap is still recognised when SyncBaseURL passes through nil on the way. Seeded
+/// from, and written back to, the configurator's persisted record so that a swap spanning a
+/// daemon restart is recognised too.
+@property NSURL* lastSyncServerURL;
+
+/// Pending clear of synced state, or NULL if none is armed. Only touched on `syncdQueue`.
+@property dispatch_source_t clearSyncStateTimer;
+
+/// A property, not the constant directly, so tests don't wait out the real grace period.
+@property NSTimeInterval clearSyncStateGracePeriod;
 @end
 
 @implementation SNTSyncdQueue {
@@ -44,6 +60,8 @@
     _uploadBackoff = std::make_unique<SantaCache<std::string, NSDate*>>(cacheSize);
     _syncdQueue = dispatch_queue_create("com.northpolesec.syncd_queue",
                                         DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+    _clearSyncStateGracePeriod = kDefaultClearSyncStateGracePeriod;
+    _lastSyncServerURL = [[SNTConfigurator configurator] savedLastSyncServerURL];
   }
   return self;
 }
@@ -66,6 +84,8 @@
 - (void)reassessSyncServiceConnectionWithDelay:(uint32_t)seconds {
   WEAKIFY(self);
   dispatch_sync(self.syncdQueue, ^{
+    // Coalesce: a still-pending reassessment is superseded by this one. The handler retires its
+    // own source, so a non-NULL timer here always means one is genuinely still pending.
     if (self.timer) {
       dispatch_source_cancel(self.timer);
     }
@@ -78,10 +98,27 @@
     // WEAKIFY(self);
     dispatch_source_set_event_handler(self.timer, ^{
       STRONGIFY(self);
+      if (!self) {
+        return;
+      }
+
+      // One-shot: retire the source before doing any work, so that every exit path below is
+      // covered and a non-NULL `timer` always means "armed and not yet fired". Dropping our
+      // reference here is safe -- nothing touches the source afterwards, and dispatch keeps it
+      // alive for the duration of this handler.
+      dispatch_source_cancel(self.timer);
+      self.timer = NULL;
+
       SNTConfigurator* configurator = [SNTConfigurator configurator];
 
       NSURL* newSyncBaseURL = [configurator syncBaseURL];
-      BOOL telemetryExportEnabled = [configurator enableTelemetryExport];
+
+      // The server changed identity, rather than appearing or disappearing. Compared against the
+      // last non-nil URL, so removing one server and adding another still counts. Computed before
+      // the trackers are updated below, and independent of connection state. Only sees changes
+      // within this santad's lifetime: an edit made while it was down is missed.
+      BOOL syncServerChanged = self.lastSyncServerURL && newSyncBaseURL &&
+                               ![self.lastSyncServerURL isEqual:newSyncBaseURL];
 
       // If the SyncBaseURL was added or changed, and a connection already
       // exists, it must be bounced.
@@ -94,20 +131,30 @@
       }
 
       self.previousSyncBaseURL = newSyncBaseURL;
+      if (newSyncBaseURL && ![self.lastSyncServerURL isEqual:newSyncBaseURL]) {
+        self.lastSyncServerURL = newSyncBaseURL;
+        // Written only on change: persisting rewrites the whole state file. A failure leaves the
+        // record stale, so the change is acted on now but missed after a restart.
+        if (![configurator persistLastSyncServerURL:newSyncBaseURL]) {
+          LOGW(@"Failed to record the current sync server; a change made while santad is not "
+               @"running may go unnoticed");
+        }
+      }
 
-      // If newSyncBaseURL or telemetryExportEnabled is set, start the sync service
-      if (newSyncBaseURL || telemetryExportEnabled) {
+      // A SyncBaseURL is the only thing the sync service exists for.
+      if (newSyncBaseURL) {
+        // Runs once per change: the bounce above returns early, so this is the pass driven by
+        // the old sync service's invalidation, i.e. after it exited and can no longer write.
+        if (syncServerChanged) {
+          [self dropStateFromPreviousSyncServerSerialized];
+        }
+
         if (!self.syncConnection.isConnected) {
           [self establishSyncServiceConnectionSerialized];
         }
 
-        // Ensure any pending requests to clear sync state are cancelled, but
-        // only if there is a sync base URL set
-        if (newSyncBaseURL) {
-          [NSObject cancelPreviousPerformRequestsWithTarget:[SNTConfigurator configurator]
-                                                   selector:@selector(clearSyncState)
-                                                     object:nil];
-        }
+        // A sync server is configured again, so any pending clear is no longer wanted.
+        [self cancelPendingClearSyncStateSerialized];
       } else {
         if (self.syncConnection.isConnected) {
           // Note: Only teardown the connection if we're connected. This helps
@@ -117,20 +164,95 @@
           [self tearDownSyncServiceConnectionSerialized];
         }
 
-        // Keep the syncState active for 10 min in case com.apple.ManagedClient is
-        // flapping.
-        [[SNTConfigurator configurator] performSelector:@selector(clearSyncState)
-                                             withObject:nil
-                                             afterDelay:600];
+        // Keep the syncState active for the grace period in case
+        // com.apple.ManagedClient is flapping.
+        [self scheduleClearSyncStateSerialized];
       }
-
-      // Only run once
-      dispatch_source_cancel(self.timer);
-      self.timer = NULL;
     });
 
     dispatch_resume(self.timer);
   });
+}
+
+/// Drop the previous sync server's settings and ask the new one for a clean sync. Rules are left
+/// alone: the Clean sync replaces them in one transaction, so policy is never momentarily empty.
+///
+/// Must be called on `syncdQueue`. The hop to main is async because the main thread may itself be
+/// blocked in `dispatch_sync(syncdQueue, ...)` via `reassessSyncServiceConnection`.
+- (void)dropStateFromPreviousSyncServerSerialized {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    LOGI(@"SyncBaseURL now points at a different sync server, dropping the previous server's "
+         @"synced settings and requesting a clean sync");
+    SNTConfigurator* configurator = [SNTConfigurator configurator];
+    [configurator performSyncStateBatch:^{
+      [configurator clearSyncState];
+      [configurator setSyncTypeRequired:SNTSyncTypeClean];
+    }];
+  });
+}
+
+/// Arm a one-shot clear of synced state, `clearSyncStateGracePeriod` from now. An already-armed
+/// request is left alone so config churn can't push the deadline out indefinitely.
+///
+/// Must be called on `syncdQueue`. The hop to main is async because the main thread may itself be
+/// blocked in `dispatch_sync(syncdQueue, ...)` via `reassessSyncServiceConnection`.
+- (void)scheduleClearSyncStateSerialized {
+  if (self.clearSyncStateTimer) {
+    return;
+  }
+
+  self.clearSyncStateTimer =
+      dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.syncdQueue);
+  dispatch_source_set_timer(
+      self.clearSyncStateTimer,
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.clearSyncStateGracePeriod * NSEC_PER_SEC)),
+      DISPATCH_TIME_FOREVER,  // won't repeat
+      1 * NSEC_PER_SEC);
+
+  WEAKIFY(self);
+  dispatch_source_set_event_handler(self.clearSyncStateTimer, ^{
+    STRONGIFY(self);
+    if (!self) {
+      return;
+    }
+
+    // Only run once.
+    dispatch_source_cancel(self.clearSyncStateTimer);
+    self.clearSyncStateTimer = NULL;
+
+    NSTimeInterval gracePeriod = self.clearSyncStateGracePeriod;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      // Re-check after the hop: cancelPendingClearSyncStateSerialized only stops a clear that is
+      // still armed, so a URL landing between the timer firing and this block would be missed.
+      SNTConfigurator* configurator = [SNTConfigurator configurator];
+      if (configurator.syncBaseURL) {
+        LOGD(@"SyncBaseURL reappeared before synced state was cleared, keeping it");
+        return;
+      }
+
+      LOGI(@"No SyncBaseURL configured for %g seconds, clearing synced state", gracePeriod);
+      [configurator clearSyncState];
+
+      // The rules stay, so whichever server comes next must be asked to replace them. Recorded
+      // explicitly because `syncTypeRequired`'s empty-state default lapses to Normal the moment
+      // postflight writes any other key, and a server that declines the clean sync would then
+      // merge its rules onto the departed server's. Not batched with the clear above:
+      // `clearSyncState` only removes the plist when it runs outside a batch.
+      [configurator setSyncTypeRequired:SNTSyncTypeClean];
+    });
+  });
+
+  dispatch_resume(self.clearSyncStateTimer);
+}
+
+/// Drop any armed request to clear synced state. Must be called on `syncdQueue`.
+- (void)cancelPendingClearSyncStateSerialized {
+  if (!self.clearSyncStateTimer) {
+    return;
+  }
+
+  dispatch_source_cancel(self.clearSyncStateTimer);
+  self.clearSyncStateTimer = NULL;
 }
 
 - (void)establishSyncServiceConnectionSerialized {

--- a/Source/santad/SNTSyncdQueue.mm
+++ b/Source/santad/SNTSyncdQueue.mm
@@ -131,23 +131,28 @@ static constexpr NSTimeInterval kDefaultClearSyncStateGracePeriod = 600;
       }
 
       self.previousSyncBaseURL = newSyncBaseURL;
-      if (newSyncBaseURL && ![self.lastSyncServerURL isEqual:newSyncBaseURL]) {
-        self.lastSyncServerURL = newSyncBaseURL;
-        // Written only on change: persisting rewrites the whole state file. A failure leaves the
-        // record stale, so the change is acted on now but missed after a restart.
-        if (![configurator persistLastSyncServerURL:newSyncBaseURL]) {
-          LOGW(@"Failed to record the current sync server; a change made while santad is not "
-               @"running may go unnoticed");
-        }
-      }
 
       // A SyncBaseURL is the only thing the sync service exists for.
       if (newSyncBaseURL) {
         // Runs once per change: the bounce above returns early, so this is the pass driven by
         // the old sync service's invalidation, i.e. after it exited and can no longer write.
         if (syncServerChanged) {
-          [self dropStateFromPreviousSyncServerSerialized];
+          // Persists the new server as the last sync server itself, once the drop has committed.
+          [self dropStateFromPreviousSyncServerSerialized:newSyncBaseURL];
+        } else if (!self.lastSyncServerURL) {
+          // The first sync server this host has seen: nothing to drop, so record it now. Any other
+          // server is either unchanged (nothing to write, and persisting rewrites the whole state
+          // file) or a change, handled above.
+          if (![configurator persistLastSyncServerURL:newSyncBaseURL]) {
+            LOGW(@"Failed to record the current sync server; a change made while santad is not "
+                 @"running may go unnoticed");
+          }
         }
+
+        // Tracked in memory as soon as the change is acted on, so a drop that fails to reach disk
+        // is not retried on every pass. The persisted record is what carries the retry: it still
+        // names the previous server, so the next launch detects the change again.
+        self.lastSyncServerURL = newSyncBaseURL;
 
         if (!self.syncConnection.isConnected) {
           [self establishSyncServiceConnectionSerialized];
@@ -177,17 +182,27 @@ static constexpr NSTimeInterval kDefaultClearSyncStateGracePeriod = 600;
 /// Drop the previous sync server's settings and ask the new one for a clean sync. Rules are left
 /// alone: the Clean sync replaces them in one transaction, so policy is never momentarily empty.
 ///
+/// `syncServerURL` is recorded as the last sync server only once the drop has committed. The two
+/// records have to move together: the persisted record is what stops the change being detected
+/// again after a restart, so marking it handled while the drop is still in the air would strand
+/// the departed server's settings on disk with nothing left to notice them.
+///
 /// Must be called on `syncdQueue`. The hop to main is async because the main thread may itself be
 /// blocked in `dispatch_sync(syncdQueue, ...)` via `reassessSyncServiceConnection`.
-- (void)dropStateFromPreviousSyncServerSerialized {
+- (void)dropStateFromPreviousSyncServerSerialized:(NSURL*)syncServerURL {
   dispatch_async(dispatch_get_main_queue(), ^{
     LOGI(@"SyncBaseURL now points at a different sync server, dropping the previous server's "
          @"synced settings and requesting a clean sync");
     SNTConfigurator* configurator = [SNTConfigurator configurator];
-    [configurator performSyncStateBatch:^{
-      [configurator clearSyncState];
-      [configurator setSyncTypeRequired:SNTSyncTypeClean];
-    }];
+    if (![configurator clearSyncStateRequiringSyncType:SNTSyncTypeClean]) {
+      LOGE(@"Failed to drop the previous sync server's synced settings. They will be dropped again "
+           @"on the next launch rather than reapplied.");
+      return;
+    }
+    if (![configurator persistLastSyncServerURL:syncServerURL]) {
+      LOGW(@"Failed to record the current sync server; this change will be detected again after a "
+           @"restart, costing a redundant clean sync");
+    }
   });
 }
 
@@ -230,15 +245,26 @@ static constexpr NSTimeInterval kDefaultClearSyncStateGracePeriod = 600;
         return;
       }
 
+      // Never synced, or already cleared by an earlier launch. Nothing to drop, and nothing worth
+      // recording: with no synced settings `syncTypeRequired` already answers Clean. Without this,
+      // every host that does not use a sync server writes a sync state plist it has no use for.
+      if (!configurator.hasSyncedSettings) {
+        LOGD(@"No SyncBaseURL configured");
+        return;
+      }
+
       LOGI(@"No SyncBaseURL configured for %g seconds, clearing synced state", gracePeriod);
-      [configurator clearSyncState];
 
       // The rules stay, so whichever server comes next must be asked to replace them. Recorded
       // explicitly because `syncTypeRequired`'s empty-state default lapses to Normal the moment
       // postflight writes any other key, and a server that declines the clean sync would then
-      // merge its rules onto the departed server's. Not batched with the clear above:
-      // `clearSyncState` only removes the plist when it runs outside a batch.
-      [configurator setSyncTypeRequired:SNTSyncTypeClean];
+      // merge its rules onto the departed server's. Cleared and recorded in one call because the
+      // ordinary sync-state write path is gated on a configured sync server, which is exactly what
+      // just went away.
+      if (![configurator clearSyncStateRequiringSyncType:SNTSyncTypeClean]) {
+        LOGE(@"Failed to clear the departed sync server's synced settings from disk. They are no "
+             @"longer in effect, and will be cleared again on the next launch.");
+      }
     });
   });
 

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -53,6 +53,7 @@
 }
 
 - (void)tearDown {
+  [self drainMainQueue];
   // Both are class mocks, so retire them explicitly rather than leaving it to deallocation.
   [self.mockSyncServiceInterface stopMocking];
   [self.stubSyncConnection stopMocking];
@@ -201,6 +202,28 @@
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
   }
   return predicate();
+}
+
+/// Run the main queue until everything already enqueued on it has executed.
+///
+/// Both drop paths end in a `dispatch_async` to the main queue whose block captures no test state:
+/// it resolves `[SNTConfigurator configurator]` when it runs. That is right in production, where
+/// there is one configurator for the life of the process, but in tests a block enqueued by one
+/// test can execute during the next one and act on *its* mock -- clearing sync state that test
+/// expected to survive. Draining between tests is what keeps each test's async work its own.
+///
+/// Deterministic rather than a fixed sleep: the main queue is FIFO, so a sentinel enqueued now
+/// runs after everything already queued ahead of it.
+- (void)drainMainQueue {
+  __block BOOL drained = NO;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    drained = YES;
+  });
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return drained;
+                    }],
+                @"The main queue must drain between tests");
 }
 
 /// A reassessment timer is one-shot, so a non-NULL `timer` must mean "armed and not yet fired".

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -19,6 +19,7 @@
 #import <XCTest/XCTest.h>
 
 #import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStoredFileAccessEvent.h"
 #import "Source/common/SNTXPCSyncServiceInterface.h"
@@ -26,6 +27,9 @@
 @interface SNTSyncdQueue (Testing)
 @property dispatch_queue_t syncdQueue;
 @property MOLXPCConnection* syncConnection;
+@property dispatch_source_t timer;
+@property dispatch_source_t clearSyncStateTimer;
+@property NSTimeInterval clearSyncStateGracePeriod;
 
 - (BOOL)backoffForPrimaryHash:(NSString*)hash;
 - (void)dispatchBlockOnSyncdQueue:(void (^)(void))block;
@@ -162,6 +166,443 @@
   dispatch_sync(sut.syncdQueue, ^{
                 });
   OCMVerify(times(2), [mockProxy postEventsToSyncServer:[OCMArg any] reply:[OCMArg any]]);
+}
+
+#pragma mark - Sync state cleanup on SyncBaseURL removal
+
+/// Spin the main run loop until `predicate` holds or `timeout` elapses. The run loop must keep
+/// turning because clearSyncState is dispatched to the main queue.
+- (BOOL)waitUpTo:(NSTimeInterval)timeout forCondition:(BOOL (^)(void))predicate {
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+  while ([deadline timeIntervalSinceNow] > 0) {
+    if (predicate()) {
+      return YES;
+    }
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+  }
+  return predicate();
+}
+
+/// A reassessment timer is one-shot, so a non-NULL `timer` must mean "armed and not yet fired".
+/// Read on syncdQueue, the only place it is touched.
+- (BOOL)reassessTimerArmedOn:(SNTSyncdQueue*)sut {
+  __block BOOL armed = NO;
+  dispatch_sync(sut.syncdQueue, ^{
+    armed = (sut.timer != NULL);
+  });
+  return armed;
+}
+
+/// Whether a clear is armed. Read on syncdQueue, the only place clearSyncStateTimer is touched.
+- (BOOL)clearIsArmedOn:(SNTSyncdQueue*)sut {
+  __block BOOL armed = NO;
+  dispatch_sync(sut.syncdQueue, ^{
+    armed = (sut.clearSyncStateTimer != NULL);
+  });
+  return armed;
+}
+
+/// Stub the configurator singleton: SyncBaseURL from `urlProvider` (re-read on every call, so
+/// tests can change it), and `onClear` in place of clearSyncState.
+- (id)stubbedConfiguratorWithSyncBaseURLProvider:(NSURL* (^)(void))urlProvider
+                                         onClear:(void (^)(void))onClear {
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator configurator]).andReturn(mockConfigurator);
+  OCMStub([mockConfigurator syncBaseURL]).andDo(^(NSInvocation* invocation) {
+    NSURL* url = urlProvider();
+    [invocation setReturnValue:&url];
+  });
+  OCMStub([mockConfigurator clearSyncState]).andDo(^(NSInvocation* invocation) {
+    onClear();
+  });
+  return mockConfigurator;
+}
+
+- (void)testSyncStateIsClearedAfterSyncBaseURLIsRemoved {
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
+
+  __block NSUInteger cleared = 0;
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return nil;
+      }
+      onClear:^{
+        ++cleared;
+      }];
+
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"clearSyncState must run once the grace period elapses with no SyncBaseURL");
+
+  [mockConfigurator stopMocking];
+}
+
+// The rules left behind came from a server that is no longer an authority, so whichever server
+// comes next must be asked for a clean sync. Recorded explicitly rather than left to
+// `syncTypeRequired`'s empty-state default, which lapses to Normal as soon as postflight writes
+// any other key.
+- (void)testSyncBaseURLRemovalRecordsThatACleanSyncIsRequired {
+  __block NSUInteger cleared = 0;
+  __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return nil;
+      }
+      onClear:^{
+        ++cleared;
+      }];
+  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        SNTSyncType type;
+        [invocation getArgument:&type atIndex:2];
+        [syncTypesSet addObject:@(type)];
+      });
+
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"Removing SyncBaseURL must clear the synced state");
+  XCTAssertEqualObjects(syncTypesSet, (@[ @(SNTSyncTypeClean) ]),
+                        @"Removing SyncBaseURL must record that a clean sync is required");
+
+  [mockConfigurator stopMocking];
+}
+
+// The old server is no longer an authority, so its settings must not carry over. Rules are left
+// alone: the requested Clean sync replaces them atomically during the new server's rule download.
+- (void)testChangingSyncServerDropsPreviousServerStateAndRequestsCleanSync {
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+
+  __block NSURL* syncBaseURL = [NSURL URLWithString:@"https://server-a.example.com/"];
+  __block NSUInteger cleared = 0;
+  __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return syncBaseURL;
+      }
+      onClear:^{
+        ++cleared;
+      }];
+  // Let the batch body run so the clear and sync-type writes inside it are observable.
+  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
+  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        SNTSyncType type;
+        [invocation getArgument:&type atIndex:2];
+        [syncTypesSet addObject:@(type)];
+      });
+
+  // Pretend the sync service is up, so the first pass records server A without a real XPC
+  // connection.
+  __block BOOL connected = YES;
+  id mockConnection = OCMClassMock([MOLXPCConnection class]);
+  OCMStub([mockConnection remoteObjectProxy])
+      .andReturn(OCMProtocolMock(@protocol(SNTSyncServiceXPC)));
+  OCMStub([mockConnection isConnected]).andDo(^(NSInvocation* invocation) {
+    BOOL value = connected;
+    [invocation setReturnValue:&value];
+  });
+  sut.syncConnection = mockConnection;
+
+  [sut reassessSyncServiceConnectionImmediately];
+  [self waitUpTo:0.2
+      forCondition:^BOOL {
+        return NO;
+      }];
+  XCTAssertEqual(cleared, 0u, @"Merely observing the current sync server must not drop state");
+
+  // Server A -> server B. The first pass only bounces the connection.
+  syncBaseURL = [NSURL URLWithString:@"https://server-b.example.com/"];
+  [sut reassessSyncServiceConnectionImmediately];
+  [self waitUpTo:0.2
+      forCondition:^BOOL {
+        return NO;
+      }];
+  XCTAssertEqual(cleared, 0u, @"State must not be dropped until the old sync service is down");
+
+  // The old sync service has now exited, which is what drives the second reassessment.
+  connected = NO;
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"Changing sync servers must drop the previous server's synced state");
+  XCTAssertEqualObjects(syncTypesSet, (@[ @(SNTSyncTypeClean) ]),
+                        @"Changing sync servers must request exactly one Clean sync");
+
+  [mockConfigurator stopMocking];
+}
+
+// The reassessment timer is one-shot, so every path through its handler must retire it -- not
+// just the ones that reach the end. The bounce path returns early, and leaving a fired source
+// parked in `timer` makes the coalescing check at the top of the next reassessment cancel an
+// already-dead source, which is inert but reads as though a reassessment were still pending.
+- (void)testBouncingTheSyncServiceRetiresTheReassessmentTimer {
+  __block NSURL* syncBaseURL = [NSURL URLWithString:@"https://server-a.example.com/"];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return syncBaseURL;
+      }
+                                         onClear:^{
+                                         }];
+  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
+
+  // A connected sync service is what makes the change below take the bounce path.
+  id mockConnection = OCMClassMock([MOLXPCConnection class]);
+  OCMStub([mockConnection remoteObjectProxy])
+      .andReturn(OCMProtocolMock(@protocol(SNTSyncServiceXPC)));
+  OCMStub([mockConnection isConnected]).andReturn(YES);
+  sut.syncConnection = mockConnection;
+
+  [sut reassessSyncServiceConnectionImmediately];
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return ![self reassessTimerArmedOn:sut];
+                    }],
+                @"Sanity: a reassessment that runs to completion must retire its timer");
+
+  // Server A -> server B with a live connection: the handler tears down and returns early.
+  syncBaseURL = [NSURL URLWithString:@"https://server-b.example.com/"];
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return ![self reassessTimerArmedOn:sut];
+                    }],
+                @"The bounce path must retire its timer too");
+
+  [mockConfigurator stopMocking];
+}
+
+// Telemetry export is uploaded by santad via Sleigh, not by the sync service, so it has no say in
+// whether synced state is kept once SyncBaseURL is gone.
+- (void)testTelemetryExportDoesNotKeepSyncedStateAlive {
+  __block NSUInteger cleared = 0;
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
+
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator configurator]).andReturn(mockConfigurator);
+  OCMStub([mockConfigurator syncBaseURL]).andDo(^(NSInvocation* invocation) {
+    NSURL* url = nil;
+    [invocation setReturnValue:&url];
+  });
+  OCMStub([mockConfigurator enableTelemetryExport]).andReturn(YES);
+  OCMStub([mockConfigurator clearSyncState]).andDo(^(NSInvocation* invocation) {
+    ++cleared;
+  });
+
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"Telemetry export must not keep synced state alive once SyncBaseURL is gone");
+
+  [mockConfigurator stopMocking];
+}
+
+// A SyncBaseURL edited while santad was not running is the ordinary way a fleet changes sync
+// servers -- the profile lands while the Mac is asleep or off. In-memory tracking starts empty
+// every launch, so the previous server has to come from the persisted record instead.
+- (void)testSyncServerChangeAcrossARestartIsDetectedFromPersistedState {
+  __block NSUInteger cleared = 0;
+  __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return [NSURL URLWithString:@"https://server-b.example.com/"];
+      }
+      onClear:^{
+        ++cleared;
+      }];
+  // Stands in for server A having been recorded before this launch.
+  OCMStub([mockConfigurator savedLastSyncServerURL])
+      .andReturn([NSURL URLWithString:@"https://server-a.example.com/"]);
+  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
+  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        SNTSyncType type;
+        [invocation getArgument:&type atIndex:2];
+        [syncTypesSet addObject:@(type)];
+      });
+
+  // Constructed after the stub is in place: the queue seeds itself at init.
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"A sync server change spanning a restart must drop the previous server's state");
+  XCTAssertEqualObjects(syncTypesSet, (@[ @(SNTSyncTypeClean) ]),
+                        @"It must request exactly one Clean sync");
+
+  [mockConfigurator stopMocking];
+}
+
+// Removing one server and adding another is still a server change, even though SyncBaseURL passes
+// through nil on the way. Swapping inside the grace period cancels the pending clear, so without
+// change detection across the gap the new server would silently inherit the old server's state.
+- (void)testSwappingSyncServersViaNilStillDropsPreviousServerState {
+  __block NSURL* syncBaseURL = [NSURL URLWithString:@"https://server-a.example.com/"];
+  __block NSUInteger cleared = 0;
+  __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  // Long enough that the swap below lands well inside the grace period.
+  sut.clearSyncStateGracePeriod = 60;
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return syncBaseURL;
+      }
+      onClear:^{
+        ++cleared;
+      }];
+  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
+  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        SNTSyncType type;
+        [invocation getArgument:&type atIndex:2];
+        [syncTypesSet addObject:@(type)];
+      });
+
+  // Observe server A. Reassessments coalesce, so this must be given time to land before the
+  // removal below, or server A is never recorded in the first place.
+  [sut reassessSyncServiceConnectionImmediately];
+  [self waitUpTo:0.2
+      forCondition:^BOOL {
+        return NO;
+      }];
+
+  // Remove it. Removal only arms a clear; nothing is dropped yet.
+  syncBaseURL = nil;
+  [sut reassessSyncServiceConnectionImmediately];
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return [self clearIsArmedOn:sut];
+                    }],
+                @"Removing SyncBaseURL must arm a pending sync state clear");
+  XCTAssertEqual(cleared, 0u, @"The grace period must not have elapsed yet");
+
+  // Server B arrives inside the grace period, cancelling that pending clear.
+  syncBaseURL = [NSURL URLWithString:@"https://server-b.example.com/"];
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"Swapping servers via nil must still drop the previous server's synced state");
+  XCTAssertEqualObjects(syncTypesSet, (@[ @(SNTSyncTypeClean) ]),
+                        @"Swapping servers via nil must request exactly one Clean sync");
+
+  [mockConfigurator stopMocking];
+}
+
+// A SyncBaseURL landing during the hop to the main queue arrives too late for
+// -cancelPendingClearSyncStateSerialized to stop the clear, so the far side must re-check.
+- (void)testClearIsSkippedWhenSyncBaseURLReturnsDuringMainQueueHop {
+  __block NSURL* syncBaseURL = nil;
+  __block NSUInteger cleared = 0;
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 1;
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return syncBaseURL;
+      }
+      onClear:^{
+        ++cleared;
+      }];
+
+  // Arm a clear, and wait for it so restoring the URL below genuinely happens after arming.
+  [sut reassessSyncServiceConnectionImmediately];
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return [self clearIsArmedOn:sut];
+                    }],
+                @"Removing SyncBaseURL must arm a pending sync state clear");
+
+  // No reassessment, so nothing calls -cancelPendingClearSyncStateSerialized: the armed clear
+  // fires anyway and must catch this itself after the hop.
+  syncBaseURL = [NSURL URLWithString:@"https://sync.example.com/"];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return ![self clearIsArmedOn:sut];
+                    }],
+                @"The armed clear must fire rather than stay armed");
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.2]];
+  XCTAssertEqual(cleared, 0u,
+                 @"A SyncBaseURL that lands during the main-queue hop must cancel the clear");
+
+  [mockConfigurator stopMocking];
+}
+
+- (void)testPendingSyncStateClearIsCancelledWhenSyncBaseURLReturns {
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 30;
+
+  __block NSURL* syncBaseURL = nil;
+  __block NSUInteger cleared = 0;
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return syncBaseURL;
+      }
+      onClear:^{
+        ++cleared;
+      }];
+
+  // Wait for the clear to be armed, otherwise the cancellation below races nothing and the test
+  // is vacuous.
+  [sut reassessSyncServiceConnectionImmediately];
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return [self clearIsArmedOn:sut];
+                    }],
+                @"Removing SyncBaseURL must arm a pending sync state clear");
+
+  // SyncBaseURL comes back within the grace period; the pending clear must be dropped.
+  syncBaseURL = [NSURL URLWithString:@"https://sync.example.com/"];
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return ![self clearIsArmedOn:sut];
+                    }],
+                @"A returning SyncBaseURL must disarm the pending sync state clear");
+  XCTAssertEqual(cleared, 0u, @"Sync state must survive a SyncBaseURL that returns in time");
+
+  [mockConfigurator stopMocking];
 }
 
 @end

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -272,9 +272,6 @@
 }
 
 - (void)testSyncStateIsClearedAfterSyncBaseURLIsRemoved {
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  sut.clearSyncStateGracePeriod = 0.1;
-
   __block NSUInteger cleared = 0;
   id mockConfigurator = [self
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
@@ -284,6 +281,9 @@
         ++cleared;
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
 
   [sut reassessSyncServiceConnectionImmediately];
 
@@ -304,9 +304,6 @@
   __block NSUInteger cleared = 0;
   __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
 
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  sut.clearSyncStateGracePeriod = 0.1;
-
   id mockConfigurator = [self
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return nil;
@@ -316,6 +313,9 @@
         [syncTypesSet addObject:@(syncType)];
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
 
   [sut reassessSyncServiceConnectionImmediately];
 
@@ -333,8 +333,6 @@
 // The old server is no longer an authority, so its settings must not carry over. Rules are left
 // alone: the requested Clean sync replaces them atomically during the new server's rule download.
 - (void)testChangingSyncServerDropsPreviousServerStateAndRequestsCleanSync {
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-
   __block NSURL* syncBaseURL = [NSURL URLWithString:@"https://server-a.example.com/"];
   __block NSUInteger cleared = 0;
   __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
@@ -348,6 +346,8 @@
         [syncTypesSet addObject:@(syncType)];
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
 
   // Pretend the sync service is up: a live connection is what makes the change below take the
   // bounce path, and dropping it afterwards is what lets the pass after that proceed.
@@ -399,8 +399,6 @@
 - (void)testBouncingTheSyncServiceRetiresTheReassessmentTimer {
   __block NSURL* syncBaseURL = [NSURL URLWithString:@"https://server-a.example.com/"];
 
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-
   id mockConfigurator = [self
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
@@ -408,6 +406,8 @@
       onDrop:^BOOL(SNTSyncType syncType) {
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
 
   // A connected sync service is what makes the change below take the bounce path.
   id mockConnection = OCMClassMock([MOLXPCConnection class]);
@@ -441,9 +441,6 @@
 - (void)testTelemetryExportDoesNotKeepSyncedStateAlive {
   __block NSUInteger cleared = 0;
 
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  sut.clearSyncStateGracePeriod = 0.1;
-
   id mockConfigurator = [self
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return nil;
@@ -453,6 +450,9 @@
         return YES;
       }];
   OCMStub([mockConfigurator enableTelemetryExport]).andReturn(YES);
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
 
   [sut reassessSyncServiceConnectionImmediately];
 
@@ -508,9 +508,6 @@
 - (void)testNothingIsDroppedWhenThereAreNoSyncedSettings {
   __block NSUInteger dropped = 0;
 
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  sut.clearSyncStateGracePeriod = 0.1;
-
   id mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([mockConfigurator configurator]).andReturn(mockConfigurator);
   OCMStub([mockConfigurator syncBaseURL]).andDo(^(NSInvocation* invocation) {
@@ -523,6 +520,9 @@
       .andDo(^(NSInvocation* invocation) {
         ++dropped;
       });
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
 
   [sut reassessSyncServiceConnectionImmediately];
 
@@ -615,10 +615,6 @@
   __block NSUInteger cleared = 0;
   __block NSMutableArray<NSNumber*>* syncTypesSet = [NSMutableArray array];
 
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  // Long enough that the swap below lands well inside the grace period.
-  sut.clearSyncStateGracePeriod = 60;
-
   id mockConfigurator = [self
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
@@ -628,6 +624,10 @@
         [syncTypesSet addObject:@(syncType)];
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  // Long enough that the swap below lands well inside the grace period.
+  sut.clearSyncStateGracePeriod = 60;
 
   // Observe server A. Reassessments coalesce, so this must be given time to land before the
   // removal below, or server A is never recorded in the first place.
@@ -668,9 +668,6 @@
   __block NSURL* syncBaseURL = nil;
   __block NSUInteger cleared = 0;
 
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  sut.clearSyncStateGracePeriod = 1;
-
   id mockConfigurator = [self
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
@@ -679,6 +676,9 @@
         ++cleared;
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 1;
 
   // Arm a clear, and wait for it so restoring the URL below genuinely happens after arming.
   [sut reassessSyncServiceConnectionImmediately];
@@ -705,9 +705,6 @@
 }
 
 - (void)testPendingSyncStateClearIsCancelledWhenSyncBaseURLReturns {
-  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
-  sut.clearSyncStateGracePeriod = 30;
-
   __block NSURL* syncBaseURL = nil;
   __block NSUInteger cleared = 0;
   id mockConfigurator = [self
@@ -718,6 +715,9 @@
         ++cleared;
         return YES;
       }];
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 30;
 
   // Wait for the clear to be armed, otherwise the cancellation below races nothing and the test
   // is vacuous.

--- a/Source/santad/SNTSyncdQueueTest.mm
+++ b/Source/santad/SNTSyncdQueueTest.mm
@@ -36,9 +36,29 @@
 @end
 
 @interface SNTSyncdQueueTest : XCTestCase
+@property id mockSyncServiceInterface;
+@property id stubSyncConnection;
 @end
 
 @implementation SNTSyncdQueueTest
+
+- (void)setUp {
+  // Keep these tests off the real com.northpolesec.santa.syncservice mach service. Any
+  // reassessment that finds a SyncBaseURL and no live connection calls
+  // -establishSyncServiceConnectionSerialized, and a real MOLXPCConnection then blocks for two
+  // seconds failing to reach it -- or, on a Mac with Santa installed, actually launches it.
+  self.stubSyncConnection = OCMClassMock([MOLXPCConnection class]);
+  self.mockSyncServiceInterface = OCMClassMock([SNTXPCSyncServiceInterface class]);
+  OCMStub([self.mockSyncServiceInterface configuredConnection]).andReturn(self.stubSyncConnection);
+}
+
+- (void)tearDown {
+  // Both are class mocks, so retire them explicitly rather than leaving it to deallocation.
+  [self.mockSyncServiceInterface stopMocking];
+  [self.stubSyncConnection stopMocking];
+  self.mockSyncServiceInterface = nil;
+  self.stubSyncConnection = nil;
+}
 
 - (void)testBackoffForPrimaryHash {
   SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:256];
@@ -203,18 +223,28 @@
 }
 
 /// Stub the configurator singleton: SyncBaseURL from `urlProvider` (re-read on every call, so
-/// tests can change it), and `onClear` in place of clearSyncState.
+/// tests can change it), and `onDrop` in place of `clearSyncStateRequiringSyncType:`, which is how
+/// both transitions drop synced state -- removing a SyncBaseURL, and changing to a different one.
+/// `onDrop` receives the sync type being recorded alongside the clear, and returns what the real
+/// call would: NO when the new state did not reach disk.
 - (id)stubbedConfiguratorWithSyncBaseURLProvider:(NSURL* (^)(void))urlProvider
-                                         onClear:(void (^)(void))onClear {
+                                          onDrop:(BOOL (^)(SNTSyncType))onDrop {
   id mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([mockConfigurator configurator]).andReturn(mockConfigurator);
   OCMStub([mockConfigurator syncBaseURL]).andDo(^(NSInvocation* invocation) {
     NSURL* url = urlProvider();
     [invocation setReturnValue:&url];
   });
-  OCMStub([mockConfigurator clearSyncState]).andDo(^(NSInvocation* invocation) {
-    onClear();
-  });
+  // These tests are all about a host that does hold a departed server's settings.
+  OCMStub([mockConfigurator hasSyncedSettings]).andReturn(YES);
+  OCMStub([mockConfigurator clearSyncStateRequiringSyncType:SNTSyncTypeNormal])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        SNTSyncType syncType;
+        [invocation getArgument:&syncType atIndex:2];
+        BOOL committed = onDrop(syncType);
+        [invocation setReturnValue:&committed];
+      });
   return mockConfigurator;
 }
 
@@ -227,8 +257,9 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return nil;
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        return YES;
       }];
 
   [sut reassessSyncServiceConnectionImmediately];
@@ -237,7 +268,7 @@
                     forCondition:^BOOL {
                       return cleared > 0;
                     }],
-                @"clearSyncState must run once the grace period elapses with no SyncBaseURL");
+                @"Synced state must be dropped once the grace period elapses with no SyncBaseURL");
 
   [mockConfigurator stopMocking];
 }
@@ -257,16 +288,11 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return nil;
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        [syncTypesSet addObject:@(syncType)];
+        return YES;
       }];
-  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
-      .ignoringNonObjectArgs()
-      .andDo(^(NSInvocation* invocation) {
-        SNTSyncType type;
-        [invocation getArgument:&type atIndex:2];
-        [syncTypesSet addObject:@(type)];
-      });
 
   [sut reassessSyncServiceConnectionImmediately];
 
@@ -294,21 +320,14 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        [syncTypesSet addObject:@(syncType)];
+        return YES;
       }];
-  // Let the batch body run so the clear and sync-type writes inside it are observable.
-  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
-  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
-      .ignoringNonObjectArgs()
-      .andDo(^(NSInvocation* invocation) {
-        SNTSyncType type;
-        [invocation getArgument:&type atIndex:2];
-        [syncTypesSet addObject:@(type)];
-      });
 
-  // Pretend the sync service is up, so the first pass records server A without a real XPC
-  // connection.
+  // Pretend the sync service is up: a live connection is what makes the change below take the
+  // bounce path, and dropping it afterwards is what lets the pass after that proceed.
   __block BOOL connected = YES;
   id mockConnection = OCMClassMock([MOLXPCConnection class]);
   OCMStub([mockConnection remoteObjectProxy])
@@ -363,9 +382,9 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
       }
-                                         onClear:^{
-                                         }];
-  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
+      onDrop:^BOOL(SNTSyncType syncType) {
+        return YES;
+      }];
 
   // A connected sync service is what makes the change below take the bounce path.
   id mockConnection = OCMClassMock([MOLXPCConnection class]);
@@ -402,16 +421,15 @@
   SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
   sut.clearSyncStateGracePeriod = 0.1;
 
-  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
-  OCMStub([mockConfigurator configurator]).andReturn(mockConfigurator);
-  OCMStub([mockConfigurator syncBaseURL]).andDo(^(NSInvocation* invocation) {
-    NSURL* url = nil;
-    [invocation setReturnValue:&url];
-  });
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return nil;
+      }
+      onDrop:^BOOL(SNTSyncType syncType) {
+        ++cleared;
+        return YES;
+      }];
   OCMStub([mockConfigurator enableTelemetryExport]).andReturn(YES);
-  OCMStub([mockConfigurator clearSyncState]).andDo(^(NSInvocation* invocation) {
-    ++cleared;
-  });
 
   [sut reassessSyncServiceConnectionImmediately];
 
@@ -435,20 +453,14 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return [NSURL URLWithString:@"https://server-b.example.com/"];
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        [syncTypesSet addObject:@(syncType)];
+        return YES;
       }];
   // Stands in for server A having been recorded before this launch.
   OCMStub([mockConfigurator savedLastSyncServerURL])
       .andReturn([NSURL URLWithString:@"https://server-a.example.com/"]);
-  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
-  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
-      .ignoringNonObjectArgs()
-      .andDo(^(NSInvocation* invocation) {
-        SNTSyncType type;
-        [invocation getArgument:&type atIndex:2];
-        [syncTypesSet addObject:@(type)];
-      });
 
   // Constructed after the stub is in place: the queue seeds itself at init.
   SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
@@ -462,6 +474,112 @@
                 @"A sync server change spanning a restart must drop the previous server's state");
   XCTAssertEqualObjects(syncTypesSet, (@[ @(SNTSyncTypeClean) ]),
                         @"It must request exactly one Clean sync");
+
+  [mockConfigurator stopMocking];
+}
+
+// A host that never had a sync server has nothing to drop. Recording a clean-sync requirement it
+// has no use for would materialise a sync state plist on every Mac that does not sync, which reads
+// as though the host held synced state when it holds none. Built without the shared helper so the
+// absence of synced settings is unambiguous.
+- (void)testNothingIsDroppedWhenThereAreNoSyncedSettings {
+  __block NSUInteger dropped = 0;
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  sut.clearSyncStateGracePeriod = 0.1;
+
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator configurator]).andReturn(mockConfigurator);
+  OCMStub([mockConfigurator syncBaseURL]).andDo(^(NSInvocation* invocation) {
+    NSURL* url = nil;
+    [invocation setReturnValue:&url];
+  });
+  OCMStub([mockConfigurator hasSyncedSettings]).andReturn(NO);
+  OCMStub([mockConfigurator clearSyncStateRequiringSyncType:SNTSyncTypeNormal])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        ++dropped;
+      });
+
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return ![self clearIsArmedOn:sut];
+                    }],
+                @"The armed clear must fire rather than stay armed");
+  // The clear hops to the main queue, so give that block a chance to run before concluding it
+  // did nothing.
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.2]];
+  XCTAssertEqual(dropped, 0u, @"A host with no synced settings must not write a sync state");
+
+  [mockConfigurator stopMocking];
+}
+
+// The persisted record of the current sync server is what stops a change being detected a second
+// time, so it must not be written until the drop it stands for has actually reached disk.
+- (void)testTheNewSyncServerIsRecordedOnceTheDropCommits {
+  NSURL* serverB = [NSURL URLWithString:@"https://server-b.example.com/"];
+  __block NSUInteger cleared = 0;
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return serverB;
+      }
+      onDrop:^BOOL(SNTSyncType syncType) {
+        ++cleared;
+        return YES;
+      }];
+  OCMStub([mockConfigurator savedLastSyncServerURL])
+      .andReturn([NSURL URLWithString:@"https://server-a.example.com/"]);
+  OCMStub([mockConfigurator persistLastSyncServerURL:OCMOCK_ANY]).andReturn(YES);
+
+  // Constructed after the stub is in place: the queue seeds itself at init.
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return cleared > 0;
+                    }],
+                @"Sanity: the change must be acted on");
+  OCMVerify(times(1), [mockConfigurator persistLastSyncServerURL:serverB]);
+
+  [mockConfigurator stopMocking];
+}
+
+// The dangerous ordering. Recording server B while the drop is still in the air, or after it
+// failed, leaves server A's settings on disk with nothing left to notice them: the next launch
+// compares B against B, sees no change, and reapplies a departed server's ClientMode and path
+// regexes for good. Leaving the record naming A costs a redundant clean sync and nothing worse.
+- (void)testAFailedDropLeavesThePreviousSyncServerRecorded {
+  __block NSUInteger attempted = 0;
+
+  id mockConfigurator = [self
+      stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
+        return [NSURL URLWithString:@"https://server-b.example.com/"];
+      }
+      onDrop:^BOOL(SNTSyncType syncType) {
+        ++attempted;
+        return NO;
+      }];
+  OCMStub([mockConfigurator savedLastSyncServerURL])
+      .andReturn([NSURL URLWithString:@"https://server-a.example.com/"]);
+
+  SNTSyncdQueue* sut = [[SNTSyncdQueue alloc] initWithCacheSize:1];
+  [sut reassessSyncServiceConnectionImmediately];
+
+  XCTAssertTrue([self waitUpTo:5
+                    forCondition:^BOOL {
+                      return attempted > 0;
+                    }],
+                @"Sanity: the drop must be attempted");
+  // Give the main queue a chance to run anything the drop might have queued behind it.
+  [self waitUpTo:0.2
+      forCondition:^BOOL {
+        return NO;
+      }];
+  OCMVerify(never(), [mockConfigurator persistLastSyncServerURL:OCMOCK_ANY]);
 
   [mockConfigurator stopMocking];
 }
@@ -482,17 +600,11 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        [syncTypesSet addObject:@(syncType)];
+        return YES;
       }];
-  OCMStub([mockConfigurator performSyncStateBatch:[OCMArg invokeBlock]]);
-  OCMStub([mockConfigurator setSyncTypeRequired:SNTSyncTypeNormal])
-      .ignoringNonObjectArgs()
-      .andDo(^(NSInvocation* invocation) {
-        SNTSyncType type;
-        [invocation getArgument:&type atIndex:2];
-        [syncTypesSet addObject:@(type)];
-      });
 
   // Observe server A. Reassessments coalesce, so this must be given time to land before the
   // removal below, or server A is never recorded in the first place.
@@ -540,8 +652,9 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        return YES;
       }];
 
   // Arm a clear, and wait for it so restoring the URL below genuinely happens after arming.
@@ -578,8 +691,9 @@
       stubbedConfiguratorWithSyncBaseURLProvider:^NSURL* {
         return syncBaseURL;
       }
-      onClear:^{
+      onDrop:^BOOL(SNTSyncType syncType) {
         ++cleared;
+        return YES;
       }];
 
   // Wait for the clear to be armed, otherwise the cancellation below races nothing and the test

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -663,8 +663,6 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                    LOGI(@"EnableTelemetryExport changed: %d -> %d", oldBool,
                                         newBool);
 
-                                   [syncd_queue reassessSyncServiceConnection];
-
                                    if (newBool) {
                                      LOGW(@"WARNING - Telemetry export is currently in beta. "
                                           @"Configuration and format are subject to change.");

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -85,6 +85,15 @@ namespace {
 
 void HandleV2Responses(const ::pbv2::PreflightResponse& resp, SNTSyncState* syncState);
 
+NSString* SyncTypeName(SNTSyncType syncType) {
+  switch (syncType) {
+    case SNTSyncTypeNormal: return @"normal";
+    case SNTSyncTypeClean: return @"clean";
+    case SNTSyncTypeCleanAll: return @"clean all";
+    default: return @"unknown";
+  }
+}
+
 SNTNetworkFlowDefaultAction NetworkFlowDefaultActionFromProto(
     ::pbv2::NetworkFlowDefaultAction action) {
   switch (action) {
@@ -400,6 +409,16 @@ BOOL Preflight(SNTSyncPreflight* self, google::protobuf::Arena* arena,
   } else {
     // Fallback if unspecified is a normal sync
     self.syncState.syncType = SNTSyncTypeNormal;
+  }
+
+  // Always report the resolved sync type. Without this a server that silently ignores
+  // `request_clean_sync` looks identical to one that was never asked, which leaves the client
+  // requesting a clean sync on every sync with nothing in the log to explain why.
+  SLOGD(@"Sync type: %@", SyncTypeName(self.syncState.syncType));
+  if (self.syncState.syncType == SNTSyncTypeNormal && requestSyncType != SNTSyncTypeNormal) {
+    SLOGW(@"Client requested a %@ sync but the server responded with a normal sync. The client "
+          @"will keep requesting one until the server performs it.",
+          SyncTypeName(requestSyncType));
   }
 
   // When running as sync v1, check if we have a push token chain. If so, save


### PR DESCRIPTION
Fixes SNT-533.
Fixes #361 

The delayed cleanup that drops synced state after `SyncBaseURL` goes away has been dead since #360 moved it into a `dispatch_source` event handler. `performSelector:withObject:afterDelay:` needs a run loop on the calling thread, and a serial dispatch queue has none, so it never fired. Removing `SyncBaseURL` did nothing: the departed server's `ClientMode`, regexes, push token chain, export config and `SyncTypeRequired` kept applying until santad restarted.

**Removal (A → nil)** now clears synced settings after the grace period and records that a clean sync is required. Rules are deliberately left alone: whichever server comes next replaces them via that clean sync, and an operator managing rules locally can clear them with `santactl rule --clean`.

**Change (A → B)** discards the old server's settings and records a clean sync, so the new server replaces rules in one transaction instead of merging onto its predecessor's. Detected across a nil gap and across a daemon restart (last sync server persisted in `state.plist`). Rules are again left alone until that clean sync lands.

Also:
- `syncTypeRequired` defaults to `Clean`, not `CleanAll`, with no synced state. Fresh installs unaffected.
- Preflight logs the resolved sync type and warns when the server declines a requested clean sync. This is the fix for the originating report.
- Empty synced state removes the plist instead of writing an empty one; removal failures are logged.
- `santactl rule --clean` permitted with only `StaticRules` set, so a locally managed host can clear a departed server's rules. Adding still refused; both still refused with `SyncBaseURL` set. The gate is decided from parsed options, not raw argv.
- `EnableTelemetryExport` no longer affects whether the sync service runs.
- Reassessment timer is retired before its handler branches.

**Behavior change:** hosts with `SyncBaseURL` removed lose synced *settings* 10 min after the daemon next starts, falling back to the configuration profile — including `ClientMode`. Rules are untouched. Release note drafted in SNT-533.

**Testing:** 129 test targets pass. 14 new tests, each watched failing first. Run-loop behavior, `dispatch_source_cancel(nil)` (segfaults, hence the nil guard) and the sync-vs-async deadlock were verified with probes.

**Not addressed:** `CLEAN_RULES`/`CLEAN_STANDALONE`/`CLEAN_FILE_ACCESS_RULES` plumbing; the one-shot `count == 0` signal; the ignored durability result in `dropStateFromPreviousSyncServerSerialized`; the bypassable `santactl rule` pre-check (daemon gate is authoritative).
