### PR TITLE
MOLCodesignChecker: Detect platform binaries without a platform identifier

### DIFF
--- a/Source/common/MOLCodesignChecker.h
+++ b/Source/common/MOLCodesignChecker.h
@@ -90,7 +90,15 @@
 /** The developer provided signing ID for this binary. */
 @property(readonly) NSString* signingID;
 
-/** Whether or not this binary is considered a platform binary (i.e. part of the OS) */
+/**
+  Whether or not this binary is considered a platform binary, i.e. Apple's own code.
+
+  This is the static equivalent of the kernel's `CS_PLATFORM_BINARY` (surfaced by
+  EndpointSecurity as `es_process_t.is_platform_binary`), and covers both binaries shipped in the
+  OS image and Apple software delivered separately, such as Xcode from the developer portal or the
+  Command Line Tools. Code signed for the Mac App Store or with a Developer ID is not platform
+  code, even when Apple is the signer.
+*/
 @property(readonly) BOOL platformBinary;
 
 /** The entitlements encoded in this binary. */

--- a/Source/common/MOLCodesignChecker.mm
+++ b/Source/common/MOLCodesignChecker.mm
@@ -63,6 +63,30 @@ static const SecCSFlags kStaticSigningFlags =
 */
 static const SecCSFlags kSigningFlags = kSecCSDefaultFlags;
 
+/**
+  The `anchor apple` requirement, used to identify Apple's own platform code.
+
+  A CodeDirectory platform identifier is only stamped on binaries shipped in the OS image, but the
+  kernel reports `CS_PLATFORM_BINARY` for all code AMFI recognizes as Apple's own — including Apple
+  software delivered separately, such as Xcode from the developer portal, the Command Line Tools
+  and the contents of /Library/Apple. Those carry no platform identifier, so the identifier alone
+  under-reports platform code relative to EndpointSecurity's `is_platform_binary`.
+
+  `anchor apple` is the OS-provided equivalent: it is satisfied when the cdhash is in AMFI's trust
+  cache, or when the code is signed by Apple's internal code signing chain. Note this is stricter
+  than `anchor apple generic`, which also matches Developer ID and Mac App Store signatures; an
+  App Store copy of Xcode is not platform code, and neither the kernel nor this requirement treats
+  it as such.
+*/
+static SecRequirementRef PlatformBinaryRequirement(void) {
+  static SecRequirementRef requirement;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    SecRequirementCreateWithString(CFSTR("anchor apple"), kSecCSDefaultFlags, &requirement);
+  });
+  return requirement;
+}
+
 NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcodesignchecker";
 
 @interface MOLCodesignChecker ()
@@ -78,6 +102,9 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 // The flags this instance validates on-disk code with. kStaticSigningFlags unless the caller asked
 // for something else. Has no effect on in-memory (SecCodeRef) checks, which use kSigningFlags.
 @property SecCSFlags staticSigningFlags;
+
+// Cached result of -platformBinary. Nil until first computed.
+@property NSNumber* cachedPlatformBinary;
 
 - (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef
                               binaryPath:(NSString*)binaryPath
@@ -373,9 +400,32 @@ NSString* const kMOLCodesignCheckerErrorDomain = @"com.northpolesec.santa.molcod
 }
 
 - (BOOL)platformBinary {
+  if (!_cachedPlatformBinary) {
+    _cachedPlatformBinary = @([self computePlatformBinary]);
+  }
+  return _cachedPlatformBinary.boolValue;
+}
+
+- (BOOL)computePlatformBinary {
+  // Binaries shipped in the OS image carry a non-zero CodeDirectory platform identifier. That is
+  // the bulk of platform code and needs no signature evaluation, so check it before falling back
+  // to the requirement below.
   id p = self.signingInformation[(__bridge id)kSecCodeInfoPlatformIdentifier];
-  if (![p isKindOfClass:[NSNumber class]] || [p intValue] == 0) return NO;
-  return YES;
+  if ([p isKindOfClass:[NSNumber class]] && [p intValue] != 0) return YES;
+
+  SecRequirementRef requirement = PlatformBinaryRequirement();
+  if (!requirement) return NO;
+
+  // Evaluate with the same flags this instance was already validated with, so a platform verdict
+  // never rests on a weaker check than the rest of this object's signing information. The
+  // executable must still be verified against the CodeDirectory in particular: skipping that
+  // would let an Apple-signed CodeDirectory grafted onto other code read as platform code.
+  if (CFGetTypeID(self.codeRef) == SecStaticCodeGetTypeID()) {
+    return SecStaticCodeCheckValidity(self.codeRef, self.staticSigningFlags, requirement) ==
+           errSecSuccess;
+  }
+  return SecCodeCheckValidity((SecCodeRef)self.codeRef, kSigningFlags, requirement) ==
+         errSecSuccess;
 }
 
 - (NSDictionary*)entitlements {

--- a/Source/common/MOLCodesignCheckerTest.mm
+++ b/Source/common/MOLCodesignCheckerTest.mm
@@ -317,6 +317,51 @@
   XCTAssertTrue(sut.platformBinary);
 }
 
+/**
+  Apple stamps a CodeDirectory platform identifier only on binaries shipped in the OS image, but
+  the kernel reports `CS_PLATFORM_BINARY` for Apple software delivered separately too. XProtect is
+  such a binary: it ships under /Library/Apple rather than on the signed system volume, so it
+  exercises the `anchor apple` fallback rather than the platform identifier fast path.
+*/
+- (void)testPlatformBinaryWithoutPlatformIdentifier {
+  NSString* path =
+      @"/Library/Apple/System/Library/CoreServices/XProtect.app/Contents/MacOS/XProtect";
+  if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+    XCTSkip(@"XProtect is not present on this host");
+  }
+
+  MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path];
+  XCTAssertNotNil(sut);
+
+  // Guard the premise. If this binary ever gains a platform identifier the assertion below would
+  // be satisfied by the fast path and would stop covering the fallback.
+  id platformIdentifier = sut.signingInformation[(__bridge id)kSecCodeInfoPlatformIdentifier];
+  XCTAssertTrue(!platformIdentifier || [platformIdentifier intValue] == 0,
+                @"expected no platform identifier, got %@", platformIdentifier);
+
+  XCTAssertTrue(sut.platformBinary);
+}
+
+/**
+  The platform check must not be relaxed to `anchor apple generic`. Both signed fixtures below
+  chain up to an Apple CA and so satisfy `anchor apple generic`, but neither is signed by Apple's
+  internal code signing chain, and the kernel does not report either as a platform binary.
+*/
+- (void)testPlatformBinaryDoesNotMatchNonAppleAnchoredCode {
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+
+  for (NSString* resource in
+       @[ @"signed-with-teamid", @"yikes-universal_signed", @"yikes-universal_adhoc" ]) {
+    NSString* path = [bundle pathForResource:resource ofType:@""];
+    XCTAssertNotNil(path, @"missing fixture %@", resource);
+
+    MOLCodesignChecker* sut = [[MOLCodesignChecker alloc] initWithBinaryPath:path];
+    // Assert the object exists, otherwise the check below would pass vacuously.
+    XCTAssertNotNil(sut, @"%@ failed to validate", resource);
+    XCTAssertFalse(sut.platformBinary, @"%@ should not be platform code", resource);
+  }
+}
+
 - (void)testEntitlements {
   NSError* error;
   NSBundle* bundle = [NSBundle bundleForClass:[self class]];


### PR DESCRIPTION
Use the `anchor apple` requirement to identify platform binaries statically.