### PR TITLE
santad: add SNTTimedRuleKills which the kill-at-window-end component

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -921,6 +921,22 @@ extern NSString* _Nonnull const kEnableMenuItemUserOverride;
 extern NSString* _Nonnull const kStateTempAdminModeKey;
 extern NSString* _Nonnull const kStateTempAdminTargetUIDKey;
 
+#pragma mark - Timed Rule Kill State
+
+///
+///  Persist (or delete, when `entries` is nil) the pending timed rule kills:
+///  one dictionary per entry, with RuleType, Identifier, CELHash, Deadline,
+///  NotifyAt and Notified. Returns NO when the record could not be written to
+///  disk; unlike the demoted-admins record the in-memory value is kept, since
+///  it still governs the kills this daemon owes.
+///
+- (BOOL)persistTimedRuleKills:(nullable NSArray<NSDictionary*>*)entries;
+
+///
+///  Returns the persisted timed rule kill entries, or nil if none exist.
+///
+- (nullable NSArray<NSDictionary*>*)savedTimedRuleKills;
+
 #pragma mark - USB Settings
 
 ///

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -1020,9 +1020,6 @@ static SNTConfigurator* sharedConfigurator = nil;
 
 - (BOOL)persistTimedRuleKills:(NSArray<NSDictionary*>*)entries {
   @synchronized(self) {
-    // No rollback on a failed write, unlike the demoted-admins record: the
-    // entries the daemon holds in memory are the kills it still owes, and
-    // discarding them here would cancel those kills outright.
     return [self updateStateSynchronizedKey:kStateTimedRuleKillsKey value:entries];
   }
 }

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -117,6 +117,7 @@ NSString* const kStateTempAdminModeKey = @"TempAdmin";
 NSString* const kStateTempAdminTargetUIDKey = @"TargetUID";
 static NSString* const kStateDemotedAdminsKey = @"DemotedAdmins";
 static NSString* const kStateLastBootUUIDKey = @"LastBootUUID";
+static NSString* const kStateTimedRuleKillsKey = @"TimedRuleKills";
 
 /// User defaults key for user override of the menu item enabled setting.
 NSString* const kEnableMenuItemUserOverride = @"EnableMenuItemUserOverride";
@@ -1015,6 +1016,19 @@ static SNTConfigurator* sharedConfigurator = nil;
 
 - (nullable NSArray<NSDictionary*>*)savedDemotedAdmins {
   return self.state[kStateDemotedAdminsKey];
+}
+
+- (BOOL)persistTimedRuleKills:(NSArray<NSDictionary*>*)entries {
+  @synchronized(self) {
+    // No rollback on a failed write, unlike the demoted-admins record: the
+    // entries the daemon holds in memory are the kills it still owes, and
+    // discarding them here would cancel those kills outright.
+    return [self updateStateSynchronizedKey:kStateTimedRuleKillsKey value:entries];
+  }
+}
+
+- (nullable NSArray<NSDictionary*>*)savedTimedRuleKills {
+  return self.state[kStateTimedRuleKillsKey];
 }
 
 - (void)updateLastBootUUID:(NSString*)bootUUID {
@@ -2246,6 +2260,10 @@ static SNTConfigurator* sharedConfigurator = nil;
   if ([state[kStateLastBootUUIDKey] isKindOfClass:[NSString class]]) {
     _lastBootUUID = state[kStateLastBootUUIDKey];
     newState[kStateLastBootUUIDKey] = _lastBootUUID;
+  }
+
+  if ([state[kStateTimedRuleKillsKey] isKindOfClass:[NSArray class]]) {
+    newState[kStateTimedRuleKillsKey] = state[kStateTimedRuleKillsKey];
   }
 
   return newState;

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1171,6 +1171,7 @@ objc_library(
         "//Source/common:SNTRule",
         "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SNTXPCNotifierInterface",
+        "//Source/common:String",
         "//Source/common:Timer",
     ],
 )
@@ -1188,7 +1189,6 @@ santa_unit_test(
         "//Source/common:MOLXPCConnection",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
-        "//Source/common:SNTKillCommand",
         "//Source/common:SNTRule",
         "//Source/common:SNTXPCNotifierInterface",
         "@FMDB",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1156,6 +1156,47 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTTimedRuleKills",
+    srcs = ["SNTTimedRuleKills.mm"],
+    hdrs = ["SNTTimedRuleKills.h"],
+    deps = [
+        ":KillingMachine",
+        ":SNTNotificationQueue",
+        ":SNTRuleTable",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTCommonEnums",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTKillCommand",
+        "//Source/common:SNTLogging",
+        "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
+        "//Source/common:SNTXPCNotifierInterface",
+        "//Source/common:Timer",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTTimedRuleKillsTest",
+    srcs = ["SNTTimedRuleKillsTest.mm"],
+    deps = [
+        ":KillingMachine",
+        ":SNTNotificationQueue",
+        ":SNTRuleTable",
+        ":SNTTimedRuleKills",
+        "//Source/common:AuditUtilities",
+        "//Source/common:CSOpsHelper",
+        "//Source/common:MOLXPCConnection",
+        "//Source/common:SNTCommonEnums",
+        "//Source/common:SNTConfigurator",
+        "//Source/common:SNTKillCommand",
+        "//Source/common:SNTRule",
+        "//Source/common:SNTXPCNotifierInterface",
+        "@FMDB",
+        "@OCMock",
+    ],
+)
+
+objc_library(
     name = "SandboxExpectations",
     srcs = ["SandboxExpectations.mm"],
     hdrs = ["SandboxExpectations.h"],
@@ -1391,6 +1432,7 @@ objc_library(
         ":SNTNotificationQueue",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
+        ":SNTTimedRuleKills",
         ":SandboxExpectations",
         ":SignalScanner",
         ":SleighLauncher",
@@ -2127,6 +2169,7 @@ test_suite(
         ":SNTPolicyProcessorTest",
         ":SNTRuleTableTest",
         ":SNTSyncdQueueTest",
+        ":SNTTimedRuleKillsTest",
         ":SandboxExpectationsTest",
         ":SantadTest",
         ":SleighLauncherTest",

--- a/Source/santad/KillingMachine.h
+++ b/Source/santad/KillingMachine.h
@@ -56,8 +56,7 @@ struct KillEnv {
   std::function<pid_t(pid_t)> pgid_for_pid = getpgid;
 
   // Signal one process, validated against its audit token. Returns 0 or errno.
-  std::function<int(audit_token_t*, int)> signal_token =
-      proc_signal_with_audittoken;
+  std::function<int(audit_token_t*, int)> signal_token = proc_signal_with_audittoken;
 
   // Signal every process in a group. Returns 0 or errno.
   std::function<int(pid_t, int)> signal_group = SignalProcessGroup;
@@ -72,12 +71,19 @@ SNTKillResponse* KillingMachine(SNTKillRequest* request, const KillEnv& env);
 // Sends SIGTERM to everything the request matches, blocks the calling thread
 // for `grace`, then re-matches and SIGKILLs whatever is still there. Blocking
 // is the contract: callers run this on a queue they own. The request's own
-// `signal` field is not used by this path.
-SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request,
-                                            NSTimeInterval grace);
-SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request,
-                                            NSTimeInterval grace,
+// `signal` field is not used by this path. If nothing was signaled, the grace
+// wait is skipped.
+SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInterval grace);
+SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInterval grace,
                                             const KillEnv& env);
+
+// The same for several requests at once, sharing one grace period. One response
+// per request, in the order given. A process group reached by more than one
+// request is signaled once per pass; a request whose matches were covered by
+// another request's group signal is still re-matched at SIGKILL, since the
+// request that signaled the group may no longer match by then.
+NSArray<SNTKillResponse*>* KillingMachineTermThenKill(NSArray<SNTKillRequest*>* requests,
+                                                      NSTimeInterval grace, const KillEnv& env);
 
 // The pid of one process the request matches, or nullopt when nothing does.
 // Signals nothing: this is the match pass on its own, so a caller can find out
@@ -86,8 +92,7 @@ SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request,
 // may be gone by the time the caller looks at it. Running-process requests are
 // not supported here, as they already name the process the caller wants.
 std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request);
-std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request,
-                                            const KillEnv& env);
+std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request, const KillEnv& env);
 
 }  // namespace santa
 

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -133,12 +133,17 @@ SNTKilledProcessError LibprocSignalErrorToKilledProcessError(int error) {
 // Delivers `sig` to the process `token` identifies, or to that process's group
 // when the request targets process groups. `sig` is passed in rather than read
 // from the request so the term-then-kill path can drive two passes at different
-// signals through the same request. `signaledPgids` holds the groups this pass
-// has already signaled, so each group is signaled exactly once no matter how
-// many of its members matched: the first member signals the group and later
-// members return nil, having already been reached by that one signal.
+// signals through the same request.
+//
+// `signaledPgids` is shared across the pass and holds groups signaled
+// successfully, so a group reached by several requests gets one delivery.
+// `attemptedPgids` is per-request and holds every group tried, landed or not,
+// so a failed attempt is not retried within a request but does not block
+// another request's own attempt. A nil return can mean "already covered", not
+// only "did not match".
 SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* token,
-                              const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
+                              const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids,
+                              absl::flat_hash_set<pid_t>* attemptedPgids) {
   static pid_t myPid = getpid();
   pid_t targetPid = Pid(*token);
   pid_t targetPidversion = Pidversion(*token);
@@ -170,13 +175,14 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
     // signaling the one matched process, which is never broader than what was
     // asked for.
     if (targetPgid > 1 && targetPgid != getpgrp()) {
-      if (!signaledPgids->insert(targetPgid).second) {
-        // Signaled earlier in this pass, which reached this process too.
+      // Already signaled by this pass, or already tried by this request.
+      if (signaledPgids->count(targetPgid) || !attemptedPgids->insert(targetPgid).second) {
         return nil;
       }
 
       int error = env.signal_group(targetPgid, sig);
       if (error == 0) {
+        signaledPgids->insert(targetPgid);
         LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
              request.uuid);
       } else {
@@ -203,9 +209,12 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
                                          error:LibprocSignalErrorToKilledProcessError(error)];
 }
 
+// `matched` is set when the named process was found, even if no signal record
+// resulted.
 SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, int sig,
                                        const KillEnv& env,
-                                       absl::flat_hash_set<pid_t>* signaledPgids) {
+                                       absl::flat_hash_set<pid_t>* signaledPgids,
+                                       absl::flat_hash_set<pid_t>* attemptedPgids, bool* matched) {
   if (![[SNTSystemInfo bootSessionUUID] isEqualToString:request.bootSessionUUID]) {
     LOGW(@"Request to kill running process with non-matching boot session UUID");
     return [[SNTKilledProcess alloc] initWithPid:request.pid
@@ -216,7 +225,8 @@ SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, in
   audit_token_t token;
   if (env.token_for_pid(request.pid, &token)) {
     if (Pidversion(token) == request.pidversion) {
-      return KillProcess(request, sig, &token, env, signaledPgids);
+      *matched = true;
+      return KillProcess(request, sig, &token, env, signaledPgids, attemptedPgids);
     } else {
       LOGW(@"Rejecting request to kill pid (%d) due to pidversion mismatch (got: %d, want: %d)",
            request.pid, Pidversion(token), request.pidversion);
@@ -265,14 +275,18 @@ std::optional<audit_token_t> MatchProcess(
   return token_after;
 }
 
+// `matched` is set when `pid` matched, even if its group was already signaled
+// and no record resulted.
 SNTKilledProcess* KillByMatchers(SNTKillRequest* request, int sig, pid_t pid,
                                  const std::vector<std::unique_ptr<ProcessMatcher>>& matchers,
-                                 const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
+                                 const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids,
+                                 absl::flat_hash_set<pid_t>* attemptedPgids, bool* matched) {
   std::optional<audit_token_t> token = MatchProcess(pid, matchers, env);
   if (!token) {
     return nil;
   }
-  return KillProcess(request, sig, &token.value(), env, signaledPgids);
+  *matched = true;
+  return KillProcess(request, sig, &token.value(), env, signaledPgids, attemptedPgids);
 }
 
 // The matchers a request's criteria come down to, or nullopt when the request
@@ -308,17 +322,28 @@ std::optional<std::vector<std::unique_ptr<ProcessMatcher>>> BuildMatchers(SNTKil
   return matchers;
 }
 
-// One kill pass at signal `sig`: match every process, then signal the matches.
-SNTKillResponse* RunKillPass(SNTKillRequest* request, int sig, const KillEnv& env) {
-  NSMutableArray<SNTKilledProcess*>* killedProcs = [NSMutableArray array];
+// One pass's response, plus whether the request matched anything. The two
+// differ when a match's group was already signaled by another request: no
+// record results, but the request still has processes to escalate at SIGKILL.
+struct PassOutcome {
+  SNTKillResponse* response;
+  bool matched;
+};
 
-  // Groups already signaled by this pass, so a group with several matching
-  // members is signaled once. Empty unless the request targets groups.
-  absl::flat_hash_set<pid_t> signaledPgids;
+// One kill pass at signal `sig`: match every process, then signal the matches.
+// `signaledPgids` is the caller's because a pass can span several requests: a
+// group two requests both reach must be signaled once, not twice. Empty unless
+// a request targets groups.
+PassOutcome RunKillPass(SNTKillRequest* request, int sig, const KillEnv& env,
+                        absl::flat_hash_set<pid_t>* signaledPgids) {
+  NSMutableArray<SNTKilledProcess*>* killedProcs = [NSMutableArray array];
+  bool matched = false;
+  // This request's own attempts; see KillProcess.
+  absl::flat_hash_set<pid_t> attemptedPgids;
 
   if ([request isKindOfClass:[SNTKillRequestRunningProcess class]]) {
-    SNTKilledProcess* killed =
-        KillByRunningProcess((SNTKillRequestRunningProcess*)request, sig, env, &signaledPgids);
+    SNTKilledProcess* killed = KillByRunningProcess((SNTKillRequestRunningProcess*)request, sig,
+                                                    env, signaledPgids, &attemptedPgids, &matched);
     if (killed) {
       [killedProcs addObject:killed];
     }
@@ -326,13 +351,16 @@ SNTKillResponse* RunKillPass(SNTKillRequest* request, int sig, const KillEnv& en
     std::optional<std::vector<pid_t>> pids = env.list_pids();
     if (!pids) {
       LOGE(@"Unable to get list of running processes");
-      return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorListPids];
+      return {.response = [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorListPids],
+              .matched = false};
     }
 
     std::optional<std::vector<std::unique_ptr<ProcessMatcher>>> matchers =
         BuildMatchers(request, env);
     if (!matchers) {
-      return [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorInvalidRequest];
+      return {
+          .response = [[SNTKillResponse alloc] initWithError:SNTKillResponseErrorInvalidRequest],
+          .matched = false};
     }
 
     for (pid_t pid : *pids) {
@@ -340,14 +368,26 @@ SNTKillResponse* RunKillPass(SNTKillRequest* request, int sig, const KillEnv& en
         continue;
       }
 
-      SNTKilledProcess* killed = KillByMatchers(request, sig, pid, *matchers, env, &signaledPgids);
+      SNTKilledProcess* killed = KillByMatchers(request, sig, pid, *matchers, env, signaledPgids,
+                                                &attemptedPgids, &matched);
       if (killed) {
         [killedProcs addObject:killed];
       }
     }
   }
 
-  return [[SNTKillResponse alloc] initWithKilledProcesses:killedProcs];
+  return {.response = [[SNTKillResponse alloc] initWithKilledProcesses:killedProcs],
+          .matched = matched};
+}
+
+// Whether the pass delivered a signal to anything. An error response did not.
+bool AnySignalDelivered(SNTKillResponse* response) {
+  for (SNTKilledProcess* killedProc in response.killedProcesses) {
+    if (killedProc.error == SNTKilledProcessErrorNone) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace
@@ -381,7 +421,8 @@ SNTKillResponse* KillingMachine(SNTKillRequest* request) {
 }
 
 SNTKillResponse* KillingMachine(SNTKillRequest* request, const KillEnv& env) {
-  return RunKillPass(request, request.signal, env);
+  absl::flat_hash_set<pid_t> signaledPgids;
+  return RunKillPass(request, request.signal, env, &signaledPgids).response;
 }
 
 SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInterval grace) {
@@ -390,37 +431,55 @@ SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInter
 
 SNTKillResponse* KillingMachineTermThenKill(SNTKillRequest* request, NSTimeInterval grace,
                                             const KillEnv& env) {
-  SNTKillResponse* termed = RunKillPass(request, SIGTERM, env);
-  if (termed.error != SNTKillResponseErrorNone) {
-    return termed;
+  return KillingMachineTermThenKill(@[ request ], grace, env).firstObject;
+}
+
+NSArray<SNTKillResponse*>* KillingMachineTermThenKill(NSArray<SNTKillRequest*>* requests,
+                                                      NSTimeInterval grace, const KillEnv& env) {
+  // All SIGTERMs first, so one grace period covers every request.
+  NSMutableArray<SNTKillResponse*>* termed = [NSMutableArray arrayWithCapacity:requests.count];
+  std::vector<bool> matched;
+  matched.reserve(requests.count);
+  absl::flat_hash_set<pid_t> termedPgids;
+  BOOL anySignaled = NO;
+  for (SNTKillRequest* request in requests) {
+    PassOutcome outcome = RunKillPass(request, SIGTERM, env, &termedPgids);
+    [termed addObject:outcome.response];
+    matched.push_back(outcome.matched);
+    anySignaled = anySignaled || AnySignalDelivered(outcome.response);
   }
 
-  // Nothing was actually sent SIGTERM: nothing matched, or every match was
-  // rejected or already gone. Nothing can survive a signal that was never
-  // delivered, so don't hold the caller's queue for a second pass.
-  BOOL anySignaled = NO;
-  for (SNTKilledProcess* termedProc in termed.killedProcesses) {
-    if (termedProc.error == SNTKilledProcessErrorNone) {
-      anySignaled = YES;
-      break;
-    }
-  }
+  // Nothing was signaled, so nothing can survive it: skip the grace wait.
   if (!anySignaled) {
     return termed;
   }
 
   env.wait(grace);
 
-  SNTKillResponse* killed = RunKillPass(request, SIGKILL, env);
+  // The SIGKILL pass dedupes groups on a set of its own; SIGTERM's is done. Its
+  // results replace the SIGTERM responses in place, so `termed` ends up holding
+  // both passes.
+  absl::flat_hash_set<pid_t> killedPgids;
+  for (NSUInteger index = 0; index < requests.count; index++) {
+    // Re-match every request that matched, not only those that delivered a
+    // signal: the request that signaled a shared group may no longer match
+    // (its process honored SIGTERM), leaving this one's survivors to escalate.
+    if (!matched[index]) {
+      continue;
+    }
 
-  // Both passes are reported, in order: what was sent SIGTERM, then whichever
-  // of those survived long enough to be sent SIGKILL.
-  NSMutableArray<SNTKilledProcess*>* all = [NSMutableArray arrayWithArray:termed.killedProcesses];
-  if (killed.killedProcesses) {
-    [all addObjectsFromArray:killed.killedProcesses];
+    SNTKillResponse* killed = RunKillPass(requests[index], SIGKILL, env, &killedPgids).response;
+
+    // Report both passes in order: SIGTERM deliveries, then SIGKILL survivors.
+    NSMutableArray<SNTKilledProcess*>* both =
+        [NSMutableArray arrayWithArray:termed[index].killedProcesses];
+    if (killed.killedProcesses) {
+      [both addObjectsFromArray:killed.killedProcesses];
+    }
+    termed[index] = [[SNTKillResponse alloc] initWithError:killed.error killedProcesses:both];
   }
 
-  return [[SNTKillResponse alloc] initWithError:killed.error killedProcesses:all];
+  return termed;
 }
 
 std::optional<pid_t> KillingMachineAnyMatch(SNTKillRequest* request) {

--- a/Source/santad/KillingMachineTest.mm
+++ b/Source/santad/KillingMachineTest.mm
@@ -51,6 +51,10 @@ namespace {
 // pids the real (unfaked) matching machinery matches.
 static NSString* const kMatchingTeamID = @"ABCDE12345";
 
+// A second team ID, for the cases that need two requests matching two different
+// processes. Same length as the first, so the fake blob math is the same.
+static NSString* const kSecondTeamID = @"FGHIJ67890";
+
 // One recorded signal delivery. `target` is a pid when `group` is false and a
 // pgid when it is true.
 struct FakeSignal {
@@ -69,6 +73,9 @@ struct FakeEnv {
   std::map<pid_t, int> pidversions;
   // pids the fake csops reports kMatchingTeamID for.
   std::set<pid_t> matching;
+  // pids it reports kSecondTeamID for instead, so a test can have two requests
+  // match two different processes.
+  std::set<pid_t> matchingSecond;
   // pid -> pgid. A pid that isn't here has an unreadable process group.
   std::map<pid_t, pid_t> pgids;
   // pid -> the audit token read after which that pid is recycled: its live
@@ -107,14 +114,17 @@ santa::KillEnv MakeEnv(FakeEnv* fake) {
   };
 
   env.csops_func = [fake](pid_t pid, unsigned int ops, void* useraddr, size_t usersize) {
-    if (ops != santa::kCsopTeamID || !fake->matching.count(pid) ||
-        usersize < sizeof(santa::csops_blob) + kMatchingTeamID.length) {
+    NSString* teamID = fake->matching.count(pid)
+                           ? kMatchingTeamID
+                           : (fake->matchingSecond.count(pid) ? kSecondTeamID : nil);
+    if (ops != santa::kCsopTeamID || !teamID ||
+        usersize < sizeof(santa::csops_blob) + teamID.length) {
       return -1;
     }
     santa::csops_blob* blob = (santa::csops_blob*)useraddr;
     blob->type = 0;
-    blob->len = htonl(sizeof(santa::csops_blob) + 1 + kMatchingTeamID.length);
-    std::memcpy(blob->data, kMatchingTeamID.UTF8String, kMatchingTeamID.length);
+    blob->len = htonl(sizeof(santa::csops_blob) + 1 + teamID.length);
+    std::memcpy(blob->data, teamID.UTF8String, teamID.length);
     return 0;
   };
 
@@ -147,6 +157,30 @@ santa::KillEnv MakeEnv(FakeEnv* fake) {
   };
 
   return env;
+}
+
+// The request pair the multi-request tests share: two team IDs matching two
+// different processes, both targeting process groups.
+NSArray<SNTKillRequest*>* TwoGroupTargetingRequests() {
+  return @[
+    [[SNTKillRequestTeamID alloc] initWithUUID:@"first"
+                                        teamID:kMatchingTeamID
+                                        signal:SIGKILL
+                           targetProcessGroups:YES],
+    [[SNTKillRequestTeamID alloc] initWithUUID:@"second"
+                                        teamID:kSecondTeamID
+                                        signal:SIGKILL
+                           targetProcessGroups:YES],
+  ];
+}
+
+// One process per request of that pair, both in the same process group.
+void TwoMatchesInOneGroup(FakeEnv* fake, pid_t pgid) {
+  fake->pids = std::vector<pid_t>{10, 11};
+  fake->pidversions = {{10, 1}, {11, 2}};
+  fake->matching = {10};
+  fake->matchingSecond = {11};
+  fake->pgids = {{10, pgid}, {11, pgid}};
 }
 
 // Renders recorded deliveries as "pid:10:9" / "group:100:15" so a failing
@@ -626,6 +660,120 @@ NSArray<NSString*>* SignalDescriptions(const std::vector<FakeSignal>& signals) {
   XCTAssertEqual(fake.waits.size(), 0);
   XCTAssertEqual(response.killedProcesses.count, 1);
   XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+}
+
+// Several requests in one call share the grace period: all SIGTERMs first,
+// one wait, then each request's SIGKILL re-match.
+- (void)testTermThenKillSharesOneGracePeriodAcrossRequests {
+  pid_t firstPgid = getpgrp() + 1;
+  pid_t secondPgid = getpgrp() + 2;
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  fake.matching = {10};
+  fake.matchingSecond = {11};
+  fake.pgids = {{10, firstPgid}, {11, secondPgid}};
+  // The first request's process exits during the grace period; the second's
+  // survives.
+  fake.onWait = [&fake] {
+    fake.matching.erase(10);
+    fake.pidversions.erase(10);
+  };
+
+  NSArray<SNTKillResponse*>* responses =
+      santa::KillingMachineTermThenKill(TwoGroupTargetingRequests(), 5.0, MakeEnv(&fake));
+
+  // Both SIGTERMs precede any SIGKILL, and there is one wait between them.
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
+                          [NSString stringWithFormat:@"group:%d:15", firstPgid],
+                          [NSString stringWithFormat:@"group:%d:15", secondPgid],
+                          [NSString stringWithFormat:@"group:%d:9", secondPgid],
+                        ]));
+  XCTAssertEqual(fake.waits.size(), 1);
+  XCTAssertEqual(fake.waits[0], 5.0);
+
+  // One response per request, in order.
+  XCTAssertEqual(responses.count, 2);
+  XCTAssertEqual(responses[0].killedProcesses.count, 1);
+  XCTAssertEqual(responses[1].killedProcesses.count, 2);
+}
+
+// Two requests whose matches share a process group: the group is signaled
+// once per pass, not once per request.
+- (void)testTermThenKillSignalsASharedGroupOncePerPass {
+  pid_t sharedPgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  TwoMatchesInOneGroup(&fake, sharedPgid);
+
+  NSArray<SNTKillResponse*>* responses =
+      santa::KillingMachineTermThenKill(TwoGroupTargetingRequests(), 5.0, MakeEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
+                          [NSString stringWithFormat:@"group:%d:15", sharedPgid],
+                          [NSString stringWithFormat:@"group:%d:9", sharedPgid],
+                        ]));
+  XCTAssertEqual(fake.waits.size(), 1);
+
+  // The delivery is reported by the request that signaled the group; the
+  // second reports none of its own.
+  XCTAssertEqual(responses.count, 2);
+  XCTAssertEqual(responses[0].killedProcesses.count, 2);
+  XCTAssertEqual(responses[1].killedProcesses.count, 0);
+}
+
+// The process that owned the shared group's signal honors SIGTERM and stops
+// matching. The covered request must still re-match, or the survivor in the
+// group would never be SIGKILLed.
+- (void)testTermThenKillEscalatesACoveredRequestWhenTheGroupOwnerExits {
+  pid_t sharedPgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  TwoMatchesInOneGroup(&fake, sharedPgid);
+  // pid 10 quits on SIGTERM; pid 11 ignores it.
+  fake.onWait = [&fake] {
+    fake.matching.erase(10);
+    fake.pidversions.erase(10);
+  };
+
+  NSArray<SNTKillResponse*>* responses =
+      santa::KillingMachineTermThenKill(TwoGroupTargetingRequests(), 5.0, MakeEnv(&fake));
+
+  // The survivor's group is still SIGKILLed, and still only once.
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
+                          [NSString stringWithFormat:@"group:%d:15", sharedPgid],
+                          [NSString stringWithFormat:@"group:%d:9", sharedPgid],
+                        ]));
+  XCTAssertEqual(fake.waits.size(), 1);
+
+  // The second request reports the escalation; the first no longer matched.
+  XCTAssertEqual(responses.count, 2);
+  XCTAssertEqual(responses[0].killedProcesses.count, 1);
+  XCTAssertEqual(responses[1].killedProcesses.count, 1);
+  XCTAssertEqual(responses[1].killedProcesses[0].pid, 11);
+}
+
+// A failed group signal does not suppress another request's attempt. Nothing
+// landed, so no grace period is served either.
+- (void)testTermThenKillRetriesAGroupWhoseSignalFailed {
+  pid_t sharedPgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  TwoMatchesInOneGroup(&fake, sharedPgid);
+  fake.signalError = ESRCH;
+
+  NSArray<SNTKillResponse*>* responses =
+      santa::KillingMachineTermThenKill(TwoGroupTargetingRequests(), 5.0, MakeEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
+                          [NSString stringWithFormat:@"group:%d:15", sharedPgid],
+                          [NSString stringWithFormat:@"group:%d:15", sharedPgid],
+                        ]));
+  XCTAssertEqual(fake.waits.size(), 0);
+  XCTAssertEqual(responses.count, 2);
+  XCTAssertEqual(responses[0].killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+  XCTAssertEqual(responses[1].killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
 }
 
 - (void)testTermThenKillPropagatesFirstPassFailure {

--- a/Source/santad/SNTTimedRuleKills.h
+++ b/Source/santad/SNTTimedRuleKills.h
@@ -1,0 +1,100 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA_SANTAD_SNTTIMEDRULEKILLS_H
+#define SANTA_SANTAD_SNTTIMEDRULEKILLS_H
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTCommonEnums.h"
+
+@class SNTConfigurator;
+@class SNTNotificationQueue;
+@class SNTRuleTable;
+
+///
+///  Owns the kills asked for by CEL rules using policy_for_range(...,
+///  should_kill=true): one entry per rule, a timer for the next event across
+///  them, the warning banner shortly before a deadline, and the kill itself at
+///  the deadline.
+///
+///  Nothing running is touched except at a recorded deadline. A rule arriving,
+///  a window opening, or a window closing never kills anything by itself.
+///
+///  Entries are persisted, so a deadline is an appointment that survives a
+///  daemon restart: `resumeFromSavedState` runs the ones that came due while
+///  the daemon was down and re-arms the timer for the rest.
+///
+@interface SNTTimedRuleKills : NSObject
+
+- (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
+                            ruleTable:(SNTRuleTable*)ruleTable
+                         configurator:(SNTConfigurator*)configurator NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+///
+///  Loads the persisted entries: past-due ones run the kill path immediately
+///  (rule re-check first), future ones arm the timer.
+///
+///  Split out of the initializer because it starts the timer and can run kills,
+///  neither of which may happen before construction is complete. This is the
+///  same split TimedSyncSession makes with SetupFromState.
+///
+- (void)resumeFromSavedState;
+
+///
+///  Records a kill for the rule identified by (ruleType, identifier, celHash).
+///  Repeated execs inside the same window recompute the same deadline and
+///  change nothing, including writing nothing; when the deadlines differ the
+///  earlier one wins, so everything the rule covers is quit at the first
+///  pending deadline.
+///
+///  `celHash` is the rule's CEL text hashed with +celHashForExpression:. It is
+///  part of the key and it is re-checked when the timer fires, so editing the
+///  rule cancels the pending kill rather than quitting things under text that
+///  no longer exists.
+///
+///  `identifier` must be byte-for-byte what the rule table stores for the rule:
+///  the re-check looks the rule up with `identifier = ?`, which SQLite compares
+///  case-sensitively. A caller that normalizes case or whitespace on the way in
+///  will find nothing at fire time, and every kill for that rule is silently
+///  cancelled instead of running.
+///
+///  At `notifyAt` the user is warned that whatever the rule covers will be
+///  quit, once per (rule, deadline) and only when something the rule covers is
+///  actually running. A warning is never allowed to hold up a kill: one owed at
+///  a moment the deadline has already arrived is dropped, not delivered late.
+///
+///  Only the rule types that can be matched against a running process are
+///  supported: SIGNINGID (including `platform:`), TEAMID and CDHASH. BINARY and
+///  CERTIFICATE rules are refused with a log line; their window still gates new
+///  executions.
+///
+- (void)recordKillForRuleType:(SNTRuleType)ruleType
+                   identifier:(NSString*)identifier
+                      celHash:(NSString*)celHash
+                     deadline:(NSDate*)deadline
+                     notifyAt:(NSDate*)notifyAt;
+
+///
+///  SHA-256 (lowercase hex) of a rule's CEL text, or nil when there is none.
+///  Exposed so the caller that records an entry and the fire-time re-check
+///  derive CELHash the same way.
+///
++ (NSString*)celHashForExpression:(NSString*)celExpr;
+
+@end
+
+#endif  // SANTA_SANTAD_SNTTIMEDRULEKILLS_H

--- a/Source/santad/SNTTimedRuleKills.h
+++ b/Source/santad/SNTTimedRuleKills.h
@@ -18,6 +18,7 @@
 #import <Foundation/Foundation.h>
 
 #import "Source/common/SNTCommonEnums.h"
+#include "Source/santad/KillingMachine.h"
 
 @class SNTConfigurator;
 @class SNTNotificationQueue;
@@ -38,9 +39,14 @@
 ///
 @interface SNTTimedRuleKills : NSObject
 
+///
+///  `killEnv` is the syscall environment kills and match checks run against:
+///  santa::KillEnv() in production, faked in tests.
+///
 - (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
                             ruleTable:(SNTRuleTable*)ruleTable
-                         configurator:(SNTConfigurator*)configurator NS_DESIGNATED_INITIALIZER;
+                         configurator:(SNTConfigurator*)configurator
+                              killEnv:(santa::KillEnv)killEnv NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Source/santad/SNTTimedRuleKills.mm
+++ b/Source/santad/SNTTimedRuleKills.mm
@@ -1,0 +1,564 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/SNTTimedRuleKills.h"
+
+#import <CommonCrypto/CommonDigest.h>
+#import <Foundation/Foundation.h>
+#include <libproc.h>
+#include <signal.h>
+#include <sys/param.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTKillCommand.h"
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SNTRule.h"
+#import "Source/common/SNTRuleIdentifiers.h"
+#import "Source/common/SNTXPCNotifierInterface.h"
+#include "Source/common/Timer.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
+#include "Source/santad/KillingMachine.h"
+#import "Source/santad/SNTNotificationQueue.h"
+
+// Fields of a persisted entry.
+static NSString* const kEntryRuleTypeKey = @"RuleType";
+static NSString* const kEntryIdentifierKey = @"Identifier";
+static NSString* const kEntryCELHashKey = @"CELHash";
+static NSString* const kEntryDeadlineKey = @"Deadline";
+static NSString* const kEntryNotifyAtKey = @"NotifyAt";
+static NSString* const kEntryNotifiedKey = @"Notified";
+
+// A timer can fire marginally early; anything due within this window is treated
+// as due now rather than re-arming for a fraction of a second.
+static const NSTimeInterval kDueTolerance = 0.25;
+
+// How long a matched process has to exit after SIGTERM before it is SIGKILLed.
+static const NSTimeInterval kTermGrace = 5.0;
+
+/// One pending kill: the rule it came from, when it fires, and whether the user
+/// has already been warned.
+@interface SNTTimedRuleKillEntry : NSObject
+@property SNTRuleType ruleType;
+@property(copy) NSString* identifier;
+@property(copy) NSString* celHash;
+@property NSDate* deadline;
+@property NSDate* notifyAt;
+@property BOOL notified;
+
+/// Deserializes a persisted entry, or nil when it isn't one: the state file is
+/// on disk, so every field is validated rather than trusted.
++ (instancetype)entryFromDictionary:(NSDictionary*)dict;
+
+@property(readonly) NSDictionary* dictionaryRepresentation;
+
+/// Opaque map key: rule type, identifier and CEL hash. Never parsed back.
+@property(readonly) NSString* key;
+@end
+
+namespace {
+
+// Only the rule types KillingMachine can match against a running process. A
+// BINARY or CERTIFICATE rule would mean hashing the executable of every process
+// at the deadline.
+bool SupportedRuleType(SNTRuleType ruleType) {
+  return ruleType == SNTRuleTypeSigningID || ruleType == SNTRuleTypeTeamID ||
+         ruleType == SNTRuleTypeCDHash;
+}
+
+// Identifiers that fetch exactly the rule an entry came from: one field set, so
+// the rule table's type precedence never picks a different rule type.
+struct RuleIdentifiers IdentifiersForEntry(SNTTimedRuleKillEntry* entry) {
+  switch (entry.ruleType) {
+    case SNTRuleTypeCDHash: return {.cdhash = entry.identifier};
+    case SNTRuleTypeSigningID: return {.signingID = entry.identifier};
+    case SNTRuleTypeTeamID: return {.teamID = entry.identifier};
+    default: return {};
+  }
+}
+
+// What to call a process in the warning banner: the file name of its
+// executable, which is what the user sees in the Dock, falling back to the (16
+// character) accounting name. Nil when neither can be read.
+NSString* DisplayNameForPid(pid_t pid) {
+  char path[PROC_PIDPATHINFO_MAXSIZE] = {};
+  if (proc_pidpath(pid, path, sizeof(path)) > 0) {
+    return [@(path) lastPathComponent];
+  }
+
+  char name[2 * MAXCOMLEN] = {};
+  if (proc_name(pid, name, sizeof(name)) > 0) {
+    return @(name);
+  }
+
+  return nil;
+}
+
+// The kill is delivered to the process group of every match, with SIGKILL as
+// the nominal signal; the term-then-kill path sends SIGTERM and SIGKILL itself
+// and ignores this field.
+SNTKillRequest* KillRequestForEntry(SNTTimedRuleKillEntry* entry) {
+  NSString* uuid = [[NSUUID UUID] UUIDString];
+
+  switch (entry.ruleType) {
+    case SNTRuleTypeCDHash:
+      return [[SNTKillRequestCDHash alloc] initWithUUID:uuid
+                                                 cdHash:entry.identifier
+                                                 signal:SIGKILL
+                                    targetProcessGroups:YES];
+    case SNTRuleTypeSigningID:
+      return [[SNTKillRequestSigningID alloc] initWithUUID:uuid
+                                                 signingID:entry.identifier
+                                                    signal:SIGKILL
+                                       targetProcessGroups:YES];
+    case SNTRuleTypeTeamID:
+      return [[SNTKillRequestTeamID alloc] initWithUUID:uuid
+                                                 teamID:entry.identifier
+                                                 signal:SIGKILL
+                                    targetProcessGroups:YES];
+    default: return nil;
+  }
+}
+
+}  // namespace
+
+@implementation SNTTimedRuleKillEntry
+
++ (instancetype)entryFromDictionary:(NSDictionary*)dict {
+  if (![dict isKindOfClass:[NSDictionary class]] ||
+      ![dict[kEntryRuleTypeKey] isKindOfClass:[NSNumber class]] ||
+      ![dict[kEntryIdentifierKey] isKindOfClass:[NSString class]] ||
+      ![dict[kEntryCELHashKey] isKindOfClass:[NSString class]] ||
+      ![dict[kEntryDeadlineKey] isKindOfClass:[NSNumber class]] ||
+      ![dict[kEntryNotifyAtKey] isKindOfClass:[NSNumber class]]) {
+    return nil;
+  }
+
+  SNTRuleType ruleType = static_cast<SNTRuleType>([dict[kEntryRuleTypeKey] integerValue]);
+  NSString* identifier = dict[kEntryIdentifierKey];
+  NSString* celHash = dict[kEntryCELHashKey];
+  if (!SupportedRuleType(ruleType) || !identifier.length || !celHash.length) {
+    return nil;
+  }
+
+  SNTTimedRuleKillEntry* entry = [[SNTTimedRuleKillEntry alloc] init];
+  entry.ruleType = ruleType;
+  entry.identifier = identifier;
+  entry.celHash = celHash;
+  entry.deadline = [NSDate dateWithTimeIntervalSince1970:[dict[kEntryDeadlineKey] doubleValue]];
+  entry.notifyAt = [NSDate dateWithTimeIntervalSince1970:[dict[kEntryNotifyAtKey] doubleValue]];
+  // The one optional field: absent on entries written before the warning banner
+  // existed, so a missing key is a valid NO rather than a reason to drop the
+  // entry. Guarded like every other field, though, so a non-NSNumber value on
+  // disk can't reach -boolValue and crash-loop the daemon at startup.
+  id notified = dict[kEntryNotifiedKey];
+  entry.notified = [notified isKindOfClass:[NSNumber class]] && [notified boolValue];
+  return entry;
+}
+
+- (NSDictionary*)dictionaryRepresentation {
+  return @{
+    kEntryRuleTypeKey : @(self.ruleType),
+    kEntryIdentifierKey : self.identifier,
+    kEntryCELHashKey : self.celHash,
+    kEntryDeadlineKey : @(self.deadline.timeIntervalSince1970),
+    kEntryNotifyAtKey : @(self.notifyAt.timeIntervalSince1970),
+    kEntryNotifiedKey : @(self.notified),
+  };
+}
+
+- (NSString*)key {
+  return
+      [NSString stringWithFormat:@"%ld|%@|%@", (long)self.ruleType, self.identifier, self.celHash];
+}
+
+@end
+
+@interface SNTTimedRuleKills ()
+@property SNTNotificationQueue* notifierQueue;
+@property SNTRuleTable* ruleTable;
+@property SNTConfigurator* configurator;
+@property dispatch_queue_t queue;
+/// Entries keyed by rule type, identifier and CEL hash, so repeated execs under
+/// the same rule share one entry. Only ever touched on `queue`.
+@property NSMutableDictionary<NSString*, SNTTimedRuleKillEntry*>* entries;
+/// Test seam for the one call with no safe form to exercise against real
+/// processes. Never set in production, where the real kill runs instead.
+@property(copy) SNTKillResponse* (^killBlock)(SNTKillRequest* request, NSTimeInterval grace);
+/// Test seam paired with killBlock: the pid of something the rule covers that
+/// is running, or nil for nothing running. Nothing a test runs can be made to
+/// match a rule, so the match is the part that is faked; naming the pid and
+/// deciding on the banner are the production path either way. Never set in
+/// production.
+@property(copy) NSNumber* (^matchBlock)(SNTKillRequest* request);
+
+- (void)onDeadlineTimer;
+@end
+
+namespace {
+
+// Timer<T> is a CRTP mixin, so the fire hook has to be a C++ type. This shim is
+// that type and nothing more: it holds a weak reference to the component and
+// hands the fire straight back to it.
+class DeadlineTimer : public santa::Timer<DeadlineTimer> {
+ public:
+  explicit DeadlineTimer(SNTTimedRuleKills* owner)
+      // No clamping: the interval is a distance to the next deadline, not a
+      // configured period. The label only appears in the clamp warning, which
+      // this range makes unreachable.
+      : santa::Timer<DeadlineTimer>(0, std::numeric_limits<uint32_t>::max(),
+                                    santa::Timer<DeadlineTimer>::OnStart::kWaitOneCycle,
+                                    "TimedRuleKills",
+                                    santa::Timer<DeadlineTimer>::RescheduleMode::kTrailingEdge),
+        owner_(owner) {}
+
+  bool OnTimer() {
+    [owner_ onDeadlineTimer];
+    // Never self-rescheduled: the component re-arms from its own queue once it
+    // knows the next deadline, which the interval this fired on does not.
+    return false;
+  }
+
+ private:
+  __weak SNTTimedRuleKills* owner_;
+};
+
+}  // namespace
+
+@implementation SNTTimedRuleKills {
+  std::shared_ptr<DeadlineTimer> _timer;
+}
+
+- (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
+                            ruleTable:(SNTRuleTable*)ruleTable
+                         configurator:(SNTConfigurator*)configurator {
+  self = [super init];
+  if (self) {
+    _notifierQueue = notifierQueue;
+    _ruleTable = ruleTable;
+    _configurator = configurator;
+    _entries = [NSMutableDictionary dictionary];
+    _queue = dispatch_queue_create("com.northpolesec.santa.daemon.timed_rule_kills",
+                                   DISPATCH_QUEUE_SERIAL);
+    _timer = std::make_shared<DeadlineTimer>(self);
+  }
+  return self;
+}
+
++ (NSString*)celHashForExpression:(NSString*)celExpr {
+  if (!celExpr.length) {
+    return nil;
+  }
+
+  NSData* text = [celExpr dataUsingEncoding:NSUTF8StringEncoding];
+  unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(text.bytes, (CC_LONG)text.length, digest);
+
+  NSMutableString* hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+    [hex appendFormat:@"%02x", digest[i]];
+  }
+  return hex;
+}
+
+- (void)resumeFromSavedState {
+  dispatch_async(self.queue, ^{
+    NSArray<NSDictionary*>* saved = [self.configurator savedTimedRuleKills];
+    NSUInteger dropped = 0;
+
+    for (NSDictionary* dict in saved) {
+      SNTTimedRuleKillEntry* entry = [SNTTimedRuleKillEntry entryFromDictionary:dict];
+      if (!entry) {
+        dropped++;
+        continue;
+      }
+
+      // Earlier deadline wins here as it does at record time, so a duplicated
+      // key on disk can never extend a pending kill.
+      SNTTimedRuleKillEntry* existing = self.entries[entry.key];
+      if (existing && [existing.deadline compare:entry.deadline] != NSOrderedDescending) {
+        dropped++;
+        continue;
+      }
+      self.entries[entry.key] = entry;
+    }
+
+    if (self.entries.count || dropped) {
+      LOGI(@"Restored %lu pending timed rule kill(s)%@", (unsigned long)self.entries.count,
+           dropped ? [NSString stringWithFormat:@", dropping %lu unusable record(s)",
+                                                (unsigned long)dropped]
+                   : @"");
+    }
+    if (dropped) {
+      [self persistSerialized];
+    }
+
+    // Anything already due runs now; the rest arms the timer.
+    [self processDueEntriesSerialized];
+  });
+}
+
+- (void)recordKillForRuleType:(SNTRuleType)ruleType
+                   identifier:(NSString*)identifier
+                      celHash:(NSString*)celHash
+                     deadline:(NSDate*)deadline
+                     notifyAt:(NSDate*)notifyAt {
+  if (!identifier.length || !celHash.length || !deadline || !notifyAt) {
+    LOGW(@"Ignoring incomplete timed rule kill for %@", identifier);
+    return;
+  }
+
+  if (!SupportedRuleType(ruleType)) {
+    LOGW(@"Ignoring timed rule kill for unsupported rule type %ld (%@); only SIGNINGID, TEAMID "
+         @"and CDHASH rules can be matched against a running process",
+         (long)ruleType, identifier);
+    return;
+  }
+
+  dispatch_async(self.queue, ^{
+    SNTTimedRuleKillEntry* entry = [[SNTTimedRuleKillEntry alloc] init];
+    entry.ruleType = ruleType;
+    entry.identifier = identifier;
+    entry.celHash = celHash;
+    entry.deadline = deadline;
+    entry.notifyAt = notifyAt;
+
+    SNTTimedRuleKillEntry* existing = self.entries[entry.key];
+    if (existing) {
+      if ([existing.deadline compare:deadline] != NSOrderedDescending) {
+        // The pending deadline is the earlier one; it governs everything the
+        // rule covers, including this execution. Nothing changed, so nothing is
+        // written: this is the common case of a binary executing repeatedly
+        // inside its window.
+        return;
+      }
+      LOGD(@"Timed rule kill for %@ moved earlier: %@ -> %@", identifier, existing.deadline,
+           deadline);
+    }
+
+    self.entries[entry.key] = entry;
+    LOGI(@"Recorded timed rule kill for %@: quitting at %@, warning at %@", identifier, deadline,
+         notifyAt);
+
+    [self persistSerialized];
+    [self rescheduleTimerSerialized];
+  });
+}
+
+- (void)onDeadlineTimer {
+  // Runs on the Timer's queue. The work moves to our own queue: the kill blocks
+  // it for the term-then-kill grace period, and the entries are only touched
+  // there.
+  dispatch_async(self.queue, ^{
+    [self processDueEntriesSerialized];
+  });
+}
+
+#pragma mark Private methods, all on self.queue
+
+/// Runs everything that has come due, then arms the timer for the next event.
+///
+/// Kills go first and warnings second, both measured against the one `now` this
+/// pass started with. That ordering is the guarantee that a warning never
+/// delays a kill: the process snapshot behind a warning is the slow part, and
+/// no kill is waiting on it by the time it is taken. It also means an entry
+/// whose deadline has arrived is gone before the warning pass sees it, so
+/// nothing is warned about a kill that is already happening.
+- (void)processDueEntriesSerialized {
+  NSDate* now = [NSDate date];
+  BOOL changed = NO;
+
+  for (NSString* key in self.entries.allKeys) {
+    SNTTimedRuleKillEntry* entry = self.entries[key];
+    if ([entry.deadline timeIntervalSinceDate:now] > kDueTolerance) {
+      continue;
+    }
+
+    [self killForEntrySerialized:entry];
+    [self.entries removeObjectForKey:key];
+    changed = YES;
+  }
+
+  for (NSString* key in self.entries.allKeys) {
+    SNTTimedRuleKillEntry* entry = self.entries[key];
+    if (entry.notified || [entry.notifyAt timeIntervalSinceDate:now] > kDueTolerance) {
+      continue;
+    }
+
+    // The same re-check the deadline makes, a lead window earlier. A rule that
+    // no longer governs has no kill coming, so there is nothing to warn about
+    // and no reason to hold the entry until its deadline.
+    if (![self ruleStillGovernsSerialized:entry]) {
+      [self.entries removeObjectForKey:key];
+      changed = YES;
+      continue;
+    }
+
+    [self notifyForEntrySerialized:entry];
+    // Marked whether or not a banner went out. This is the one warning pass for
+    // this (rule, deadline): the user is warned once, or not at all when there
+    // was nothing to warn about, and persisting the flag is what carries that
+    // across a restart. It is also what keeps the timer from re-arming on a
+    // notify time that has already passed.
+    entry.notified = YES;
+    changed = YES;
+  }
+
+  if (changed) {
+    [self persistSerialized];
+  }
+  [self rescheduleTimerSerialized];
+}
+
+/// Whether the rule an entry came from still exists with the text its deadline
+/// was computed from. A rule that is gone, or whose text changed, cancels the
+/// pending kill: the next allowed exec under the new text records a fresh entry.
+///
+/// Checked at the warning as well as at the deadline, so a rule withdrawn during
+/// the lead window neither warns about a quit that will not happen nor leaves a
+/// dead entry sitting until its deadline.
+- (BOOL)ruleStillGovernsSerialized:(SNTTimedRuleKillEntry*)entry {
+  SNTRule* rule = [self.ruleTable executionRuleForIdentifiers:IdentifiersForEntry(entry)];
+  if (!rule) {
+    LOGI(@"Timed rule kill for %@ cancelled: the rule is gone", entry.identifier);
+    return NO;
+  }
+  if (![[SNTTimedRuleKills celHashForExpression:rule.celExpr] isEqualToString:entry.celHash]) {
+    LOGI(@"Timed rule kill for %@ cancelled: the rule's expression changed", entry.identifier);
+    return NO;
+  }
+  return YES;
+}
+
+/// The kill at a deadline: re-check the rule, then quit what it covers.
+- (void)killForEntrySerialized:(SNTTimedRuleKillEntry*)entry {
+  if (![self ruleStillGovernsSerialized:entry]) {
+    return;
+  }
+
+  SNTKillRequest* request = KillRequestForEntry(entry);
+  if (!request) {
+    LOGW(@"Unable to build a kill request for %@; nothing killed", entry.identifier);
+    return;
+  }
+
+  SNTKillResponse* response = self.killBlock
+                                  ? self.killBlock(request, kTermGrace)
+                                  : santa::KillingMachineTermThenKill(request, kTermGrace);
+
+  // killedProcesses holds one result per delivery across both passes, so a
+  // process that survived SIGTERM appears twice. It is a count of deliveries,
+  // not of processes.
+  LOGI(@"Timed rule kill fired for %@: %lu signal delivery result(s), error: %ld", entry.identifier,
+       (unsigned long)response.killedProcesses.count, (long)response.error);
+}
+
+/// The warning shortly before a deadline: find something the rule covers that
+/// is running, name it, and hand the banner to the GUI. Signals nothing. The
+/// caller has already confirmed the rule still governs.
+- (void)notifyForEntrySerialized:(SNTTimedRuleKillEntry*)entry {
+  // Asked first because it is the cheap question: with no GUI to warn, there is
+  // no reason to walk every process on the machine looking for a name for it.
+  id<SNTNotifierXPC> proxy = self.notifierQueue.notifierConnection.remoteObjectProxy;
+  if (!proxy) {
+    LOGD(@"No GUI connection; skipping timed rule kill banner for %@", entry.identifier);
+    return;
+  }
+
+  SNTKillRequest* request = KillRequestForEntry(entry);
+  if (!request) {
+    LOGW(@"Unable to build a kill request for %@; nothing to warn about", entry.identifier);
+    return;
+  }
+
+  std::optional<pid_t> pid;
+  if (self.matchBlock) {
+    NSNumber* matched = self.matchBlock(request);
+    if (matched) {
+      pid = matched.intValue;
+    }
+  } else {
+    pid = santa::KillingMachineAnyMatch(request);
+  }
+
+  if (!pid) {
+    // Nothing the rule covers is running, so there is nothing to warn about.
+    LOGD(@"No running process matches %@; skipping timed rule kill banner", entry.identifier);
+    return;
+  }
+
+  // The rule's own identifier is the fallback for a process that matched but
+  // can't be named, which is mostly what one that exited in between looks like.
+  NSString* app = DisplayNameForPid(*pid);
+  if (!app.length) {
+    app = entry.identifier;
+  }
+
+  LOGI(@"Sending timed rule kill banner for %@ (%@), quitting at %@", app, entry.identifier,
+       entry.deadline);
+  [proxy postTimedRuleKillNotificationForApplication:app deadline:entry.deadline];
+}
+
+/// Writes the current entry set, or clears the key when there are none. Callers
+/// only reach here when the set actually changed.
+- (void)persistSerialized {
+  NSMutableArray<NSDictionary*>* serialized = [NSMutableArray array];
+  for (SNTTimedRuleKillEntry* entry in self.entries.allValues) {
+    [serialized addObject:entry.dictionaryRepresentation];
+  }
+
+  if (![self.configurator persistTimedRuleKills:(serialized.count ? serialized : nil)]) {
+    // The in-memory set still governs this daemon's lifetime; only a restart
+    // before the next successful write loses the pending kills.
+    LOGE(@"Unable to persist %lu pending timed rule kill(s)", (unsigned long)serialized.count);
+  }
+}
+
+/// Arms the one-shot timer for the earliest event across all entries, which is
+/// the earliest of every deadline and every warning still owed, or stops it
+/// when there are none. Timer.h schedules on wall time, so a machine asleep at
+/// the deadline runs the kill on wake.
+- (void)rescheduleTimerSerialized {
+  NSDate* next = nil;
+  for (SNTTimedRuleKillEntry* entry in self.entries.allValues) {
+    if (!next || [entry.deadline compare:next] == NSOrderedAscending) {
+      next = entry.deadline;
+    }
+    if (!entry.notified && [entry.notifyAt compare:next] == NSOrderedAscending) {
+      next = entry.notifyAt;
+    }
+  }
+
+  if (!next) {
+    _timer->StopTimerAsync();
+    return;
+  }
+
+  // Round up: firing a whole second early would find nothing due and re-arm.
+  NSTimeInterval remaining = next.timeIntervalSinceNow;
+  uint32_t seconds = 0;
+  if (remaining > 0) {
+    seconds = static_cast<uint32_t>(
+        std::min(std::ceil(remaining), static_cast<double>(std::numeric_limits<uint32_t>::max())));
+  }
+  _timer->StartTimerWithIntervalAsync(seconds);
+}
+
+@end

--- a/Source/santad/SNTTimedRuleKills.mm
+++ b/Source/santad/SNTTimedRuleKills.mm
@@ -33,6 +33,7 @@
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
+#include "Source/common/String.h"
 #include "Source/common/Timer.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #include "Source/santad/KillingMachine.h"
@@ -113,7 +114,8 @@ NSString* DisplayNameForPid(pid_t pid) {
 
 // The kill is delivered to the process group of every match, with SIGKILL as
 // the nominal signal; the term-then-kill path sends SIGTERM and SIGKILL itself
-// and ignores this field.
+// and ignores this field. Never nil for an entry that exists: every write site
+// gates on SupportedRuleType, so only the switch needs the default arm.
 SNTKillRequest* KillRequestForEntry(SNTTimedRuleKillEntry* entry) {
   NSString* uuid = [[NSUUID UUID] UUIDString];
 
@@ -164,10 +166,8 @@ SNTKillRequest* KillRequestForEntry(SNTTimedRuleKillEntry* entry) {
   entry.celHash = celHash;
   entry.deadline = [NSDate dateWithTimeIntervalSince1970:[dict[kEntryDeadlineKey] doubleValue]];
   entry.notifyAt = [NSDate dateWithTimeIntervalSince1970:[dict[kEntryNotifyAtKey] doubleValue]];
-  // The one optional field: absent on entries written before the warning banner
-  // existed, so a missing key is a valid NO rather than a reason to drop the
-  // entry. Guarded like every other field, though, so a non-NSNumber value on
-  // disk can't reach -boolValue and crash-loop the daemon at startup.
+  // Guarded like every other field: a non-NSNumber value on disk must not reach
+  // -boolValue and crash-loop the daemon at startup.
   id notified = dict[kEntryNotifiedKey];
   entry.notified = [notified isKindOfClass:[NSNumber class]] && [notified boolValue];
   return entry;
@@ -199,15 +199,6 @@ SNTKillRequest* KillRequestForEntry(SNTTimedRuleKillEntry* entry) {
 /// Entries keyed by rule type, identifier and CEL hash, so repeated execs under
 /// the same rule share one entry. Only ever touched on `queue`.
 @property NSMutableDictionary<NSString*, SNTTimedRuleKillEntry*>* entries;
-/// Test seam for the one call with no safe form to exercise against real
-/// processes. Never set in production, where the real kill runs instead.
-@property(copy) SNTKillResponse* (^killBlock)(SNTKillRequest* request, NSTimeInterval grace);
-/// Test seam paired with killBlock: the pid of something the rule covers that
-/// is running, or nil for nothing running. Nothing a test runs can be made to
-/// match a rule, so the match is the part that is faked; naming the pid and
-/// deciding on the banner are the production path either way. Never set in
-/// production.
-@property(copy) NSNumber* (^matchBlock)(SNTKillRequest* request);
 
 - (void)onDeadlineTimer;
 @end
@@ -244,13 +235,17 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
 
 @implementation SNTTimedRuleKills {
   std::shared_ptr<DeadlineTimer> _timer;
+  /// The syscalls every kill and every match here go through.
+  santa::KillEnv _killEnv;
 }
 
 - (instancetype)initWithNotifierQueue:(SNTNotificationQueue*)notifierQueue
                             ruleTable:(SNTRuleTable*)ruleTable
-                         configurator:(SNTConfigurator*)configurator {
+                         configurator:(SNTConfigurator*)configurator
+                              killEnv:(santa::KillEnv)killEnv {
   self = [super init];
   if (self) {
+    _killEnv = std::move(killEnv);
     _notifierQueue = notifierQueue;
     _ruleTable = ruleTable;
     _configurator = configurator;
@@ -268,14 +263,9 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
   }
 
   NSData* text = [celExpr dataUsingEncoding:NSUTF8StringEncoding];
-  unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
   CC_SHA256(text.bytes, (CC_LONG)text.length, digest);
-
-  NSMutableString* hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
-  for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
-    [hex appendFormat:@"%02x", digest[i]];
-  }
-  return hex;
+  return santa::StringToNSString(santa::BufToHexString(digest, sizeof(digest)));
 }
 
 - (void)resumeFromSavedState {
@@ -381,19 +371,32 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
 /// no kill is waiting on it by the time it is taken. It also means an entry
 /// whose deadline has arrived is gone before the warning pass sees it, so
 /// nothing is warned about a kill that is already happening.
+///
+/// Due entries are gathered and killed in one pass, sharing one grace period.
 - (void)processDueEntriesSerialized {
   NSDate* now = [NSDate date];
   BOOL changed = NO;
 
+  NSMutableArray<SNTTimedRuleKillEntry*>* due = [NSMutableArray array];
   for (NSString* key in self.entries.allKeys) {
     SNTTimedRuleKillEntry* entry = self.entries[key];
     if ([entry.deadline timeIntervalSinceDate:now] > kDueTolerance) {
       continue;
     }
 
-    [self killForEntrySerialized:entry];
+    // A deadline is spent once, whether or not anything is killed.
     [self.entries removeObjectForKey:key];
     changed = YES;
+
+    // A rule that no longer governs has no kill coming.
+    if (![self ruleStillGovernsSerialized:entry]) {
+      continue;
+    }
+    [due addObject:entry];
+  }
+
+  if (due.count) {
+    [self killEntriesSerialized:due];
   }
 
   for (NSString* key in self.entries.allKeys) {
@@ -447,27 +450,26 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
   return YES;
 }
 
-/// The kill at a deadline: re-check the rule, then quit what it covers.
-- (void)killForEntrySerialized:(SNTTimedRuleKillEntry*)entry {
-  if (![self ruleStillGovernsSerialized:entry]) {
-    return;
+/// The kill at a deadline: one pass over every due entry, sharing the grace
+/// period. Rules have already been re-checked.
+- (void)killEntriesSerialized:(NSArray<SNTTimedRuleKillEntry*>*)entries {
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray arrayWithCapacity:entries.count];
+  for (SNTTimedRuleKillEntry* entry in entries) {
+    [requests addObject:KillRequestForEntry(entry)];
   }
 
-  SNTKillRequest* request = KillRequestForEntry(entry);
-  if (!request) {
-    LOGW(@"Unable to build a kill request for %@; nothing killed", entry.identifier);
-    return;
+  NSArray<SNTKillResponse*>* responses =
+      santa::KillingMachineTermThenKill(requests, kTermGrace, _killEnv);
+
+  // One response per request, in order, so `entries` indexes them.
+  // killedProcesses counts deliveries, not processes: a survivor of SIGTERM
+  // appears twice, and a group shared with another entry is reported against
+  // whichever entry signaled it.
+  for (NSUInteger index = 0; index < responses.count; index++) {
+    LOGI(@"Timed rule kill fired for %@: %lu signal delivery result(s) of its own, error: %ld",
+         entries[index].identifier, (unsigned long)responses[index].killedProcesses.count,
+         (long)responses[index].error);
   }
-
-  SNTKillResponse* response = self.killBlock
-                                  ? self.killBlock(request, kTermGrace)
-                                  : santa::KillingMachineTermThenKill(request, kTermGrace);
-
-  // killedProcesses holds one result per delivery across both passes, so a
-  // process that survived SIGTERM appears twice. It is a count of deliveries,
-  // not of processes.
-  LOGI(@"Timed rule kill fired for %@: %lu signal delivery result(s), error: %ld", entry.identifier,
-       (unsigned long)response.killedProcesses.count, (long)response.error);
 }
 
 /// The warning shortly before a deadline: find something the rule covers that
@@ -482,22 +484,7 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
     return;
   }
 
-  SNTKillRequest* request = KillRequestForEntry(entry);
-  if (!request) {
-    LOGW(@"Unable to build a kill request for %@; nothing to warn about", entry.identifier);
-    return;
-  }
-
-  std::optional<pid_t> pid;
-  if (self.matchBlock) {
-    NSNumber* matched = self.matchBlock(request);
-    if (matched) {
-      pid = matched.intValue;
-    }
-  } else {
-    pid = santa::KillingMachineAnyMatch(request);
-  }
-
+  std::optional<pid_t> pid = santa::KillingMachineAnyMatch(KillRequestForEntry(entry), _killEnv);
   if (!pid) {
     // Nothing the rule covers is running, so there is nothing to warn about.
     LOGD(@"No running process matches %@; skipping timed rule kill banner", entry.identifier);

--- a/Source/santad/SNTTimedRuleKillsTest.mm
+++ b/Source/santad/SNTTimedRuleKillsTest.mm
@@ -1,0 +1,1172 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/santad/SNTTimedRuleKills.h"
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import <arpa/inet.h>
+#include <signal.h>
+
+#include <cstring>
+#include <map>
+#include <optional>
+#include <set>
+#include <vector>
+
+#include "Source/common/AuditUtilities.h"
+#include "Source/common/CSOpsHelper.h"
+#import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTKillCommand.h"
+#import "Source/common/SNTRule.h"
+#import "Source/common/SNTXPCNotifierInterface.h"
+#import "Source/santad/DataLayer/SNTRuleTable.h"
+#include "Source/santad/KillingMachine.h"
+#import "Source/santad/SNTNotificationQueue.h"
+
+typedef BOOL (^StateFileAccessAuthorizer)(void);
+
+// The private initializer that lets a test point a configurator at its own
+// state file rather than /var/db/santa. Same declaration SNTConfiguratorTest
+// uses.
+@interface SNTConfigurator (Testing)
+- (instancetype)initWithSyncStateFile:(NSString*)syncStateFilePath
+                            stateFile:(NSString*)stateFilePath
+            syncStateAccessAuthorizer:(StateFileAccessAuthorizer)syncStateAccessAuthorizer
+                stateAccessAuthorizer:(StateFileAccessAuthorizer)stateAccessAuthorizer;
+@end
+
+// Making these readwrite is how the other rule tests build a rule without
+// going through a full initializer.
+@interface SNTRule ()
+@property(readwrite) SNTRuleState state;
+@property(readwrite) SNTRuleType type;
+@property(readwrite) NSString* identifier;
+@property(readwrite) NSString* celExpr;
+@end
+
+// The seams SNTTimedRuleKills keeps private: the kill call and the process
+// snapshot behind a warning, neither of which has a safe form to exercise
+// against real processes, and the serial queue the component does all of its
+// work on, which a test drains to observe the result of a record.
+@interface SNTTimedRuleKills (Testing)
+@property(copy) SNTKillResponse* (^killBlock)(SNTKillRequest* request, NSTimeInterval grace);
+@property(copy) NSNumber* (^matchBlock)(SNTKillRequest* request);
+@property(readonly) dispatch_queue_t queue;
+@end
+
+// Counts the writes the component makes, so a test can assert that a repeated
+// recording of the same deadline writes nothing. Everything else about the
+// configurator is real, including the state file on disk.
+@interface CountingConfigurator : SNTConfigurator
+@property NSUInteger timedRuleKillWrites;
+@end
+
+@implementation CountingConfigurator
+- (BOOL)persistTimedRuleKills:(NSArray<NSDictionary*>*)entries {
+  self.timedRuleKillWrites++;
+  return [super persistTimedRuleKills:entries];
+}
+@end
+
+namespace {
+
+// The team ID the fake csops reports for the pids a test wants matched. Paired
+// with a TEAMID rule for the same value, this is how the term-then-kill test
+// chooses what the real matching machinery matches.
+static NSString* const kMatchingTeamID = @"ABCDE12345";
+
+// One recorded signal delivery. `target` is a pgid when `group` is true.
+struct FakeSignal {
+  pid_t target;
+  int sig;
+  bool group;
+};
+
+// State behind a fully faked santa::KillEnv, trimmed from KillingMachineTest's.
+// Every seam is replaced, so nothing here can reach a real syscall.
+struct FakeEnv {
+  std::vector<pid_t> pids;
+  // pid -> pidversion. A pid that isn't here has no audit token.
+  std::map<pid_t, int> pidversions;
+  // pids the fake csops reports kMatchingTeamID for.
+  std::set<pid_t> matching;
+  // pid -> pgid.
+  std::map<pid_t, pid_t> pgids;
+
+  std::vector<FakeSignal> signals;
+  std::vector<NSTimeInterval> waits;
+};
+
+santa::KillEnv MakeEnv(FakeEnv* fake) {
+  santa::KillEnv env;
+
+  env.list_pids = [fake]() -> std::optional<std::vector<pid_t>> { return fake->pids; };
+
+  env.token_for_pid = [fake](pid_t pid, audit_token_t* token) {
+    auto it = fake->pidversions.find(pid);
+    if (it == fake->pidversions.end()) {
+      return false;
+    }
+    *token = santa::MakeStubAuditToken(pid, it->second);
+    return true;
+  };
+
+  env.csops_func = [fake](pid_t pid, unsigned int ops, void* useraddr, size_t usersize) {
+    if (ops != santa::kCsopTeamID || !fake->matching.count(pid) ||
+        usersize < sizeof(santa::csops_blob) + kMatchingTeamID.length) {
+      return -1;
+    }
+    santa::csops_blob* blob = (santa::csops_blob*)useraddr;
+    blob->type = 0;
+    blob->len = htonl(sizeof(santa::csops_blob) + 1 + kMatchingTeamID.length);
+    std::memcpy(blob->data, kMatchingTeamID.UTF8String, kMatchingTeamID.length);
+    return 0;
+  };
+
+  env.pgid_for_pid = [fake](pid_t pid) -> pid_t {
+    auto it = fake->pgids.find(pid);
+    return it == fake->pgids.end() ? -1 : it->second;
+  };
+
+  env.signal_token = [fake](audit_token_t* token, int sig) {
+    fake->signals.push_back({santa::Pid(*token), sig, false});
+    return 0;
+  };
+
+  env.signal_group = [fake](pid_t pgid, int sig) {
+    fake->signals.push_back({pgid, sig, true});
+    return 0;
+  };
+
+  env.wait = [fake](NSTimeInterval seconds) { fake->waits.push_back(seconds); };
+
+  return env;
+}
+
+// Renders recorded deliveries as "group:100:15" so a failing assertion prints
+// the whole sequence instead of a count mismatch.
+NSArray<NSString*>* SignalDescriptions(const std::vector<FakeSignal>& signals) {
+  NSMutableArray<NSString*>* out = [NSMutableArray array];
+  for (const FakeSignal& signal : signals) {
+    [out addObject:[NSString stringWithFormat:@"%@:%d:%d", signal.group ? @"group" : @"pid",
+                                              signal.target, signal.sig]];
+  }
+  return out;
+}
+
+}  // namespace
+
+// A CEL expression that compiles under CELv2, so the rule table accepts the
+// rules these tests insert. The text itself is never evaluated here; only its
+// hash matters.
+static NSString* const kCELExpr = @"euid == 0 ? REQUIRE_TOUCHID : ALLOWLIST";
+static NSString* const kEditedCELExpr = @"euid == 1 ? REQUIRE_TOUCHID : ALLOWLIST";
+
+static NSString* const kTimedRuleKillsStateKey = @"TimedRuleKills";
+static NSString* const kTMMStateKey = @"TMM";
+static NSString* const kTAMStateKey = @"TempAdmin";
+
+@interface SNTTimedRuleKillsTest : XCTestCase
+@property NSFileManager* fileMgr;
+@property NSString* testDir;
+@property NSString* statePath;
+@property CountingConfigurator* configurator;
+@property SNTRuleTable* ruleTable;
+@property FMDatabaseQueue* dbq;
+@property id mockConfiguratorClass;
+@property id mockNotifierQueue;
+@property id mockNotifierConnection;
+@property id mockNotifierProxy;
+@end
+
+@implementation SNTTimedRuleKillsTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.fileMgr = [NSFileManager defaultManager];
+  self.testDir = [NSString stringWithFormat:@"%@santa-timed-rule-kills-%d-%@",
+                                            NSTemporaryDirectory(), getpid(), [NSUUID UUID]];
+  XCTAssertTrue([self.fileMgr createDirectoryAtPath:self.testDir
+                        withIntermediateDirectories:YES
+                                         attributes:nil
+                                              error:nil]);
+  self.statePath = [NSString stringWithFormat:@"%@/state.plist", self.testDir];
+
+  // The rule table reads the shared configurator for static rules; keep the
+  // host's real configuration out of these tests.
+  self.mockConfiguratorClass = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfiguratorClass configurator]).andReturn(self.mockConfiguratorClass);
+
+  self.configurator = [self makeConfigurator];
+
+  self.dbq = [[FMDatabaseQueue alloc] init];
+  self.ruleTable = [[SNTRuleTable alloc] initWithDatabaseQueue:self.dbq];
+}
+
+- (void)tearDown {
+  [self.mockConfiguratorClass stopMocking];
+  // Class mocks swizzle the class itself, so they have to be undone or they
+  // follow the process into the next test.
+  [self.mockNotifierQueue stopMocking];
+  [self.mockNotifierConnection stopMocking];
+  [self.fileMgr removeItemAtPath:self.testDir error:nil];
+  [super tearDown];
+}
+
+#pragma mark Helpers
+
+- (CountingConfigurator*)makeConfigurator {
+  CountingConfigurator* cfg = [[CountingConfigurator alloc]
+      initWithSyncStateFile:[NSString stringWithFormat:@"%@/sync-state.plist", self.testDir]
+      stateFile:self.statePath
+      syncStateAccessAuthorizer:^BOOL {
+        return YES;
+      }
+      stateAccessAuthorizer:^BOOL {
+        return YES;
+      }];
+  XCTAssertNotNil(cfg);
+  return cfg;
+}
+
+/// The component under test, wired to whatever notifier queue setUpNotifierProxy
+/// left behind: nil unless a test asked for one, which is the "no GUI running"
+/// case.
+- (SNTTimedRuleKills*)makeSUT {
+  SNTTimedRuleKills* sut = [[SNTTimedRuleKills alloc] initWithNotifierQueue:self.mockNotifierQueue
+                                                                  ruleTable:self.ruleTable
+                                                               configurator:self.configurator];
+  XCTAssertNotNil(sut);
+  return sut;
+}
+
+/// Wires up a notifier queue whose remote proxy is a protocol mock, the same
+/// shape SNTNetworkExtensionQueueTest uses. Call before makeSUT; the strong
+/// test references keep the stubs alive for the test's duration.
+- (id)setUpNotifierProxy {
+  self.mockNotifierQueue = OCMClassMock([SNTNotificationQueue class]);
+  self.mockNotifierConnection = OCMClassMock([MOLXPCConnection class]);
+  self.mockNotifierProxy = OCMProtocolMock(@protocol(SNTNotifierXPC));
+  OCMStub([self.mockNotifierQueue notifierConnection]).andReturn(self.mockNotifierConnection);
+  OCMStub([self.mockNotifierConnection remoteObjectProxy]).andReturn(self.mockNotifierProxy);
+  return self.mockNotifierProxy;
+}
+
+- (void)addRuleOfType:(SNTRuleType)type identifier:(NSString*)identifier cel:(NSString*)cel {
+  SNTRule* rule = [[SNTRule alloc] init];
+  rule.identifier = identifier;
+  rule.type = type;
+  rule.state = SNTRuleStateCELv2;
+  rule.celExpr = cel;
+
+  NSArray<NSError*>* errors;
+  XCTAssertTrue([self.ruleTable addExecutionRules:@[ rule ]
+                                      ruleCleanup:SNTRuleCleanupNone
+                                           errors:&errors]);
+  XCTAssertEqual(errors.count, 0u, @"%@", errors);
+}
+
+/// Waits for everything already enqueued on the component's serial queue,
+/// which is where a record lands.
+- (void)drain:(SNTTimedRuleKills*)sut {
+  dispatch_sync(sut.queue, ^{
+                });
+}
+
+- (NSArray<NSDictionary*>*)savedEntries {
+  return [self.configurator savedTimedRuleKills];
+}
+
+- (NSDictionary*)rawStateFile {
+  return [NSDictionary dictionaryWithContentsOfFile:self.statePath];
+}
+
+/// Sets a kill block that records the requests it is handed and fulfills
+/// `expectation` for each one, without signaling anything.
+- (void)captureKillsOn:(SNTTimedRuleKills*)sut
+                  into:(NSMutableArray<SNTKillRequest*>*)requests
+           expectation:(XCTestExpectation*)expectation {
+  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
+    @synchronized(requests) {
+      [requests addObject:request];
+    }
+    [expectation fulfill];
+    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+  };
+}
+
+/// Records every banner the component sends, in order, as
+/// @{@"app": ..., @"deadline": ...}, fulfilling `expectation` for each one.
+/// Pass a nil expectation when the test's point is that no banner arrives.
+- (void)recordBannersOn:(id)proxy
+                   into:(NSMutableArray<NSDictionary*>*)banners
+            expectation:(XCTestExpectation*)expectation {
+  OCMStub([proxy postTimedRuleKillNotificationForApplication:OCMOCK_ANY deadline:OCMOCK_ANY])
+      .andDo(^(NSInvocation* invocation) {
+        __unsafe_unretained NSString* app;
+        __unsafe_unretained NSDate* deadline;
+        [invocation getArgument:&app atIndex:2];
+        [invocation getArgument:&deadline atIndex:3];
+        // Built key by key rather than as a literal: andDo() is a macro, and a
+        // comma inside a braced literal would be read as another argument to it.
+        NSMutableDictionary* banner = [NSMutableDictionary dictionary];
+        banner[@"app"] = app;
+        banner[@"deadline"] = deadline;
+        @synchronized(banners) {
+          [banners addObject:banner];
+        }
+        [expectation fulfill];
+      });
+}
+
+- (NSDictionary*)entryDictForRuleType:(SNTRuleType)type
+                           identifier:(NSString*)identifier
+                              celHash:(NSString*)celHash
+                             deadline:(NSDate*)deadline {
+  return @{
+    @"RuleType" : @(type),
+    @"Identifier" : identifier,
+    @"CELHash" : celHash,
+    @"Deadline" : @(deadline.timeIntervalSince1970),
+    @"NotifyAt" : @(deadline.timeIntervalSince1970 - 60),
+    @"Notified" : @NO,
+  };
+}
+
+#pragma mark Recording
+
+- (void)testCELHashIsSHA256OfTheExpression {
+  // sha256("abc")
+  XCTAssertEqualObjects([SNTTimedRuleKills celHashForExpression:@"abc"],
+                        @"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  XCTAssertNil([SNTTimedRuleKills celHashForExpression:nil]);
+  XCTAssertNil([SNTTimedRuleKills celHashForExpression:@""]);
+}
+
+- (void)testEarlierDeadlineWinsAndLaterIsIgnored {
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+
+  NSDate* far = [NSDate dateWithTimeIntervalSinceNow:3600];
+  NSDate* near = [NSDate dateWithTimeIntervalSinceNow:1800];
+  NSDate* farther = [NSDate dateWithTimeIntervalSinceNow:7200];
+
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:far
+                    notifyAt:[far dateByAddingTimeInterval:-60]];
+  [self drain:sut];
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqualWithAccuracy([self.savedEntries.firstObject[@"Deadline"] doubleValue],
+                             far.timeIntervalSince1970, 0.001);
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 1u);
+
+  // Earlier deadline replaces it.
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:near
+                    notifyAt:[near dateByAddingTimeInterval:-60]];
+  [self drain:sut];
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqualWithAccuracy([self.savedEntries.firstObject[@"Deadline"] doubleValue],
+                             near.timeIntervalSince1970, 0.001);
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 2u);
+
+  // A later deadline for the same key changes nothing, and writes nothing.
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:farther
+                    notifyAt:[farther dateByAddingTimeInterval:-60]];
+  [self drain:sut];
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqualWithAccuracy([self.savedEntries.firstObject[@"Deadline"] doubleValue],
+                             near.timeIntervalSince1970, 0.001);
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 2u);
+}
+
+- (void)testRepeatedIdenticalRecordingWritesNothing {
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
+
+  for (int i = 0; i < 5; i++) {
+    [sut recordKillForRuleType:SNTRuleTypeTeamID
+                    identifier:kMatchingTeamID
+                       celHash:hash
+                      deadline:deadline
+                      notifyAt:[deadline dateByAddingTimeInterval:-60]];
+  }
+  [self drain:sut];
+
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 1u);
+}
+
+- (void)testDifferentCELHashIsADifferentEntry {
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
+
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kEditedCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self drain:sut];
+
+  XCTAssertEqual(self.savedEntries.count, 2u);
+}
+
+- (void)testBinaryAndCertificateRuleTypesAreRefused {
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
+
+  [sut recordKillForRuleType:SNTRuleTypeBinary
+                  identifier:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
+                     celHash:hash
+                    deadline:deadline
+                    notifyAt:deadline];
+  [sut recordKillForRuleType:SNTRuleTypeCertificate
+                  identifier:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
+                     celHash:hash
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self drain:sut];
+
+  XCTAssertNil(self.savedEntries);
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 0u);
+}
+
+- (void)testIncompleteRecordingsAreRefused {
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
+
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:@""
+                     celHash:hash
+                    deadline:deadline
+                    notifyAt:deadline];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:nil
+                    deadline:deadline
+                    notifyAt:deadline];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:nil
+                    notifyAt:deadline];
+  [self drain:sut];
+
+  XCTAssertNil(self.savedEntries);
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 0u);
+}
+
+#pragma mark Persistence
+
+- (void)testEntryWritesPreserveOtherStateKeys {
+  [self.configurator persistTimedSessionState:@{@"Deadline" : @123} forKey:kTMMStateKey];
+  [self.configurator persistTimedSessionState:@{@"Deadline" : @456} forKey:kTAMStateKey];
+  XCTAssertTrue([self.configurator persistDemotedAdmins:@[ @{@"Username" : @"jane"} ]]);
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:3540]];
+  [self drain:sut];
+
+  NSDictionary* onDisk = [self rawStateFile];
+  XCTAssertEqualObjects(onDisk[kTMMStateKey], (@{@"Deadline" : @123}));
+  XCTAssertEqualObjects(onDisk[kTAMStateKey], (@{@"Deadline" : @456}));
+  XCTAssertEqualObjects(onDisk[@"DemotedAdmins"], (@[ @{@"Username" : @"jane"} ]));
+  XCTAssertNotNil(onDisk[@"LastBootUUID"]);
+  XCTAssertEqual([onDisk[kTimedRuleKillsStateKey] count], 1u);
+}
+
+- (void)testEntriesSurviveReloadAndUnknownKeysStillDoNot {
+  NSDictionary* entry = [self entryDictForRuleType:SNTRuleTypeTeamID
+                                        identifier:kMatchingTeamID
+                                           celHash:@"abc"
+                                          deadline:[NSDate dateWithTimeIntervalSinceNow:3600]];
+  NSDictionary* onDisk = @{
+    kTimedRuleKillsStateKey : @[ entry ],
+    kTMMStateKey : @{@"Deadline" : @1},
+    @"Bogus" : @"unknown",
+  };
+  XCTAssertTrue([onDisk writeToFile:self.statePath atomically:YES]);
+
+  CountingConfigurator* reloaded = [self makeConfigurator];
+  XCTAssertEqual([reloaded savedTimedRuleKills].count, 1u);
+  XCTAssertNotNil([reloaded savedTimedSessionStateForKey:kTMMStateKey]);
+  XCTAssertNil([reloaded savedTimedSessionStateForKey:@"Bogus"]);
+
+  // A value of the wrong type under the key is stripped by the allowlist too.
+  NSDictionary* wrongType = @{kTimedRuleKillsStateKey : @"not-an-array"};
+  XCTAssertTrue([wrongType writeToFile:self.statePath atomically:YES]);
+  XCTAssertNil([[self makeConfigurator] savedTimedRuleKills]);
+}
+
+- (void)testEntryIsRemovedAndPersistedAfterFiring {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+
+  [self waitForExpectations:@[ killed ] timeout:10];
+  [self drain:sut];
+
+  XCTAssertEqual(requests.count, 1u);
+  XCTAssertNil(self.savedEntries);
+  XCTAssertNil([self rawStateFile][kTimedRuleKillsStateKey]);
+}
+
+#pragma mark The kill
+
+- (void)testTeamIDKillRequestTargetsProcessGroups {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self waitForExpectations:@[ killed ] timeout:10];
+
+  XCTAssertEqual(requests.count, 1u);
+  XCTAssertTrue([requests.firstObject isKindOfClass:[SNTKillRequestTeamID class]]);
+  XCTAssertEqualObjects(((SNTKillRequestTeamID*)requests.firstObject).teamID, kMatchingTeamID);
+  XCTAssertTrue(requests.firstObject.targetProcessGroups);
+}
+
+- (void)testPlatformSigningIDKillRequest {
+  [self addRuleOfType:SNTRuleTypeSigningID identifier:@"platform:com.apple.ls" cel:kCELExpr];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeSigningID
+                  identifier:@"platform:com.apple.ls"
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self waitForExpectations:@[ killed ] timeout:10];
+
+  XCTAssertEqual(requests.count, 1u);
+  SNTKillRequestSigningID* request = (SNTKillRequestSigningID*)requests.firstObject;
+  XCTAssertTrue([request isKindOfClass:[SNTKillRequestSigningID class]]);
+  XCTAssertEqualObjects(request.teamID, @"platform");
+  XCTAssertEqualObjects(request.signingID, @"com.apple.ls");
+  XCTAssertTrue(request.targetProcessGroups);
+}
+
+- (void)testCDHashKillRequest {
+  NSString* cdhash = @"deadbeefcafebabe0123456789abcdeffedcba98";
+  [self addRuleOfType:SNTRuleTypeCDHash identifier:cdhash cel:kCELExpr];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeCDHash
+                  identifier:cdhash
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self waitForExpectations:@[ killed ] timeout:10];
+
+  XCTAssertEqual(requests.count, 1u);
+  XCTAssertTrue([requests.firstObject isKindOfClass:[SNTKillRequestCDHash class]]);
+  XCTAssertEqualObjects(((SNTKillRequestCDHash*)requests.firstObject).cdhash, cdhash);
+  XCTAssertTrue(requests.firstObject.targetProcessGroups);
+}
+
+- (void)testSIGTERMThenSIGKILLWithFiveSecondGrace {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+
+  pid_t pgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  fake.pids = {100};
+  fake.pidversions = {{100, 1}};
+  fake.matching = {100};
+  fake.pgids = {{100, pgid}};
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  // A block captures a C++ object by const copy, so the fake is reached
+  // through a pointer; it outlives the block, which runs before the wait below
+  // returns.
+  FakeEnv* fakePtr = &fake;
+  // The seam routes into the real term-then-kill against a fully faked
+  // KillEnv, so the ordering under test is the production one.
+  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
+    santa::KillEnv env = MakeEnv(fakePtr);
+    SNTKillResponse* response = santa::KillingMachineTermThenKill(request, grace, env);
+    [killed fulfill];
+    return response;
+  };
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self waitForExpectations:@[ killed ] timeout:10];
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
+                          [NSString stringWithFormat:@"group:%d:%d", pgid, SIGTERM],
+                          [NSString stringWithFormat:@"group:%d:%d", pgid, SIGKILL],
+                        ]));
+  XCTAssertEqual(fake.waits.size(), 1u);
+  XCTAssertEqualWithAccuracy(fake.waits.front(), 5.0, 0.001);
+}
+
+- (void)testRemovedRuleDropsTheEntryWithoutKilling {
+  // No rule is ever added, so the fire-time re-check finds nothing.
+  SNTTimedRuleKills* sut = [self makeSUT];
+  __block BOOL killCalled = NO;
+  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
+    killCalled = YES;
+    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+  };
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self drain:sut];
+  XCTAssertEqual(self.savedEntries.count, 1u);
+
+  [self waitForEntriesToClear];
+  XCTAssertFalse(killCalled);
+}
+
+- (void)testEditedRuleDropsTheEntryWithoutKilling {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  __block BOOL killCalled = NO;
+  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
+    killCalled = YES;
+    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+  };
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+  [self drain:sut];
+
+  // The rule's text changes between recording and firing.
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kEditedCELExpr];
+
+  [self waitForEntriesToClear];
+  XCTAssertFalse(killCalled);
+}
+
+#pragma mark The warning banner
+
+- (void)testWarningNamesTheRunningProcessAndIsRecorded {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:posted];
+  // Nothing a test runs can be made to match a rule, so the match is faked.
+  // Naming the pid it returns is the production path.
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    return @(getpid());
+  };
+
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+
+  // The banner arrives long before the deadline, so the timer fired for the
+  // warning rather than the kill.
+  [self waitForExpectations:@[ posted ] timeout:10];
+  [self drain:sut];
+
+  XCTAssertEqual(banners.count, 1u);
+  // Named from the process, not from the rule it matched.
+  XCTAssertGreaterThan([banners.firstObject[@"app"] length], 0u);
+  XCTAssertNotEqualObjects(banners.firstObject[@"app"], kMatchingTeamID);
+  XCTAssertEqualWithAccuracy([banners.firstObject[@"deadline"] timeIntervalSince1970],
+                             deadline.timeIntervalSince1970, 0.001);
+
+  // The entry is still pending, now marked warned on disk so a restart doesn't
+  // warn again.
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertTrue([self.savedEntries.firstObject[@"Notified"] boolValue]);
+}
+
+- (void)testWarningFallsBackToTheRuleIdentifierWhenTheProcessCannotBeNamed {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:posted];
+  // A pid nothing can be read for, which is what a process that exited between
+  // the match and the banner looks like.
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    return @(99999999);
+  };
+
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+
+  [self waitForExpectations:@[ posted ] timeout:10];
+
+  XCTAssertEqual(banners.count, 1u);
+  XCTAssertEqualObjects(banners.firstObject[@"app"], kMatchingTeamID);
+}
+
+- (void)testNoWarningWhenNothingMatchingIsRunning {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:nil];
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    return nil;
+  };
+
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+
+  [self waitForTheWarningPass];
+  [self drain:sut];
+
+  XCTAssertEqual(banners.count, 0u);
+  // The pass is recorded even though no banner went out: it runs once per
+  // (rule, deadline), whether or not it had anything to warn about.
+  XCTAssertTrue([self.savedEntries.firstObject[@"Notified"] boolValue]);
+}
+
+- (void)testOneWarningPerRuleAndDeadline {
+  // Two entries, so the warning pass comes back over the first one.
+  NSString* cdhash = @"deadbeefcafebabe0123456789abcdeffedcba98";
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  [self addRuleOfType:SNTRuleTypeCDHash identifier:cdhash cel:kCELExpr];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* posted = [self expectationWithDescription:@"two banners"];
+  posted.expectedFulfillmentCount = 2;
+  posted.assertForOverFulfill = YES;
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:posted];
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    return @(getpid());
+  };
+
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+  NSDate* firstDeadline = [NSDate dateWithTimeIntervalSinceNow:3600];
+  NSDate* secondDeadline = [NSDate dateWithTimeIntervalSinceNow:7200];
+
+  // Already past, so the first warning goes out as soon as it is recorded.
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:firstDeadline
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:-10]];
+  // A later warning, which is what brings the pass back over the first entry.
+  [sut recordKillForRuleType:SNTRuleTypeCDHash
+                  identifier:cdhash
+                     celHash:hash
+                    deadline:secondDeadline
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.7]];
+
+  [self waitForExpectations:@[ posted ] timeout:10];
+  [self drain:sut];
+
+  NSCountedSet* deadlines = [NSCountedSet set];
+  for (NSDictionary* banner in banners) {
+    [deadlines addObject:banner[@"deadline"]];
+  }
+  XCTAssertEqual(banners.count, 2u);
+  XCTAssertEqual([deadlines countForObject:firstDeadline], 1u);
+  XCTAssertEqual([deadlines countForObject:secondDeadline], 1u);
+}
+
+// A rule withdrawn during the lead window has no kill coming, so warning about
+// it would promise a quit that never happens. The entry goes at warning time
+// rather than sitting until a deadline it will never act on.
+- (void)testNoWarningWhenTheRuleIsGoneAndTheEntryIsDropped {
+  // No rule is ever added, so the warning-time re-check finds nothing.
+  id proxy = [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:nil];
+  __block BOOL snapshotTaken = NO;
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    snapshotTaken = YES;
+    return @(getpid());
+  };
+
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
+                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+  [self drain:sut];
+  XCTAssertEqual(self.savedEntries.count, 1u);
+
+  // Cleared at warning time, an hour before the deadline it was recorded for.
+  [self waitForEntriesToClear];
+
+  XCTAssertEqual(banners.count, 0u);
+  XCTAssertFalse(snapshotTaken, @"snapshot taken for a rule that no longer governs");
+}
+
+- (void)testWarningIsSkippedWhenTheDeadlineIsAlreadyDue {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  id proxy = [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:nil];
+  __block BOOL snapshotTaken = NO;
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    snapshotTaken = YES;
+    return @(getpid());
+  };
+
+  // Warning time and deadline land in the same pass.
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                    deadline:deadline
+                    notifyAt:deadline];
+
+  [self waitForExpectations:@[ killed ] timeout:10];
+  [self drain:sut];
+
+  XCTAssertEqual(requests.count, 1u);
+  XCTAssertFalse(snapshotTaken, @"snapshot taken for an entry that was already being killed");
+  XCTAssertEqual(banners.count, 0u);
+}
+
+- (void)testWarningNeverDelaysTheKill {
+  NSString* cdhash = @"deadbeefcafebabe0123456789abcdeffedcba98";
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  [self addRuleOfType:SNTRuleTypeCDHash identifier:cdhash cel:kCELExpr];
+  [self setUpNotifierProxy];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSMutableArray<NSString*>* order = [NSMutableArray array];
+
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
+    @synchronized(order) {
+      [order addObject:@"kill"];
+    }
+    [killed fulfill];
+    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+  };
+
+  // A slow snapshot: taken before the kill it would hold the kill for a second.
+  XCTestExpectation* snapshotted = [self expectationWithDescription:@"snapshot taken"];
+  // Taking more snapshots than expected is what a regression here looks like;
+  // let `order` be the thing that reports it.
+  snapshotted.assertForOverFulfill = NO;
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    @synchronized(order) {
+      [order addObject:@"match"];
+    }
+    [NSThread sleepForTimeInterval:1.0];
+    [snapshotted fulfill];
+    return nil;
+  };
+
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+  NSDate* due = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  // One entry warning at `due`, one entry deadlined at `due`: the same pass.
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
+                    notifyAt:due];
+  [sut recordKillForRuleType:SNTRuleTypeCDHash
+                  identifier:cdhash
+                     celHash:hash
+                    deadline:due
+                    notifyAt:due];
+
+  [self waitForExpectations:@[ killed, snapshotted ] timeout:10];
+  XCTAssertEqualObjects(order, (@[ @"kill", @"match" ]));
+}
+
+#pragma mark Restart
+
+- (void)testRestartDoesNotWarnAgainForAnAlreadyWarnedEntry {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  NSMutableDictionary* entry =
+      [[self entryDictForRuleType:SNTRuleTypeTeamID
+                       identifier:kMatchingTeamID
+                          celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                         deadline:[NSDate dateWithTimeIntervalSinceNow:3600]] mutableCopy];
+  entry[@"NotifyAt"] = @([NSDate dateWithTimeIntervalSinceNow:-60].timeIntervalSince1970);
+  entry[@"Notified"] = @YES;
+  XCTAssertTrue([self.configurator persistTimedRuleKills:@[ entry ]]);
+
+  id proxy = [self setUpNotifierProxy];
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:nil];
+  __block BOOL snapshotTaken = NO;
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    snapshotTaken = YES;
+    return @(getpid());
+  };
+
+  [sut resumeFromSavedState];
+  [self drain:sut];
+
+  XCTAssertFalse(snapshotTaken);
+  XCTAssertEqual(banners.count, 0u);
+  XCTAssertEqual(self.savedEntries.count, 1u);
+}
+
+// A Notified value that isn't a number (an array here, from a corrupted or
+// hand-edited state file) must never reach -boolValue: that raises
+// unrecognized-selector and crash-loops the daemon at every startup, since
+// resumeFromSavedState runs on every launch. The entry loads with notified = NO
+// instead, so the load is clean and the warning it still owes goes out.
+- (void)testMalformedNotifiedValueLoadsAsNotWarnedAndDoesNotThrow {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  NSMutableDictionary* entry =
+      [[self entryDictForRuleType:SNTRuleTypeTeamID
+                       identifier:kMatchingTeamID
+                          celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                         deadline:[NSDate dateWithTimeIntervalSinceNow:3600]] mutableCopy];
+  // A warning is still owed, and Notified is the wrong type.
+  entry[@"NotifyAt"] = @([NSDate dateWithTimeIntervalSinceNow:-60].timeIntervalSince1970);
+  entry[@"Notified"] = @[ @"not", @"a", @"number" ];
+  XCTAssertTrue([self.configurator persistTimedRuleKills:@[ entry ]]);
+
+  id proxy = [self setUpNotifierProxy];
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:posted];
+  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
+    return @(getpid());
+  };
+
+  // Not throwing here is the point: the malformed Notified was guarded, not sent
+  // -boolValue.
+  [sut resumeFromSavedState];
+
+  // The warning fires, which only happens if the entry loaded with notified NO.
+  [self waitForExpectations:@[ posted ] timeout:10];
+  [self drain:sut];
+
+  XCTAssertEqual(banners.count, 1u);
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertTrue([self.savedEntries.firstObject[@"Notified"] boolValue]);
+}
+
+- (void)testRestartRunsPastDueEntryAfterRecheck {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  XCTAssertTrue([self.configurator persistTimedRuleKills:@[
+    [self entryDictForRuleType:SNTRuleTypeTeamID
+                    identifier:kMatchingTeamID
+                       celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                      deadline:[NSDate dateWithTimeIntervalSinceNow:-3600]]
+  ]]);
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  [sut resumeFromSavedState];
+
+  [self waitForExpectations:@[ killed ] timeout:10];
+  [self drain:sut];
+  XCTAssertEqual(requests.count, 1u);
+  XCTAssertNil(self.savedEntries);
+}
+
+- (void)testRestartDropsPastDueEntryWhoseRuleIsGone {
+  XCTAssertTrue([self.configurator persistTimedRuleKills:@[
+    [self entryDictForRuleType:SNTRuleTypeTeamID
+                    identifier:kMatchingTeamID
+                       celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                      deadline:[NSDate dateWithTimeIntervalSinceNow:-3600]]
+  ]]);
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  __block BOOL killCalled = NO;
+  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
+    killCalled = YES;
+    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
+  };
+
+  [sut resumeFromSavedState];
+  [self drain:sut];
+
+  XCTAssertFalse(killCalled);
+  XCTAssertNil(self.savedEntries);
+}
+
+- (void)testRestartRestoresTheTimerForAFutureEntry {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  XCTAssertTrue([self.configurator persistTimedRuleKills:@[
+    [self entryDictForRuleType:SNTRuleTypeTeamID
+                    identifier:kMatchingTeamID
+                       celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                      deadline:[NSDate dateWithTimeIntervalSinceNow:1]]
+  ]]);
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
+  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
+  [self captureKillsOn:sut into:requests expectation:killed];
+
+  [sut resumeFromSavedState];
+  [self drain:sut];
+  // Not due yet: still pending, waiting on the restored timer.
+  XCTAssertEqual(self.savedEntries.count, 1u);
+
+  [self waitForExpectations:@[ killed ] timeout:10];
+  XCTAssertEqual(requests.count, 1u);
+}
+
+- (void)testRestartDropsMalformedEntries {
+  NSArray<NSDictionary*>* saved = @[
+    // No type, hash or deadline.
+    @{@"Identifier" : kMatchingTeamID},
+    // No identifier or hash.
+    @{@"RuleType" : @(SNTRuleTypeTeamID), @"Deadline" : @1},
+    [self entryDictForRuleType:SNTRuleTypeTeamID
+                    identifier:kMatchingTeamID
+                       celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                      deadline:[NSDate dateWithTimeIntervalSinceNow:3600]],
+  ];
+  XCTAssertTrue([self.configurator persistTimedRuleKills:saved]);
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  [sut resumeFromSavedState];
+  [self drain:sut];
+
+  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqualObjects(self.savedEntries.firstObject[@"Identifier"], kMatchingTeamID);
+}
+
+#pragma mark Helpers that wait
+
+/// Polls `condition` until it holds. The component works on its own queue at a
+/// time the test doesn't control, so state it has written is waited for rather
+/// than assumed.
+- (void)waitUntil:(BOOL (^)(void))condition described:(NSString*)description {
+  XCTestExpectation* met = [self expectationWithDescription:description];
+  dispatch_source_t poll =
+      dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+  dispatch_source_set_timer(poll, dispatch_time(DISPATCH_TIME_NOW, 0), 50 * NSEC_PER_MSEC, 0);
+  __block BOOL done = NO;
+  dispatch_source_set_event_handler(poll, ^{
+    if (!done && condition()) {
+      done = YES;
+      [met fulfill];
+    }
+  });
+  dispatch_resume(poll);
+  [self waitForExpectations:@[ met ] timeout:10];
+  dispatch_source_cancel(poll);
+}
+
+/// Polls until the component has cleared its persisted entries, which happens
+/// once every recorded deadline has been processed.
+- (void)waitForEntriesToClear {
+  [self
+      waitUntil:^BOOL {
+        return self.savedEntries == nil;
+      }
+      described:@"entries cleared"];
+}
+
+/// Polls until the component has recorded that it ran the warning pass for its
+/// single pending entry.
+- (void)waitForTheWarningPass {
+  [self
+      waitUntil:^BOOL {
+        return [self.savedEntries.firstObject[@"Notified"] boolValue];
+      }
+      described:@"warning pass ran"];
+}
+
+@end

--- a/Source/santad/SNTTimedRuleKillsTest.mm
+++ b/Source/santad/SNTTimedRuleKillsTest.mm
@@ -15,11 +15,14 @@
 #import "Source/santad/SNTTimedRuleKills.h"
 
 #import <Foundation/Foundation.h>
+#import <Kernel/kern/cs_blobs.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 #import <arpa/inet.h>
 #include <signal.h>
+#include <unistd.h>
 
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <optional>
@@ -31,7 +34,6 @@
 #import "Source/common/MOLXPCConnection.h"
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigurator.h"
-#import "Source/common/SNTKillCommand.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
@@ -59,13 +61,9 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
 @property(readwrite) NSString* celExpr;
 @end
 
-// The seams SNTTimedRuleKills keeps private: the kill call and the process
-// snapshot behind a warning, neither of which has a safe form to exercise
-// against real processes, and the serial queue the component does all of its
-// work on, which a test drains to observe the result of a record.
+// The serial queue the component does all of its work on, which a test drains
+// to observe the result of a record.
 @interface SNTTimedRuleKills (Testing)
-@property(copy) SNTKillResponse* (^killBlock)(SNTKillRequest* request, NSTimeInterval grace);
-@property(copy) NSNumber* (^matchBlock)(SNTKillRequest* request);
 @property(readonly) dispatch_queue_t queue;
 @end
 
@@ -85,10 +83,15 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
 
 namespace {
 
-// The team ID the fake csops reports for the pids a test wants matched. Paired
-// with a TEAMID rule for the same value, this is how the term-then-kill test
-// chooses what the real matching machinery matches.
+// The code signing identity the fake csops reports for every matched pid.
+// Each rule below is written against one of these criteria.
 static NSString* const kMatchingTeamID = @"ABCDE12345";
+static NSString* const kMatchingSigningID = @"com.apple.ls";
+// The hex form of kMatchingCDHashBytes, which is what a CDHASH rule holds.
+static NSString* const kMatchingCDHash = @"deadbeefcafebabe0123456789abcdeffedcba98";
+static const uint8_t kMatchingCDHashBytes[CS_CDHASH_LEN] = {
+    0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0x01, 0x23,
+    0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98};
 
 // One recorded signal delivery. `target` is a pgid when `group` is true.
 struct FakeSignal {
@@ -103,14 +106,35 @@ struct FakeEnv {
   std::vector<pid_t> pids;
   // pid -> pidversion. A pid that isn't here has no audit token.
   std::map<pid_t, int> pidversions;
-  // pids the fake csops reports kMatchingTeamID for.
+  // pids the fake csops reports the identity above for.
   std::set<pid_t> matching;
   // pid -> pgid.
   std::map<pid_t, pid_t> pgids;
 
   std::vector<FakeSignal> signals;
   std::vector<NSTimeInterval> waits;
+
+  // Puts one process in the fake world that every rule below matches, in a
+  // process group of its own.
+  void AddMatching(pid_t pid, pid_t pgid) {
+    pids.push_back(pid);
+    pidversions[pid] = 1;
+    matching.insert(pid);
+    pgids[pid] = pgid;
+  }
 };
+
+// Writes `value` into the blob-wrapped form csops returns for the string ops.
+int WriteCSOpsBlob(NSString* value, void* useraddr, size_t usersize) {
+  if (usersize < sizeof(santa::csops_blob) + 1 + value.length) {
+    return -1;
+  }
+  santa::csops_blob* blob = (santa::csops_blob*)useraddr;
+  blob->type = 0;
+  blob->len = htonl(sizeof(santa::csops_blob) + 1 + value.length);
+  std::memcpy(blob->data, value.UTF8String, value.length);
+  return 0;
+}
 
 santa::KillEnv MakeEnv(FakeEnv* fake) {
   santa::KillEnv env;
@@ -127,15 +151,26 @@ santa::KillEnv MakeEnv(FakeEnv* fake) {
   };
 
   env.csops_func = [fake](pid_t pid, unsigned int ops, void* useraddr, size_t usersize) {
-    if (ops != santa::kCsopTeamID || !fake->matching.count(pid) ||
-        usersize < sizeof(santa::csops_blob) + kMatchingTeamID.length) {
+    if (!fake->matching.count(pid)) {
       return -1;
     }
-    santa::csops_blob* blob = (santa::csops_blob*)useraddr;
-    blob->type = 0;
-    blob->len = htonl(sizeof(santa::csops_blob) + 1 + kMatchingTeamID.length);
-    std::memcpy(blob->data, kMatchingTeamID.UTF8String, kMatchingTeamID.length);
-    return 0;
+    switch (ops) {
+      case santa::kCsopTeamID: return WriteCSOpsBlob(kMatchingTeamID, useraddr, usersize);
+      case santa::kCsopIdentity: return WriteCSOpsBlob(kMatchingSigningID, useraddr, usersize);
+      case santa::kCsopCDHash:
+        if (usersize != sizeof(kMatchingCDHashBytes)) {
+          return -1;
+        }
+        std::memcpy(useraddr, kMatchingCDHashBytes, sizeof(kMatchingCDHashBytes));
+        return 0;
+      case santa::kCsopStatus:
+        if (usersize != sizeof(uint32_t)) {
+          return -1;
+        }
+        *(uint32_t*)useraddr = CS_PLATFORM_BINARY;
+        return 0;
+      default: return -1;
+    }
   };
 
   env.pgid_for_pid = [fake](pid_t pid) -> pid_t {
@@ -179,7 +214,6 @@ static NSString* const kEditedCELExpr = @"euid == 1 ? REQUIRE_TOUCHID : ALLOWLIS
 
 static NSString* const kTimedRuleKillsStateKey = @"TimedRuleKills";
 static NSString* const kTMMStateKey = @"TMM";
-static NSString* const kTAMStateKey = @"TempAdmin";
 
 @interface SNTTimedRuleKillsTest : XCTestCase
 @property NSFileManager* fileMgr;
@@ -192,12 +226,23 @@ static NSString* const kTAMStateKey = @"TempAdmin";
 @property id mockNotifierQueue;
 @property id mockNotifierConnection;
 @property id mockNotifierProxy;
+/// The process group the one process in the fake world is in.
+@property pid_t matchingPgid;
 @end
 
-@implementation SNTTimedRuleKillsTest
+@implementation SNTTimedRuleKillsTest {
+  /// The faked syscalls the component's santa::KillEnv runs against, so the
+  /// production match and kill code runs against a world the test describes.
+  FakeEnv _fake;
+}
 
 - (void)setUp {
   [super setUp];
+
+  // A real pid that isn't ours, because the banner names it with real
+  // syscalls; the pgid is arbitrary, since every signal is faked.
+  self.matchingPgid = getpgrp() + 1;
+  _fake.AddMatching(getppid(), self.matchingPgid);
 
   self.fileMgr = [NSFileManager defaultManager];
   self.testDir = [NSString stringWithFormat:@"%@santa-timed-rule-kills-%d-%@",
@@ -251,9 +296,19 @@ static NSString* const kTAMStateKey = @"TempAdmin";
 - (SNTTimedRuleKills*)makeSUT {
   SNTTimedRuleKills* sut = [[SNTTimedRuleKills alloc] initWithNotifierQueue:self.mockNotifierQueue
                                                                   ruleTable:self.ruleTable
-                                                               configurator:self.configurator];
+                                                               configurator:self.configurator
+                                                                    killEnv:MakeEnv(&_fake)];
   XCTAssertNotNil(sut);
   return sut;
+}
+
+/// The two deliveries a kill makes to the matching process's group: SIGTERM,
+/// then SIGKILL to whatever survived the grace period.
+- (NSArray<NSString*>*)termThenKillOfTheProcessGroup {
+  return @[
+    [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid, SIGTERM],
+    [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid, SIGKILL],
+  ];
 }
 
 /// Wires up a notifier queue whose remote proxy is a protocol mock, the same
@@ -297,26 +352,15 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   return [NSDictionary dictionaryWithContentsOfFile:self.statePath];
 }
 
-/// Sets a kill block that records the requests it is handed and fulfills
-/// `expectation` for each one, without signaling anything.
-- (void)captureKillsOn:(SNTTimedRuleKills*)sut
-                  into:(NSMutableArray<SNTKillRequest*>*)requests
-           expectation:(XCTestExpectation*)expectation {
-  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
-    @synchronized(requests) {
-      [requests addObject:request];
-    }
-    [expectation fulfill];
-    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
-  };
-}
-
 /// Records every banner the component sends, in order, as
-/// @{@"app": ..., @"deadline": ...}, fulfilling `expectation` for each one.
-/// Pass a nil expectation when the test's point is that no banner arrives.
+/// @{@"app": ..., @"deadline": ..., @"signals": ...}, fulfilling `expectation`
+/// for each one. `signals` is how many deliveries the kill pass had already made
+/// when the banner went out, which is what an ordering test reads. Pass a nil
+/// expectation when the test's point is that no banner arrives.
 - (void)recordBannersOn:(id)proxy
                    into:(NSMutableArray<NSDictionary*>*)banners
             expectation:(XCTestExpectation*)expectation {
+  FakeEnv* fake = &_fake;
   OCMStub([proxy postTimedRuleKillNotificationForApplication:OCMOCK_ANY deadline:OCMOCK_ANY])
       .andDo(^(NSInvocation* invocation) {
         __unsafe_unretained NSString* app;
@@ -328,6 +372,7 @@ static NSString* const kTAMStateKey = @"TempAdmin";
         NSMutableDictionary* banner = [NSMutableDictionary dictionary];
         banner[@"app"] = app;
         banner[@"deadline"] = deadline;
+        banner[@"signals"] = @(fake->signals.size());
         @synchronized(banners) {
           [banners addObject:banner];
         }
@@ -397,50 +442,40 @@ static NSString* const kTAMStateKey = @"TempAdmin";
                     deadline:farther
                     notifyAt:[farther dateByAddingTimeInterval:-60]];
   [self drain:sut];
-  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqual(self.savedEntries.count, 1u, @"a later deadline");
   XCTAssertEqualWithAccuracy([self.savedEntries.firstObject[@"Deadline"] doubleValue],
                              near.timeIntervalSince1970, 0.001);
-  XCTAssertEqual(self.configurator.timedRuleKillWrites, 2u);
-}
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 2u, @"a later deadline");
 
-- (void)testRepeatedIdenticalRecordingWritesNothing {
-  SNTTimedRuleKills* sut = [self makeSUT];
-  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
-
+  // Re-recording the deadline that already governs is the common case of a
+  // binary executing repeatedly inside its window: nothing changes, so nothing
+  // is written.
   for (int i = 0; i < 5; i++) {
     [sut recordKillForRuleType:SNTRuleTypeTeamID
                     identifier:kMatchingTeamID
                        celHash:hash
-                      deadline:deadline
-                      notifyAt:[deadline dateByAddingTimeInterval:-60]];
+                      deadline:near
+                      notifyAt:[near dateByAddingTimeInterval:-60]];
   }
   [self drain:sut];
+  XCTAssertEqual(self.savedEntries.count, 1u, @"the same deadline again");
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 2u, @"the same deadline again");
 
-  XCTAssertEqual(self.savedEntries.count, 1u);
-  XCTAssertEqual(self.configurator.timedRuleKillWrites, 1u);
-}
-
-- (void)testDifferentCELHashIsADifferentEntry {
-  SNTTimedRuleKills* sut = [self makeSUT];
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
-
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
+  // A different CEL hash is a different key, so it is a second entry rather
+  // than an arbitration against the first.
   [sut recordKillForRuleType:SNTRuleTypeTeamID
                   identifier:kMatchingTeamID
                      celHash:[SNTTimedRuleKills celHashForExpression:kEditedCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
+                    deadline:farther
+                    notifyAt:[farther dateByAddingTimeInterval:-60]];
   [self drain:sut];
-
-  XCTAssertEqual(self.savedEntries.count, 2u);
+  XCTAssertEqual(self.savedEntries.count, 2u, @"a different CEL hash");
+  XCTAssertEqual(self.configurator.timedRuleKillWrites, 3u, @"a different CEL hash");
 }
 
-- (void)testBinaryAndCertificateRuleTypesAreRefused {
+// Both guards on the recording path: rule types no kill request can be built
+// for, and each field the completeness check requires.
+- (void)testUnsupportedAndIncompleteRecordingsAreRefused {
   SNTTimedRuleKills* sut = [self makeSUT];
   NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
   NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
@@ -455,17 +490,6 @@ static NSString* const kTAMStateKey = @"TempAdmin";
                      celHash:hash
                     deadline:deadline
                     notifyAt:deadline];
-  [self drain:sut];
-
-  XCTAssertNil(self.savedEntries);
-  XCTAssertEqual(self.configurator.timedRuleKillWrites, 0u);
-}
-
-- (void)testIncompleteRecordingsAreRefused {
-  SNTTimedRuleKills* sut = [self makeSUT];
-  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
-
   [sut recordKillForRuleType:SNTRuleTypeTeamID
                   identifier:@""
                      celHash:hash
@@ -481,9 +505,15 @@ static NSString* const kTAMStateKey = @"TempAdmin";
                      celHash:hash
                     deadline:nil
                     notifyAt:deadline];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:deadline
+                    notifyAt:nil];
   [self drain:sut];
 
-  XCTAssertNil(self.savedEntries);
+  XCTAssertNil(self.savedEntries, @"one of: BINARY, CERTIFICATE, empty identifier, nil celHash, "
+                                  @"nil deadline, nil notifyAt");
   XCTAssertEqual(self.configurator.timedRuleKillWrites, 0u);
 }
 
@@ -491,8 +521,6 @@ static NSString* const kTAMStateKey = @"TempAdmin";
 
 - (void)testEntryWritesPreserveOtherStateKeys {
   [self.configurator persistTimedSessionState:@{@"Deadline" : @123} forKey:kTMMStateKey];
-  [self.configurator persistTimedSessionState:@{@"Deadline" : @456} forKey:kTAMStateKey];
-  XCTAssertTrue([self.configurator persistDemotedAdmins:@[ @{@"Username" : @"jane"} ]]);
 
   SNTTimedRuleKills* sut = [self makeSUT];
   [sut recordKillForRuleType:SNTRuleTypeTeamID
@@ -504,216 +532,117 @@ static NSString* const kTAMStateKey = @"TempAdmin";
 
   NSDictionary* onDisk = [self rawStateFile];
   XCTAssertEqualObjects(onDisk[kTMMStateKey], (@{@"Deadline" : @123}));
-  XCTAssertEqualObjects(onDisk[kTAMStateKey], (@{@"Deadline" : @456}));
-  XCTAssertEqualObjects(onDisk[@"DemotedAdmins"], (@[ @{@"Username" : @"jane"} ]));
-  XCTAssertNotNil(onDisk[@"LastBootUUID"]);
   XCTAssertEqual([onDisk[kTimedRuleKillsStateKey] count], 1u);
 }
 
-- (void)testEntriesSurviveReloadAndUnknownKeysStillDoNot {
+- (void)testEntriesSurviveReloadButAWrongTypedValueDoesNot {
   NSDictionary* entry = [self entryDictForRuleType:SNTRuleTypeTeamID
                                         identifier:kMatchingTeamID
                                            celHash:@"abc"
                                           deadline:[NSDate dateWithTimeIntervalSinceNow:3600]];
-  NSDictionary* onDisk = @{
-    kTimedRuleKillsStateKey : @[ entry ],
-    kTMMStateKey : @{@"Deadline" : @1},
-    @"Bogus" : @"unknown",
-  };
-  XCTAssertTrue([onDisk writeToFile:self.statePath atomically:YES]);
+  XCTAssertTrue([@{kTimedRuleKillsStateKey : @[ entry ]} writeToFile:self.statePath
+                                                          atomically:YES]);
+  XCTAssertEqual([[self makeConfigurator] savedTimedRuleKills].count, 1u);
 
-  CountingConfigurator* reloaded = [self makeConfigurator];
-  XCTAssertEqual([reloaded savedTimedRuleKills].count, 1u);
-  XCTAssertNotNil([reloaded savedTimedSessionStateForKey:kTMMStateKey]);
-  XCTAssertNil([reloaded savedTimedSessionStateForKey:@"Bogus"]);
-
-  // A value of the wrong type under the key is stripped by the allowlist too.
+  // A value of the wrong type under the key is stripped by the allowlist.
   NSDictionary* wrongType = @{kTimedRuleKillsStateKey : @"not-an-array"};
   XCTAssertTrue([wrongType writeToFile:self.statePath atomically:YES]);
   XCTAssertNil([[self makeConfigurator] savedTimedRuleKills]);
 }
 
-- (void)testEntryIsRemovedAndPersistedAfterFiring {
-  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
-
-  [self waitForExpectations:@[ killed ] timeout:10];
-  [self drain:sut];
-
-  XCTAssertEqual(requests.count, 1u);
-  XCTAssertNil(self.savedEntries);
-  XCTAssertNil([self rawStateFile][kTimedRuleKillsStateKey]);
-}
-
 #pragma mark The kill
 
-- (void)testTeamIDKillRequestTargetsProcessGroups {
+// Every rule type builds a different kill request, and each must quit the
+// process group of what it matches: SIGTERM, five seconds, then SIGKILL to
+// whatever is still there. The rows are not interchangeable: the `platform:`
+// SIGNINGID one is the only end-to-end cover of the flags-plus-signingID split,
+// since the whole identifier is not an identity anything reports.
+- (void)testEachRuleTypeTermsThenKillsTheProcessGroup {
+  NSArray<NSArray*>* rows = @[
+    @[ @(SNTRuleTypeTeamID), kMatchingTeamID ],
+    @[ @(SNTRuleTypeSigningID), [NSString stringWithFormat:@"platform:%@", kMatchingSigningID] ],
+    @[ @(SNTRuleTypeCDHash), kMatchingCDHash ],
+  ];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  for (NSArray* row in rows) {
+    SNTRuleType type = (SNTRuleType)[row[0] integerValue];
+    NSString* identifier = row[1];
+    _fake.signals.clear();
+    _fake.waits.clear();
+    [self addRuleOfType:type identifier:identifier cel:kCELExpr];
+
+    NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+    [sut recordKillForRuleType:type
+                    identifier:identifier
+                       celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                      deadline:deadline
+                      notifyAt:deadline];
+    [self waitForEntriesToClear:sut];
+    [self drain:sut];
+
+    XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup],
+                          @"%@", identifier);
+    XCTAssertEqual(_fake.waits.size(), 1u, @"%@", identifier);
+    XCTAssertEqualWithAccuracy(_fake.waits.front(), 5.0, 0.001);
+    // The clear reached disk, not just the configurator's in-memory state.
+    XCTAssertNil([self rawStateFile][kTimedRuleKillsStateKey], @"%@", identifier);
+  }
+}
+
+// Two deadlines landing in one pass share one grace period: every due entry
+// is collected into a single kill call. Both rules cover the one process, so
+// the shared group is also signaled once per pass.
+- (void)testDeadlinesInOnePassShareTheGracePeriod {
+  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
+  [self addRuleOfType:SNTRuleTypeCDHash identifier:kMatchingCDHash cel:kCELExpr];
+
+  SNTTimedRuleKills* sut = [self makeSUT];
+  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
+  NSDate* due = [NSDate dateWithTimeIntervalSinceNow:0.5];
+  [sut recordKillForRuleType:SNTRuleTypeTeamID
+                  identifier:kMatchingTeamID
+                     celHash:hash
+                    deadline:due
+                    notifyAt:due];
+  [sut recordKillForRuleType:SNTRuleTypeCDHash
+                  identifier:kMatchingCDHash
+                     celHash:hash
+                    deadline:due
+                    notifyAt:due];
+
+  [self waitForEntriesToClear:sut];
+  [self drain:sut];
+
+  XCTAssertEqual(_fake.waits.size(), 1u);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+}
+
+// Both branches of the fire-time re-check, in one pass: the CDHash entry's rule
+// was never added (gone), and the TeamID entry was recorded against text the
+// added rule does not hold (edited). Either one failing to drop signals.
+- (void)testRuleThatIsGoneOrEditedDropsTheEntryWithoutKilling {
   [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
 
   SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
-  [self waitForExpectations:@[ killed ] timeout:10];
-
-  XCTAssertEqual(requests.count, 1u);
-  XCTAssertTrue([requests.firstObject isKindOfClass:[SNTKillRequestTeamID class]]);
-  XCTAssertEqualObjects(((SNTKillRequestTeamID*)requests.firstObject).teamID, kMatchingTeamID);
-  XCTAssertTrue(requests.firstObject.targetProcessGroups);
-}
-
-- (void)testPlatformSigningIDKillRequest {
-  [self addRuleOfType:SNTRuleTypeSigningID identifier:@"platform:com.apple.ls" cel:kCELExpr];
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
-  [sut recordKillForRuleType:SNTRuleTypeSigningID
-                  identifier:@"platform:com.apple.ls"
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
-  [self waitForExpectations:@[ killed ] timeout:10];
-
-  XCTAssertEqual(requests.count, 1u);
-  SNTKillRequestSigningID* request = (SNTKillRequestSigningID*)requests.firstObject;
-  XCTAssertTrue([request isKindOfClass:[SNTKillRequestSigningID class]]);
-  XCTAssertEqualObjects(request.teamID, @"platform");
-  XCTAssertEqualObjects(request.signingID, @"com.apple.ls");
-  XCTAssertTrue(request.targetProcessGroups);
-}
-
-- (void)testCDHashKillRequest {
-  NSString* cdhash = @"deadbeefcafebabe0123456789abcdeffedcba98";
-  [self addRuleOfType:SNTRuleTypeCDHash identifier:cdhash cel:kCELExpr];
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
   NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
   [sut recordKillForRuleType:SNTRuleTypeCDHash
-                  identifier:cdhash
+                  identifier:kMatchingCDHash
                      celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
                     deadline:deadline
                     notifyAt:deadline];
-  [self waitForExpectations:@[ killed ] timeout:10];
-
-  XCTAssertEqual(requests.count, 1u);
-  XCTAssertTrue([requests.firstObject isKindOfClass:[SNTKillRequestCDHash class]]);
-  XCTAssertEqualObjects(((SNTKillRequestCDHash*)requests.firstObject).cdhash, cdhash);
-  XCTAssertTrue(requests.firstObject.targetProcessGroups);
-}
-
-- (void)testSIGTERMThenSIGKILLWithFiveSecondGrace {
-  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
-
-  pid_t pgid = getpgrp() + 1;
-
-  FakeEnv fake;
-  fake.pids = {100};
-  fake.pidversions = {{100, 1}};
-  fake.matching = {100};
-  fake.pgids = {{100, pgid}};
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  // A block captures a C++ object by const copy, so the fake is reached
-  // through a pointer; it outlives the block, which runs before the wait below
-  // returns.
-  FakeEnv* fakePtr = &fake;
-  // The seam routes into the real term-then-kill against a fully faked
-  // KillEnv, so the ordering under test is the production one.
-  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
-    santa::KillEnv env = MakeEnv(fakePtr);
-    SNTKillResponse* response = santa::KillingMachineTermThenKill(request, grace, env);
-    [killed fulfill];
-    return response;
-  };
-
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
   [sut recordKillForRuleType:SNTRuleTypeTeamID
                   identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
-  [self waitForExpectations:@[ killed ] timeout:10];
-
-  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
-                          [NSString stringWithFormat:@"group:%d:%d", pgid, SIGTERM],
-                          [NSString stringWithFormat:@"group:%d:%d", pgid, SIGKILL],
-                        ]));
-  XCTAssertEqual(fake.waits.size(), 1u);
-  XCTAssertEqualWithAccuracy(fake.waits.front(), 5.0, 0.001);
-}
-
-- (void)testRemovedRuleDropsTheEntryWithoutKilling {
-  // No rule is ever added, so the fire-time re-check finds nothing.
-  SNTTimedRuleKills* sut = [self makeSUT];
-  __block BOOL killCalled = NO;
-  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
-    killCalled = YES;
-    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
-  };
-
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
+                     celHash:[SNTTimedRuleKills celHashForExpression:kEditedCELExpr]
                     deadline:deadline
                     notifyAt:deadline];
   [self drain:sut];
-  XCTAssertEqual(self.savedEntries.count, 1u);
+  XCTAssertEqual(self.savedEntries.count, 2u);
 
-  [self waitForEntriesToClear];
-  XCTAssertFalse(killCalled);
-}
-
-- (void)testEditedRuleDropsTheEntryWithoutKilling {
-  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  __block BOOL killCalled = NO;
-  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
-    killCalled = YES;
-    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
-  };
-
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
+  [self waitForEntriesToClear:sut];
   [self drain:sut];
-
-  // The rule's text changes between recording and firing.
-  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kEditedCELExpr];
-
-  [self waitForEntriesToClear];
-  XCTAssertFalse(killCalled);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), @[],
+                        @"a rule that is gone or edited has no kill coming");
 }
 
 #pragma mark The warning banner
@@ -726,11 +655,6 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
   NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
   [self recordBannersOn:proxy into:banners expectation:posted];
-  // Nothing a test runs can be made to match a rule, so the match is faked.
-  // Naming the pid it returns is the production path.
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    return @(getpid());
-  };
 
   NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3600];
   [sut recordKillForRuleType:SNTRuleTypeTeamID
@@ -750,6 +674,8 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   XCTAssertNotEqualObjects(banners.firstObject[@"app"], kMatchingTeamID);
   XCTAssertEqualWithAccuracy([banners.firstObject[@"deadline"] timeIntervalSince1970],
                              deadline.timeIntervalSince1970, 0.001);
+  // The warning is the match pass on its own: nothing was signaled.
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), @[]);
 
   // The entry is still pending, now marked warned on disk so a restart doesn't
   // warn again.
@@ -761,15 +687,15 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
   id proxy = [self setUpNotifierProxy];
 
+  // The one matching process is a pid nothing can be read for, which is what a
+  // process that exited between the match and the banner looks like.
+  _fake = FakeEnv();
+  _fake.AddMatching(99999999, self.matchingPgid);
+
   SNTTimedRuleKills* sut = [self makeSUT];
   XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
   NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
   [self recordBannersOn:proxy into:banners expectation:posted];
-  // A pid nothing can be read for, which is what a process that exited between
-  // the match and the banner looks like.
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    return @(99999999);
-  };
 
   [sut recordKillForRuleType:SNTRuleTypeTeamID
                   identifier:kMatchingTeamID
@@ -787,12 +713,12 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
   id proxy = [self setUpNotifierProxy];
 
+  // Nothing is running at all, so the match pass finds nothing.
+  _fake = FakeEnv();
+
   SNTTimedRuleKills* sut = [self makeSUT];
   NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
   [self recordBannersOn:proxy into:banners expectation:nil];
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    return nil;
-  };
 
   [sut recordKillForRuleType:SNTRuleTypeTeamID
                   identifier:kMatchingTeamID
@@ -800,7 +726,11 @@ static NSString* const kTAMStateKey = @"TempAdmin";
                     deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
                     notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.3]];
 
-  [self waitForTheWarningPass];
+  [self
+      waitUntil:^BOOL {
+        return [self.savedEntries.firstObject[@"Notified"] boolValue];
+      }
+      described:@"warning pass ran"];
   [self drain:sut];
 
   XCTAssertEqual(banners.count, 0u);
@@ -809,67 +739,17 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   XCTAssertTrue([self.savedEntries.firstObject[@"Notified"] boolValue]);
 }
 
-- (void)testOneWarningPerRuleAndDeadline {
-  // Two entries, so the warning pass comes back over the first one.
-  NSString* cdhash = @"deadbeefcafebabe0123456789abcdeffedcba98";
-  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
-  [self addRuleOfType:SNTRuleTypeCDHash identifier:cdhash cel:kCELExpr];
-  id proxy = [self setUpNotifierProxy];
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* posted = [self expectationWithDescription:@"two banners"];
-  posted.expectedFulfillmentCount = 2;
-  posted.assertForOverFulfill = YES;
-  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
-  [self recordBannersOn:proxy into:banners expectation:posted];
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    return @(getpid());
-  };
-
-  NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
-  NSDate* firstDeadline = [NSDate dateWithTimeIntervalSinceNow:3600];
-  NSDate* secondDeadline = [NSDate dateWithTimeIntervalSinceNow:7200];
-
-  // Already past, so the first warning goes out as soon as it is recorded.
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:hash
-                    deadline:firstDeadline
-                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:-10]];
-  // A later warning, which is what brings the pass back over the first entry.
-  [sut recordKillForRuleType:SNTRuleTypeCDHash
-                  identifier:cdhash
-                     celHash:hash
-                    deadline:secondDeadline
-                    notifyAt:[NSDate dateWithTimeIntervalSinceNow:0.7]];
-
-  [self waitForExpectations:@[ posted ] timeout:10];
-  [self drain:sut];
-
-  NSCountedSet* deadlines = [NSCountedSet set];
-  for (NSDictionary* banner in banners) {
-    [deadlines addObject:banner[@"deadline"]];
-  }
-  XCTAssertEqual(banners.count, 2u);
-  XCTAssertEqual([deadlines countForObject:firstDeadline], 1u);
-  XCTAssertEqual([deadlines countForObject:secondDeadline], 1u);
-}
-
 // A rule withdrawn during the lead window has no kill coming, so warning about
 // it would promise a quit that never happens. The entry goes at warning time
 // rather than sitting until a deadline it will never act on.
 - (void)testNoWarningWhenTheRuleIsGoneAndTheEntryIsDropped {
-  // No rule is ever added, so the warning-time re-check finds nothing.
+  // No rule is ever added, so the warning-time re-check finds nothing. The
+  // fake process would match if the pass ever got as far as looking.
   id proxy = [self setUpNotifierProxy];
 
   SNTTimedRuleKills* sut = [self makeSUT];
   NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
   [self recordBannersOn:proxy into:banners expectation:nil];
-  __block BOOL snapshotTaken = NO;
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    snapshotTaken = YES;
-    return @(getpid());
-  };
 
   [sut recordKillForRuleType:SNTRuleTypeTeamID
                   identifier:kMatchingTeamID
@@ -880,76 +760,24 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   XCTAssertEqual(self.savedEntries.count, 1u);
 
   // Cleared at warning time, an hour before the deadline it was recorded for.
-  [self waitForEntriesToClear];
+  [self waitForEntriesToClear:sut];
 
-  XCTAssertEqual(banners.count, 0u);
-  XCTAssertFalse(snapshotTaken, @"snapshot taken for a rule that no longer governs");
-}
-
-- (void)testWarningIsSkippedWhenTheDeadlineIsAlreadyDue {
-  [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
-  id proxy = [self setUpNotifierProxy];
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
-  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
-  [self recordBannersOn:proxy into:banners expectation:nil];
-  __block BOOL snapshotTaken = NO;
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    snapshotTaken = YES;
-    return @(getpid());
-  };
-
-  // Warning time and deadline land in the same pass.
-  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
-  [sut recordKillForRuleType:SNTRuleTypeTeamID
-                  identifier:kMatchingTeamID
-                     celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                    deadline:deadline
-                    notifyAt:deadline];
-
-  [self waitForExpectations:@[ killed ] timeout:10];
-  [self drain:sut];
-
-  XCTAssertEqual(requests.count, 1u);
-  XCTAssertFalse(snapshotTaken, @"snapshot taken for an entry that was already being killed");
   XCTAssertEqual(banners.count, 0u);
 }
 
 - (void)testWarningNeverDelaysTheKill {
-  NSString* cdhash = @"deadbeefcafebabe0123456789abcdeffedcba98";
   [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID cel:kCELExpr];
-  [self addRuleOfType:SNTRuleTypeCDHash identifier:cdhash cel:kCELExpr];
-  [self setUpNotifierProxy];
+  [self addRuleOfType:SNTRuleTypeCDHash identifier:kMatchingCDHash cel:kCELExpr];
+  id proxy = [self setUpNotifierProxy];
 
   SNTTimedRuleKills* sut = [self makeSUT];
-  NSMutableArray<NSString*>* order = [NSMutableArray array];
-
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
-    @synchronized(order) {
-      [order addObject:@"kill"];
-    }
-    [killed fulfill];
-    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
-  };
-
-  // A slow snapshot: taken before the kill it would hold the kill for a second.
-  XCTestExpectation* snapshotted = [self expectationWithDescription:@"snapshot taken"];
-  // Taking more snapshots than expected is what a regression here looks like;
-  // let `order` be the thing that reports it.
-  snapshotted.assertForOverFulfill = NO;
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    @synchronized(order) {
-      [order addObject:@"match"];
-    }
-    [NSThread sleepForTimeInterval:1.0];
-    [snapshotted fulfill];
-    return nil;
-  };
+  XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
+  // Warning the entry that is being killed is what a regression here looks
+  // like, and an over-fulfilled expectation aborts the whole process; let the
+  // assertions below report it instead.
+  posted.assertForOverFulfill = NO;
+  NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
+  [self recordBannersOn:proxy into:banners expectation:posted];
 
   NSString* hash = [SNTTimedRuleKills celHashForExpression:kCELExpr];
   NSDate* due = [NSDate dateWithTimeIntervalSinceNow:0.5];
@@ -960,13 +788,19 @@ static NSString* const kTAMStateKey = @"TempAdmin";
                     deadline:[NSDate dateWithTimeIntervalSinceNow:3600]
                     notifyAt:due];
   [sut recordKillForRuleType:SNTRuleTypeCDHash
-                  identifier:cdhash
+                  identifier:kMatchingCDHash
                      celHash:hash
                     deadline:due
                     notifyAt:due];
 
-  [self waitForExpectations:@[ killed, snapshotted ] timeout:10];
-  XCTAssertEqualObjects(order, (@[ @"kill", @"match" ]));
+  [self waitForExpectations:@[ posted ] timeout:10];
+  [self drain:sut];
+
+  // Both of the kill's deliveries were already out when the banner went, so
+  // the process snapshot behind the warning never held the kill up.
+  XCTAssertEqual(banners.count, 1u);
+  XCTAssertEqualObjects(banners.firstObject[@"signals"], @2);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
 }
 
 #pragma mark Restart
@@ -986,16 +820,12 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   SNTTimedRuleKills* sut = [self makeSUT];
   NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
   [self recordBannersOn:proxy into:banners expectation:nil];
-  __block BOOL snapshotTaken = NO;
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    snapshotTaken = YES;
-    return @(getpid());
-  };
 
   [sut resumeFromSavedState];
   [self drain:sut];
 
-  XCTAssertFalse(snapshotTaken);
+  // The fake process matches the entry's rule, so the only reason no banner
+  // went out is the flag the entry was restored with.
   XCTAssertEqual(banners.count, 0u);
   XCTAssertEqual(self.savedEntries.count, 1u);
 }
@@ -1022,9 +852,6 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   XCTestExpectation* posted = [self expectationWithDescription:@"banner sent"];
   NSMutableArray<NSDictionary*>* banners = [NSMutableArray array];
   [self recordBannersOn:proxy into:banners expectation:posted];
-  sut.matchBlock = ^NSNumber*(SNTKillRequest* request) {
-    return @(getpid());
-  };
 
   // Not throwing here is the point: the malformed Notified was guarded, not sent
   // -boolValue.
@@ -1049,37 +876,11 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   ]]);
 
   SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
   [sut resumeFromSavedState];
 
-  [self waitForExpectations:@[ killed ] timeout:10];
+  [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqual(requests.count, 1u);
-  XCTAssertNil(self.savedEntries);
-}
-
-- (void)testRestartDropsPastDueEntryWhoseRuleIsGone {
-  XCTAssertTrue([self.configurator persistTimedRuleKills:@[
-    [self entryDictForRuleType:SNTRuleTypeTeamID
-                    identifier:kMatchingTeamID
-                       celHash:[SNTTimedRuleKills celHashForExpression:kCELExpr]
-                      deadline:[NSDate dateWithTimeIntervalSinceNow:-3600]]
-  ]]);
-
-  SNTTimedRuleKills* sut = [self makeSUT];
-  __block BOOL killCalled = NO;
-  sut.killBlock = ^SNTKillResponse*(SNTKillRequest* request, NSTimeInterval grace) {
-    killCalled = YES;
-    return [[SNTKillResponse alloc] initWithKilledProcesses:@[]];
-  };
-
-  [sut resumeFromSavedState];
-  [self drain:sut];
-
-  XCTAssertFalse(killCalled);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
   XCTAssertNil(self.savedEntries);
 }
 
@@ -1093,17 +894,14 @@ static NSString* const kTAMStateKey = @"TempAdmin";
   ]]);
 
   SNTTimedRuleKills* sut = [self makeSUT];
-  XCTestExpectation* killed = [self expectationWithDescription:@"kill ran"];
-  NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
-  [self captureKillsOn:sut into:requests expectation:killed];
-
   [sut resumeFromSavedState];
   [self drain:sut];
   // Not due yet: still pending, waiting on the restored timer.
   XCTAssertEqual(self.savedEntries.count, 1u);
 
-  [self waitForExpectations:@[ killed ] timeout:10];
-  XCTAssertEqual(requests.count, 1u);
+  [self waitForEntriesToClear:sut];
+  [self drain:sut];
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
 }
 
 - (void)testRestartDropsMalformedEntries {
@@ -1150,23 +948,16 @@ static NSString* const kTAMStateKey = @"TempAdmin";
 }
 
 /// Polls until the component has cleared its persisted entries, which happens
-/// once every recorded deadline has been processed.
-- (void)waitForEntriesToClear {
+/// once every recorded deadline has been processed. Drains first: a record is
+/// asynchronous, and "no entries persisted" is also true before its write lands,
+/// so polling straight away can pass before the deadline was ever processed.
+- (void)waitForEntriesToClear:(SNTTimedRuleKills*)sut {
+  [self drain:sut];
   [self
       waitUntil:^BOOL {
         return self.savedEntries == nil;
       }
       described:@"entries cleared"];
-}
-
-/// Polls until the component has recorded that it ran the warning pass for its
-/// single pending entry.
-- (void)waitForTheWarningPass {
-  [self
-      waitUntil:^BOOL {
-        return [self.savedEntries.firstObject[@"Notified"] boolValue];
-      }
-      described:@"warning pass ran"];
 }
 
 @end

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -101,8 +101,10 @@ class SantadDeps {
   SNTSyncdQueue* syncd_queue_;
   SNTNetworkExtensionQueue* netext_queue_;
   SNTExecutionController* exec_controller_;
-  // Held here so the component outlives Create(); the exec path takes it from
-  // the accessor once there is something recording entries.
+  // Held here so the component outlives Create(): it keeps only weak references
+  // to itself, so without this nothing retains it and every restored deadline
+  // is dropped. The accessor is the exec path's wiring point, and is also what
+  // keeps this field from tripping -Wunused-private-field until then.
   SNTTimedRuleKills* timed_rule_kills_;
   std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree_;
   std::shared_ptr<santa::TTYWriter> tty_writer_;

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -39,6 +39,7 @@
 #import "Source/santad/SNTNetworkExtensionQueue.h"
 #import "Source/santad/SNTNotificationQueue.h"
 #import "Source/santad/SNTSyncdQueue.h"
+#import "Source/santad/SNTTimedRuleKills.h"
 #include "Source/santad/SandboxExpectations.h"
 #include "Source/santad/TTYWriter.h"
 
@@ -61,6 +62,7 @@ class SantadDeps {
       SNTNotificationQueue* notifier_queue, SNTSyncdQueue* syncd_queue,
       SNTNetworkExtensionQueue* netext_queue,
       SNTExecutionController* exec_controller,
+      SNTTimedRuleKills* timed_rule_kills,
       std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree,
       std::shared_ptr<santa::TTYWriter> tty_writer,
       std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree,
@@ -79,6 +81,7 @@ class SantadDeps {
   SNTSyncdQueue* SyncdQueue();
   SNTNetworkExtensionQueue* NetworkExtensionQueue();
   SNTExecutionController* ExecController();
+  SNTTimedRuleKills* TimedRuleKills();
   std::shared_ptr<santa::PrefixTree<santa::Unit>> PrefixTree();
   std::shared_ptr<santa::TTYWriter> TTYWriter();
   std::shared_ptr<santa::santad::process_tree::ProcessTree> ProcessTree();
@@ -98,6 +101,9 @@ class SantadDeps {
   SNTSyncdQueue* syncd_queue_;
   SNTNetworkExtensionQueue* netext_queue_;
   SNTExecutionController* exec_controller_;
+  // Held here so the component outlives Create(); the exec path takes it from
+  // the accessor once there is something recording entries.
+  SNTTimedRuleKills* timed_rule_kills_;
   std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree_;
   std::shared_ptr<santa::TTYWriter> tty_writer_;
   std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree_;

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -39,6 +39,7 @@
 #import "Source/santad/SNTDecisionCache.h"
 #import "Source/santad/SNTNetworkExtensionQueue.h"
 #import "Source/santad/SNTPolicyProcessor.h"
+#import "Source/santad/SNTTimedRuleKills.h"
 #include "Source/santad/SignalScanner.h"
 #include "Source/santad/SleighLauncher.h"
 #include "Source/santad/TTYWriter.h"
@@ -98,6 +99,19 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator* configurator,
     LOGE(@"Failed to initialize notification queue.");
     exit(EXIT_FAILURE);
   }
+
+  // Owns the kills asked for by CEL rules using policy_for_range(...,
+  // should_kill=true). Nothing records entries yet, so the only thing it does
+  // in production today is settle the entries a previous daemon left behind.
+  SNTTimedRuleKills* timed_rule_kills =
+      [[SNTTimedRuleKills alloc] initWithNotifierQueue:notifier_queue
+                                             ruleTable:rule_table
+                                          configurator:configurator];
+  if (!timed_rule_kills) {
+    LOGE(@"Failed to initialize timed rule kills.");
+    exit(EXIT_FAILURE);
+  }
+  [timed_rule_kills resumeFromSavedState];
 
   SNTSyncdQueue* syncd_queue = [[SNTSyncdQueue alloc] initWithCacheSize:1024];
   if (!syncd_queue) {
@@ -285,8 +299,8 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator* configurator,
   return std::make_unique<SantadDeps>(
       esapi, logger, std::move(metrics), std::move(watch_items), std::move(auth_result_cache),
       control_connection, compiler_controller, notifier_queue, syncd_queue, netext_queue,
-      exec_controller, prefix_tree, std::move(tty_writer), std::move(process_tree),
-      std::move(entitlements_filter), std::move(sandbox_expectations));
+      exec_controller, timed_rule_kills, prefix_tree, std::move(tty_writer),
+      std::move(process_tree), std::move(entitlements_filter), std::move(sandbox_expectations));
 }
 
 SantadDeps::SantadDeps(
@@ -295,8 +309,8 @@ SantadDeps::SantadDeps(
     std::shared_ptr<santa::AuthResultCache> auth_result_cache, MOLXPCConnection* control_connection,
     SNTCompilerController* compiler_controller, SNTNotificationQueue* notifier_queue,
     SNTSyncdQueue* syncd_queue, SNTNetworkExtensionQueue* netext_queue,
-    SNTExecutionController* exec_controller, std::shared_ptr<::PrefixTree<Unit>> prefix_tree,
-    std::shared_ptr<::TTYWriter> tty_writer,
+    SNTExecutionController* exec_controller, SNTTimedRuleKills* timed_rule_kills,
+    std::shared_ptr<::PrefixTree<Unit>> prefix_tree, std::shared_ptr<::TTYWriter> tty_writer,
     std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree,
     std::shared_ptr<santa::EntitlementsFilter> entitlements_filter,
     std::shared_ptr<santa::SandboxExpectations> sandbox_expectations)
@@ -312,6 +326,7 @@ SantadDeps::SantadDeps(
       syncd_queue_(syncd_queue),
       netext_queue_(netext_queue),
       exec_controller_(exec_controller),
+      timed_rule_kills_(timed_rule_kills),
       prefix_tree_(prefix_tree),
       tty_writer_(std::move(tty_writer)),
       process_tree_(std::move(process_tree)),
@@ -363,6 +378,10 @@ SNTNetworkExtensionQueue* SantadDeps::NetworkExtensionQueue() {
 
 SNTExecutionController* SantadDeps::ExecController() {
   return exec_controller_;
+}
+
+SNTTimedRuleKills* SantadDeps::TimedRuleKills() {
+  return timed_rule_kills_;
 }
 
 std::shared_ptr<PrefixTree<Unit>> SantadDeps::PrefixTree() {

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -102,11 +102,13 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator* configurator,
 
   // Owns the kills asked for by CEL rules using policy_for_range(...,
   // should_kill=true). Nothing records entries yet, so the only thing it does
-  // in production today is settle the entries a previous daemon left behind.
+  // in production today is settle the entries a previous daemon left behind. A
+  // default-constructed KillEnv is the real syscalls.
   SNTTimedRuleKills* timed_rule_kills =
       [[SNTTimedRuleKills alloc] initWithNotifierQueue:notifier_queue
                                              ruleTable:rule_table
-                                          configurator:configurator];
+                                          configurator:configurator
+                                               killEnv:santa::KillEnv()];
   if (!timed_rule_kills) {
     LOGE(@"Failed to initialize timed rule kills.");
     exit(EXIT_FAILURE);


### PR DESCRIPTION
Stacked on #1152 

Note to reviewers: over half the diff is a single test suite, the new change is `SNTTimedRuleKills` plus small wiring (~660 lines)

New component that quits processes when
their policy_for_range window closes. Nothing records entries yet; that isthe next PR, so this still is inert. 

- SNTTimedRuleKills: one persisted entry per rule (state.plist, same
  per-key accessors as the temporary-mode keys), a wall-clock timer, a
  pre-quit banner at the warning time, and at the deadline a rule
  re-check followed by term-then-kill of matching process groups.
  BINARY and CERTIFICATE rules log and skip.
- SNTConfigurator gains the TimedRuleKills state key; SantadDeps wires
  the component up.
- Most of the diff is tests: 1172 of 1942 added lines, 28 tests covering
  persistence, restart, rule edits, and kill ordering.
  
Part of SNT-532