### PR TITLE
santad/gui: add sigterm-then-sigkill to KillingMachine and a pre-quit UI notification

### DIFF
--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -48,7 +48,7 @@
 - (void)postRuleSyncNotificationForApplication:(NSString*)app;
 /// Warns that a rule's time window is about to close and the application will
 /// be quit at `deadline`. Fire-and-forget: the kill happens whether or not the
-/// banner is shown.
+/// warning window is shown.
 - (void)postTimedRuleKillNotificationForApplication:(NSString*)app deadline:(NSDate*)deadline;
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply;
 - (void)enterTemporaryMonitorMode:(NSDate*)expiration;

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -46,6 +46,10 @@
                             configBundle:(SNTConfigBundle*)configBundle;
 - (void)postClientModeNotification:(SNTClientMode)clientmode;
 - (void)postRuleSyncNotificationForApplication:(NSString*)app;
+/// Warns that a rule's time window is about to close and the application will
+/// be quit at `deadline`. Fire-and-forget: the kill happens whether or not the
+/// banner is shown.
+- (void)postTimedRuleKillNotificationForApplication:(NSString*)app deadline:(NSDate*)deadline;
 - (void)authorizeTemporaryMonitorMode:(void (^)(BOOL authenticated))reply;
 - (void)enterTemporaryMonitorMode:(NSDate*)expiration;
 - (void)leaveTemporaryMonitorMode;

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -146,6 +146,17 @@ swift_library(
     ],
 )
 
+swift_library(
+    name = "SNTTimedRuleKillMessageWindowView",
+    srcs = [
+        "SNTTimedRuleKillMessageWindowView.swift",
+    ],
+    generates_header = 1,
+    deps = [
+        ":SNTMessageView",
+    ],
+)
+
 objc_library(
     name = "SNTSystemExtensionDelegate",
     srcs = ["SNTSystemExtensionDelegate.mm"],
@@ -319,6 +330,7 @@ objc_library(
         ":SNTNetworkFlowMessageWindowController",
         ":SNTNetworkMountMessageWindowController",
         ":SNTStatusItemManager",
+        ":SNTTimedRuleKillMessageWindowController",
         "//Source/common:MOLCertificate",
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTBlockMessage_SantaGUI",
@@ -365,6 +377,17 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTTimedRuleKillMessageWindowController",
+    srcs = ["SNTTimedRuleKillMessageWindowController.mm"],
+    hdrs = ["SNTTimedRuleKillMessageWindowController.h"],
+    deps = [
+        ":SNTMessageWindowController",
+        ":SNTTimedRuleKillMessageWindowView",
+        "//Source/common:SNTStrengthify",
+    ],
+)
+
+objc_library(
     name = "SantaGUI_lib",
     srcs = ["main.mm"],
     sdk_frameworks = [
@@ -387,6 +410,7 @@ objc_library(
         ":SNTNotificationManager",
         ":SNTStatusItemManager",
         ":SNTSystemExtensionDelegate",
+        ":SNTTimedRuleKillMessageWindowController",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
     ],
@@ -473,7 +497,6 @@ santa_unit_test(
     ],
     sdk_frameworks = [
         "Cocoa",
-        "UserNotifications",
     ],
     deps = [
         ":SNTNotificationManager",

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -473,10 +473,12 @@ santa_unit_test(
     ],
     sdk_frameworks = [
         "Cocoa",
+        "UserNotifications",
     ],
     deps = [
         ":SNTNotificationManager",
         "//Source/common:SNTConfigBundle",
+        "//Source/common:SNTConfigurator",
         "//Source/common:SNTStoredExecutionEvent",
         "//Source/common:SNTStoredNetworkFlowEvent",
         "@OCMock",

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ kann nun ausgeführt werden";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "\"%1$@\" wird um %2$@ beendet.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "Eine Begründung ist erforderlich";
 

--- a/Source/gui/Resources/de.lproj/Localizable.strings
+++ b/Source/gui/Resources/de.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ kann nun ausgeführt werden";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "\"%1$@\" wird um %2$@ beendet.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ can now be run";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "\"%1$@\" will quit at %2$@.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "a justification is required";
 

--- a/Source/gui/Resources/en.lproj/Localizable.strings
+++ b/Source/gui/Resources/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ can now be run";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "\"%1$@\" will quit at %2$@.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ ahora se puede ejecutar";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "\"%1$@\" se cerrará a las %2$@.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "se requiere una justificación";
 

--- a/Source/gui/Resources/es.lproj/Localizable.strings
+++ b/Source/gui/Resources/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ ahora se puede ejecutar";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "\"%1$@\" se cerrará a las %2$@.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ peut maintenant être exécuté";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "\"%1$@\" se fermera à %2$@.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "une justification est requise";
 

--- a/Source/gui/Resources/fr-CA.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr-CA.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ peut maintenant être exécuté";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "\"%1$@\" se fermera à %2$@.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ peut maintenant être exécuté";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "\"%1$@\" se fermera à %2$@.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/fr.lproj/Localizable.strings
+++ b/Source/gui/Resources/fr.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ peut maintenant être exécuté";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "\"%1$@\" se fermera à %2$@.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "une justification est requise";
 

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@が実行できるようになった";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "%2$@に「%1$@」を終了します。";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "理由の入力が必要です";
 

--- a/Source/gui/Resources/ja.lproj/Localizable.strings
+++ b/Source/gui/Resources/ja.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@が実行できるようになった";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "%2$@に「%1$@」を終了します。";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "Теперь можно запустить %@";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "Приложение \"%1$@\" будет закрыто в %2$@.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "требуется обоснование";
 

--- a/Source/gui/Resources/ru.lproj/Localizable.strings
+++ b/Source/gui/Resources/ru.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "Теперь можно запустить %@";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "Приложение \"%1$@\" будет закрыто в %2$@.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ тепер можна запускати";
 
-/* Notification message warning that an app will be quit at a time */
+/* Window message warning that an app will be quit at a time */
 "\"%@\" will quit at %@." = "Програму \"%1$@\" буде закрито в %2$@.";
 
 /* Reason shown when a justification is required but not given */

--- a/Source/gui/Resources/uk.lproj/Localizable.strings
+++ b/Source/gui/Resources/uk.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Notification message shown when a known app has been unblocked */
 "%@ can now be run" = "%@ тепер можна запускати";
 
+/* Notification message warning that an app will be quit at a time */
+"\"%@\" will quit at %@." = "Програму \"%1$@\" буде закрито в %2$@.";
+
 /* Reason shown when a justification is required but not given */
 "a justification is required" = "потрібне обґрунтування";
 

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -408,6 +408,36 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
   [un addNotificationRequest:req withCompletionHandler:nil];
 }
 
+- (void)postTimedRuleKillNotificationForApplication:(NSString*)app deadline:(NSDate*)deadline {
+  if ([SNTConfigurator configurator].enableSilentMode) return;
+  if (!app || !deadline) return;
+
+  UNUserNotificationCenter* un = [UNUserNotificationCenter currentNotificationCenter];
+
+  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+  formatter.timeStyle = NSDateFormatterShortStyle;
+  formatter.dateStyle = NSDateFormatterNoStyle;
+
+  UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];
+  content.title = @"Santa";
+  content.body = [NSString
+      stringWithFormat:NSLocalizedString(
+                           @"\"%@\" will quit at %@.",
+                           @"Notification message warning that an app will be quit at a time"),
+                       app, [formatter stringFromDate:deadline]];
+
+  // One banner per (application, deadline): a repeated warning for the same
+  // deadline replaces the previous one rather than stacking up.
+  NSString* identifier = [NSString
+      stringWithFormat:@"timedRuleKillNotification_%@_%f", app, deadline.timeIntervalSince1970];
+
+  UNNotificationRequest* req = [UNNotificationRequest requestWithIdentifier:identifier
+                                                                    content:content
+                                                                    trigger:nil];
+
+  [un addNotificationRequest:req withCompletionHandler:nil];
+}
+
 - (void)postBlockNotification:(SNTStoredExecutionEvent*)event
             withCustomMessage:(NSString*)message
                     customURL:(NSString*)url

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -44,6 +44,7 @@
 #import "Source/gui/SNTNetworkFlowMessageWindowController.h"
 #import "Source/gui/SNTNetworkMountMessageWindowController.h"
 #import "Source/gui/SNTStatusItemManager.h"
+#import "Source/gui/SNTTimedRuleKillMessageWindowController.h"
 #import "src/santanetd/SNDFilterConfigurationHelper.h"
 
 @interface SNTNotificationManager ()
@@ -408,34 +409,26 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
   [un addNotificationRequest:req withCompletionHandler:nil];
 }
 
+// A window, not a UNUserNotificationCenter banner: Do Not Disturb and Focus
+// modes suppress banners, and a warning that something is about to be quit must
+// not be dropped that way.
 - (void)postTimedRuleKillNotificationForApplication:(NSString*)app deadline:(NSDate*)deadline {
-  if ([SNTConfigurator configurator].enableSilentMode) return;
-  if (!app || !deadline) return;
+  // Length, not just nil: an empty name has no identity, so its window would
+  // both read absurdly and defeat the queue's dedup, stacking one focus-stealing
+  // window per repeated call. Logged like the other bad-input bails here, so a
+  // daemon-side regression is visible instead of silently dropping warnings.
+  if (!app.length || !deadline) {
+    LOGI(@"Error: Missing application name or deadline in message received from daemon!");
+    return;
+  }
 
-  UNUserNotificationCenter* un = [UNUserNotificationCenter currentNotificationCenter];
+  SNTTimedRuleKillMessageWindowController* pendingMsg =
+      [[SNTTimedRuleKillMessageWindowController alloc] initWithApplication:app deadline:deadline];
 
-  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-  formatter.timeStyle = NSDateFormatterShortStyle;
-  formatter.dateStyle = NSDateFormatterNoStyle;
-
-  UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];
-  content.title = @"Santa";
-  content.body = [NSString
-      stringWithFormat:NSLocalizedString(
-                           @"\"%@\" will quit at %@.",
-                           @"Notification message warning that an app will be quit at a time"),
-                       app, [formatter stringFromDate:deadline]];
-
-  // One banner per (application, deadline): a repeated warning for the same
-  // deadline replaces the previous one rather than stacking up.
-  NSString* identifier = [NSString
-      stringWithFormat:@"timedRuleKillNotification_%@_%f", app, deadline.timeIntervalSince1970];
-
-  UNNotificationRequest* req = [UNNotificationRequest requestWithIdentifier:identifier
-                                                                    content:content
-                                                                    trigger:nil];
-
-  [un addNotificationRequest:req withCompletionHandler:nil];
+  // Silences are a block-event feature: a warning that an application is about
+  // to be quit is not something a user should be able to turn off per
+  // application. Silent mode still suppresses it, through the queue's own check.
+  [self queueMessage:pendingMsg enableSilences:NO];
 }
 
 - (void)postBlockNotification:(SNTStoredExecutionEvent*)event

--- a/Source/gui/SNTNotificationManagerTest.mm
+++ b/Source/gui/SNTNotificationManagerTest.mm
@@ -68,6 +68,7 @@
 @interface SNTNotificationManagerTest : XCTestCase
 @property id mockConfigurator;
 @property id mockWindowControllerClass;
+@property NSApplicationActivationPolicy savedActivationPolicy;
 @end
 
 @implementation SNTNotificationManagerTest
@@ -87,12 +88,15 @@
   // [NSApp activateIgnoringOtherApps:YES] a no-op.
   self.mockWindowControllerClass = OCMClassMock([SNTMessageWindowController class]);
   OCMStub([self.mockWindowControllerClass defaultWindow]).andReturn([[OffScreenWindow alloc] init]);
+  self.savedActivationPolicy = NSApp.activationPolicy;
   [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
 }
 
 - (void)tearDown {
   // Class mocks swizzle the class itself, so they have to be undone or they
-  // follow the process into the next test.
+  // follow the process into the next test. The activation policy is process
+  // state too, so it goes back to whatever it was before setUp changed it.
+  [NSApp setActivationPolicy:self.savedActivationPolicy];
   [self.mockConfigurator stopMocking];
   [self.mockWindowControllerClass stopMocking];
   [super tearDown];

--- a/Source/gui/SNTNotificationManagerTest.mm
+++ b/Source/gui/SNTNotificationManagerTest.mm
@@ -14,6 +14,7 @@
 /// limitations under the License.
 
 #import <OCMock/OCMock.h>
+#import <UserNotifications/UserNotifications.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/gui/SNTMessageWindowController.h"
@@ -22,6 +23,7 @@
 #import "Source/gui/SNTStatusItemManager.h"
 
 #import "Source/common/SNTConfigBundle.h"
+#import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTStoredExecutionEvent.h"
 #import "Source/common/SNTStoredNetworkFlowEvent.h"
 
@@ -44,6 +46,8 @@
 @end
 
 @interface SNTNotificationManagerTest : XCTestCase
+@property id mockConfigurator;
+@property id mockNotificationCenter;
 @end
 
 @implementation SNTNotificationManagerTest
@@ -51,6 +55,14 @@
 - (void)setUp {
   [super setUp];
   fclose(stdout);
+}
+
+- (void)tearDown {
+  // Class mocks swizzle the class itself, so they have to be undone or they
+  // follow the process into the next test.
+  [self.mockConfigurator stopMocking];
+  [self.mockNotificationCenter stopMocking];
+  [super tearDown];
 }
 
 - (void)testPostBlockNotificationSendsDistributedNotification {
@@ -295,6 +307,71 @@
           record();
         });
       }];
+}
+
+#pragma mark Timed rule kill warning
+
+// The notification center is a class mock so the informational-notification
+// path can be driven without a real app bundle behind it; silent mode comes
+// from the configurator, which is also mocked.
+- (id)mockNotificationCenterSilent:(BOOL)silent {
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  OCMStub([self.mockConfigurator enableSilentMode]).andReturn(silent);
+
+  self.mockNotificationCenter = OCMClassMock([UNUserNotificationCenter class]);
+  OCMStub([self.mockNotificationCenter currentNotificationCenter])
+      .andReturn(self.mockNotificationCenter);
+  return self.mockNotificationCenter;
+}
+
+- (NSString*)shortTimeFromDate:(NSDate*)date {
+  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+  formatter.timeStyle = NSDateFormatterShortStyle;
+  formatter.dateStyle = NSDateFormatterNoStyle;
+  return [formatter stringFromDate:date];
+}
+
+- (void)testPostTimedRuleKillNotificationNamesTheAppAndTheTime {
+  id un = [self mockNotificationCenterSilent:NO];
+  NSDate* deadline = [NSDate dateWithTimeIntervalSince1970:1660221048];
+
+  [[[SNTNotificationManager alloc] init] postTimedRuleKillNotificationForApplication:@"Calculator"
+                                                                            deadline:deadline];
+
+  NSString* expected = [NSString
+      stringWithFormat:@"\"Calculator\" will quit at %@.", [self shortTimeFromDate:deadline]];
+  // One banner per (application, deadline): a repeat replaces rather than
+  // stacks, so both have to appear in the request's identifier.
+  NSString* stamp = [NSString stringWithFormat:@"%f", deadline.timeIntervalSince1970];
+  OCMVerify([un addNotificationRequest:[OCMArg checkWithBlock:^BOOL(UNNotificationRequest* req) {
+                  XCTAssertEqualObjects(req.content.body, expected);
+                  XCTAssertTrue([req.identifier containsString:@"Calculator"]);
+                  XCTAssertTrue([req.identifier containsString:stamp]);
+                  return YES;
+                }]
+                 withCompletionHandler:nil]);
+}
+
+- (void)testPostTimedRuleKillNotificationHonorsSilentMode {
+  id un = [self mockNotificationCenterSilent:YES];
+
+  [[[SNTNotificationManager alloc] init]
+      postTimedRuleKillNotificationForApplication:@"Calculator"
+                                         deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
+
+  OCMVerify(never(), [un addNotificationRequest:OCMOCK_ANY withCompletionHandler:OCMOCK_ANY]);
+}
+
+- (void)testPostTimedRuleKillNotificationIgnoresIncompleteWarnings {
+  id un = [self mockNotificationCenterSilent:NO];
+  SNTNotificationManager* mgr = [[SNTNotificationManager alloc] init];
+
+  [mgr postTimedRuleKillNotificationForApplication:nil
+                                          deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
+  [mgr postTimedRuleKillNotificationForApplication:@"Calculator" deadline:nil];
+
+  OCMVerify(never(), [un addNotificationRequest:OCMOCK_ANY withCompletionHandler:OCMOCK_ANY]);
 }
 
 @end

--- a/Source/gui/SNTNotificationManagerTest.mm
+++ b/Source/gui/SNTNotificationManagerTest.mm
@@ -14,13 +14,13 @@
 /// limitations under the License.
 
 #import <OCMock/OCMock.h>
-#import <UserNotifications/UserNotifications.h>
 #import <XCTest/XCTest.h>
 
 #import "Source/gui/SNTMessageWindowController.h"
 #import "Source/gui/SNTNetworkFlowMessageWindowController.h"
 #import "Source/gui/SNTNotificationManager.h"
 #import "Source/gui/SNTStatusItemManager.h"
+#import "Source/gui/SNTTimedRuleKillMessageWindowController.h"
 
 #import "Source/common/SNTConfigBundle.h"
 #import "Source/common/SNTConfigurator.h"
@@ -30,9 +30,11 @@
 @class SNTBinaryMessageWindowController;
 
 @interface SNTNotificationManager (Testing)
+@property(readonly) NSMutableArray* pendingNotifications;
 - (void)hashBundleBinariesForEvent:(SNTStoredEvent*)event
                     withController:(SNTBinaryMessageWindowController*)controller;
 - (void)queueMessage:(SNTMessageWindowController*)pendingMsg enableSilences:(BOOL)enableSilences;
+- (void)showQueuedWindow;
 @end
 
 // Overrides only messageHash, to confirm the base queueDedupeHash defaults to it.
@@ -45,9 +47,27 @@
 }
 @end
 
+// A real NSWindow that refuses to come on screen. Nothing any test here asserts
+// needs a window to be visible: a dialog is closed through -close and its
+// delegate, both of which work the same off screen.
+@interface OffScreenWindow : NSWindow
+@end
+
+@implementation OffScreenWindow
+- (instancetype)init {
+  return [super initWithContentRect:NSZeroRect
+                          styleMask:NSWindowStyleMaskTitled
+                            backing:NSBackingStoreBuffered
+                              defer:NO];
+}
+
+- (void)makeKeyAndOrderFront:(id)sender {
+}
+@end
+
 @interface SNTNotificationManagerTest : XCTestCase
 @property id mockConfigurator;
-@property id mockNotificationCenter;
+@property id mockWindowControllerClass;
 @end
 
 @implementation SNTNotificationManagerTest
@@ -55,13 +75,26 @@
 - (void)setUp {
   [super setUp];
   fclose(stdout);
+
+  // Nothing in this suite may reach the screen. Several tests here run the real
+  // queueMessage:, which shows the dialog it accepted, so without these two lines
+  // a test run puts santa dialogs in front of whoever is running it: an xctest
+  // bundle has a real WindowServer connection and a live NSApplication.
+  //
+  // +defaultWindow is the single place any message window controller gets its
+  // window, so handing back one that refuses to be ordered in covers every path,
+  // and a prohibited activation policy makes the base class's
+  // [NSApp activateIgnoringOtherApps:YES] a no-op.
+  self.mockWindowControllerClass = OCMClassMock([SNTMessageWindowController class]);
+  OCMStub([self.mockWindowControllerClass defaultWindow]).andReturn([[OffScreenWindow alloc] init]);
+  [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
 }
 
 - (void)tearDown {
   // Class mocks swizzle the class itself, so they have to be undone or they
   // follow the process into the next test.
   [self.mockConfigurator stopMocking];
-  [self.mockNotificationCenter stopMocking];
+  [self.mockWindowControllerClass stopMocking];
   [super tearDown];
 }
 
@@ -311,67 +344,170 @@
 
 #pragma mark Timed rule kill warning
 
-// The notification center is a class mock so the informational-notification
-// path can be driven without a real app bundle behind it; silent mode comes
-// from the configurator, which is also mocked.
-- (id)mockNotificationCenterSilent:(BOOL)silent {
+- (void)mockSilentMode:(BOOL)silent {
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
   OCMStub([self.mockConfigurator enableSilentMode]).andReturn(silent);
-
-  self.mockNotificationCenter = OCMClassMock([UNUserNotificationCenter class]);
-  OCMStub([self.mockNotificationCenter currentNotificationCenter])
-      .andReturn(self.mockNotificationCenter);
-  return self.mockNotificationCenter;
 }
 
-- (NSString*)shortTimeFromDate:(NSDate*)date {
-  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-  formatter.timeStyle = NSDateFormatterShortStyle;
-  formatter.dateStyle = NSDateFormatterNoStyle;
-  return [formatter stringFromDate:date];
-}
+// Every window the message-window base class hands out for the rest of the test
+// is one that cannot come on screen. +defaultWindow is the single place any
+// controller gets its window, so stubbing it is enough to keep a test run silent
+// no matter which path ends up creating a window.
+//
+// The warning is a window on the block-dialog queue, not a UNUserNotificationCenter
+// banner, because Do Not Disturb and Focus modes suppress banners. Silences stay
+// off: a warning that something is about to be quit is not silenceable per app.
+- (void)testPostTimedRuleKillNotificationQueuesAWindow {
+  SNTNotificationManager* mgr = [[SNTNotificationManager alloc] init];
+  id mgrMock = OCMPartialMock(mgr);
+  OCMExpect([mgrMock
+        queueMessage:[OCMArg isKindOfClass:[SNTTimedRuleKillMessageWindowController class]]
+      enableSilences:NO]);
 
-- (void)testPostTimedRuleKillNotificationNamesTheAppAndTheTime {
-  id un = [self mockNotificationCenterSilent:NO];
-  NSDate* deadline = [NSDate dateWithTimeIntervalSince1970:1660221048];
+  [mgr postTimedRuleKillNotificationForApplication:@"Calculator"
+                                          deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
 
-  [[[SNTNotificationManager alloc] init] postTimedRuleKillNotificationForApplication:@"Calculator"
-                                                                            deadline:deadline];
-
-  NSString* expected = [NSString
-      stringWithFormat:@"\"Calculator\" will quit at %@.", [self shortTimeFromDate:deadline]];
-  // One banner per (application, deadline): a repeat replaces rather than
-  // stacks, so both have to appear in the request's identifier.
-  NSString* stamp = [NSString stringWithFormat:@"%f", deadline.timeIntervalSince1970];
-  OCMVerify([un addNotificationRequest:[OCMArg checkWithBlock:^BOOL(UNNotificationRequest* req) {
-                  XCTAssertEqualObjects(req.content.body, expected);
-                  XCTAssertTrue([req.identifier containsString:@"Calculator"]);
-                  XCTAssertTrue([req.identifier containsString:stamp]);
-                  return YES;
-                }]
-                 withCompletionHandler:nil]);
-}
-
-- (void)testPostTimedRuleKillNotificationHonorsSilentMode {
-  id un = [self mockNotificationCenterSilent:YES];
-
-  [[[SNTNotificationManager alloc] init]
-      postTimedRuleKillNotificationForApplication:@"Calculator"
-                                         deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
-
-  OCMVerify(never(), [un addNotificationRequest:OCMOCK_ANY withCompletionHandler:OCMOCK_ANY]);
+  OCMVerifyAll(mgrMock);
+  [mgrMock stopMocking];
 }
 
 - (void)testPostTimedRuleKillNotificationIgnoresIncompleteWarnings {
-  id un = [self mockNotificationCenterSilent:NO];
   SNTNotificationManager* mgr = [[SNTNotificationManager alloc] init];
+  id mgrMock = OCMPartialMock(mgr);
+  OCMReject([mgrMock queueMessage:OCMOCK_ANY enableSilences:NO]);
 
   [mgr postTimedRuleKillNotificationForApplication:nil
                                           deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
+  // An empty name has no identity either: its messageHash is nil, so repeats
+  // would stack rather than collapse.
+  [mgr postTimedRuleKillNotificationForApplication:@""
+                                          deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
   [mgr postTimedRuleKillNotificationForApplication:@"Calculator" deadline:nil];
 
-  OCMVerify(never(), [un addNotificationRequest:OCMOCK_ANY withCompletionHandler:OCMOCK_ANY]);
+  OCMVerifyAll(mgrMock);
+  [mgrMock stopMocking];
+}
+
+// One window per (application, deadline): the queue collapses on this key, so a
+// repeated warning for the same deadline cannot stack a second window, while a
+// moved deadline or a different application still gets its own.
+- (void)testTimedRuleKillWindowIdentityIsApplicationAndDeadline {
+  NSDate* deadline = [NSDate dateWithTimeIntervalSince1970:1660221048];
+  NSString* (^key)(NSString*, NSDate*) = ^(NSString* app, NSDate* d) {
+    return [[[SNTTimedRuleKillMessageWindowController alloc] initWithApplication:app deadline:d]
+        queueDedupeHash];
+  };
+
+  XCTAssertEqualObjects(key(@"Calculator", deadline), key(@"Calculator", deadline));
+  XCTAssertNotEqualObjects(key(@"Calculator", deadline),
+                           key(@"Calculator", [deadline dateByAddingTimeInterval:60]));
+  XCTAssertNotEqualObjects(key(@"Calculator", deadline), key(@"Chess", deadline));
+}
+
+// Silent mode is enforced once, by the queue, so the warning path carries no gate
+// of its own. Both rows run the real queueMessage: and differ only in the
+// configurator's answer.
+- (void)testTimedRuleKillWarningIsQueuedUnlessSilentMode {
+  for (NSNumber* silent in @[ @NO, @YES ]) {
+    [self mockSilentMode:silent.boolValue];
+
+    SNTNotificationManager* mgr = [[SNTNotificationManager alloc] init];
+    id mgrMock = OCMPartialMock(mgr);
+    // What the queue accepted is the assertion; presentation is stubbed out so
+    // the test cannot put anything on screen.
+    OCMStub([mgrMock showQueuedWindow]).andDo(nil);
+
+    [mgr postTimedRuleKillNotificationForApplication:@"Calculator"
+                                            deadline:[NSDate dateWithTimeIntervalSinceNow:600]];
+
+    // queueMessage: finishes its bookkeeping in a block on the main queue, so
+    // hop through that queue to let the block run before asserting.
+    XCTestExpectation* drained = [self expectationWithDescription:@"main queue drained"];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [drained fulfill];
+    });
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(mgr.pendingNotifications.count, silent.boolValue ? 0u : 1u);
+
+    [mgrMock stopMocking];
+    [self.mockConfigurator stopMocking];
+    self.mockConfigurator = nil;
+  }
+}
+
+// Queues a warning for real and hands back the manager once the queue has retired
+// it again. The manager's own cleanup callback is the signal, so what is being
+// waited on is the queue advancing, not merely a window closing.
+- (SNTNotificationManager*)queueUntilRetired:(SNTMessageWindowController*)controller
+                                 describedAs:(NSString*)description
+                                  onRetiring:(void (^)(void))onRetiring {
+  [self mockSilentMode:NO];
+
+  SNTNotificationManager* mgr = [[SNTNotificationManager alloc] init];
+  id mgrMock = OCMPartialMock(mgr);
+
+  XCTestExpectation* retired = [self expectationWithDescription:description];
+  OCMStub([mgrMock windowDidCloseSilenceHash:OCMOCK_ANY withInterval:0])
+      .andDo(^(NSInvocation* i) {
+        onRetiring();
+        [retired fulfill];
+      })
+      .andForwardToRealObject();
+
+  [mgr queueMessage:controller enableSilences:NO];
+
+  [self waitForExpectationsWithTimeout:10.0 handler:nil];
+  [mgrMock stopMocking];
+  return mgr;
+}
+
+// The warning stops being true at its deadline, and it holds the one dialog slot
+// until it closes, so it closes itself with nobody touching it.
+- (void)testTimedRuleKillWindowClosesItselfAtTheDeadline {
+  SNTTimedRuleKillMessageWindowController* controller =
+      [[SNTTimedRuleKillMessageWindowController alloc]
+          initWithApplication:@"Calculator"
+                     deadline:[NSDate dateWithTimeIntervalSinceNow:0.25]];
+
+  // The window was stood up and its delegate wired, which is what the deadline
+  // timer closed. windowWillClose: runs while the window is still in the screen
+  // list, so a window that had been displayed would read visible here: that is
+  // the assertion that keeps the suite from ever flashing a dialog.
+  dispatch_block_t nothingWasSeen = ^{
+    XCTAssertNotNil(controller.window);
+    XCTAssertFalse(controller.window.isVisible);
+  };
+
+  SNTNotificationManager* mgr = [self queueUntilRetired:controller
+                                            describedAs:@"warning closed itself at its deadline"
+                                             onRetiring:nothingWasSeen];
+
+  XCTAssertEqual(mgr.pendingNotifications.count, 0u);
+}
+
+// A warning whose deadline passed while it waited behind another dialog must not
+// be drawn at all: it says something untrue and would steal focus on its way out.
+// It still has to be retired through the delegate, or it would hold the one dialog
+// slot and everything behind it would wait on it forever.
+- (void)testExpiredTimedRuleKillWindowIsRetiredWithoutBeingShown {
+  SNTTimedRuleKillMessageWindowController* controller =
+      [[SNTTimedRuleKillMessageWindowController alloc]
+          initWithApplication:@"Calculator"
+                     deadline:[NSDate dateWithTimeIntervalSinceNow:-1]];
+
+  // No window was ever built, so there was nothing to order in, draw, or activate.
+  dispatch_block_t noWindowAtAll = ^{
+    XCTAssertNil(controller.window);
+  };
+
+  SNTNotificationManager* mgr =
+      [self queueUntilRetired:controller
+                  describedAs:@"expired warning retired without being shown"
+                   onRetiring:noWindowAtAll];
+
+  XCTAssertEqual(mgr.pendingNotifications.count, 0u);
 }
 
 @end

--- a/Source/gui/SNTTimedRuleKillMessageWindowController.h
+++ b/Source/gui/SNTTimedRuleKillMessageWindowController.h
@@ -1,0 +1,26 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Cocoa/Cocoa.h>
+
+#import "Source/gui/SNTMessageWindowController.h"
+
+@interface SNTTimedRuleKillMessageWindowController : SNTMessageWindowController <NSWindowDelegate>
+
+@property(readonly) NSString* application;
+@property(readonly) NSDate* deadline;
+
+- (instancetype)initWithApplication:(NSString*)application deadline:(NSDate*)deadline;
+
+@end

--- a/Source/gui/SNTTimedRuleKillMessageWindowController.mm
+++ b/Source/gui/SNTTimedRuleKillMessageWindowController.mm
@@ -1,0 +1,111 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/gui/SNTTimedRuleKillMessageWindowController.h"
+
+#import "Source/gui/SNTTimedRuleKillMessageWindowView-Swift.h"
+
+#import "Source/common/SNTStrengthify.h"
+
+@interface SNTTimedRuleKillMessageWindowController ()
+// One-shot close at the deadline, held so a dismissal before the deadline can
+// cancel it.
+@property(atomic, strong) NSTimer* deadlineTimer;
+@end
+
+@implementation SNTTimedRuleKillMessageWindowController
+
+- (instancetype)initWithApplication:(NSString*)application deadline:(NSDate*)deadline {
+  self = [super init];
+  if (self) {
+    _application = application;
+    _deadline = deadline;
+  }
+  return self;
+}
+
+- (void)showWindow:(id)sender {
+  // A deadline that has already passed makes the warning untrue: the quit it
+  // warns about has happened. Showing it anyway orders a dialog in, steals focus,
+  // and blips the Dock icon for the few milliseconds before the timer below
+  // closes it again, all with nothing readable on screen. Retire it instead.
+  //
+  // Retired through the delegate rather than by returning: the queue has already
+  // made this controller its current window, and that callback is the only thing
+  // that clears it, so a bare return would leave this warning holding the one
+  // dialog slot and every dialog behind it waiting on it forever. The callback
+  // re-enters the queue through dispatch_async, not recursion, so this is safe.
+  if (self.deadline.timeIntervalSinceNow <= 0) {
+    [self.delegate windowDidCloseSilenceHash:nil withInterval:0];
+    return;
+  }
+
+  if (self.window) [self.window orderOut:sender];
+
+  self.window = [SNTMessageWindowController defaultWindow];
+
+  // No uiStateCallback: this window offers no per-application silence, so there
+  // is no UI state to carry back to the notification manager.
+  self.window.contentViewController =
+      [SNTTimedRuleKillMessageWindowViewFactory createWithWindow:self.window
+                                                     application:self.application
+                                                        deadline:self.deadline];
+  self.window.delegate = self;
+
+  [super showWindow:sender];
+
+  // The warning stops being true once the deadline passes, and it holds the one
+  // dialog slot until it closes, so a warning nobody dismisses would sit in front
+  // of the block dialogs queued behind it, some of which carry reply blocks.
+  //
+  // Armed here rather than at init because only the window currently on screen
+  // can be retired through the delegate that advances the queue; a warning whose
+  // deadline passed while it was still queued is handled by the skip above
+  // instead, so the interval here is always positive. showWindow: is main-thread
+  // only (the queue hops there before calling it), so this lands on the main run
+  // loop.
+  [self.deadlineTimer invalidate];
+  WEAKIFY(self);
+  self.deadlineTimer = [NSTimer scheduledTimerWithTimeInterval:self.deadline.timeIntervalSinceNow
+                                                       repeats:NO
+                                                         block:^(NSTimer* timer) {
+                                                           STRONGIFY(self);
+                                                           // -close, not -closeWindow:, so the
+                                                           // window's delegate callback runs
+                                                           // exactly once and the queue advances
+                                                           // the same way a dismissal does.
+                                                           [self.window close];
+                                                         }];
+}
+
+- (void)windowWillClose:(NSNotification*)notification {
+  // A warning dismissed before its deadline must not leave a timer holding this
+  // controller and waiting to close an already-closed window.
+  [self.deadlineTimer invalidate];
+  self.deadlineTimer = nil;
+
+  [super windowWillClose:notification];
+}
+
+- (NSString*)messageHash {
+  // One window per (application, deadline), so a repeated warning for the same
+  // deadline collapses in the queue instead of stacking a second window.
+  // Return nil rather than a bare prefix when either half is missing, so
+  // unidentified warnings do not collapse onto one shared key.
+  if (!self.application.length || !self.deadline) return nil;
+  return [NSString stringWithFormat:@"timedrulekill:%@|%f", self.application,
+                                    self.deadline.timeIntervalSince1970];
+}
+
+@end

--- a/Source/gui/SNTTimedRuleKillMessageWindowView.swift
+++ b/Source/gui/SNTTimedRuleKillMessageWindowView.swift
@@ -1,0 +1,99 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+import SwiftUI
+
+import santa_gui_SNTMessageView
+
+// TextWithLimit's bound (SNTMessageView.swift), which is what every other view
+// applies to a process-derived string. Applied to the name rather than to the
+// composed sentence so the localized format keeps both of its arguments, which
+// is what lets ja reorder them.
+private let maxApplicationNameLength = 50
+
+// The number of lines the sentence may occupy. The block-message slot bounds
+// long free text at 15 lines; this view holds one sentence, so a name that
+// survives truncation with newlines in it still cannot grow the window.
+private let maxMessageLines = 3
+
+@objc public class SNTTimedRuleKillMessageWindowViewFactory: NSObject {
+  @objc public static func createWith(
+    window: NSWindow,
+    application: String,
+    deadline: Date
+  ) -> NSViewController {
+    return NSHostingController(
+      rootView: SNTTimedRuleKillMessageWindowView(
+        window: window,
+        application: application,
+        deadline: deadline
+      ).fixedSize()
+    )
+  }
+}
+
+struct SNTTimedRuleKillMessageWindowView: View {
+  let window: NSWindow?
+  let application: String
+  let deadline: Date
+
+  var body: some View {
+    // The warning is the whole message, so it takes the content slot rather than
+    // SNTMessageView's block-message slot: the application name is read from a
+    // running process, and the block-message slot renders HTML.
+    SNTMessageView {
+      Text(warningMessage())
+        .multilineTextAlignment(.center)
+        .lineLimit(maxMessageLines)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Spacer()
+
+      HStack(spacing: 15.0) {
+        DismissButton(customText: nil, silence: false, action: dismissButton)
+      }
+
+      Spacer()
+    }.fixedSize()
+  }
+
+  // The name is whatever the running process calls itself, so it is bounded the
+  // same way TextWithLimit bounds one: middle elided, so both ends stay readable.
+  func boundedApplicationName() -> String {
+    guard application.count > maxApplicationNameLength else { return application }
+    let half = maxApplicationNameLength / 2
+    return "\(application.prefix(half))…\(application.suffix(half))"
+  }
+
+  func warningMessage() -> String {
+    // Time of day only. A deadline is always the end of the window the process
+    // was launched in, so the date would say nothing the user needs.
+    let formatter = DateFormatter()
+    formatter.timeStyle = .short
+    formatter.dateStyle = .none
+
+    return String(
+      format: NSLocalizedString(
+        "\"%@\" will quit at %@.",
+        comment: "Window message warning that an app will be quit at a time"
+      ),
+      boundedApplicationName(),
+      formatter.string(from: deadline)
+    )
+  }
+
+  func dismissButton() {
+    window?.close()
+  }
+}

--- a/Source/santad/KillingMachine.h
+++ b/Source/santad/KillingMachine.h
@@ -31,8 +31,10 @@
 
 namespace santa {
 
-// Default for KillEnv::signal_group. Defined in KillingMachine.mm.
+// Defaults for the seams in KillEnv that aren't a bare syscall. Defined in
+// KillingMachine.mm.
 int SignalProcessGroup(pid_t pgid, int sig);
+void BlockingWait(NSTimeInterval seconds);
 
 // Everything a kill pass reaches for outside this file, injectable because
 // signal delivery has no safe form to exercise against real processes. The
@@ -59,10 +61,33 @@ struct KillEnv {
 
   // Signal every process in a group. Returns 0 or errno.
   std::function<int(pid_t, int)> signal_group = SignalProcessGroup;
+
+  // Blocks the calling thread for the term-then-kill grace period.
+  std::function<void(NSTimeInterval)> wait = BlockingWait;
 };
 
 SNTKillResponse* KillingMachine(SNTKillRequest* request);
 SNTKillResponse* KillingMachine(SNTKillRequest* request, const KillEnv& env);
+
+// Sends SIGTERM to everything the request matches, blocks the calling thread
+// for `grace`, then re-matches and SIGKILLs whatever is still there. Blocking
+// is the contract: callers run this on a queue they own. The request's own
+// `signal` field is not used by this path.
+SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request,
+                                            NSTimeInterval grace);
+SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request,
+                                            NSTimeInterval grace,
+                                            const KillEnv& env);
+
+// The pid of one process the request matches, or nullopt when nothing does.
+// Signals nothing: this is the match pass on its own, so a caller can find out
+// whether a kill would hit anything before the kill is due. Which of several
+// matches comes back is unspecified, and the answer is a snapshot: the process
+// may be gone by the time the caller looks at it. Running-process requests are
+// not supported here, as they already name the process the caller wants.
+std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request);
+std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request,
+                                            const KillEnv& env);
 
 }  // namespace santa
 

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -42,6 +42,10 @@ int SignalProcessGroup(pid_t pgid, int sig) {
   return kill(-pgid, sig) == 0 ? 0 : errno;
 }
 
+void BlockingWait(NSTimeInterval seconds) {
+  [NSThread sleepForTimeInterval:seconds];
+}
+
 namespace {
 
 // Base class for process matchers
@@ -126,14 +130,15 @@ SNTKilledProcessError LibprocSignalErrorToKilledProcessError(int error) {
   }
 }
 
-// Delivers the request's signal to the process `token` identifies, or to that
-// process's group when the request targets process groups. `signaledPgids`
-// holds the groups this pass has already signaled, so each group is signaled
-// exactly once no matter how many of its members matched: the first member
-// signals the group and later members return nil, having already been reached
-// by that one signal.
-SNTKilledProcess* KillProcess(SNTKillRequest* request, audit_token_t* token, const KillEnv& env,
-                              absl::flat_hash_set<pid_t>* signaledPgids) {
+// Delivers `sig` to the process `token` identifies, or to that process's group
+// when the request targets process groups. `sig` is passed in rather than read
+// from the request so the term-then-kill path can drive two passes at different
+// signals through the same request. `signaledPgids` holds the groups this pass
+// has already signaled, so each group is signaled exactly once no matter how
+// many of its members matched: the first member signals the group and later
+// members return nil, having already been reached by that one signal.
+SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* token,
+                              const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
   static pid_t myPid = getpid();
   pid_t targetPid = Pid(*token);
   pid_t targetPidversion = Pidversion(*token);
@@ -170,13 +175,13 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, audit_token_t* token, con
         return nil;
       }
 
-      int error = env.signal_group(targetPgid, request.signal);
+      int error = env.signal_group(targetPgid, sig);
       if (error == 0) {
-        LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", request.signal, targetPgid,
+        LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
              request.uuid);
       } else {
-        LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)",
-             request.signal, targetPgid, error, request.uuid);
+        LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
+             targetPgid, error, request.uuid);
       }
 
       return [[SNTKilledProcess alloc] initWithPid:targetPid
@@ -185,13 +190,12 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, audit_token_t* token, con
     }
   }
 
-  int error = env.signal_token(token, request.signal);
+  int error = env.signal_token(token, sig);
   if (error == 0) {
-    LOGI(@"Signaled (%d) process: %d (from kill command: %@)", request.signal, targetPid,
-         request.uuid);
+    LOGI(@"Signaled (%d) process: %d (from kill command: %@)", sig, targetPid, request.uuid);
   } else {
-    LOGW(@"Failed to signal (%d) process: %d, error: %d (from kill command: %@)", request.signal,
-         targetPid, error, request.uuid);
+    LOGW(@"Failed to signal (%d) process: %d, error: %d (from kill command: %@)", sig, targetPid,
+         error, request.uuid);
   }
 
   return [[SNTKilledProcess alloc] initWithPid:targetPid
@@ -199,7 +203,8 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, audit_token_t* token, con
                                          error:LibprocSignalErrorToKilledProcessError(error)];
 }
 
-SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, const KillEnv& env,
+SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, int sig,
+                                       const KillEnv& env,
                                        absl::flat_hash_set<pid_t>* signaledPgids) {
   if (![[SNTSystemInfo bootSessionUUID] isEqualToString:request.bootSessionUUID]) {
     LOGW(@"Request to kill running process with non-matching boot session UUID");
@@ -211,7 +216,7 @@ SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, co
   audit_token_t token;
   if (env.token_for_pid(request.pid, &token)) {
     if (Pidversion(token) == request.pidversion) {
-      return KillProcess(request, &token, env, signaledPgids);
+      return KillProcess(request, sig, &token, env, signaledPgids);
     } else {
       LOGW(@"Rejecting request to kill pid (%d) due to pidversion mismatch (got: %d, want: %d)",
            request.pid, Pidversion(token), request.pidversion);
@@ -223,9 +228,11 @@ SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, co
   return nil;
 }
 
-SNTKilledProcess* KillByMatchers(SNTKillRequest* request, pid_t pid,
-                                 const std::vector<std::unique_ptr<ProcessMatcher>>& matchers,
-                                 const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
+// Returns the audit token to signal when every matcher matches `pid`, or
+// nullopt otherwise. Signals nothing: this is the match half on its own, so
+// both the kill loop and the banner's is-anything-running check share it.
+std::optional<audit_token_t> MatchProcess(
+    pid_t pid, const std::vector<std::unique_ptr<ProcessMatcher>>& matchers, const KillEnv& env) {
   // To protect against pid wrap races, we must grab the audit token before
   // and after the matcher checks to ensure the process that info was looked
   // up for matches the process we will signal.
@@ -234,28 +241,113 @@ SNTKilledProcess* KillByMatchers(SNTKillRequest* request, pid_t pid,
 
   if (!env.token_for_pid(pid, &token_before)) {
     // Process likely exited.
-    return nil;
+    return std::nullopt;
   }
 
   // Check all matchers
   for (const auto& matcher : matchers) {
     if (!matcher->Matches(pid)) {
-      return nil;
+      return std::nullopt;
     }
   }
 
-  // All matchers matched. Now verify the process didn't change and kill it.
-  if (env.token_for_pid(pid, &token_after)) {
-    if (Pidversion(token_before) == Pidversion(token_after)) {
-      return KillProcess(request, &token_after, env, signaledPgids);
+  // All matchers matched. Now verify the process didn't change.
+  if (!env.token_for_pid(pid, &token_after)) {
+    LOGD(@"Failed to get audit token for matching. Process likely exited.");
+    return std::nullopt;
+  }
+
+  if (Pidversion(token_before) != Pidversion(token_after)) {
+    LOGD(@"Audit token mismatch. Process exited.");
+    return std::nullopt;
+  }
+
+  return token_after;
+}
+
+SNTKilledProcess* KillByMatchers(SNTKillRequest* request, int sig, pid_t pid,
+                                 const std::vector<std::unique_ptr<ProcessMatcher>>& matchers,
+                                 const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
+  std::optional<audit_token_t> token = MatchProcess(pid, matchers, env);
+  if (!token) {
+    return nil;
+  }
+  return KillProcess(request, sig, &token.value(), env, signaledPgids);
+}
+
+// The matchers a request's criteria come down to, or nullopt when the request
+// can't be matched against running processes at all. Not for a running-process
+// request, which names one process directly rather than matching for it.
+std::optional<std::vector<std::unique_ptr<ProcessMatcher>>> BuildMatchers(SNTKillRequest* request,
+                                                                          const KillEnv& env) {
+  std::vector<std::unique_ptr<ProcessMatcher>> matchers;
+
+  if ([request isKindOfClass:[SNTKillRequestCDHash class]]) {
+    matchers.push_back(MakeCDHashMatcher(((SNTKillRequestCDHash*)request).cdhash, env.csops_func));
+  } else if ([request isKindOfClass:[SNTKillRequestSigningID class]]) {
+    SNTKillRequestSigningID* signingIDRequest = (SNTKillRequestSigningID*)request;
+    if ([signingIDRequest.teamID isEqualToString:kPlatformTeamID]) {
+      matchers.push_back(MakeStatusFlagsMatcher(CS_PLATFORM_BINARY, env.csops_func));
     } else {
-      LOGD(@"Audit token mismatch. Process exited.");
+      matchers.push_back(MakeTeamIDMatcher(signingIDRequest.teamID, env.csops_func));
+    }
+    matchers.push_back(MakeSigningIDMatcher(signingIDRequest.signingID, env.csops_func));
+  } else if ([request isKindOfClass:[SNTKillRequestTeamID class]]) {
+    // Don't allow `platform` here as killing all platform binaries is a bad
+    // idea and isn't supported.
+    SNTKillRequestTeamID* teamIDRequest = (SNTKillRequestTeamID*)request;
+    if ([teamIDRequest.teamID isEqualToString:kPlatformTeamID]) {
+      return std::nullopt;
+    }
+    matchers.push_back(MakeTeamIDMatcher(teamIDRequest.teamID, env.csops_func));
+  } else {
+    LOGE(@"Unexpected request type: %@", [request class]);
+    return std::nullopt;
+  }
+
+  return matchers;
+}
+
+// One kill pass at signal `sig`: match every process, then signal the matches.
+SNTKillResponse* RunKillPass(SNTKillRequest* request, int sig, const KillEnv& env) {
+  NSMutableArray<SNTKilledProcess*>* killedProcs = [NSMutableArray array];
+
+  // Groups already signaled by this pass, so a group with several matching
+  // members is signaled once. Empty unless the request targets groups.
+  absl::flat_hash_set<pid_t> signaledPgids;
+
+  if ([request isKindOfClass:[SNTKillRequestRunningProcess class]]) {
+    SNTKilledProcess* killed =
+        KillByRunningProcess((SNTKillRequestRunningProcess*)request, sig, env, &signaledPgids);
+    if (killed) {
+      [killedProcs addObject:killed];
     }
   } else {
-    LOGD(@"Failed to get audit token for matching. Process likely exited.");
+    std::optional<std::vector<pid_t>> pids = env.list_pids();
+    if (!pids) {
+      LOGE(@"Unable to get list of running processes");
+      return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorListPids];
+    }
+
+    std::optional<std::vector<std::unique_ptr<ProcessMatcher>>> matchers =
+        BuildMatchers(request, env);
+    if (!matchers) {
+      return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorInvalidRequest];
+    }
+
+    for (pid_t pid : *pids) {
+      if (pid == 0) {
+        continue;
+      }
+
+      SNTKilledProcess* killed = KillByMatchers(request, sig, pid, *matchers, env, &signaledPgids);
+      if (killed) {
+        [killedProcs addObject:killed];
+      }
+    }
   }
 
-  return nil;
+  return [[SNTKillResponse alloc] initWithKilledProcesses:killedProcs];
 }
 
 }  // namespace
@@ -289,65 +381,83 @@ SNTKillResponse* KillingMachine(SNTKillRequest* request) {
 }
 
 SNTKillResponse* KillingMachine(SNTKillRequest* request, const KillEnv& env) {
-  NSMutableArray<SNTKilledProcess*>* killedProcs = [NSMutableArray array];
+  return RunKillPass(request, request.signal, env);
+}
 
-  // Groups already signaled by this pass, so a group with several matching
-  // members is signaled once. Empty unless the request targets groups.
-  absl::flat_hash_set<pid_t> signaledPgids;
+SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInterval grace) {
+  return KillingMachineTermThenKill(request, grace, KillEnv());
+}
 
-  if ([request isKindOfClass:[SNTKillRequestRunningProcess class]]) {
-    SNTKilledProcess* killed =
-        KillByRunningProcess((SNTKillRequestRunningProcess*)request, env, &signaledPgids);
-    if (killed) {
-      [killedProcs addObject:killed];
+SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInterval grace,
+                                            const KillEnv& env) {
+  SNTKillResponse* termed = RunKillPass(request, SIGTERM, env);
+  if (termed.error != SNTKillResponseErrorNone) {
+    return termed;
+  }
+
+  // Nothing was actually sent SIGTERM: nothing matched, or every match was
+  // rejected or already gone. Nothing can survive a signal that was never
+  // delivered, so don't hold the caller's queue for a second pass.
+  BOOL anySignaled = NO;
+  for (SNTKilledProcess* termedProc in termed.killedProcesses) {
+    if (termedProc.error == SNTKilledProcessErrorNone) {
+      anySignaled = YES;
+      break;
     }
-  } else {
-    std::optional<std::vector<pid_t>> pids = env.list_pids();
-    if (!pids) {
-      LOGE(@"Unable to get list of running processes");
-      return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorListPids];
+  }
+  if (!anySignaled) {
+    return termed;
+  }
+
+  env.wait(grace);
+
+  SNTKillResponse* killed = RunKillPass(request, SIGKILL, env);
+
+  // Both passes are reported, in order: what was sent SIGTERM, then whichever
+  // of those survived long enough to be sent SIGKILL.
+  NSMutableArray<SNTKilledProcess*>* all = [NSMutableArray arrayWithArray:termed.killedProcesses];
+  if (killed.killedProcesses) {
+    [all addObjectsFromArray:killed.killedProcesses];
+  }
+
+  return [[SNTKillResponse alloc] initWithError:killed.error killedProcesses:all];
+}
+
+std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request) {
+  return KillingMachineAnyMatch(request, KillEnv());
+}
+
+std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request, const KillEnv& env) {
+  // Before listing processes, unlike the kill pass: nothing here distinguishes
+  // one failure from another, so a request that can never match shouldn't pay
+  // for the snapshot.
+  std::optional<std::vector<std::unique_ptr<ProcessMatcher>>> matchers =
+      BuildMatchers(request, env);
+  if (!matchers) {
+    return std::nullopt;
+  }
+
+  std::optional<std::vector<pid_t>> pids = env.list_pids();
+  if (!pids) {
+    LOGE(@"Unable to get list of running processes");
+    return std::nullopt;
+  }
+
+  // The processes KillProcess refuses to signal are skipped here too: reporting
+  // one of them as a match would promise a kill that never happens.
+  const pid_t myPid = getpid();
+
+  for (pid_t pid : *pids) {
+    if (pid == 0 || pid == 1 || pid == myPid) {
+      continue;
     }
 
-    std::vector<std::unique_ptr<ProcessMatcher>> matchers;
-
-    // Populate the appropriate matchers for the request
-    if ([request isKindOfClass:[SNTKillRequestCDHash class]]) {
-      matchers.push_back(
-          MakeCDHashMatcher(((SNTKillRequestCDHash*)request).cdhash, env.csops_func));
-    } else if ([request isKindOfClass:[SNTKillRequestSigningID class]]) {
-      SNTKillRequestSigningID* signingIDRequest = (SNTKillRequestSigningID*)request;
-      if ([signingIDRequest.teamID isEqualToString:kPlatformTeamID]) {
-        matchers.push_back(MakeStatusFlagsMatcher(CS_PLATFORM_BINARY, env.csops_func));
-      } else {
-        matchers.push_back(MakeTeamIDMatcher(signingIDRequest.teamID, env.csops_func));
-      }
-      matchers.push_back(MakeSigningIDMatcher(signingIDRequest.signingID, env.csops_func));
-    } else if ([request isKindOfClass:[SNTKillRequestTeamID class]]) {
-      // Don't allow `platform` here as killing all platform binaries is a bad
-      // idea and isn't supported.
-      SNTKillRequestTeamID* teamIDRequest = (SNTKillRequestTeamID*)request;
-      if ([teamIDRequest.teamID isEqualToString:kPlatformTeamID]) {
-        return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorInvalidRequest];
-      }
-      matchers.push_back(MakeTeamIDMatcher(teamIDRequest.teamID, env.csops_func));
-    } else {
-      LOGE(@"Unexpected request type: %@", [request class]);
-      return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorInvalidRequest];
-    }
-
-    for (pid_t pid : *pids) {
-      if (pid == 0) {
-        continue;
-      }
-
-      SNTKilledProcess* killed = KillByMatchers(request, pid, matchers, env, &signaledPgids);
-      if (killed) {
-        [killedProcs addObject:killed];
-      }
+    if (std::optional<audit_token_t> token = MatchProcess(pid, *matchers, env)) {
+      return Pid(*token);
     }
   }
 
-  return [[SNTKillResponse alloc] initWithKilledProcesses:killedProcs];
+  return std::nullopt;
 }
 
 }  // namespace santa

--- a/Source/santad/KillingMachineTest.mm
+++ b/Source/santad/KillingMachineTest.mm
@@ -80,7 +80,11 @@ struct FakeEnv {
   int signalError = 0;
 
   std::vector<FakeSignal> signals;
+  std::vector<NSTimeInterval> waits;
   std::map<pid_t, int> tokenReads;
+  // Runs when the term-then-kill grace wait starts, so a test can retire the
+  // processes that died from SIGTERM.
+  std::function<void()> onWait = [] {};
 };
 
 santa::KillEnv MakeEnv(FakeEnv* fake) {
@@ -135,6 +139,11 @@ santa::KillEnv MakeEnv(FakeEnv* fake) {
   env.signal_group = [fake](pid_t pgid, int sig) {
     fake->signals.push_back({pgid, sig, true});
     return fake->signalError;
+  };
+
+  env.wait = [fake](NSTimeInterval seconds) {
+    fake->waits.push_back(seconds);
+    fake->onWait();
   };
 
   return env;
@@ -517,6 +526,193 @@ NSArray<NSString*>* SignalDescriptions(const std::vector<FakeSignal>& signals) {
   XCTAssertEqual(response.killedProcesses.count, 1);
   XCTAssertEqual(response.killedProcesses[0].pid, 10);
   XCTAssertEqual(response.killedProcesses[0].pidversion, 7);
+}
+
+//
+// KillingMachineTermThenKill
+//
+
+- (void)testTermThenKillSigkillsSurvivors {
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  fake.matching = {10, 11};
+  // pid 10 exits during the grace period; pid 11 survives SIGTERM.
+  fake.onWait = [&fake] {
+    fake.matching.erase(10);
+    fake.pidversions.erase(10);
+  };
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  SNTKillResponse* response = santa::KillingMachineTermThenKill(request, 5.0, MakeEnv(&fake));
+
+  XCTAssertEqual(response.error, SNTKillResponseErrorNone);
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals),
+                        (@[ @"pid:10:15", @"pid:11:15", @"pid:11:9" ]));
+  XCTAssertEqual(fake.waits.size(), 1);
+  XCTAssertEqual(fake.waits[0], 5.0);
+
+  // Both passes are reported: the two processes sent SIGTERM, then the survivor
+  // sent SIGKILL.
+  XCTAssertEqual(response.killedProcesses.count, 3);
+  XCTAssertEqual(response.killedProcesses[2].pid, 11);
+}
+
+- (void)testTermThenKillGroupTargeting {
+  pid_t sharedPgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  fake.matching = {10, 11};
+  fake.pgids = {{10, sharedPgid}, {11, sharedPgid}};
+  fake.onWait = [&fake] {
+    fake.matching.erase(10);
+    fake.pidversions.erase(10);
+  };
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID
+                                                                signal:SIGKILL
+                                                   targetProcessGroups:YES];
+
+  SNTKillResponse* response = santa::KillingMachineTermThenKill(request, 1.5, MakeEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
+                          [NSString stringWithFormat:@"group:%d:15", sharedPgid],
+                          [NSString stringWithFormat:@"group:%d:9", sharedPgid],
+                        ]));
+  XCTAssertEqual(fake.waits.size(), 1);
+  XCTAssertEqual(fake.waits[0], 1.5);
+  // One result per group per pass, not per matched pid: the SIGTERM pass reports
+  // the group once and the SIGKILL pass reports the survivor's group once.
+  XCTAssertEqual(response.killedProcesses.count, 2);
+}
+
+// Nothing matched the SIGTERM pass, so nothing can survive it. The caller's
+// queue must not be blocked for the grace period.
+- (void)testTermThenKillSkipsWaitWhenNothingMatched {
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10};
+  fake.pidversions = {{10, 1}};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  SNTKillResponse* response = santa::KillingMachineTermThenKill(request, 5.0, MakeEnv(&fake));
+
+  XCTAssertEqual(response.error, SNTKillResponseErrorNone);
+  XCTAssertEqual(response.killedProcesses.count, 0);
+  XCTAssertEqual(fake.signals.size(), 0);
+  XCTAssertEqual(fake.waits.size(), 0);
+}
+
+// A SIGTERM that was never delivered has nothing to escalate either.
+- (void)testTermThenKillSkipsWaitWhenNoSignalLanded {
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10};
+  fake.pidversions = {{10, 1}};
+  fake.matching = {10};
+  fake.signalError = ESRCH;
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  SNTKillResponse* response = santa::KillingMachineTermThenKill(request, 5.0, MakeEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[ @"pid:10:15" ]));
+  XCTAssertEqual(fake.waits.size(), 0);
+  XCTAssertEqual(response.killedProcesses.count, 1);
+  XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+}
+
+- (void)testTermThenKillPropagatesFirstPassFailure {
+  FakeEnv fake;
+  fake.pids = std::nullopt;
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  SNTKillResponse* response = santa::KillingMachineTermThenKill(request, 5.0, MakeEnv(&fake));
+
+  XCTAssertEqual(response.error, SNTKillResponseErrorListPids);
+  XCTAssertEqual(fake.waits.size(), 0);
+  XCTAssertEqual(fake.signals.size(), 0);
+}
+
+//
+// KillingMachineAnyMatch
+//
+
+- (void)testAnyMatchFindsAMatchingPidAndSignalsNothing {
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  fake.matching = {11};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  std::optional<pid_t> match = santa::KillingMachineAnyMatch(request, MakeEnv(&fake));
+
+  XCTAssertTrue(match.has_value());
+  XCTAssertEqual(*match, 11);
+  // A match pass is not a kill pass.
+  XCTAssertEqual(fake.signals.size(), 0);
+}
+
+- (void)testAnyMatchReturnsNothingWhenNothingMatches {
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  // Nothing reports the team ID.
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  XCTAssertFalse(santa::KillingMachineAnyMatch(request, MakeEnv(&fake)).has_value());
+  XCTAssertEqual(fake.signals.size(), 0);
+}
+
+// The processes KillProcess refuses to signal must not be reported as matches
+// either: naming one in a warning would promise a kill that never happens.
+- (void)testAnyMatchSkipsKernelLaunchdAndSelf {
+  pid_t selfPid = getpid();
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{0, 1, selfPid};
+  fake.pidversions = {{0, 1}, {1, 2}, {selfPid, 3}};
+  fake.matching = {0, 1, selfPid};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  XCTAssertFalse(santa::KillingMachineAnyMatch(request, MakeEnv(&fake)).has_value());
+}
+
+- (void)testAnyMatchReturnsNothingWhenThePidSnapshotFails {
+  FakeEnv fake;
+  fake.pids = std::nullopt;
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID];
+
+  XCTAssertFalse(santa::KillingMachineAnyMatch(request, MakeEnv(&fake)).has_value());
+}
+
+// `platform` as a bare team ID is refused by the kill pass, so the match pass
+// must refuse it too rather than reporting every platform binary as a match.
+- (void)testAnyMatchRefusesPlatformTeamID {
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10};
+  fake.pidversions = {{10, 1}};
+  fake.matching = {10};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid" teamID:@"platform"];
+
+  XCTAssertFalse(santa::KillingMachineAnyMatch(request, MakeEnv(&fake)).has_value());
 }
 
 @end


### PR DESCRIPTION
Plumbing for timed rule kills, on top of #1149. Nothing calls this yet;
the component that uses it comes in the next PR, so this is inert.

- KillingMachine: KillingMachineTermThenKill() sends SIGTERM to matching
  process groups, waits a grace period, re-matches, and SIGKILLs
  survivors. KillingMachineAnyMatch() reports whether any process
  matches a request.
- Notifier XPC protocol gains postTimedRuleKillNotificationForApplication:deadline:.
  The GUI shows a "will quit at 5:00 PM" style banner for it, honoring
  silent mode. Strings added to all eight catalogs.
- Tests for both sides; no behavior change for anything existing.

Part of SNT-532