### PR TITLE
santad: negative cache for execution rule lookups

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -43,6 +43,7 @@ objc_library(
         "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SNTSignal",
         "//Source/common:SNTXxhash",
+        "//Source/common:SantaCache",
         "//Source/common:SigningIDHelpers",
         "//Source/common:String",
         "//Source/common/cel:CEL",

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -628,6 +628,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // planner and costs a temp B-tree sort on every lookup.
   //
   // clang-format off
+  __block BOOL queryFailed = NO;
   [self inDatabase:^(FMDatabase* db) {
     FMResultSet* rs = [db executeQuery:@"SELECT * FROM ("
                                       @"            SELECT 1 AS prio, * FROM execution_rules WHERE identifier=? AND type=500  "
@@ -641,6 +642,13 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
                                       @(SNTRuleStateAllowTransitive), identifiers.signingID,
                                       identifiers.certificateSHA256, identifiers.teamID,
                                       identifiers.binarySHA256, @(SNTRuleStateAllowTransitive)];
+    // A nil result set means the statement itself failed (e.g. a locked or corrupt db), not
+    // that the file has no rule. Note the failure so it isn't remembered as a miss below.
+    if (!rs) {
+      queryFailed = YES;
+      LOGE(@"Failed to query execution rules: %@", [db lastErrorMessage]);
+      return;
+    }
     if ([rs next]) {
       rule = [self executionRuleFromResultSet:rs];
     }
@@ -648,9 +656,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   }];
   // clang-format on
 
-  // No rule exists, cache that fact so we don't needlessly keep looking in the
-  // db during future execs.
-  if (!rule && !missCacheKey.empty()) {
+  // The query ran and found nothing, so cache that fact to avoid needlessly looking in the db
+  // during future execs. A failed query is deliberately not cached: the miss cache is only ever
+  // invalidated by a rule write, so caching a transient db error would pin it in place and deny
+  // this file its rule indefinitely.
+  if (!rule && !queryFailed && !missCacheKey.empty()) {
     _executionRuleMissCache->set(missCacheKey, true);
   }
 

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -31,9 +31,13 @@
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTSignal.h"
 #import "Source/common/SNTXxhash.h"
+#import "Source/common/SantaCache.h"
 #import "Source/common/SigningIDHelpers.h"
 #include "Source/common/String.h"
 #include "Source/common/cel/Evaluator.h"
+
+#include <memory>
+#include <string>
 
 static const uint32_t kRuleTableCurrentVersion = 16;
 
@@ -41,6 +45,10 @@ static const uint32_t kRuleTableCurrentVersion = 16;
 static const int64_t kTransitiveRuleCullingThreshold = 500000;
 // Consider transitive rules out of date if they haven't been used in six months.
 static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
+
+// Maximum number of file hashes remembered by the execution rule miss cache.
+// Maxes out around 322KiB.
+static const uint64_t kExecutionRuleMissCacheSize = 10000;
 
 static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // Create a temporary ES client in order to grab the default set of muted paths.
@@ -77,6 +85,14 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   std::unique_ptr<santa::cel::Evaluator<false>> _celEvaluator;
   std::unique_ptr<santa::cel::Evaluator<true>> _celV2Evaluator;
   dispatch_once_t _criticalSystemBinariesToken;
+  // Negative cache for the `execution_rules` query in `executionRuleForIdentifiers:`: records the
+  // file hashes that matched no row, so repeat executions of the same unruled binary skip the
+  // query entirely. Only the SQL lookup is cached -- the static rules are an in-memory dictionary
+  // and are checked on every call. Keyed on the binary SHA-256 alone -- it identifies the file
+  // contents, and so determines every other identifier a lookup would match on. Entries are only
+  // ever cleared wholesale (see `clearExecutionRuleMissCache`) -- there is no per-entry
+  // invalidation.
+  std::unique_ptr<SantaCache<std::string, bool>> _executionRuleMissCache;
 }
 @property MOLCodesignChecker* santadCSInfo;
 @property MOLCodesignChecker* launchdCSInfo;
@@ -247,6 +263,9 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 }
 
 - (uint32_t)initializeDatabase:(FMDatabase*)db fromVersion:(uint32_t)version {
+  _executionRuleMissCache =
+      std::make_unique<SantaCache<std::string, bool>>(kExecutionRuleMissCacheSize);
+
   // Lock this database from other processes
   [[db executeQuery:@"PRAGMA locking_mode = EXCLUSIVE;"] close];
 
@@ -575,6 +594,21 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     if (rule.type == SNTRuleTypeTeamID) {
       return rule;
     }
+
+    // A static rule found under one identifier but typed for another is not a
+    // match.
+    rule = nil;
+  }
+
+  // If we already looked in the db during another exec and there was no rule,
+  // return early. The cache will be cleared when new rules are added. Keyed by
+  // file sha256. Using a cdhash is appealing, but a cdhash is not guaranteed
+  // unique across files.
+  std::string missCacheKey = identifiers.binarySHA256.length
+                                 ? santa::NSStringToUTF8String(identifiers.binarySHA256)
+                                 : std::string();
+  if (!missCacheKey.empty() && _executionRuleMissCache->get(missCacheKey)) {
+    return nil;
   }
 
   // Now query the database.
@@ -613,6 +647,13 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     [rs close];
   }];
   // clang-format on
+
+  // No rule exists, cache that fact so we don't needlessly keep looking in the
+  // db during future execs.
+  if (!rule && !missCacheKey.empty()) {
+    _executionRuleMissCache->set(missCacheKey, true);
+  }
+
   return rule;
 }
 
@@ -871,6 +912,10 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   if (blockErrors.count > 0 && errors) {
     *errors = [blockErrors copy];
   }
+
+  // Clear the miss cache regardless of rule type. We could ignore clearing if
+  // there were only REMOVE rules, but it is not worth the effort.
+  _executionRuleMissCache->clear();
 
   // If the DB updated successfully, call the "rules changed" callbacks if appropriate
   if (!failed && self.fileAccessRulesChangedCallback &&

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -499,6 +499,89 @@
   XCTAssertNil(r);
 }
 
+// A lookup with no binary SHA-256 has no key to cache a miss under, so it must not record one --
+// doing so would make the first unhashable file's miss the answer for every later lookup.
+- (void)testExecutionRuleMissCacheIgnoresLookupsWithoutAFileHash {
+  [self.sut addExecutionRules:@[ [self _exampleCDHashRule] ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:nil];
+
+  struct RuleIdentifiers missed = {
+      .cdhash = @"ffffffffffffffffffffffffffffffffffffffff",
+  };
+  XCTAssertNil([self.sut executionRuleForIdentifiers:missed]);
+
+  SNTRule* r = [self.sut
+      executionRuleForIdentifiers:(struct RuleIdentifiers){
+                                      .cdhash = @"dbe8c39801f93e05fc7bc53a02af5b4d3cfc670a",
+                                  }];
+  XCTAssertNotNil(r, @"a miss with no file hash must not be cached");
+  XCTAssertEqual(r.type, SNTRuleTypeCDHash);
+}
+
+// A cached miss must only suppress lookups for the file it was recorded for. Note there is no
+// rule write between the two lookups here -- a write would clear the cache and hide the bug.
+- (void)testExecutionRuleMissCacheIsPerFileHash {
+  [self.sut addExecutionRules:@[ [self _exampleBinaryRule] ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:nil];
+
+  struct RuleIdentifiers missed = {
+      .binarySHA256 = @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
+  };
+  XCTAssertNil([self.sut executionRuleForIdentifiers:missed]);
+
+  struct RuleIdentifiers ruled = {
+      .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+  };
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ruled];
+  XCTAssertNotNil(r, @"a miss must only suppress lookups for the same file hash");
+  XCTAssertEqual(r.type, SNTRuleTypeBinary);
+}
+
+// The only invalidation the miss cache has is a full clear on the rule write paths. Without it a
+// remembered miss would outlive the rule that resolves it -- which is exactly what happens to a
+// transitive rule SNTCompilerController writes after its own lookup missed.
+- (void)testExecutionRuleMissCacheClearedByRuleAdd {
+  struct RuleIdentifiers ids = {
+      .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+  };
+
+  XCTAssertNil([self.sut executionRuleForIdentifiers:ids]);
+
+  [self.sut addExecutionRules:@[ [self _exampleBinaryRule] ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:nil];
+
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ids];
+  XCTAssertNotNil(r, @"a rule added after a cached miss must still be found");
+  XCTAssertEqual(r.type, SNTRuleTypeBinary);
+}
+
+// Static rules are checked ahead of the cache, so a remembered miss must never shadow one. Both
+// lookups here carry the same file hash -- the second is answered from the static rules despite
+// the first having recorded a miss under that key, with no rule write in between to clear it.
+- (void)testExecutionRuleMissCacheDoesNotShadowStaticRules {
+  [self.sut updateStaticRules:@[ @{
+              @"identifier" : @"ZZZZZZZZZZ",
+              @"policy" : @"BLOCKLIST",
+              @"rule_type" : @"TEAMID",
+            } ]];
+
+  struct RuleIdentifiers missed = {
+      .binarySHA256 = @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
+  };
+  XCTAssertNil([self.sut executionRuleForIdentifiers:missed]);
+
+  struct RuleIdentifiers ruled = {
+      .binarySHA256 = @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
+      .teamID = @"ZZZZZZZZZZ",
+  };
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ruled];
+  XCTAssertNotNil(r, @"a cached miss must not shadow a static rule");
+  XCTAssertEqual(r.type, SNTRuleTypeTeamID);
+}
+
 - (void)testFetchRuleOrdering {
   NSArray<NSError*>* err;
   [self.sut addExecutionRules:@[

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -582,6 +582,37 @@
   XCTAssertEqual(r.type, SNTRuleTypeTeamID);
 }
 
+// executeQuery: returns nil when the statement itself fails -- a locked or corrupt db, a schema
+// that isn't what was expected. That is not evidence the file has no rule, and the only
+// invalidation the miss cache has is a full clear on the rule write paths, so a cached failure
+// would outlive it. Renaming the table away and back simulates the failure and its recovery with
+// no rule write in between, which would otherwise clear the cache and hide the bug.
+- (void)testExecutionRuleMissCacheIgnoresQueryFailures {
+  [self.sut addExecutionRules:@[ [self _exampleBinaryRule] ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:nil];
+
+  struct RuleIdentifiers ids = {
+      .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+  };
+
+  [self.dbq inDatabase:^(FMDatabase* db) {
+    XCTAssertTrue(
+        [db executeUpdate:@"ALTER TABLE execution_rules RENAME TO execution_rules_hidden"]);
+  }];
+
+  XCTAssertNil([self.sut executionRuleForIdentifiers:ids]);
+
+  [self.dbq inDatabase:^(FMDatabase* db) {
+    XCTAssertTrue(
+        [db executeUpdate:@"ALTER TABLE execution_rules_hidden RENAME TO execution_rules"]);
+  }];
+
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ids];
+  XCTAssertNotNil(r, @"a failed query must not be cached as a rule miss");
+  XCTAssertEqual(r.type, SNTRuleTypeBinary);
+}
+
 - (void)testFetchRuleOrdering {
   NSArray<NSError*>* err;
   [self.sut addExecutionRules:@[


### PR DESCRIPTION
Adds a negative cache to `SNTRuleTable` that records binary SHA-256s with no matching row in `execution_rules`, so repeat executions of an unruled binary skip the SQL query. The cache is cleared wholesale whenever rules are added or removed.

Traces show that during tight loop executions, like builds, we pay over and over to lookup rules that don't exist.