### PR TITLE
santad: Evaluate ProcessesWithOptions FAA rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ single_version_override(
 bazel_dep(name = "protos", version = "1.0.1", repo_name = "northpolesec_protos")
 git_override(
     module_name = "protos",
-    commit = "23a2f8eabf88805d32140d7ea6584c0d8d47c9b9",
+    commit = "68fc3caa33bbdf14a980229f50a25d80bfc72a33",
     remote = "https://github.com/northpolesec/protos",
 )
 

--- a/Source/common/faa/WatchItemPolicy.h
+++ b/Source/common/faa/WatchItemPolicy.h
@@ -244,7 +244,14 @@ struct WatchItemPolicyBase {
         rule_type(rt),
         options(std::move(opts)),
         processes(std::move(procs)),
-        rule_id(rid) {}
+        rule_id(rid) {
+    for (const WatchItemProcess& process : processes) {
+      if (process.options && process.options->allow_read_access != options.allow_read_access) {
+        has_read_access_override = true;
+        break;
+      }
+    }
+  }
 
   virtual ~WatchItemPolicyBase() = default;
 
@@ -274,6 +281,13 @@ struct WatchItemPolicyBase {
   WatchItemProcessOptions options;
   WatchItemProcessList processes;
   int64_t rule_id;
+  // True when some configured process sets a different AllowReadAccess than the
+  // rule. Discovering such an override is the only reason the process match has
+  // to be computed before a read-only access can be answered, so when this is
+  // false FAAPolicyProcessor::ApplyPolicy can skip the match entirely and
+  // short-circuit on the rule's own value. Derived from `options` and
+  // `processes` by the constructor; neither is mutated afterwards.
+  bool has_read_access_override = false;
 };
 
 struct DataWatchItemPolicy : public WatchItemPolicyBase {

--- a/Source/common/faa/WatchItemPolicy.h
+++ b/Source/common/faa/WatchItemPolicy.h
@@ -81,11 +81,20 @@ static constexpr WatchItemRuleType kWatchItemPolicyDefaultRuleType =
 static constexpr bool kWatchItemPolicyDefaultEnableSilentMode = false;
 static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 
-/// The outcome of a match against a single configured process. `kInherit`
-/// defers to the rule's `rule_type` and `audit_only` options, which is the
-/// behavior of every process listed under the `Processes` key. The remaining
-/// values state their own outcome, which is how a `ProcessesWithOptions` entry
-/// can e.g. deny a process under a `PathsWithAllowedProcesses` rule.
+/// The outcome a `ProcessesWithOptions` entry states for itself, bypassing the
+/// rule's `rule_type` and `audit_only` options. `kInherit` defers to the rule
+/// entirely, which is the behavior of every process listed under `Processes`.
+///
+/// What the outcome applies to depends on what the entry describes:
+///   - Under the `PathsWith*` rule types the entry describes the instigating
+///     process, so the action is that process's verdict for the rule's paths.
+///     This is how a process can be denied under a `PathsWithAllowedProcesses`
+///     rule.
+///   - Under the `ProcessesWith*` rule types the entry describes the watched
+///     process, and the rule's path list decides each access. The action states
+///     what happens when that process violates the rule, so it can e.g. put one
+///     process of a `ProcessesWithAllowedPaths` rule into audit while the rest
+///     stay enforcing. Accesses the rule permits are unaffected.
 enum class WatchItemProcessAction {
   kInherit,
   kAllow,

--- a/Source/santad/EventProviders/FAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.h
@@ -67,15 +67,40 @@ class FAAPolicyProcessor {
 
   using TargetPolicyPair = std::pair<size_t, std::optional<std::shared_ptr<WatchItemPolicyBase>>>;
 
+  /// The outcome of asking a client whether a policy applies to a message.
+  /// `options` points at the overrides of the process that was matched, when
+  /// that process had any. They are already merged against the rule's own
+  /// options by WatchItems, so they hold effective values.
+  ///
+  /// Note: `options` may be set even when `matched` is false. For process rule
+  /// types the process is matched once at exec time while `matched` reflects
+  /// the per-event path match, so the overrides still apply to the event even
+  /// though the path decided the outcome. Only `options.action` is conditional
+  /// on `matched`.
+  struct PolicyMatch {
+    bool matched = false;
+    const WatchItemProcessOptions* options = nullptr;
+  };
+
   /// When this block is called, the policy enforcement client must determine
   /// whether or not the given policy applies to the given ES message.
-  using CheckIfPolicyMatchesBlock = bool (^)(const santa::WatchItemPolicyBase& base_policy,
-                                             const Message::PathTarget& target, const Message& msg);
+  using CheckIfPolicyMatchesBlock = PolicyMatch (^)(const santa::WatchItemPolicyBase& base_policy,
+                                                    const Message::PathTarget& target,
+                                                    const Message& msg);
   using URLTextPair = std::pair<NSString*, NSString*>;
   /// A block that resolves the given event detail URL and text, filling in
   /// global defaults for any value that is unset.
   using GenerateEventDetailLinkBlock = URLTextPair (^)(std::optional<NSString*> event_detail_url,
                                                        std::optional<NSString*> event_detail_text);
+
+  /// A decision paired with the effective options that produced it. `options`
+  /// points at either the matched process's overrides or the policy's own
+  /// options, both of which outlive the call. It is null only when no policy was
+  /// evaluated at all.
+  struct DecisionAndOptions {
+    FileAccessPolicyDecision decision;
+    const WatchItemProcessOptions* options = nullptr;
+  };
 
   using ReadsCacheKey = std::tuple<pid_t, int, FAAClientType>;
   using StoreAccessEventBlock = void (^)(SNTStoredFileAccessEvent*, bool);
@@ -127,11 +152,13 @@ class FAAPolicyProcessor {
   ///     1. Compute the FileAccessPolicyDecision (ApplyPolicy())
   ///         1. Ensure a policy exists
   ///         2. Ensure the process is valid or EnableBadSignatureProtection is false
-  ///         3. Check if policy allows for reading the target (PolicyAllowsReadsForTarget())
+  ///         3. Check if the policy applies to the current ES message (CheckIfPolicyMatchesBlock())
+  ///            and resolve the effective options for the match (ResolveOptions())
+  ///         4. Check if policy allows for reading the target (PolicyAllowsReadsForTarget())
   ///             1. For the current event type, ensure the policy allows reads and the current
   ///                target being evaluated is readable
-  ///         4. Check if the policy applies to the current ES message (CheckIfPolicyMatchesBlock())
-  ///         5. Invert results and/or set audit-only based on configured options
+  ///         5. Apply the matched process's action, or invert results and/or set audit-only
+  ///            based on configured options
   ///     2. Apply override if configured
   ///     3. Log telemetry if denied/audit-only and not rate-limited (LogTelemetry())
   ///     4. Notify the user if configured (SNTFileAccessDeniedBlock(), LogTTY())
@@ -150,13 +177,13 @@ class FAAPolicyProcessor {
   /// Used by callers to inform when a process has exited and will no longer process events.
   void NotifyExit(const audit_token_t& tok, FAAClientType client_type);
 
-  FileAccessPolicyDecision ProcessTargetAndPolicy(
-      const Message& msg, const TargetPolicyPair& target_policy_pair,
-      CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock,
-      SNTFileAccessDeniedBlock file_access_denied_block,
-      SNTOverrideFileAccessAction override_action);
+  DecisionAndOptions ProcessTargetAndPolicy(const Message& msg,
+                                            const TargetPolicyPair& target_policy_pair,
+                                            CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock,
+                                            SNTFileAccessDeniedBlock file_access_denied_block,
+                                            SNTOverrideFileAccessAction override_action);
 
-  virtual FileAccessPolicyDecision ApplyPolicy(
+  virtual DecisionAndOptions ApplyPolicy(
       const Message& msg, const Message::PathTarget& target,
       const std::optional<std::shared_ptr<WatchItemPolicyBase>> optional_policy,
       CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock);
@@ -171,7 +198,7 @@ class FAAPolicyProcessor {
   void LogTelemetry(const WatchItemPolicyBase& policy, const Message& msg, size_t target_index,
                     FileAccessPolicyDecision decision);
   void LogTTY(SNTStoredFileAccessEvent* event, URLTextPair link_info, const Message& msg,
-              const WatchItemPolicyBase& policy);
+              const WatchItemPolicyBase& policy, const WatchItemProcessOptions& options);
 };
 
 /// The proxy classes are used to wrap calls into the FAAPolicyProcessor and not expose

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -16,6 +16,7 @@
 
 #include <bsm/libbsm.h>
 
+#include <optional>
 #include <vector>
 
 #include "Source/common/AccountLookup.h"
@@ -95,6 +96,16 @@ static inline bool ShouldMessageTTY(const WatchItemProcessOptions& options, cons
     return false;
   }
   return true;
+}
+
+/// The decision an entry's action states, or nullopt when it defers to the rule.
+static std::optional<FileAccessPolicyDecision> DecisionForAction(WatchItemProcessAction action) {
+  switch (action) {
+    case WatchItemProcessAction::kAllow: return FileAccessPolicyDecision::kAllowed;
+    case WatchItemProcessAction::kAudit: return FileAccessPolicyDecision::kAllowedAuditOnly;
+    case WatchItemProcessAction::kDeny: return FileAccessPolicyDecision::kDenied;
+    case WatchItemProcessAction::kInherit: return std::nullopt;
+  }
 }
 
 /// The options to use for this event: the matched process's overrides when it
@@ -373,18 +384,18 @@ FAAPolicyProcessor::DecisionAndOptions FAAPolicyProcessor::ApplyPolicy(
     return {FileAccessPolicyDecision::kDeniedInvalidSignature, &policy->options};
   }
 
-  // When no configured process overrides the rule's allow_read_access, the
-  // rule's own value decides, and a readable target can be answered without
-  // scanning the process list at all.
-  if (!policy->has_read_access_override &&
-      PolicyAllowsReadsForTarget(msg, target, policy->options.allow_read_access)) {
-    return {FileAccessPolicyDecision::kAllowedReadAccess, &policy->options};
+  // The match only has to be computed before the read-access check when a
+  // configured process can override the rule's allow_read_access. Otherwise the
+  // rule's own value decides, and deferring the match keeps the common case
+  // from scanning the process list to answer a read-only access.
+  PolicyMatch match;
+  bool have_match = false;
+  if (policy->has_read_access_override) {
+    match = check_if_policy_matches_block(*policy, target, msg);
+    have_match = true;
   }
 
-  // Otherwise the match must be computed before the read-access check below,
-  // because the matched process can override allow_read_access.
-  PolicyMatch match = check_if_policy_matches_block(*policy, target, msg);
-  const WatchItemProcessOptions& options = ResolveOptions(*policy, match);
+  const WatchItemProcessOptions* options = &ResolveOptions(*policy, match);
 
   // If the policy allows read access and the target is readable, produce
   // an immediate result.
@@ -393,18 +404,23 @@ FAAPolicyProcessor::DecisionAndOptions FAAPolicyProcessor::ApplyPolicy(
   // layer. If the policy would generally allow access to the resource,
   // producing the full kAllow result would potentially result in better
   // system performance.
-  if (PolicyAllowsReadsForTarget(msg, target, options.allow_read_access)) {
-    return {FileAccessPolicyDecision::kAllowedReadAccess, &options};
+  if (PolicyAllowsReadsForTarget(msg, target, options->allow_read_access)) {
+    return {FileAccessPolicyDecision::kAllowedReadAccess, options};
   }
 
-  // A matched process that states its own action bypasses the rule's RuleType
-  // and audit-only options entirely. This is what allows e.g. a silently denied
-  // process under a PathsWithAllowedProcesses rule.
+  if (!have_match) {
+    match = check_if_policy_matches_block(*policy, target, msg);
+    options = &ResolveOptions(*policy, match);
+  }
+
+  // An entry that states its own action bypasses the rule's RuleType and
+  // audit-only options entirely. Where that action is applied depends on what
+  // the entry describes, which differs between the two families of rule type.
   //
-  // Note: This only applies to an actual match. Process rule types supply the
-  // overrides of the process matched at exec time even for events whose path
-  // didn't match, and in that case the rule's path semantics below must still
-  // decide allowed vs denied.
+  // For the path-centric rule types the entry describes the instigating
+  // process, so a match means "this is the process the entry is about" and the
+  // action states that process's outcome. This is what allows e.g. a silently
+  // denied process under a PathsWithAllowedProcesses rule.
   //
   // Note: The effective allow_read_access option is applied above and takes
   // precedence over the action, so a read-only operation is allowed even for an
@@ -412,13 +428,13 @@ FAAPolicyProcessor::DecisionAndOptions FAAPolicyProcessor::ApplyPolicy(
   // allow_read_access scopes which operations the rule covers at all rather
   // than deciding their outcome. An entry that must also deny reads has to set
   // AllowReadAccess to false.
-  if (match.matched) {
-    switch (options.action) {
-      case WatchItemProcessAction::kAllow: return {FileAccessPolicyDecision::kAllowed, &options};
-      case WatchItemProcessAction::kAudit:
-        return {FileAccessPolicyDecision::kAllowedAuditOnly, &options};
-      case WatchItemProcessAction::kDeny: return {FileAccessPolicyDecision::kDenied, &options};
-      case WatchItemProcessAction::kInherit: break;
+  const bool path_centric_rule =
+      policy->rule_type == WatchItemRuleType::kPathsWithAllowedProcesses ||
+      policy->rule_type == WatchItemRuleType::kPathsWithDeniedProcesses;
+
+  if (path_centric_rule && match.matched) {
+    if (std::optional<FileAccessPolicyDecision> stated = DecisionForAction(options->action)) {
+      return {*stated, options};
     }
   }
 
@@ -438,11 +454,23 @@ FAAPolicyProcessor::DecisionAndOptions FAAPolicyProcessor::ApplyPolicy(
     }
   }
 
+  // For the process-centric rule types the entry describes the watched process,
+  // which was matched once at exec time, while `matched` describes the path. The
+  // action there states what happens when this process violates the rule, so it
+  // is applied to the denial rather than to the match. Without this, an entry on
+  // a ProcessesWithAllowedPaths rule would state the outcome for the accesses
+  // the rule permits, which is the opposite of what it reads as.
+  if (!path_centric_rule && decision == FileAccessPolicyDecision::kDenied) {
+    if (std::optional<FileAccessPolicyDecision> stated = DecisionForAction(options->action)) {
+      return {*stated, options};
+    }
+  }
+
   if (decision == FileAccessPolicyDecision::kDenied && policy->audit_only) {
     decision = FileAccessPolicyDecision::kAllowedAuditOnly;
   }
 
-  return {decision, &options};
+  return {decision, options};
 }
 
 void FAAPolicyProcessor::LogTelemetry(const WatchItemPolicyBase& policy, const Message& msg,

--- a/Source/santad/EventProviders/FAAPolicyProcessor.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessor.mm
@@ -97,6 +97,14 @@ static inline bool ShouldMessageTTY(const WatchItemProcessOptions& options, cons
   return true;
 }
 
+/// The options to use for this event: the matched process's overrides when it
+/// carried any (WatchItems has already merged them over the rule's options),
+/// otherwise the rule's own options.
+static const WatchItemProcessOptions& ResolveOptions(const WatchItemPolicyBase& policy,
+                                                     const FAAPolicyProcessor::PolicyMatch& match) {
+  return match.options ? *match.options : policy.options;
+}
+
 es_auth_result_t FileAccessPolicyDecisionToESAuthResult(FileAccessPolicyDecision decision) {
   switch (decision) {
     case FileAccessPolicyDecision::kNoPolicy: return ES_AUTH_RESULT_ALLOW;
@@ -344,24 +352,39 @@ bool FAAPolicyProcessor::PolicyAllowsReadsForTarget(const Message& msg,
   return false;
 }
 
-FileAccessPolicyDecision FAAPolicyProcessor::ApplyPolicy(
+FAAPolicyProcessor::DecisionAndOptions FAAPolicyProcessor::ApplyPolicy(
     const Message& msg, const Message::PathTarget& target,
     const std::optional<std::shared_ptr<WatchItemPolicyBase>> optional_policy,
     CheckIfPolicyMatchesBlock check_if_policy_matches_block) {
   if (!optional_policy.has_value()) {
-    return FileAccessPolicyDecision::kNoPolicy;
+    return {FileAccessPolicyDecision::kNoPolicy, nullptr};
   }
 
-  // If the process is signed but has an invalid signature, it is denied
+  std::shared_ptr<WatchItemPolicyBase> policy = *optional_policy;
+
+  // If the process is signed but has an invalid signature, it is denied.
+  // Note: The policy isn't evaluated at all here, so the rule's own options are
+  // used for the resulting notification.
   if (((msg->process->codesigning_flags & (CS_SIGNED | CS_VALID)) == CS_SIGNED) &&
       [configurator_ enableBadSignatureProtection]) {
     // TODO(mlw): Think about how to make stronger guarantees here to handle
     // programs becoming invalid after first being granted access. Maybe we
     // should only allow things that have hardened runtime flags set?
-    return FileAccessPolicyDecision::kDeniedInvalidSignature;
+    return {FileAccessPolicyDecision::kDeniedInvalidSignature, &policy->options};
   }
 
-  std::shared_ptr<WatchItemPolicyBase> policy = *optional_policy;
+  // When no configured process overrides the rule's allow_read_access, the
+  // rule's own value decides, and a readable target can be answered without
+  // scanning the process list at all.
+  if (!policy->has_read_access_override &&
+      PolicyAllowsReadsForTarget(msg, target, policy->options.allow_read_access)) {
+    return {FileAccessPolicyDecision::kAllowedReadAccess, &policy->options};
+  }
+
+  // Otherwise the match must be computed before the read-access check below,
+  // because the matched process can override allow_read_access.
+  PolicyMatch match = check_if_policy_matches_block(*policy, target, msg);
+  const WatchItemProcessOptions& options = ResolveOptions(*policy, match);
 
   // If the policy allows read access and the target is readable, produce
   // an immediate result.
@@ -370,13 +393,37 @@ FileAccessPolicyDecision FAAPolicyProcessor::ApplyPolicy(
   // layer. If the policy would generally allow access to the resource,
   // producing the full kAllow result would potentially result in better
   // system performance.
-  if (PolicyAllowsReadsForTarget(msg, target, policy->options.allow_read_access)) {
-    return FileAccessPolicyDecision::kAllowedReadAccess;
+  if (PolicyAllowsReadsForTarget(msg, target, options.allow_read_access)) {
+    return {FileAccessPolicyDecision::kAllowedReadAccess, &options};
   }
 
-  FileAccessPolicyDecision decision = check_if_policy_matches_block(*policy, target, msg)
-                                          ? FileAccessPolicyDecision::kAllowed
-                                          : FileAccessPolicyDecision::kDenied;
+  // A matched process that states its own action bypasses the rule's RuleType
+  // and audit-only options entirely. This is what allows e.g. a silently denied
+  // process under a PathsWithAllowedProcesses rule.
+  //
+  // Note: This only applies to an actual match. Process rule types supply the
+  // overrides of the process matched at exec time even for events whose path
+  // didn't match, and in that case the rule's path semantics below must still
+  // decide allowed vs denied.
+  //
+  // Note: The effective allow_read_access option is applied above and takes
+  // precedence over the action, so a read-only operation is allowed even for an
+  // entry with an action of kDeny. This mirrors the rule-level behavior, where
+  // allow_read_access scopes which operations the rule covers at all rather
+  // than deciding their outcome. An entry that must also deny reads has to set
+  // AllowReadAccess to false.
+  if (match.matched) {
+    switch (options.action) {
+      case WatchItemProcessAction::kAllow: return {FileAccessPolicyDecision::kAllowed, &options};
+      case WatchItemProcessAction::kAudit:
+        return {FileAccessPolicyDecision::kAllowedAuditOnly, &options};
+      case WatchItemProcessAction::kDeny: return {FileAccessPolicyDecision::kDenied, &options};
+      case WatchItemProcessAction::kInherit: break;
+    }
+  }
+
+  FileAccessPolicyDecision decision =
+      match.matched ? FileAccessPolicyDecision::kAllowed : FileAccessPolicyDecision::kDenied;
 
   // If the RuleType option was configured to contain a list of denied
   // processes or denied paths, the decision should be inverted from allowed
@@ -395,7 +442,7 @@ FileAccessPolicyDecision FAAPolicyProcessor::ApplyPolicy(
     decision = FileAccessPolicyDecision::kAllowedAuditOnly;
   }
 
-  return decision;
+  return {decision, &options};
 }
 
 void FAAPolicyProcessor::LogTelemetry(const WatchItemPolicyBase& policy, const Message& msg,
@@ -446,15 +493,15 @@ bool FAAPolicyProcessor::HaveMessagedTTYForPolicy(const WatchItemPolicyBase& pol
 }
 
 void FAAPolicyProcessor::LogTTY(SNTStoredFileAccessEvent* event, URLTextPair link_info,
-                                const Message& msg, const WatchItemPolicyBase& policy) {
+                                const Message& msg, const WatchItemPolicyBase& policy,
+                                const WatchItemProcessOptions& options) {
   if (HaveMessagedTTYForPolicy(policy, msg)) {
     return;
   }
 
-  NSAttributedString* attrStr =
-      [SNTBlockMessage attributedBlockMessageForFileAccessEvent:event
-                                                  customMessage:OptionalStringToNSString(
-                                                                    policy.options.custom_message)];
+  NSAttributedString* attrStr = [SNTBlockMessage
+      attributedBlockMessageForFileAccessEvent:event
+                                 customMessage:OptionalStringToNSString(options.custom_message)];
 
   NSMutableString* blockMsg = [NSMutableString stringWithCapacity:1024];
   // Escape sequences `\033[1m` and `\033[0m` begin/end bold lettering
@@ -479,7 +526,7 @@ void FAAPolicyProcessor::LogTTY(SNTStoredFileAccessEvent* event, URLTextPair lin
   tty_writer_->WriteWithoutSignal(msg->process, blockMsg);
 }
 
-FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
+FAAPolicyProcessor::DecisionAndOptions FAAPolicyProcessor::ProcessTargetAndPolicy(
     const Message& msg, const TargetPolicyPair& target_policy_pair,
     CheckIfPolicyMatchesBlock check_if_policy_matches_block,
     SNTFileAccessDeniedBlock file_access_denied_block,
@@ -489,18 +536,23 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
   if (target.truncated) {
     LOGW(@"FAA: truncated path target on event=%d, pid=%d, proc=%s", msg->event_type,
          audit_token_to_pid(msg->process->audit_token), msg->process->executable->path.data);
-    return ApplyOverrideToDecision(FileAccessPolicyDecision::kDenied, override_action);
+    return {ApplyOverrideToDecision(FileAccessPolicyDecision::kDenied, override_action), nullptr};
   }
 
   const std::optional<std::shared_ptr<WatchItemPolicyBase>> optional_policy =
       target_policy_pair.second;
-  FileAccessPolicyDecision decision = ApplyOverrideToDecision(
-      ApplyPolicy(msg, target, optional_policy, check_if_policy_matches_block), override_action);
+  DecisionAndOptions result =
+      ApplyPolicy(msg, target, optional_policy, check_if_policy_matches_block);
+  FileAccessPolicyDecision decision = ApplyOverrideToDecision(result.decision, override_action);
+  result.decision = decision;
 
   // Note: If ShouldLogDecision, it shouldn't be possible for optionalPolicy
   // to not have a value. Performing the check just in case to prevent a crash.
   if (ShouldLogDecision(decision) && optional_policy.has_value()) {
     std::shared_ptr<WatchItemPolicyBase> policy = *optional_policy;
+    // Note: ApplyPolicy always sets options when it was given a policy. Falling
+    // back to the rule's options for the same defensive reason as above.
+    const WatchItemProcessOptions& options = result.options ? *result.options : policy->options;
 
     LogTelemetry(*policy, msg, target_policy_pair.first, decision);
 
@@ -547,8 +599,8 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
 
     URLTextPair link_info;
     if (generate_event_detail_link_block_) {
-      link_info = generate_event_detail_link_block_(policy->options.event_detail_url,
-                                                    policy->options.event_detail_text);
+      link_info =
+          generate_event_detail_link_block_(options.event_detail_url, options.event_detail_text);
     }
 
     if (store_access_event_block_) {
@@ -556,18 +608,18 @@ FileAccessPolicyDecision FAAPolicyProcessor::ProcessTargetAndPolicy(
     }
 
     if (IsBlockDecision(decision)) {
-      if (ShouldShowUI(policy->options)) {
-        file_access_denied_block(event, OptionalStringToNSString(policy->options.custom_message),
+      if (ShouldShowUI(options)) {
+        file_access_denied_block(event, OptionalStringToNSString(options.custom_message),
                                  link_info.first, link_info.second);
       }
 
-      if (ShouldMessageTTY(policy->options, msg)) {
-        LogTTY(event, link_info, msg, *policy);
+      if (ShouldMessageTTY(options, msg)) {
+        LogTTY(event, link_info, msg, *policy, options);
       }
     }
   }
 
-  return decision;
+  return result;
 }
 
 static inline FAAPolicyProcessor::ReadsCacheKey MakeReadsCacheKey(const audit_token_t& tok,
@@ -585,21 +637,22 @@ FAAPolicyProcessor::ESResult FAAPolicyProcessor::ProcessMessage(
 
   for (const TargetPolicyPair& target_policy_pair : target_policy_pairs) {
     const Message::PathTarget& path_target = msg.PathTargetAtIndex(target_policy_pair.first);
-    FileAccessPolicyDecision decision =
+    DecisionAndOptions result =
         ProcessTargetAndPolicy(msg, target_policy_pair, check_if_policy_matches_block,
                                file_access_denied_block, overrideAction);
+    FileAccessPolicyDecision decision = result.decision;
     // Populate the reads_cache_ if:
     //   1. The policy applied
     //   2. The process wasn't invalid
     //   3. A devno/ino pair existed for the target
-    //   4. The policy allowed read access
+    //   4. The effective policy allowed read access
     // Note: As long as a policy allows read access, the caller's read cache can be updated
     // regardless of the RuleType of the policy.
     if (decision != FileAccessPolicyDecision::kNoPolicy &&
         decision != FileAccessPolicyDecision::kDeniedInvalidSignature && !path_target.truncated &&
         path_target.is_readable && path_target.unsafe_file &&
-        target_policy_pair.second.has_value() &&
-        (*target_policy_pair.second)->options.allow_read_access) {
+        target_policy_pair.second.has_value() && result.options &&
+        result.options->allow_read_access) {
       reads_cache_.Set(MakeReadsCacheKey(msg->process->audit_token, client_type),
                        std::pair<dev_t, ino_t>({path_target.unsafe_file->stat.st_dev,
                                                 path_target.unsafe_file->stat.st_ino}));

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -715,12 +715,15 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   auto optionalPolicy = std::make_optional<std::shared_ptr<WatchItemPolicyBase>>(policy);
 
   __block santa::WatchItemProcessOptions options;
+  __block bool matched = false;
   auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
                                                   const Message::PathTarget&, const Message&) {
-    return {false, &options};
+    return {matched, &options};
   };
 
-  // The rule denies read access, but the matched process allows it
+  // A process's overrides apply even when the match failed, which is the case
+  // for a process rule type whose path didn't match. The rule denies read
+  // access, but the matched process allows it.
   options.allow_read_access = true;
   XCTAssertEqual(
       faaPolicyProcessor
@@ -740,6 +743,8 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // The effective allow_read_access takes precedence over an explicit action, so
   // a read-only operation is allowed even for an entry that says deny. Denying
   // reads too requires the entry to also set allow_read_access false.
+  // Note: The match has to succeed for the action to be considered at all.
+  matched = true;
   options.action = santa::WatchItemProcessAction::kDeny;
   options.allow_read_access = true;
   XCTAssertEqual(

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -549,12 +549,11 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
     return {false, &options};
   };
 
-  // An explicit action bypasses both the rule type and the audit-only option.
-  // This is checked against every rule type to prove the inversion is skipped.
+  // For the path-centric rule types the entry describes the instigating
+  // process, so a match means the action states that process's outcome,
+  // bypassing both the rule type's inversion and the audit-only option.
   for (santa::WatchItemRuleType ruleType : {santa::WatchItemRuleType::kPathsWithAllowedProcesses,
-                                            santa::WatchItemRuleType::kPathsWithDeniedProcesses,
-                                            santa::WatchItemRuleType::kProcessesWithAllowedPaths,
-                                            santa::WatchItemRuleType::kProcessesWithDeniedPaths}) {
+                                            santa::WatchItemRuleType::kPathsWithDeniedProcesses}) {
     policy->rule_type = ruleType;
 
     for (bool auditOnly : {false, true}) {
@@ -580,6 +579,53 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
               .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
               .decision,
           FileAccessPolicyDecision::kDenied);
+    }
+  }
+
+  // For the process-centric rule types the entry describes the watched process
+  // while the match describes the path, so the action states what happens when
+  // the process violates the rule. The violating access is a path that didn't
+  // match for ProcessesWithAllowedPaths and one that did for
+  // ProcessesWithDeniedPaths. A compliant access is unaffected either way -
+  // without this distinction, an action of audit on a ProcessesWithAllowedPaths
+  // rule would audit every permitted access and still hard-deny the violations.
+  for (bool allowedPaths : {true, false}) {
+    policy->rule_type = allowedPaths ? santa::WatchItemRuleType::kProcessesWithAllowedPaths
+                                     : santa::WatchItemRuleType::kProcessesWithDeniedPaths;
+    auto violating = allowedPaths ? nonMatcher : matcher;
+    auto compliant = allowedPaths ? matcher : nonMatcher;
+
+    for (bool auditOnly : {false, true}) {
+      policy->audit_only = auditOnly;
+
+      options.action = santa::WatchItemProcessAction::kAllow;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, violating)
+              .decision,
+          FileAccessPolicyDecision::kAllowed);
+
+      options.action = santa::WatchItemProcessAction::kAudit;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, violating)
+              .decision,
+          FileAccessPolicyDecision::kAllowedAuditOnly);
+
+      options.action = santa::WatchItemProcessAction::kDeny;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, violating)
+              .decision,
+          FileAccessPolicyDecision::kDenied);
+
+      // The action never turns a compliant access into a violation, or logs one
+      options.action = santa::WatchItemProcessAction::kAudit;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, compliant)
+              .decision,
+          FileAccessPolicyDecision::kAllowed);
     }
   }
 

--- a/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
+++ b/Source/santad/EventProviders/FAAPolicyProcessorTest.mm
@@ -332,14 +332,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
   // If no policy exists, the operation is allowed
   {
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, std::nullopt,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kNoPolicy);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, std::nullopt,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kNoPolicy);
     XCTAssertSemaFalse(sema, "Semaphore should never have been signaled");
   }
 
@@ -352,14 +354,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   {
     OCMExpect([self.mockConfigurator enableBadSignatureProtection]).andReturn(YES);
     esMsg.process->codesigning_flags = CS_SIGNED;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kDeniedInvalidSignature);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kDeniedInvalidSignature);
     XCTAssertSemaFalse(sema, "Semaphore should never have been signaled");
   }
 
@@ -369,14 +373,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   {
     OCMExpect([self.mockConfigurator enableBadSignatureProtection]).andReturn(NO);
     esMsg.process->codesigning_flags = CS_SIGNED;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return true;
-            }),
-        FileAccessPolicyDecision::kAllowed);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {true, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kAllowed);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
@@ -386,28 +392,32 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // If no exceptions, operations are logged and denied
   {
     policy->audit_only = false;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kDenied);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kDenied);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
   // For audit only policies with no exceptions, operations are logged but allowed
   {
     policy->audit_only = true;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kAllowedAuditOnly);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kAllowedAuditOnly);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
@@ -419,14 +429,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // then the operation should be allowed.
   {
     policy->audit_only = false;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kAllowed);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kAllowed);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
@@ -438,14 +450,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // then the operation should be allowed.
   {
     policy->audit_only = false;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kAllowed);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kAllowed);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
@@ -453,14 +467,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // denied processes/paths, operations are allowed.
   {
     policy->audit_only = true;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return false;
-            }),
-        FileAccessPolicyDecision::kAllowed);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {false, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kAllowed);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
@@ -468,14 +484,16 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // denied processes/paths, operations are allowed audit only.
   {
     policy->audit_only = true;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return true;
-            }),
-        FileAccessPolicyDecision::kAllowedAuditOnly);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {true, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kAllowedAuditOnly);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
 
@@ -483,16 +501,311 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // denied processes/paths, operations are denied.
   {
     policy->audit_only = false;
-    XCTAssertEqual(
-        faaPolicyProcessor.ApplyPolicyWrapper(
-            Message(mockESApi, &esMsg), target, optionalPolicy,
-            ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-              dispatch_semaphore_signal(sema);
-              return true;
-            }),
-        FileAccessPolicyDecision::kDenied);
+    XCTAssertEqual(faaPolicyProcessor
+                       .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy,
+                                           ^FAAPolicyProcessor::PolicyMatch(
+                                               const santa::WatchItemPolicyBase&,
+                                               const Message::PathTarget&, const Message&) {
+                                             dispatch_semaphore_signal(sema);
+                                             return {true, nullptr};
+                                           })
+                       .decision,
+                   FileAccessPolicyDecision::kDenied);
     XCTAssertSemaTrue(sema, 1, "CheckIfPolicyMatchesBlock was never called");
   }
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
+- (void)testApplyPolicyWithProcessOptions {
+  es_file_t esFile = MakeESFile("/some/binary");
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = CS_SIGNED | CS_VALID;
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_OPEN, &esProc);
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
+  EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
+      .WillRepeatedly(testing::Return(false));
+  OCMStub([self.mockConfigurator enableBadSignatureProtection]).andReturn(NO);
+
+  Message::PathTarget target = {.path = std::string_view("/some/random/path"), .is_readable = true};
+
+  auto policy = std::make_shared<WatchItemPolicyBase>("foo_policy", "ver", "/foo");
+  auto optionalPolicy = std::make_optional<std::shared_ptr<WatchItemPolicyBase>>(policy);
+
+  // Note: __block so that mutations below are visible to the already-created
+  // blocks. Without it the blocks would capture a frozen copy.
+  __block santa::WatchItemProcessOptions options;
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    return {true, &options};
+  };
+  auto nonMatcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                     const Message::PathTarget&, const Message&) {
+    return {false, &options};
+  };
+
+  // An explicit action bypasses both the rule type and the audit-only option.
+  // This is checked against every rule type to prove the inversion is skipped.
+  for (santa::WatchItemRuleType ruleType : {santa::WatchItemRuleType::kPathsWithAllowedProcesses,
+                                            santa::WatchItemRuleType::kPathsWithDeniedProcesses,
+                                            santa::WatchItemRuleType::kProcessesWithAllowedPaths,
+                                            santa::WatchItemRuleType::kProcessesWithDeniedPaths}) {
+    policy->rule_type = ruleType;
+
+    for (bool auditOnly : {false, true}) {
+      policy->audit_only = auditOnly;
+
+      options.action = santa::WatchItemProcessAction::kAllow;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+              .decision,
+          FileAccessPolicyDecision::kAllowed);
+
+      options.action = santa::WatchItemProcessAction::kAudit;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+              .decision,
+          FileAccessPolicyDecision::kAllowedAuditOnly);
+
+      options.action = santa::WatchItemProcessAction::kDeny;
+      XCTAssertEqual(
+          faaPolicyProcessor
+              .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+              .decision,
+          FileAccessPolicyDecision::kDenied);
+    }
+  }
+
+  // An action only applies to an actual match. Overrides carried over from an
+  // earlier process match must not override the rule's path semantics.
+  policy->rule_type = santa::WatchItemRuleType::kProcessesWithDeniedPaths;
+  policy->audit_only = false;
+  options.action = santa::WatchItemProcessAction::kDeny;
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, nonMatcher)
+          .decision,
+      FileAccessPolicyDecision::kAllowed);
+
+  // kInherit falls through to the rule's own behavior
+  policy->rule_type = santa::WatchItemRuleType::kPathsWithAllowedProcesses;
+  options.action = santa::WatchItemProcessAction::kInherit;
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+          .decision,
+      FileAccessPolicyDecision::kAllowed);
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, nonMatcher)
+          .decision,
+      FileAccessPolicyDecision::kDenied);
+
+  // The matched process's options are returned so callers can use them for the
+  // user notification, TTY message and reads cache.
+  options.silent = true;
+  options.silent_tty = true;
+  options.custom_message = std::make_optional<std::string>("proc msg");
+  FAAPolicyProcessor::DecisionAndOptions result = faaPolicyProcessor.ApplyPolicyWrapper(
+      Message(mockESApi, &esMsg), target, optionalPolicy, matcher);
+  XCTAssertTrue(result.options->silent);
+  XCTAssertTrue(result.options->silent_tty);
+  XCTAssertCppStringEqual(result.options->custom_message.value(), "proc msg");
+
+  // With no overrides, the rule's own options are returned
+  policy->options.silent = false;
+  policy->options.silent_tty = false;
+  policy->options.custom_message = std::make_optional<std::string>("rule msg");
+  result = faaPolicyProcessor.ApplyPolicyWrapper(
+      Message(mockESApi, &esMsg), target, optionalPolicy,
+      ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                       const Message::PathTarget&, const Message&) {
+        return {true, nullptr};
+      });
+  XCTAssertFalse(result.options->silent);
+  XCTAssertFalse(result.options->silent_tty);
+  XCTAssertCppStringEqual(result.options->custom_message.value(), "rule msg");
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
+/// The invalid-signature denial happens before the policy is evaluated, so the
+/// rule's own options must still be returned for the resulting notification.
+- (void)testApplyPolicyInvalidSignatureUsesRuleOptions {
+  es_file_t esFile = MakeESFile("/some/binary");
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = CS_SIGNED;
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_OPEN, &esProc);
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
+  OCMExpect([self.mockConfigurator enableBadSignatureProtection]).andReturn(YES);
+
+  Message::PathTarget target = {.path = std::string_view("/some/random/path"), .is_readable = true};
+
+  auto policy = std::make_shared<WatchItemPolicyBase>("foo_policy", "ver", "/foo");
+  policy->options.silent = true;
+  policy->options.silent_tty = true;
+  policy->options.custom_message = std::make_optional<std::string>("rule msg");
+  auto optionalPolicy = std::make_optional<std::shared_ptr<WatchItemPolicyBase>>(policy);
+
+  FAAPolicyProcessor::DecisionAndOptions result = faaPolicyProcessor.ApplyPolicyWrapper(
+      Message(mockESApi, &esMsg), target, optionalPolicy,
+      ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                       const Message::PathTarget&, const Message&) {
+        XCTFail(@"Policy must not be evaluated for an invalid signature");
+        return {false, nullptr};
+      });
+
+  XCTAssertEqual(result.decision, FileAccessPolicyDecision::kDeniedInvalidSignature);
+  XCTAssertTrue(result.options->silent);
+  XCTAssertTrue(result.options->silent_tty);
+  XCTAssertCppStringEqual(result.options->custom_message.value(), "rule msg");
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
+/// A matched process can override the rule's allow_read_access option, which
+/// means the match must be evaluated before the read-access short circuit.
+- (void)testApplyPolicyProcessOptionsOverrideAllowReadAccess {
+  es_file_t esFile = MakeESFile("/some/binary");
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = CS_SIGNED | CS_VALID;
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_OPEN, &esProc);
+  esMsg.event.open.fflag = FREAD;
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
+  EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
+      .WillRepeatedly([&faaPolicyProcessor](const Message& msg, const Message::PathTarget& target,
+                                            bool allow_read_access) {
+        return faaPolicyProcessor.PolicyAllowsReadsForTargetWrapper(msg, target, allow_read_access);
+      });
+  OCMStub([self.mockConfigurator enableBadSignatureProtection]).andReturn(NO);
+
+  Message::PathTarget target = {.path = std::string_view("/some/random/path"), .is_readable = true};
+
+  // The configured process must carry the override for real, not just be handed
+  // to the matcher below - that is what sets has_read_access_override and so
+  // makes ApplyPolicy evaluate the match before the read-access short circuit.
+  santa::WatchItemProcessOptions ruleOptions;
+  ruleOptions.allow_read_access = false;
+  santa::WatchItemProcessOptions procOptions;
+  procOptions.allow_read_access = true;
+
+  auto policy = std::make_shared<WatchItemPolicyBase>(
+      "foo_policy", "ver", /*audit_only=*/false,
+      santa::WatchItemRuleType::kPathsWithAllowedProcesses, ruleOptions,
+      santa::WatchItemProcessList{
+          santa::WatchItemProcess("/some/binary", "", "", {}, "", false, procOptions)});
+  XCTAssertTrue(policy->has_read_access_override);
+  auto optionalPolicy = std::make_optional<std::shared_ptr<WatchItemPolicyBase>>(policy);
+
+  __block santa::WatchItemProcessOptions options;
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    return {false, &options};
+  };
+
+  // The rule denies read access, but the matched process allows it
+  options.allow_read_access = true;
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+          .decision,
+      FileAccessPolicyDecision::kAllowedReadAccess);
+
+  // And the other direction: the rule allows read access, the process doesn't
+  policy->options.allow_read_access = true;
+  options.allow_read_access = false;
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+          .decision,
+      FileAccessPolicyDecision::kDenied);
+
+  // The effective allow_read_access takes precedence over an explicit action, so
+  // a read-only operation is allowed even for an entry that says deny. Denying
+  // reads too requires the entry to also set allow_read_access false.
+  options.action = santa::WatchItemProcessAction::kDeny;
+  options.allow_read_access = true;
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+          .decision,
+      FileAccessPolicyDecision::kAllowedReadAccess);
+
+  options.allow_read_access = false;
+  XCTAssertEqual(
+      faaPolicyProcessor
+          .ApplyPolicyWrapper(Message(mockESApi, &esMsg), target, optionalPolicy, matcher)
+          .decision,
+      FileAccessPolicyDecision::kDenied);
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
+/// With no per-process override of allow_read_access the rule's own value
+/// decides, so a readable target is answered without evaluating the match.
+- (void)testApplyPolicySkipsMatchWithoutReadAccessOverride {
+  es_file_t esFile = MakeESFile("/some/binary");
+  es_process_t esProc = MakeESProcess(&esFile);
+  esProc.codesigning_flags = CS_SIGNED | CS_VALID;
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_OPEN, &esProc);
+  esMsg.event.open.fflag = FREAD;
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+
+  MockFAAPolicyProcessor faaPolicyProcessor(self.dcMock, nullptr, nullptr, nullptr, nullptr, 0, 0,
+                                            nil, nil);
+  EXPECT_CALL(faaPolicyProcessor, PolicyAllowsReadsForTarget)
+      .WillRepeatedly([&faaPolicyProcessor](const Message& msg, const Message::PathTarget& target,
+                                            bool allow_read_access) {
+        return faaPolicyProcessor.PolicyAllowsReadsForTargetWrapper(msg, target, allow_read_access);
+      });
+  OCMStub([self.mockConfigurator enableBadSignatureProtection]).andReturn(NO);
+
+  Message::PathTarget target = {.path = std::string_view("/some/random/path"), .is_readable = true};
+
+  // The rule and its configured process agree, so there is nothing to override
+  santa::WatchItemProcessOptions allowReads;
+  allowReads.allow_read_access = true;
+
+  auto policy = std::make_shared<WatchItemPolicyBase>(
+      "foo_policy", "ver", /*audit_only=*/false,
+      santa::WatchItemRuleType::kPathsWithAllowedProcesses, allowReads,
+      santa::WatchItemProcessList{
+          santa::WatchItemProcess("/some/binary", "", "", {}, "", false, allowReads)});
+  XCTAssertFalse(policy->has_read_access_override);
+  auto optionalPolicy = std::make_optional<std::shared_ptr<WatchItemPolicyBase>>(policy);
+
+  __block bool matcherCalled = false;
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    matcherCalled = true;
+    return {true, nullptr};
+  };
+
+  FAAPolicyProcessor::DecisionAndOptions result = faaPolicyProcessor.ApplyPolicyWrapper(
+      Message(mockESApi, &esMsg), target, optionalPolicy, matcher);
+
+  XCTAssertEqual(result.decision, FileAccessPolicyDecision::kAllowedReadAccess);
+  XCTAssertFalse(matcherCalled);
+  XCTAssertEqual(result.options, &policy->options);
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
@@ -524,11 +837,11 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // The matcher block must NEVER be invoked for a truncated target — the
   // early-return branch bypasses ApplyPolicy entirely.
   dispatch_semaphore_t matcherSema = dispatch_semaphore_create(0);
-  auto matcher =
-      ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-        dispatch_semaphore_signal(matcherSema);
-        return false;
-      };
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    dispatch_semaphore_signal(matcherSema);
+    return {false, nullptr};
+  };
 
   // The denied-block must NEVER be invoked either — telemetry is intentionally
   // skipped for truncated paths in this design.
@@ -541,22 +854,28 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   FAAPolicyProcessor::TargetPolicyPair pair{0, std::nullopt};
 
   // Override = None → kDenied
-  XCTAssertEqual(faaPolicyProcessor.ProcessTargetAndPolicyWrapper(msg, pair, matcher, deniedBlock,
-                                                                  SNTOverrideFileAccessActionNone),
+  XCTAssertEqual(faaPolicyProcessor
+                     .ProcessTargetAndPolicyWrapper(msg, pair, matcher, deniedBlock,
+                                                    SNTOverrideFileAccessActionNone)
+                     .decision,
                  FileAccessPolicyDecision::kDenied);
   XCTAssertSemaFalse(matcherSema, "Matcher must not be invoked for truncated target");
   XCTAssertSemaFalse(deniedBlockSema, "Denied block must not be invoked for truncated target");
 
   // Override = AuditOnly → kAllowedAuditOnly (downgraded by ApplyOverrideToDecision)
-  XCTAssertEqual(faaPolicyProcessor.ProcessTargetAndPolicyWrapper(
-                     msg, pair, matcher, deniedBlock, SNTOverrideFileAccessActionAuditOnly),
+  XCTAssertEqual(faaPolicyProcessor
+                     .ProcessTargetAndPolicyWrapper(msg, pair, matcher, deniedBlock,
+                                                    SNTOverrideFileAccessActionAuditOnly)
+                     .decision,
                  FileAccessPolicyDecision::kAllowedAuditOnly);
   XCTAssertSemaFalse(matcherSema, "Matcher must not be invoked for truncated target");
   XCTAssertSemaFalse(deniedBlockSema, "Denied block must not be invoked for truncated target");
 
   // Override = Disable → kNoPolicy (defensive — handler short-circuits earlier in production)
-  XCTAssertEqual(faaPolicyProcessor.ProcessTargetAndPolicyWrapper(
-                     msg, pair, matcher, deniedBlock, SNTOverrideFileAccessActionDisable),
+  XCTAssertEqual(faaPolicyProcessor
+                     .ProcessTargetAndPolicyWrapper(msg, pair, matcher, deniedBlock,
+                                                    SNTOverrideFileAccessActionDisable)
+                     .decision,
                  FileAccessPolicyDecision::kNoPolicy);
   XCTAssertSemaFalse(matcherSema, "Matcher must not be invoked for truncated target");
   XCTAssertSemaFalse(deniedBlockSema, "Denied block must not be invoked for truncated target");
@@ -919,12 +1238,13 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
   // ApplyPolicy returns kAllowedAuditOnly so ShouldLogDecision is true and we
   // enter the block where GetCachedDecision and rehydrate are called.
   EXPECT_CALL(faaPolicyProcessor, ApplyPolicy)
-      .WillOnce(testing::Return(FileAccessPolicyDecision::kAllowedAuditOnly));
+      .WillOnce(testing::Return(
+          FAAPolicyProcessor::DecisionAndOptions{FileAccessPolicyDecision::kAllowedAuditOnly, {}}));
 
-  auto matcher =
-      ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-        return true;
-      };
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    return {true, nullptr};
+  };
   SNTFileAccessDeniedBlock deniedBlock =
       ^(SNTStoredFileAccessEvent*, NSString*, NSString*, NSString*) {
       };
@@ -984,16 +1304,17 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
   // ApplyPolicy returns kAllowedAuditOnly so ShouldLogDecision is true.
   EXPECT_CALL(faaPolicyProcessor, ApplyPolicy)
-      .WillOnce(testing::Return(FileAccessPolicyDecision::kAllowedAuditOnly));
+      .WillOnce(testing::Return(
+          FAAPolicyProcessor::DecisionAndOptions{FileAccessPolicyDecision::kAllowedAuditOnly, {}}));
 
   // Crucial: rehydrateAndCacheDecisionForFileInfo: must NEVER be called on cache hit.
   // OCMStrictClassMock on self.dcMock ensures any unexpected call fails verification.
   // We do NOT add an OCMExpect for rehydrateAndCacheDecisionForFileInfo:.
 
-  auto matcher =
-      ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-        return true;
-      };
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    return {true, nullptr};
+  };
   SNTFileAccessDeniedBlock deniedBlock =
       ^(SNTStoredFileAccessEvent*, NSString*, NSString*, NSString*) {
       };
@@ -1069,12 +1390,13 @@ static void ClearWatchItemPolicyProcess(WatchItemProcess& proc) {
 
   EXPECT_CALL(faaPolicyProcessor, GetCachedDecision).WillOnce(testing::Return(nil));
   EXPECT_CALL(faaPolicyProcessor, ApplyPolicy)
-      .WillOnce(testing::Return(FileAccessPolicyDecision::kAllowedAuditOnly));
+      .WillOnce(testing::Return(
+          FAAPolicyProcessor::DecisionAndOptions{FileAccessPolicyDecision::kAllowedAuditOnly, {}}));
 
-  auto matcher =
-      ^bool(const santa::WatchItemPolicyBase&, const Message::PathTarget&, const Message&) {
-        return true;
-      };
+  auto matcher = ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase&,
+                                                  const Message::PathTarget&, const Message&) {
+    return {true, nullptr};
+  };
   SNTFileAccessDeniedBlock deniedBlock =
       ^(SNTStoredFileAccessEvent*, NSString*, NSString*, NSString*) {
       };

--- a/Source/santad/EventProviders/MockFAAPolicyProcessor.h
+++ b/Source/santad/EventProviders/MockFAAPolicyProcessor.h
@@ -53,7 +53,7 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
   MOCK_METHOD(bool, PolicyAllowsReadsForTarget,
               (const Message& msg, const Message::PathTarget& target, bool allow_read_access),
               (override));
-  MOCK_METHOD(FileAccessPolicyDecision, ApplyPolicy,
+  MOCK_METHOD(FAAPolicyProcessor::DecisionAndOptions, ApplyPolicy,
               (const Message& msg, const Message::PathTarget& target,
                const std::optional<std::shared_ptr<santa::WatchItemPolicyBase>> optional_policy,
                FAAPolicyProcessor::CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock),
@@ -71,14 +71,14 @@ class MockFAAPolicyProcessor : public FAAPolicyProcessor {
     return FAAPolicyProcessor::PolicyAllowsReadsForTarget(msg, target, allow_read_access);
   }
 
-  FileAccessPolicyDecision ApplyPolicyWrapper(
+  FAAPolicyProcessor::DecisionAndOptions ApplyPolicyWrapper(
       const Message& msg, const Message::PathTarget& target,
       const std::optional<std::shared_ptr<WatchItemPolicyBase>> optional_policy,
       FAAPolicyProcessor::CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock) {
     return FAAPolicyProcessor::ApplyPolicy(msg, target, optional_policy, checkIfPolicyMatchesBlock);
   }
 
-  FileAccessPolicyDecision ProcessTargetAndPolicyWrapper(
+  FAAPolicyProcessor::DecisionAndOptions ProcessTargetAndPolicyWrapper(
       const Message& msg, const FAAPolicyProcessor::TargetPolicyPair& target_policy_pair,
       FAAPolicyProcessor::CheckIfPolicyMatchesBlock checkIfPolicyMatchesBlock,
       SNTFileAccessDeniedBlock fileAccessDeniedBlock, SNTOverrideFileAccessAction overrideAction) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityDataFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDataFileAccessAuthorizer.mm
@@ -112,15 +112,17 @@ using santa::Message;
 
   FAAPolicyProcessor::ESResult result = _faaPolicyProcessorProxy->ProcessMessage(
       msg, targetPolicyPairs,
-      ^bool(const santa::WatchItemPolicyBase& base_policy, const Message::PathTarget& target,
-            const Message& msg) {
+      ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase& base_policy,
+                                       const Message::PathTarget& target, const Message& msg) {
+        // Note: Iteration order is meaningful. ProcessesWithOptions entries
+        // come first in this list so they take precedence over Processes.
         for (const santa::WatchItemProcess& process : base_policy.processes) {
           if ((*_faaPolicyProcessorProxy)->PolicyMatchesProcess(process, msg->process)) {
-            return true;
+            return {true, process.options.has_value() ? &process.options.value() : nullptr};
           }
         }
 
-        return false;
+        return {false, nullptr};
       },
       self.fileAccessDeniedBlock, overrideAction);
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizer.mm
@@ -34,7 +34,25 @@ using santa::PidPidversion;
 using santa::ProcessWatchItemPolicy;
 
 using PidPidverPair = std::pair<pid_t, int>;
-using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchItemPolicy>>;
+
+/// The policy a process matched, plus the option overrides carried by the entry
+/// that matched it. For process rule types the process is matched once at exec
+/// time, so its overrides must be remembered alongside the policy in order to
+/// apply to every subsequent event from that process.
+///
+/// Note: `options` points into `policy->processes`, which is immutable for the
+/// lifetime of the policy, so the owning `shared_ptr` here keeps it valid. It is
+/// null when the matched entry carried no overrides.
+struct MatchedProcessPolicy {
+  std::shared_ptr<ProcessWatchItemPolicy> policy;
+  const santa::WatchItemProcessOptions* options = nullptr;
+
+  // Note: Only the policy is considered. SantaCache only ever compares against
+  // a default constructed value to determine whether an entry exists.
+  bool operator==(const MatchedProcessPolicy& other) const { return policy == other.policy; }
+};
+
+using ProcessRuleCache = SantaCache<PidPidverPair, MatchedProcessPolicy>;
 
 @interface SNTEndpointSecurityProcessFileAccessAuthorizer ()
 @property bool isSubscribed;
@@ -73,7 +91,7 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
 }
 
 - (void)processMessage:(Message)msg
-                policy:(std::shared_ptr<ProcessWatchItemPolicy>)procPolicy
+                policy:(const MatchedProcessPolicy&)matchedPolicy
         overrideAction:(SNTOverrideFileAccessAction)overrideAction {
   if (msg->action_type != ES_ACTION_TYPE_AUTH) {
     return;
@@ -82,25 +100,23 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
   std::vector<FAAPolicyProcessor::TargetPolicyPair> targetPolicyPairs;
   size_t numTargets = msg.PathTargets().size();
   for (size_t i = 0; i < numTargets; ++i) {
-    targetPolicyPairs.emplace_back(i, procPolicy);
+    targetPolicyPairs.emplace_back(i, matchedPolicy.policy);
   }
+
+  const santa::WatchItemProcessOptions* matchedOptions = matchedPolicy.options;
 
   FAAPolicyProcessor::ESResult result = _faaPolicyProcessorProxy->ProcessMessage(
       msg, targetPolicyPairs,
-      ^bool(const santa::WatchItemPolicyBase& base_policy, const Message::PathTarget& target,
-            const Message& msg) {
+      ^FAAPolicyProcessor::PolicyMatch(const santa::WatchItemPolicyBase& base_policy,
+                                       const Message::PathTarget& target, const Message& msg) {
         const ProcessWatchItemPolicy* policy =
             dynamic_cast<const ProcessWatchItemPolicy*>(&base_policy);
         if (!policy) {
           LOGW(@"Failed to cast process policy");
-          return false;
+          return {false, matchedOptions};
         }
 
-        if (policy->tree->Contains(target.Path().data())) {
-          return true;
-        } else {
-          return false;
-        }
+        return {policy->tree->Contains(target.Path().data()), matchedOptions};
       },
       self.fileAccessDeniedBlock, overrideAction);
 
@@ -156,14 +172,14 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
     return;
   }
 
-  std::shared_ptr<ProcessWatchItemPolicy> policy =
+  MatchedProcessPolicy matchedPolicy =
       _procRuleCache->get(PidPidversion(esMsg->process->audit_token));
-  if (!policy) {
+  if (!matchedPolicy.policy) {
     auto pidPidver = PidPidversion(esMsg->process->audit_token);
-    policy = [self findPolicyForProcess:esMsg->process];
-    if (policy) {
+    matchedPolicy = [self findPolicyForProcess:esMsg->process];
+    if (matchedPolicy.policy) {
       // Found match, add to the cache. The process is already being watched.
-      _procRuleCache->set(pidPidver, policy);
+      _procRuleCache->set(pidPidver, matchedPolicy);
     } else {
       // Still no match, time to give up.
       [self stopWatching:pidPidver];
@@ -181,19 +197,23 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
 
   [self processMessage:std::move(esMsg)
                handler:^(Message msg) {
-                 [self processMessage:std::move(msg) policy:policy overrideAction:overrideAction];
+                 [self processMessage:std::move(msg)
+                               policy:matchedPolicy
+                       overrideAction:overrideAction];
                  recordEventMetrics(santa::EventDisposition::kProcessed);
                }];
 }
 
-- (std::shared_ptr<ProcessWatchItemPolicy>)findPolicyForProcess:(const es_process_t*)esProc {
-  __block std::shared_ptr<ProcessWatchItemPolicy> foundPolicy;
+- (MatchedProcessPolicy)findPolicyForProcess:(const es_process_t*)esProc {
+  __block MatchedProcessPolicy foundPolicy;
   self.iterateProcessPoliciesBlock(^bool(std::shared_ptr<ProcessWatchItemPolicy> policy) {
+    // Note: Iteration order is meaningful. ProcessesWithOptions entries come
+    // first in this list so they take precedence over Processes.
     for (const santa::WatchItemProcess& policyProcess : policy->processes) {
       if ((*_faaPolicyProcessorProxy)->PolicyMatchesProcess(policyProcess, esProc)) {
         // Map the new process to the matched policy and begin
         // watching the new process
-        foundPolicy = policy;
+        foundPolicy = {policy, policyProcess.options ? &policyProcess.options.value() : nullptr};
 
         // Stop iteration, no need to continue once a match is found
         return true;
@@ -211,11 +231,10 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
     return santa::ProbeInterest::kUninterested;
   }
 
-  std::shared_ptr<ProcessWatchItemPolicy> policy =
-      [self findPolicyForProcess:esMsg->event.exec.target];
+  MatchedProcessPolicy matchedPolicy = [self findPolicyForProcess:esMsg->event.exec.target];
 
-  if (policy) {
-    [self startWatching:esMsg->event.exec.target->audit_token policy:policy];
+  if (matchedPolicy.policy) {
+    [self startWatching:esMsg->event.exec.target->audit_token policy:matchedPolicy];
 
     return santa::ProbeInterest::kInterested;
   } else {
@@ -223,10 +242,9 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
   }
 }
 
-- (void)startWatching:(const audit_token_t)tok
-               policy:(std::shared_ptr<ProcessWatchItemPolicy>)policy {
-  if (policy) {
-    _procRuleCache->set(PidPidversion(tok), policy);
+- (void)startWatching:(const audit_token_t)tok policy:(const MatchedProcessPolicy&)matchedPolicy {
+  if (matchedPolicy.policy) {
+    _procRuleCache->set(PidPidversion(tok), matchedPolicy);
   }
 
   // Note: Always start watching the process, even if no policy currently exists.
@@ -260,11 +278,10 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
   // watching any of the processes. The next time the process emits some event, it will
   // be reevaluated against the latest config. However we still notify the FAAPolicyProcessor
   // as if the process exited so that caches may be cleaned up.
-  _procRuleCache->clear(
-      ^(std::pair<pid_t, int>& pidPidver, std::shared_ptr<ProcessWatchItemPolicy>&) {
-        _faaPolicyProcessorProxy->NotifyExit(
-            santa::MakeStubAuditToken(pidPidver.first, pidPidver.second));
-      });
+  _procRuleCache->clear(^(std::pair<pid_t, int>& pidPidver, MatchedProcessPolicy&) {
+    _faaPolicyProcessorProxy->NotifyExit(
+        santa::MakeStubAuditToken(pidPidver.first, pidPidver.second));
+  });
 
   // Always clear cache to ensure operations that were previously allowed are re-evaluated.
   [super clearCache];
@@ -277,10 +294,9 @@ using ProcessRuleCache = SantaCache<PidPidverPair, std::shared_ptr<ProcessWatchI
       self.isSubscribed = false;
     }
 
-    _procRuleCache->clear(
-        ^(std::pair<pid_t, int>& pidPidver, std::shared_ptr<ProcessWatchItemPolicy>&) {
-          [self stopWatching:pidPidver];
-        });
+    _procRuleCache->clear(^(std::pair<pid_t, int>& pidPidver, MatchedProcessPolicy&) {
+      [self stopWatching:pidPidver];
+    });
   }
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityProcessFileAccessAuthorizerTest.mm
@@ -151,4 +151,66 @@ void SetExpectationsForProcessFileAccessAuthorizerInit(
   }
 }
 
+/// The process list is ordered so that ProcessesWithOptions entries precede
+/// Processes entries. Matching must visit them in that order and stop at the
+/// first match so those entries take precedence.
+- (void)testFindPolicyForProcessMatchesInOrder {
+  es_file_t esFile = MakeESFile("foo");
+  es_process_t esProc = MakeESProcess(&esFile);
+  es_file_t execFile = MakeESFile("bar");
+  es_process_t execProc = MakeESProcess(&execFile, MakeAuditToken(12, 23), MakeAuditToken(34, 45));
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, &esProc);
+  esMsg.event.exec.target = &execProc;
+
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsESNewClient();
+  mockESApi->SetExpectationsRetainReleaseMessage();
+  SetExpectationsForProcessFileAccessAuthorizerInit(mockESApi);
+
+  auto mockFAA = std::make_shared<MockFAAPolicyProcessor>(nil, nullptr, nullptr, nullptr, nullptr,
+                                                          0, 0, nil, nil);
+
+  // Record which entries were considered, in order. Only the second one matches
+  // so that iteration is observed to continue past a miss and then stop.
+  auto considered = std::make_shared<std::vector<std::string>>();
+  EXPECT_CALL(*mockFAA, PolicyMatchesProcess)
+      .WillRepeatedly([considered](const WatchItemProcess& policyProc, const es_process_t*) {
+        considered->push_back(policyProc.binary_path);
+        return policyProc.binary_path == "withopts2";
+      });
+  auto mockFAAProxy = std::make_shared<santa::ProcessFAAPolicyProcessorProxy>(mockFAA);
+
+  santa::WatchItemProcessOptions opts;
+  opts.action = santa::WatchItemProcessAction::kDeny;
+  auto pwip = std::make_shared<ProcessWatchItemPolicy>(
+      "name", "ver", SetPairPathAndType{PairPathAndType{"path1", WatchItemPathType::kLiteral}},
+      true, santa::WatchItemRuleType::kProcessesWithAllowedPaths, santa::WatchItemProcessOptions{},
+      santa::WatchItemProcessList{
+          WatchItemProcess("withopts1", "", "", {}, "", false, opts),
+          WatchItemProcess("withopts2", "", "", {}, "", false, opts),
+          WatchItemProcess("plain", "", "", {}, "", false),
+      });
+
+  IterateProcessPoliciesBlock iterPoliciesBlock = ^(CheckPolicyBlock block) {
+    block(pwip);
+  };
+
+  SNTEndpointSecurityProcessFileAccessAuthorizer* procFAAClient =
+      [[SNTEndpointSecurityProcessFileAccessAuthorizer alloc] initWithESAPI:mockESApi
+                                                                    metrics:nullptr
+                                                         faaPolicyProcessor:mockFAAProxy
+                                                iterateProcessPoliciesBlock:iterPoliciesBlock];
+  procFAAClient.isSubscribed = true;
+
+  EXPECT_CALL(*mockESApi, MuteProcess).WillOnce(testing::Return(true));
+
+  santa::Message msg(mockESApi, &esMsg);
+  XCTAssertEqual([procFAAClient probeInterest:msg], santa::ProbeInterest::kInterested);
+
+  // The trailing `plain` entry must never have been reached
+  XCTAssertEqual(considered->size(), 2);
+  XCTAssertCppStringEqual((*considered)[0], "withopts1");
+  XCTAssertCppStringEqual((*considered)[1], "withopts2");
+}
+
 @end

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -59,6 +59,9 @@ NSArray* PathsFromProtoFAARulePaths(
 NSDictionary* OptionsFromProtoFAARuleAdd(const ::pbv2::FileAccessRule::Add& pbAddRule);
 NSArray* ProcessesFromProtoFAARuleProcesses(
     const google::protobuf::RepeatedPtrField<::pbv2::FileAccessRule::Process>& pbProcesses);
+NSArray* ProcessesWithOptionsFromProtoFAARuleProcesses(
+    const google::protobuf::RepeatedPtrField<::pbv2::FileAccessRule::ProcessWithOptions>&
+        pbProcesses);
 SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRule& nr);
 SNTSignal* SignalFromProtoSignalRule(const ::pbv2::TelemetrySignalRule& sr);
 
@@ -260,32 +263,101 @@ NSDictionary* OptionsFromProtoFAARuleAdd(const ::pbv2::FileAccessRule::Add& pbAd
   return optionsDict;
 }
 
+/// Convert the identifier oneof of a single proto process into the config
+/// dictionary form. Returns nil if no identifier was set.
+NSMutableDictionary* ProcessDictFromProtoFAARuleProcess(
+    const ::pbv2::FileAccessRule::Process& process) {
+  NSMutableDictionary* processDict = [NSMutableDictionary dictionary];
+
+  switch (process.identifier_case()) {
+    case ::pbv2::FileAccessRule::Process::kBinaryPath:
+      processDict[kWatchItemConfigKeyProcessesBinaryPath] = StringToNSString(process.binary_path());
+      break;
+    case ::pbv2::FileAccessRule::Process::kCdHash:
+      processDict[kWatchItemConfigKeyProcessesCDHash] = StringToNSString(process.cd_hash());
+      break;
+    case ::pbv2::FileAccessRule::Process::kSigningId:
+      processDict[kWatchItemConfigKeyProcessesSigningID] = StringToNSString(process.signing_id());
+      break;
+    case ::pbv2::FileAccessRule::Process::kCertificateSha256:
+      processDict[kWatchItemConfigKeyProcessesCertificateSha256] =
+          StringToNSString(process.certificate_sha256());
+      break;
+    case ::pbv2::FileAccessRule::Process::kTeamId:
+      processDict[kWatchItemConfigKeyProcessesTeamID] = StringToNSString(process.team_id());
+      break;
+    default: return nil;
+  }
+
+  return processDict;
+}
+
 NSArray* ProcessesFromProtoFAARuleProcesses(
     const google::protobuf::RepeatedPtrField<::pbv2::FileAccessRule::Process>& pbProcesses) {
   NSMutableArray* processes = [NSMutableArray array];
 
   for (const ::pbv2::FileAccessRule::Process& process : pbProcesses) {
-    NSMutableDictionary* processDict = [NSMutableDictionary dictionary];
+    NSMutableDictionary* processDict = ProcessDictFromProtoFAARuleProcess(process);
+    if (!processDict) {
+      return nil;
+    }
 
-    switch (process.identifier_case()) {
-      case ::pbv2::FileAccessRule::Process::kBinaryPath:
-        processDict[kWatchItemConfigKeyProcessesBinaryPath] =
-            StringToNSString(process.binary_path());
+    [processes addObject:processDict];
+  }
+
+  return processes;
+}
+
+NSArray* ProcessesWithOptionsFromProtoFAARuleProcesses(
+    const google::protobuf::RepeatedPtrField<::pbv2::FileAccessRule::ProcessWithOptions>&
+        pbProcesses) {
+  NSMutableArray* processes = [NSMutableArray array];
+
+  for (const ::pbv2::FileAccessRule::ProcessWithOptions& process : pbProcesses) {
+    NSMutableDictionary* processDict = ProcessDictFromProtoFAARuleProcess(process.process());
+    if (!processDict) {
+      return nil;
+    }
+
+    switch (process.action()) {
+      // Unspecified means the outcome is inherited from the rule, which is
+      // conveyed by simply omitting the key.
+      case ::pbv2::FileAccessRule::ProcessWithOptions::ACTION_UNSPECIFIED: break;
+      case ::pbv2::FileAccessRule::ProcessWithOptions::ACTION_ALLOW:
+        processDict[kWatchItemConfigKeyProcessesAction] = kProcessActionAllow;
         break;
-      case ::pbv2::FileAccessRule::Process::kCdHash:
-        processDict[kWatchItemConfigKeyProcessesCDHash] = StringToNSString(process.cd_hash());
+      case ::pbv2::FileAccessRule::ProcessWithOptions::ACTION_AUDIT:
+        processDict[kWatchItemConfigKeyProcessesAction] = kProcessActionAudit;
         break;
-      case ::pbv2::FileAccessRule::Process::kSigningId:
-        processDict[kWatchItemConfigKeyProcessesSigningID] = StringToNSString(process.signing_id());
-        break;
-      case ::pbv2::FileAccessRule::Process::kCertificateSha256:
-        processDict[kWatchItemConfigKeyProcessesCertificateSha256] =
-            StringToNSString(process.certificate_sha256());
-        break;
-      case ::pbv2::FileAccessRule::Process::kTeamId:
-        processDict[kWatchItemConfigKeyProcessesTeamID] = StringToNSString(process.team_id());
+      case ::pbv2::FileAccessRule::ProcessWithOptions::ACTION_DENY:
+        processDict[kWatchItemConfigKeyProcessesAction] = kProcessActionDeny;
         break;
       default: return nil;
+    }
+
+    // Note: Only explicitly set fields are emitted. An absent key means the
+    // value is inherited from the rule.
+    if (process.has_allow_read_access()) {
+      processDict[kWatchItemConfigKeyOptionsAllowReadAccess] = @(process.allow_read_access());
+    }
+    if (process.has_enable_silent_mode()) {
+      processDict[kWatchItemConfigKeyOptionsEnableSilentMode] = @(process.enable_silent_mode());
+    }
+    if (process.has_enable_silent_tty_mode()) {
+      processDict[kWatchItemConfigKeyOptionsEnableSilentTTYMode] =
+          @(process.enable_silent_tty_mode());
+    }
+    if (process.has_block_message()) {
+      processDict[kWatchItemConfigKeyOptionsCustomMessage] =
+          StringToNSString(process.block_message());
+    }
+    if (process.has_event_detail_url()) {
+      processDict[kWatchItemConfigKeyOptionsEventDetailURL] =
+          StringToNSString(process.event_detail_url());
+    }
+    if (process.has_event_detail_text()) {
+      processDict[kWatchItemConfigKeyOptionsEventDetailText] =
+          StringToNSString(process.event_detail_text());
     }
 
     [processes addObject:processDict];
@@ -314,6 +386,15 @@ SNTFileAccessRule* FAARuleFromProtoFAARuleAdd(const ::pbv2::FileAccessRule::Add&
     return nil;
   }
   details[kWatchItemConfigKeyProcesses] = processes;
+
+  if (pbAddRule.processes_with_options_size() > 0) {
+    NSArray* processesWithOptions =
+        ProcessesWithOptionsFromProtoFAARuleProcesses(pbAddRule.processes_with_options());
+    if (!processesWithOptions) {
+      return nil;
+    }
+    details[kWatchItemConfigKeyProcessesWithOptions] = processesWithOptions;
+  }
 
   NSString* name = StringToNSString(pbAddRule.name());
 

--- a/Source/santasyncservice/SNTSyncRuleDownloadTest.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownloadTest.mm
@@ -32,6 +32,9 @@ extern NSArray* PathsFromProtoFAARulePaths(
 extern NSDictionary* OptionsFromProtoFAARuleAdd(const ::pbv2::FileAccessRule::Add& pbAddRule);
 extern NSArray* ProcessesFromProtoFAARuleProcesses(
     const google::protobuf::RepeatedPtrField<::pbv2::FileAccessRule::Process>& pbProcesses);
+extern NSArray* ProcessesWithOptionsFromProtoFAARuleProcesses(
+    const google::protobuf::RepeatedPtrField<::pbv2::FileAccessRule::ProcessWithOptions>&
+        pbProcesses);
 extern SNTFileAccessRule* FAARuleFromProtoFileAccessRule(const ::pbv2::FileAccessRule& wi);
 extern SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRule& nr);
 
@@ -172,6 +175,131 @@ extern SNTNetworkFlowRule* NetworkFlowRuleFromProto(const ::pbv2::NetworkFlowRul
   proc = addRule.add_processes();
   procs = ProcessesFromProtoFAARuleProcesses(addRule.processes());
   XCTAssertNil(procs);
+}
+
+- (void)testProcessesWithOptionsFromProtoFAARuleProcesses {
+  ::pbv2::FileAccessRule::Add addRule;
+
+  // All four actions
+  ::pbv2::FileAccessRule::ProcessWithOptions* pwo = addRule.add_processes_with_options();
+  pwo->mutable_process()->set_binary_path("/unspecified");
+  pwo = addRule.add_processes_with_options();
+  pwo->mutable_process()->set_binary_path("/allow");
+  pwo->set_action(::pbv2::FileAccessRule::ProcessWithOptions::ACTION_ALLOW);
+  pwo = addRule.add_processes_with_options();
+  pwo->mutable_process()->set_binary_path("/audit");
+  pwo->set_action(::pbv2::FileAccessRule::ProcessWithOptions::ACTION_AUDIT);
+  pwo = addRule.add_processes_with_options();
+  pwo->mutable_process()->set_binary_path("/deny");
+  pwo->set_action(::pbv2::FileAccessRule::ProcessWithOptions::ACTION_DENY);
+
+  NSArray* procs = ProcessesWithOptionsFromProtoFAARuleProcesses(addRule.processes_with_options());
+  XCTAssertEqual(procs.count, 4);
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyProcessesBinaryPath], @"/unspecified");
+  // Unspecified is conveyed by omitting the key so the rule's behavior is inherited
+  XCTAssertNil(procs[0][kWatchItemConfigKeyProcessesAction]);
+  XCTAssertEqualObjects(procs[1][kWatchItemConfigKeyProcessesAction], kProcessActionAllow);
+  XCTAssertEqualObjects(procs[2][kWatchItemConfigKeyProcessesAction], kProcessActionAudit);
+  XCTAssertEqualObjects(procs[3][kWatchItemConfigKeyProcessesAction], kProcessActionDeny);
+
+  // Unset overrides are omitted entirely so that they are inherited
+  for (NSString* key in @[
+         kWatchItemConfigKeyOptionsAllowReadAccess, kWatchItemConfigKeyOptionsEnableSilentMode,
+         kWatchItemConfigKeyOptionsEnableSilentTTYMode, kWatchItemConfigKeyOptionsCustomMessage,
+         kWatchItemConfigKeyOptionsEventDetailURL, kWatchItemConfigKeyOptionsEventDetailText
+       ]) {
+    XCTAssertNil(procs[0][key]);
+  }
+
+  // Every override, explicitly set. Note the bools are set to false to prove
+  // presence rather than truthiness is what's checked.
+  addRule.clear_processes_with_options();
+  pwo = addRule.add_processes_with_options();
+  pwo->mutable_process()->set_team_id("EXAMPLETID");
+  pwo->set_allow_read_access(false);
+  pwo->set_enable_silent_mode(false);
+  pwo->set_enable_silent_tty_mode(false);
+  pwo->set_block_message("proc msg");
+  pwo->set_event_detail_url("https://proc.example");
+  pwo->set_event_detail_text("proc text");
+
+  procs = ProcessesWithOptionsFromProtoFAARuleProcesses(addRule.processes_with_options());
+  XCTAssertEqual(procs.count, 1);
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyProcessesTeamID], @"EXAMPLETID");
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyOptionsAllowReadAccess], @(NO));
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyOptionsEnableSilentMode], @(NO));
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyOptionsEnableSilentTTYMode], @(NO));
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyOptionsCustomMessage], @"proc msg");
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyOptionsEventDetailURL],
+                        @"https://proc.example");
+  XCTAssertEqualObjects(procs[0][kWatchItemConfigKeyOptionsEventDetailText], @"proc text");
+
+  // Should return an empty array when no processes are added
+  addRule.clear_processes_with_options();
+  procs = ProcessesWithOptionsFromProtoFAARuleProcesses(addRule.processes_with_options());
+  XCTAssertEqual(procs.count, 0);
+
+  // Should return nil when an invalid identifier is used
+  addRule.add_processes_with_options();
+  procs = ProcessesWithOptionsFromProtoFAARuleProcesses(addRule.processes_with_options());
+  XCTAssertNil(procs);
+}
+
+- (void)testFAARuleFromProtoFileAccessRuleAddWithProcessesWithOptions {
+  ::pbv2::FileAccessRule wi;
+  ::pbv2::FileAccessRule::Add* addRule = wi.mutable_add();
+  ::pbv2::FileAccessRule::Path* path = addRule->add_paths();
+  path->set_path("/foo");
+  path->set_path_type(::pbv2::FileAccessRule::Path::PATH_TYPE_LITERAL);
+  addRule->set_name("my_test_rule");
+  addRule->set_version("v1");
+  addRule->set_rule_type(::pbv2::FileAccessRule::RULE_TYPE_PATHS_WITH_ALLOWED_PROCESSES);
+
+  // Servers send both arrays: `processes` for clients that predate
+  // `processes_with_options`, and the richer form for those that don't.
+  addRule->add_processes()->set_binary_path("/allowed");
+
+  ::pbv2::FileAccessRule::ProcessWithOptions* pwo = addRule->add_processes_with_options();
+  pwo->mutable_process()->set_binary_path("/allowed");
+  pwo = addRule->add_processes_with_options();
+  pwo->mutable_process()->set_binary_path("/silently/denied");
+  pwo->set_action(::pbv2::FileAccessRule::ProcessWithOptions::ACTION_DENY);
+  pwo->set_enable_silent_mode(true);
+
+  SNTFileAccessRule* rule = FAARuleFromProtoFileAccessRule(wi);
+  XCTAssertEqual(rule.state, SNTFileAccessRuleStateAdd);
+
+  NSDictionary* details = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class],
+                                                      [NSString class], [NSNumber class],
+                                                      [NSData class], nil]
+                       fromData:rule.details
+                          error:nil];
+  XCTAssertNotNil(details);
+  XCTAssertEqual([details[kWatchItemConfigKeyProcesses] count], 1);
+  XCTAssertEqual([details[kWatchItemConfigKeyProcessesWithOptions] count], 2);
+  XCTAssertEqualObjects(
+      details[kWatchItemConfigKeyProcessesWithOptions][1][kWatchItemConfigKeyProcessesAction],
+      kProcessActionDeny);
+  XCTAssertEqualObjects(details[kWatchItemConfigKeyProcessesWithOptions][1]
+                               [kWatchItemConfigKeyOptionsEnableSilentMode],
+                        @(YES));
+
+  // The key is omitted entirely when the server sends no entries
+  addRule->clear_processes_with_options();
+  details = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class],
+                                                      [NSString class], [NSNumber class],
+                                                      [NSData class], nil]
+                       fromData:FAARuleFromProtoFileAccessRule(wi).details
+                          error:nil];
+  XCTAssertNil(details[kWatchItemConfigKeyProcessesWithOptions]);
+
+  // An invalid action makes the whole rule invalid
+  addRule->add_processes_with_options()->mutable_process()->set_binary_path("/bad");
+  addRule->mutable_processes_with_options(0)->set_action(
+      static_cast<::pbv2::FileAccessRule::ProcessWithOptions::Action>(123));
+  XCTAssertNil(FAARuleFromProtoFileAccessRule(wi));
 }
 
 - (void)testFAARuleFromProtoFileAccessRuleAdd {


### PR DESCRIPTION
- Apply a matched process's Action, bypassing the rule's RuleType and AuditOnly options, and use its option overrides for the resulting notification and TTY message
- Remember the overrides of the process matched at exec time for the process-centric rule types, so they apply to every event it produces
- Skip the process match when answering a read-only access for rules with no per-process AllowReadAccess override, preserving the previous ordering
- Convert the sync server's ProcessWithOptions rules into the config form