### PR TITLE
santad: don't cache execution rule misses for file-hash-only lookups

### DIFF
--- a/Source/santad/CompilerAuthorizationScopeTest.mm
+++ b/Source/santad/CompilerAuthorizationScopeTest.mm
@@ -140,7 +140,7 @@ static const std::vector<std::string> kBlockedArgs = {"clang", "--link"};
   rule.celExpr = kCompilerCELExpr;
 
   struct RuleIdentifiers anyIdentifiers = {};
-  OCMStub([self.mockRuleDatabase executionRuleForIdentifiers:anyIdentifiers])
+  OCMStub([self.mockRuleDatabase executionRuleForIdentifiers:anyIdentifiers useCache:YES])
       .ignoringNonObjectArgs()
       .andReturn(rule);
 

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -113,6 +113,14 @@
 - (SNTRule*)executionRuleForIdentifiers:(struct RuleIdentifiers)identifiers;
 
 ///
+///  As `executionRuleForIdentifiers:`, but may answer from the negative miss cache.
+///
+///  @param useCache Pass YES only from the execution path, and only when these are all the
+///         identifiers the file has. NO behaves exactly like `executionRuleForIdentifiers:`.
+///
+- (SNTRule*)executionRuleForIdentifiers:(struct RuleIdentifiers)identifiers useCache:(BOOL)useCache;
+
+///
 ///  Add an array of execution rules, file access rules, and network flow rules to the database.
 ///  All rules across all three types are applied within a single transaction; the transaction
 ///  is aborted if any rule fails to apply.

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -36,6 +36,8 @@
 #include "Source/common/String.h"
 #include "Source/common/cel/Evaluator.h"
 
+#include <array>
+#include <cstring>
 #include <memory>
 #include <string>
 
@@ -46,9 +48,13 @@ static const int64_t kTransitiveRuleCullingThreshold = 500000;
 // Consider transitive rules out of date if they haven't been used in six months.
 static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
 
-// Maximum number of file hashes remembered by the execution rule miss cache. Measured at ~1.3MB
+// Maximum number of file hashes remembered by the execution rule miss cache. Measured at ~0.8MB
 // of live heap when full.
 static const uint64_t kExecutionRuleMissCacheSize = 10000;
+
+// Miss cache key: the binary SHA-256 as its 64 hex characters. Fixed size so the key is trivially
+// copyable into the db block and stored inline by the cache, leaving a lookup allocation-free.
+using ExecutionRuleMissCacheKey = std::array<char, 64>;
 
 static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // Create a temporary ES client in order to grab the default set of muted paths.
@@ -92,7 +98,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // contents, and so determines every other identifier a lookup would match on. Entries are only
   // ever cleared wholesale, by `addExecutionRules:...:errors:` -- there is no per-entry
   // invalidation.
-  std::unique_ptr<SantaCache<std::string, bool>> _executionRuleMissCache;
+  std::unique_ptr<SantaCache<ExecutionRuleMissCacheKey, bool>> _executionRuleMissCache;
 }
 @property MOLCodesignChecker* santadCSInfo;
 @property MOLCodesignChecker* launchdCSInfo;
@@ -264,7 +270,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 
 - (uint32_t)initializeDatabase:(FMDatabase*)db fromVersion:(uint32_t)version {
   _executionRuleMissCache =
-      std::make_unique<SantaCache<std::string, bool>>(kExecutionRuleMissCacheSize);
+      std::make_unique<SantaCache<ExecutionRuleMissCacheKey, bool>>(kExecutionRuleMissCacheSize);
 
   // Lock this database from other processes
   [[db executeQuery:@"PRAGMA locking_mode = EXCLUSIVE;"] close];
@@ -608,11 +614,16 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // If we already looked in the db during another exec and there was no rule,
   // return early. The cache will be cleared when new rules are added. Keyed by
   // file sha256. Using a cdhash is appealing, but a cdhash is not guaranteed
-  // unique across files. An empty key means this lookup must not be cached.
-  std::string missCacheKey = (useCache && identifiers.binarySHA256.length)
-                                 ? santa::NSStringToUTF8String(identifiers.binarySHA256)
-                                 : std::string();
-  if (!missCacheKey.empty() && _executionRuleMissCache->get(missCacheKey)) {
+  // unique across files. A hash that is not exactly key-length cannot be keyed, so it is not
+  // cached.
+  ExecutionRuleMissCacheKey missCacheKey{};
+  const BOOL cacheable =
+      useCache && [identifiers.binarySHA256 lengthOfBytesUsingEncoding:NSUTF8StringEncoding] ==
+                      missCacheKey.size();
+  if (cacheable) {
+    memcpy(missCacheKey.data(), identifiers.binarySHA256.UTF8String, missCacheKey.size());
+  }
+  if (cacheable && _executionRuleMissCache->get(missCacheKey)) {
     return nil;
   }
 
@@ -678,7 +689,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
     // it, and the query finds the new rule so nothing is cached. Recording the miss outside the
     // block instead admits the interleaving where a write commits and clears in between, pinning
     // a miss that no later rule write invalidates.
-    if (!rule && !queryFailed && !missCacheKey.empty()) {
+    if (!rule && !queryFailed && cacheable) {
       self->_executionRuleMissCache->set(missCacheKey, true);
     }
   }];

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -90,7 +90,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // query entirely. Only the SQL lookup is cached -- the static rules are an in-memory dictionary
   // and are checked on every call. Keyed on the binary SHA-256 alone -- it identifies the file
   // contents, and so determines every other identifier a lookup would match on. Entries are only
-  // ever cleared wholesale (see `clearExecutionRuleMissCache`) -- there is no per-entry
+  // ever cleared wholesale, by `addExecutionRules:...:errors:` -- there is no per-entry
   // invalidation.
   std::unique_ptr<SantaCache<std::string, bool>> _executionRuleMissCache;
 }
@@ -633,7 +633,6 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // planner and costs a temp B-tree sort on every lookup.
   //
   // clang-format off
-  __block BOOL queryFailed = NO;
   [self inDatabase:^(FMDatabase* db) {
     FMResultSet* rs = [db executeQuery:@"SELECT * FROM ("
                                       @"            SELECT 1 AS prio, * FROM execution_rules WHERE identifier=? AND type=500  "
@@ -648,26 +647,42 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
                                       identifiers.certificateSHA256, identifiers.teamID,
                                       identifiers.binarySHA256, @(SNTRuleStateAllowTransitive)];
     // A nil result set means the statement itself failed (e.g. a locked or corrupt db), not
-    // that the file has no rule. Note the failure so it isn't remembered as a miss below.
+    // that the file has no rule. Return without remembering it as a miss.
     if (!rs) {
-      queryFailed = YES;
       LOGE(@"Failed to query execution rules: %@", [db lastErrorMessage]);
       return;
     }
-    if ([rs next]) {
+
+    // Stepping fails for the same reasons preparing does. sqlite3_prepare_v2 succeeds and defers
+    // a busy, corrupt or I/O error to the first sqlite3_step, and `next` folds that into the same
+    // NO it returns for "no rows". Ask for the error explicitly so a transient db failure isn't
+    // mistaken for -- and then remembered as -- an absent rule.
+    BOOL queryFailed = NO;
+    NSError* stepErr;
+    if ([rs nextWithError:&stepErr]) {
       rule = [self executionRuleFromResultSet:rs];
+    } else if (stepErr) {
+      queryFailed = YES;
+      LOGE(@"Failed to step execution rules query: %@", stepErr);
     }
     [rs close];
+
+    // The query ran and found nothing, so cache that fact to avoid needlessly looking in the db
+    // during future execs. A failed query is deliberately not cached: the miss cache is only ever
+    // invalidated by a rule write, so caching a transient db error would pin it in place and deny
+    // this file its rule indefinitely.
+    //
+    // This must stay inside the db queue block. The queue is serial, so bundling the query with
+    // the set() makes the pair atomic with respect to a rule write: either both run before the
+    // write transaction, and the writer's subsequent clear() drops the entry, or both run after
+    // it, and the query finds the new rule so nothing is cached. Recording the miss outside the
+    // block instead admits the interleaving where a write commits and clears in between, pinning
+    // a miss that no later rule write invalidates.
+    if (!rule && !queryFailed && !missCacheKey.empty()) {
+      self->_executionRuleMissCache->set(missCacheKey, true);
+    }
   }];
   // clang-format on
-
-  // The query ran and found nothing, so cache that fact to avoid needlessly looking in the db
-  // during future execs. A failed query is deliberately not cached: the miss cache is only ever
-  // invalidated by a rule write, so caching a transient db error would pin it in place and deny
-  // this file its rule indefinitely.
-  if (!rule && !queryFailed && !missCacheKey.empty()) {
-    _executionRuleMissCache->set(missCacheKey, true);
-  }
 
   return rule;
 }

--- a/Source/santad/DataLayer/SNTRuleTable.mm
+++ b/Source/santad/DataLayer/SNTRuleTable.mm
@@ -46,8 +46,8 @@ static const int64_t kTransitiveRuleCullingThreshold = 500000;
 // Consider transitive rules out of date if they haven't been used in six months.
 static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
 
-// Maximum number of file hashes remembered by the execution rule miss cache.
-// Maxes out around 322KiB.
+// Maximum number of file hashes remembered by the execution rule miss cache. Measured at ~1.3MB
+// of live heap when full.
 static const uint64_t kExecutionRuleMissCacheSize = 10000;
 
 static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
@@ -563,6 +563,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
 }
 
 - (SNTRule*)executionRuleForIdentifiers:(struct RuleIdentifiers)identifiers {
+  return [self executionRuleForIdentifiers:identifiers useCache:NO];
+}
+
+- (SNTRule*)executionRuleForIdentifiers:(struct RuleIdentifiers)identifiers
+                               useCache:(BOOL)useCache {
   __block SNTRule* rule;
 
   // Look for a static rule that matches.
@@ -603,8 +608,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet* criticalPaths) {
   // If we already looked in the db during another exec and there was no rule,
   // return early. The cache will be cleared when new rules are added. Keyed by
   // file sha256. Using a cdhash is appealing, but a cdhash is not guaranteed
-  // unique across files.
-  std::string missCacheKey = identifiers.binarySHA256.length
+  // unique across files. An empty key means this lookup must not be cached.
+  std::string missCacheKey = (useCache && identifiers.binarySHA256.length)
                                  ? santa::NSStringToUTF8String(identifiers.binarySHA256)
                                  : std::string();
   if (!missCacheKey.empty() && _executionRuleMissCache->get(missCacheKey)) {

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -16,6 +16,7 @@
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#include <sqlite3.h>
 #include <stdint.h>
 #import "Source/common/SNTError.h"
 
@@ -48,6 +49,14 @@
 @property(readwrite) NSString* identifier;
 @property(readwrite) NSString* celExpr;
 @end
+
+// A progress handler that returns non-zero aborts whatever operation is running, making
+// sqlite3_step return SQLITE_INTERRUPT. sqlite3_prepare_v2 never invokes the handler, so this
+// reproduces the shape of a busy, corrupt or I/O failure: the statement compiles fine and only
+// fails once rows are actually read.
+static int InterruptStepProgressHandler(void* context) {
+  return 1;
+}
 
 @implementation SNTRuleTableTest
 
@@ -609,6 +618,34 @@
 
   SNTRule* r = [self.sut executionRuleForIdentifiers:ids useCache:YES];
   XCTAssertNotNil(r, @"a failed query must not be cached as a rule miss");
+  XCTAssertEqual(r.type, SNTRuleTypeBinary);
+}
+
+// As above, but for a failure that only surfaces once the statement is stepped, which is how
+// sqlite reports a busy or locked db, a bad page and an I/O error. `-[FMResultSet next]` signals
+// that with the same NO it uses for "no rows", so the lookup is indistinguishable from a miss
+// unless the step error is asked for explicitly.
+- (void)testExecutionRuleMissCacheIgnoresStepFailures {
+  [self.sut addExecutionRules:@[ [self _exampleBinaryRule] ]
+                  ruleCleanup:SNTRuleCleanupNone
+                       errors:nil];
+
+  struct RuleIdentifiers ids = {
+      .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+  };
+
+  [self.dbq inDatabase:^(FMDatabase* db) {
+    sqlite3_progress_handler((sqlite3*)db.sqliteHandle, 1, InterruptStepProgressHandler, NULL);
+  }];
+
+  XCTAssertNil([self.sut executionRuleForIdentifiers:ids useCache:YES]);
+
+  [self.dbq inDatabase:^(FMDatabase* db) {
+    sqlite3_progress_handler((sqlite3*)db.sqliteHandle, 0, NULL, NULL);
+  }];
+
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ids useCache:YES];
+  XCTAssertNotNil(r, @"a query that failed while stepping must not be cached as a rule miss");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 }
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -509,18 +509,19 @@
   struct RuleIdentifiers missed = {
       .cdhash = @"ffffffffffffffffffffffffffffffffffffffff",
   };
-  XCTAssertNil([self.sut executionRuleForIdentifiers:missed]);
+  XCTAssertNil([self.sut executionRuleForIdentifiers:missed useCache:YES]);
 
-  SNTRule* r = [self.sut
-      executionRuleForIdentifiers:(struct RuleIdentifiers){
-                                      .cdhash = @"dbe8c39801f93e05fc7bc53a02af5b4d3cfc670a",
-                                  }];
+  struct RuleIdentifiers ids = {
+      .cdhash = @"dbe8c39801f93e05fc7bc53a02af5b4d3cfc670a",
+  };
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ids useCache:YES];
   XCTAssertNotNil(r, @"a miss with no file hash must not be cached");
   XCTAssertEqual(r.type, SNTRuleTypeCDHash);
 }
 
-// A cached miss must only suppress lookups for the file it was recorded for. Note there is no
-// rule write between the two lookups here -- a write would clear the cache and hide the bug.
+// A cached miss must only suppress lookups for the file it was recorded for. Both lookups carry
+// the same Team ID, so only the file hash distinguishes them. Note there is no rule write between
+// them -- a write would clear the cache and hide the bug.
 - (void)testExecutionRuleMissCacheIsPerFileHash {
   [self.sut addExecutionRules:@[ [self _exampleBinaryRule] ]
                   ruleCleanup:SNTRuleCleanupNone
@@ -529,31 +530,29 @@
   struct RuleIdentifiers missed = {
       .binarySHA256 = @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
   };
-  XCTAssertNil([self.sut executionRuleForIdentifiers:missed]);
+  XCTAssertNil([self.sut executionRuleForIdentifiers:missed useCache:YES]);
 
   struct RuleIdentifiers ruled = {
       .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
   };
-  SNTRule* r = [self.sut executionRuleForIdentifiers:ruled];
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ruled useCache:YES];
   XCTAssertNotNil(r, @"a miss must only suppress lookups for the same file hash");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 }
 
-// The only invalidation the miss cache has is a full clear on the rule write paths. Without it a
-// remembered miss would outlive the rule that resolves it -- which is exactly what happens to a
-// transitive rule SNTCompilerController writes after its own lookup missed.
+// The only invalidation the miss cache has is a full clear on the rule write paths.
 - (void)testExecutionRuleMissCacheClearedByRuleAdd {
   struct RuleIdentifiers ids = {
       .binarySHA256 = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
   };
 
-  XCTAssertNil([self.sut executionRuleForIdentifiers:ids]);
+  XCTAssertNil([self.sut executionRuleForIdentifiers:ids useCache:YES]);
 
   [self.sut addExecutionRules:@[ [self _exampleBinaryRule] ]
                   ruleCleanup:SNTRuleCleanupNone
                        errors:nil];
 
-  SNTRule* r = [self.sut executionRuleForIdentifiers:ids];
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ids useCache:YES];
   XCTAssertNotNil(r, @"a rule added after a cached miss must still be found");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 }
@@ -571,13 +570,13 @@
   struct RuleIdentifiers missed = {
       .binarySHA256 = @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
   };
-  XCTAssertNil([self.sut executionRuleForIdentifiers:missed]);
+  XCTAssertNil([self.sut executionRuleForIdentifiers:missed useCache:YES]);
 
   struct RuleIdentifiers ruled = {
       .binarySHA256 = @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
       .teamID = @"ZZZZZZZZZZ",
   };
-  SNTRule* r = [self.sut executionRuleForIdentifiers:ruled];
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ruled useCache:YES];
   XCTAssertNotNil(r, @"a cached miss must not shadow a static rule");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID);
 }
@@ -601,14 +600,14 @@
         [db executeUpdate:@"ALTER TABLE execution_rules RENAME TO execution_rules_hidden"]);
   }];
 
-  XCTAssertNil([self.sut executionRuleForIdentifiers:ids]);
+  XCTAssertNil([self.sut executionRuleForIdentifiers:ids useCache:YES]);
 
   [self.dbq inDatabase:^(FMDatabase* db) {
     XCTAssertTrue(
         [db executeUpdate:@"ALTER TABLE execution_rules_hidden RENAME TO execution_rules"]);
   }];
 
-  SNTRule* r = [self.sut executionRuleForIdentifiers:ids];
+  SNTRule* r = [self.sut executionRuleForIdentifiers:ids useCache:YES];
   XCTAssertNotNil(r, @"a failed query must not be cached as a rule miss");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 }

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -331,7 +331,7 @@ static SNTSandboxExecRequest* MakeSandboxRequest(uint64_t dev, uint64_t ino, con
 }
 
 - (void)stubRule:(SNTRule*)rule forIdentifiers:(struct RuleIdentifiers)wantIdentifiers {
-  OCMStub([self.mockRuleDatabase executionRuleForIdentifiers:wantIdentifiers])
+  OCMStub([self.mockRuleDatabase executionRuleForIdentifiers:wantIdentifiers useCache:YES])
       .ignoringNonObjectArgs()
       .andDo(^(NSInvocation* inv) {
         struct RuleIdentifiers gotIdentifiers = {};

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -646,6 +646,34 @@ static void ApplyCodesignValidationFailure(SNTCachedDecision* cd, OSStatus statu
                                                                    : SNTSigningStatusInvalid);
 }
 
+// Whether this execution searched every identifier these contents can produce, which is what the
+// SHA-256-keyed miss cache requires: a miss cached from a narrower set shadows the rules the
+// missing identifiers would have matched.
+static BOOL SignatureVerdictIsStable(SNTCachedDecision* cd) {
+  // No recorded verdict: the signature identifiers may be derived differently next time.
+  if (!cd.codesignValidationStatus) {
+    return NO;
+  }
+
+  // Unsigned contents can never offer more than their hash.
+  if (cd.codesignValidationStatus.intValue == errSecCSUnsigned) {
+    return YES;
+  }
+
+  // The file validates statically, but filterIdentifiers drops every signature identifier unless
+  // the kernel also considers the running image signed and valid.
+  BOOL kernelSeesValidSignature = NO;
+  switch (cd.signingStatus) {
+    case SNTSigningStatusProduction: OS_FALLTHROUGH;
+    case SNTSigningStatusDevelopment: OS_FALLTHROUGH;
+    case SNTSigningStatusAdhoc: kernelSeesValidSignature = YES; break;
+    case SNTSigningStatusInvalid: OS_FALLTHROUGH;
+    case SNTSigningStatusUnsigned: break;
+  }
+
+  return kernelSeesValidSignature;
+}
+
 - (nonnull SNTCachedDecision*)
            decisionForFileInfo:(nonnull SNTFileInfo*)fileInfo
                    configState:(nonnull SNTConfigState*)configState
@@ -703,7 +731,7 @@ static void ApplyCodesignValidationFailure(SNTCachedDecision* cd, OSStatus statu
     }
   }
 
-  BOOL signatureVerdictIsStable = (cd.codesignValidationStatus != nil);
+  BOOL signatureVerdictIsStable = SignatureVerdictIsStable(cd);
   SNTRule* rule = [self.ruleTable executionRuleForIdentifiers:CreateRuleIDs(cd)
                                                      useCache:signatureVerdictIsStable];
   if (rule) {

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -703,7 +703,9 @@ static void ApplyCodesignValidationFailure(SNTCachedDecision* cd, OSStatus statu
     }
   }
 
-  SNTRule* rule = [self.ruleTable executionRuleForIdentifiers:CreateRuleIDs(cd)];
+  BOOL signatureVerdictIsStable = (cd.codesignValidationStatus != nil);
+  SNTRule* rule = [self.ruleTable executionRuleForIdentifiers:CreateRuleIDs(cd)
+                                                     useCache:signatureVerdictIsStable];
   if (rule) {
     // If we have a rule match we don't need to process any further.
     if ([self decision:cd

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1156,6 +1156,44 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   XCTAssertTrue([self useCacheFlagForCachedDecision:cached codesignError:nil codesigningFlags:0]);
 }
 
+- (void)testExecutionRuleLookupSkipsMissCacheWhenKernelRejectsValidlySignedImage {
+  // The kernel rejected the image, so the lookup is by hash alone even though the file validates.
+  // Caching that miss would shadow these contents' signature rules on a later healthy execution.
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+  cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+  cached.teamID = @"EQHXZ8M8AV";
+  cached.signingID = @"EQHXZ8M8AV:com.google.Chrome";
+  cached.codesignValidationStatus = @(errSecSuccess);
+
+  XCTAssertFalse([self useCacheFlagForCachedDecision:cached
+                                       codesignError:nil
+                                    codesigningFlags:CS_SIGNED]);
+}
+
+- (void)testExecutionRuleLookupSkipsMissCacheWhenKernelSeesUnsignedValidlySignedImage {
+  // Same narrowing, other route: the kernel sees no signature while the file validates
+  // statically, e.g. an exec of an unsigned slice of a binary whose native slice is signed.
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+  cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+  cached.teamID = @"EQHXZ8M8AV";
+  cached.signingID = @"EQHXZ8M8AV:com.google.Chrome";
+  cached.codesignValidationStatus = @(errSecSuccess);
+
+  XCTAssertFalse([self useCacheFlagForCachedDecision:cached codesignError:nil codesigningFlags:0]);
+}
+
+- (void)testExecutionRuleLookupUsesMissCacheOnRecordedUnsignedVerdictKernelKilled {
+  // An unsigned arm64 image reports invalid, not unsigned (see KernelWillKillForCodeSigning).
+  // The recorded unsigned verdict still means the hash is the whole identifier set.
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+  cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+  cached.codesignValidationStatus = @(errSecCSUnsigned);
+
+  XCTAssertTrue([self useCacheFlagForCachedDecision:cached
+                                      codesignError:nil
+                                   codesigningFlags:CS_SIGNED | CS_KILL]);
+}
+
 - (void)testDecisionDoesNotRecordUnsignedVerdictWhenKernelSaysSigned {
   // errSecCSUnsigned is only reusable when the kernel agrees the executable
   // itself carries no signature. When the running image is signed the two

--- a/Source/santad/SNTPolicyProcessorTest.mm
+++ b/Source/santad/SNTPolicyProcessorTest.mm
@@ -1063,6 +1063,99 @@ BOOL RuleIdentifiersAreEqual(struct RuleIdentifiers r1, struct RuleIdentifiers r
   [mockRuleTable stopMocking];
 }
 
+// The miss cache is keyed on the file hash alone, so the exec path may only opt in when the
+// identifier set CreateRuleIDs passes is the stable one for the file. A signature failure that was
+// not durable enough to record narrows that set to the hash, so such a lookup must not opt in --
+// these three tests pin the flag in each of the verdict states that decide it.
+- (BOOL)useCacheFlagForCachedDecision:(SNTCachedDecision*)cachedDecision
+                        codesignError:(NSError*)csError
+                     codesigningFlags:(uint32_t)codesigningFlags {
+  id mockRuleTable = OCMClassMock([SNTRuleTable class]);
+  SNTPolicyProcessor* processor =
+      [[SNTPolicyProcessor alloc] initWithRuleTable:mockRuleTable
+                                 entitlementsFilter:santa::EntitlementsFilter::Create(@[], @[])];
+  id mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  processor.configurator = mockConfigurator;
+
+  // ignoringNonObjectArgs() covers both the identifiers struct and the BOOL, so the flag has to be
+  // read back off the invocation rather than matched on.
+  __block BOOL useCache = NO;
+  __block int lookups = 0;
+  OCMStub([mockRuleTable executionRuleForIdentifiers:(struct RuleIdentifiers) {} useCache:NO])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* inv) {
+        BOOL got = NO;
+        [inv getArgument:&got atIndex:3];
+        useCache = got;
+        lookups++;
+      });
+
+  id mockFileInfo = OCMClassMock([SNTFileInfo class]);
+  if (csError) {
+    OCMExpect([mockFileInfo codesignCheckerWithError:[OCMArg setTo:csError]]).andReturn(nil);
+  } else {
+    OCMReject([mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]]);
+  }
+  OCMStub([mockFileInfo isMachO]).andReturn(YES);
+  OCMStub([mockFileInfo SHA256])
+      .andReturn(@"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e");
+
+  es_file_t file = MakeESFile("/tmp/miss-cache-flag");
+  es_process_t proc = MakeESProcess(&file);
+  proc.is_platform_binary = false;
+  proc.codesigning_flags = codesigningFlags;
+  SNTConfigState* configState = [[SNTConfigState alloc] initWithConfig:mockConfigurator];
+
+  [processor decisionForFileInfo:mockFileInfo
+                   targetProcess:&proc
+                    imageCPUType:CPU_TYPE_ARM64
+                     configState:configState
+              activationCallback:nil
+                  cachedDecision:cachedDecision];
+
+  XCTAssertEqual(lookups, 1, @"the rule lookup must have happened for the flag to mean anything");
+  OCMVerifyAll(mockFileInfo);
+  [mockFileInfo stopMocking];
+  [mockConfigurator stopMocking];
+  [mockRuleTable stopMocking];
+
+  return useCache;
+}
+
+- (void)testExecutionRuleLookupSkipsMissCacheOnUnrecordedSignatureFailure {
+  // The fresh-failure path: the signature could not be read, the verdict is not recorded, and
+  // CreateRuleIDs is left with the SHA-256 only. Caching that miss under the file hash would
+  // suppress the Team ID and Signing ID rules on the next execution that reads the signature.
+  NSError* csError = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                         code:errSecCSSignatureFailed
+                                     userInfo:nil];
+  XCTAssertFalse([self useCacheFlagForCachedDecision:nil
+                                       codesignError:csError
+                                    codesigningFlags:CS_SIGNED]);
+}
+
+- (void)testExecutionRuleLookupUsesMissCacheOnRecordedValidSignature {
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+  cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+  cached.codesignValidationStatus = @(errSecSuccess);
+
+  XCTAssertTrue([self useCacheFlagForCachedDecision:cached
+                                      codesignError:nil
+                                   codesigningFlags:CS_SIGNED | CS_VALID]);
+}
+
+- (void)testExecutionRuleLookupUsesMissCacheOnRecordedUnsignedVerdict {
+  // An unsigned binary passes a hash and nothing else, which is the whole question it can ask --
+  // and freshly built unsigned binaries in a build loop are what the cache exists for. A recorded
+  // unsigned verdict must keep its caching.
+  SNTCachedDecision* cached = [[SNTCachedDecision alloc] init];
+  cached.sha256 = @"a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e";
+  cached.codesignValidationStatus = @(errSecCSUnsigned);
+
+  XCTAssertTrue([self useCacheFlagForCachedDecision:cached codesignError:nil codesigningFlags:0]);
+}
+
 - (void)testDecisionDoesNotRecordUnsignedVerdictWhenKernelSaysSigned {
   // errSecCSUnsigned is only reusable when the kernel agrees the executable
   // itself carries no signature. When the running image is signed the two


### PR DESCRIPTION
Follow-up to #1162. The miss cache is keyed on the binary SHA-256. A caller could poison the cache with `santactl rule --check --sha256`.

Only use the cache on the exec path when code signing status is valid.
