### PR TITLE
common: Speed up SNTFileInfo bundle lookup

### DIFF
--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -64,7 +64,10 @@
 - (instancetype)initWithResolvedPath:(NSString*)path error:(NSError**)error;
 
 ///
-///  @return Path of this file.
+///  @return Path of this file. Always a regular file, and expected to be absolute and resolved:
+///      the initializers either standardize the path or document that they take one already
+///      resolved. bundlePath is derived from this, so an unresolved path here yields an
+///      unresolved bundle path.
 ///
 - (NSString*)path;
 
@@ -147,8 +150,10 @@
 - (BOOL)isMissingPageZero;
 
 ///
-///  If set to YES, the bundle* and infoPlist methods will search for and use the highest NSBundle
-///  found in the tree. Defaults to NO, which uses the first found bundle, if any.
+///  If set to YES, the bundle* and infoPlist methods will search for and use the highest bundle
+///  found in the tree, and only bundles with one of a small set of known extensions (.app,
+///  .framework, .xpc, ...) are considered. Defaults to NO, which uses the first found bundle with
+///  any extension, if any.
 ///
 ///  @example:
 ///      An SNTFileInfo object that represents
@@ -156,18 +161,21 @@
 ///      useAncestorBundle is set to YES
 ///        /Applications/Photos.app will be used to get data backing all the bundle methods
 ///
-///  @note: The NSBundle object backing the bundle* and infoPlist methods is cached once found.
-///         Setting the useAncestorBundle propery will clear this cache and force a re-search.
+///  @note: The result backing the bundle* and infoPlist methods is cached once found. Setting the
+///         useAncestorBundle propery will clear this cache and force a re-search.
 ///
 @property(nonatomic) BOOL useAncestorBundle;
 
 ///
 ///  @return An NSBundle if this file is part of a bundle.
 ///
+///  @note: Prefer bundlePath when only the location is needed. Building the NSBundle is the
+///         expensive part of this, and it is deferred until this method is called.
+///
 - (NSBundle*)bundle;
 
 ///
-///  @return The path to the bundle this file is a part of, if any.
+///  @return The path to the bundle this file is a part of, if any. Always a prefix of `path`.
 ///
 - (NSString*)bundlePath;
 

--- a/Source/common/SNTFileInfo.mm
+++ b/Source/common/SNTFileInfo.mm
@@ -26,6 +26,7 @@
 #include <sys/xattr.h>
 
 #include <algorithm>
+#include <iterator>
 
 #import "Source/common/AccountLookup.h"
 #import "Source/common/CertificateHelpers.h"
@@ -65,6 +66,8 @@ static const uint32_t kMaxFatArchCount = 64;
 
 // Cached properties
 @property NSBundle* bundleRef;
+@property NSString* bundlePathStorage;
+@property NSDictionary* bundleInfoDict;
 @property NSDictionary* infoDict;
 @property NSDictionary* quarantineDict;
 @property NSDictionary* cachedHeaders;
@@ -152,7 +155,13 @@ static const uint32_t kMaxFatArchCount = 64;
     return nil;
   }
   self = [self initWithResolvedPath:resolvedPath error:error];
-  if (self && bndl) _bundleRef = bndl;
+  if (self && bndl) {
+    // `resolvePath:` already located the bundle. Seed both caches from it so that `bundlePath`
+    // has a single source of truth: `resolvedPath` is `bndl.executablePath`, so `bndl.bundlePath`
+    // is a prefix of `self.path`, just like a path the search would produce.
+    _bundleRef = bndl;
+    _bundlePathStorage = bndl.bundlePath ?: (NSString*)[NSNull null];
+  }
   return self;
 }
 
@@ -345,22 +354,40 @@ static const uint32_t kMaxFatArchCount = 64;
 
 ///
 ///  Directories with a "Contents/Info.plist" entry can be mistaken as a bundle. To be considered an
-///  ancestor, the bundle must have a valid extension.
+///  ancestor, the bundle must have one of these extensions.
 ///
-- (NSSet*)allowedAncestorExtensions {
-  static NSSet* set;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    set = [NSSet setWithArray:@[
-      @"app",
-      @"bundle",
-      @"framework",
-      @"kext",
-      @"xctest",
-      @"xpc",
-    ]];
-  });
-  return set;
+static NSString* const kAllowedAncestorExtensions[] = {
+    @"app", @"bundle", @"framework", @"kext", @"xctest", @"xpc",
+};
+
+///
+///  Whether `ext` is an extension a bundle ancestor is allowed to have. Compared case
+///  insensitively, as macOS volumes are typically case insensitive.
+///
+static BOOL IsAllowedAncestorExtension(NSString* ext) {
+  for (size_t i = 0; i < std::size(kAllowedAncestorExtensions); ++i) {
+    if ([ext caseInsensitiveCompare:kAllowedAncestorExtensions[i]] == NSOrderedSame) return YES;
+  }
+  return NO;
+}
+
+///
+///  Read the Info.plist of the bundle rooted at `path`, or nil if `path` isn't a bundle.
+///
+///  `-[NSBundle infoDictionary]` is deliberately not used. `+[NSBundle bundleWithPath:]` keeps
+///  every bundle it creates in a process-wide cache for the lifetime of the process, so searching
+///  with it retains a bundle for each directory visited. That cache is also never invalidated, so
+///  changes to an Info.plist are not realized. `CFBundleCopyInfoDictionaryInDirectory` does
+///  neither.
+///
+- (NSDictionary*)infoDictionaryForBundleDirectory:(NSString*)path {
+  // Reject non-directories up front. CoreFoundation would otherwise probe several candidate
+  // bundle layouts to reach the same conclusion.
+  struct stat sb;
+  if (stat(path.UTF8String, &sb) != 0 || !S_ISDIR(sb.st_mode)) return nil;
+
+  return CFBridgingRelease(CFBundleCopyInfoDictionaryInDirectory(
+      (__bridge CFURLRef)[NSURL fileURLWithPath:path isDirectory:YES]));
 }
 
 ///
@@ -371,45 +398,81 @@ static const uint32_t kMaxFatArchCount = 64;
 ///  Also a bundle can contain multiple binaries within its subdirectories and we want any of these
 ///  to count as being part of the bundle.
 ///
-///  This method walks up the path until a bundle is found, if any.
+///  A bundle directory always has an extension, so the path is first filtered with a pure string
+///  pass and only the surviving components are touched on disk. The overwhelming majority of
+///  executables live outside a bundle entirely and are rejected without any I/O at all.
 ///
-///  @param ancestor YES this will return the highest NSBundle, with a valid extension, found in the
-///                  tree. NO will return the the lowest NSBundle, without validating the extension.
+///  @param ancestor YES this will return the highest bundle path, with a valid extension, found in
+///                  the tree. NO will return the lowest bundle path, accepting any extension.
+///  @param infoDict On return, the Info.plist of the located bundle. Cached by the caller so that
+///                  the plist read to identify the bundle isn't immediately parsed a second time.
 ///
-- (NSBundle*)findBundleWithAncestor:(BOOL)ancestor {
-  NSBundle* bundle;
-  NSMutableArray* pathComponents = [[self.path pathComponents] mutableCopy];
+- (NSString*)findBundlePathWithAncestor:(BOOL)ancestor infoDictionary:(NSDictionary**)infoDict {
+  NSArray<NSString*>* components = [self.path pathComponents];
+  // Ignore the root path "/", for some reason this is considered a bundle. The final component is
+  // also skipped: `self.path` always refers to a regular file, so it can never be a bundle itself.
+  if (components.count < 3) return nil;
 
-  // Ignore the root path "/", for some reason this is considered a bundle.
-  while (pathComponents.count > 1) {
-    NSBundle* bndl = [NSBundle bundleWithPath:[NSString pathWithComponents:pathComponents]];
-    if ([bndl objectForInfoDictionaryKey:@"CFBundleIdentifier"]) {
-      if ((!ancestor && bndl.bundlePath.pathExtension.length) ||
-          [[self allowedAncestorExtensions] containsObject:bndl.bundlePath.pathExtension]) {
-        bundle = bndl;
-      }
-      if (!ancestor) break;
-    }
-    [pathComponents removeLastObject];
+  NSMutableArray<NSString*>* candidates = [NSMutableArray array];
+  NSMutableString* prefix = [NSMutableString stringWithString:components.firstObject];
+  for (NSUInteger i = 1; i < components.count - 1; ++i) {
+    if (![prefix hasSuffix:@"/"]) [prefix appendString:@"/"];
+    [prefix appendString:components[i]];
+
+    NSString* ext = [components[i] pathExtension];
+    if (!ext.length) continue;
+    if (ancestor && !IsAllowedAncestorExtension(ext)) continue;
+    [candidates addObject:[prefix copy]];
   }
-  return bundle;
+  if (!candidates.count) return nil;
+
+  // Ancestor searches want the highest bundle in the tree, all others the lowest. Either way the
+  // search stops at the first match rather than continuing on to "/".
+  NSEnumerator* candidateEnum =
+      ancestor ? [candidates objectEnumerator] : [candidates reverseObjectEnumerator];
+  for (NSString* candidate in candidateEnum) {
+    NSDictionary* d = [self infoDictionaryForBundleDirectory:candidate];
+    if (!d[@"CFBundleIdentifier"]) continue;
+    if (infoDict) *infoDict = d;
+    return candidate;
+  }
+  return nil;
+}
+
+///
+///  The path of the containing bundle, if any, always a prefix of `path`.
+///
+///  This is the single source of truth for the bundle location: `bundle` is derived from it, never
+///  the other way around, so the value doesn't depend on the order the two are called in. Unlike
+///  `bundle` this doesn't materialize an NSBundle, which is the expensive part.
+///
+- (NSString*)locatedBundlePath {
+  if (!self.bundlePathStorage) {
+    NSDictionary* d;
+    NSString* path = [self findBundlePathWithAncestor:self.useAncestorBundle infoDictionary:&d];
+    self.bundlePathStorage = path ?: (NSString*)[NSNull null];
+    self.bundleInfoDict = d;
+  }
+  return self.bundlePathStorage == (NSString*)[NSNull null] ? nil : self.bundlePathStorage;
 }
 
 - (NSBundle*)bundle {
   if (!self.bundleRef) {
-    self.bundleRef =
-        [self findBundleWithAncestor:self.useAncestorBundle] ?: (NSBundle*)[NSNull null];
+    NSString* path = [self locatedBundlePath];
+    self.bundleRef = (path ? [NSBundle bundleWithPath:path] : nil) ?: (NSBundle*)[NSNull null];
   }
   return self.bundleRef == (NSBundle*)[NSNull null] ? nil : self.bundleRef;
 }
 
 - (NSString*)bundlePath {
-  return [self.bundle bundlePath];
+  return [self locatedBundlePath];
 }
 
 - (void)setUseAncestorBundle:(BOOL)useAncestorBundle {
   if (self.useAncestorBundle != useAncestorBundle) {
     self.bundleRef = nil;
+    self.bundlePathStorage = nil;
+    self.bundleInfoDict = nil;
     self.infoDict = nil;
   }
   _useAncestorBundle = useAncestorBundle;
@@ -423,12 +486,11 @@ static const uint32_t kMaxFatArchCount = 64;
       return self.infoDict;
     }
 
-    // `-[NSBundle infoDictionary]` is heavily cached, changes to the Info.plist are not realized.
-    // Use `CFBundleCopyInfoDictionaryInDirectory` instead, which does not appear to cache.
-    NSString* bundlePath = [self bundlePath];
-    if (bundlePath.length) {
-      d = CFBridgingRelease(CFBundleCopyInfoDictionaryInDirectory(
-          (__bridge CFURLRef)[NSURL fileURLWithPath:bundlePath]));
+    NSString* bundlePath = [self locatedBundlePath];
+    // Locating the bundle already read its Info.plist. Reuse it rather than parsing it again.
+    d = self.bundleInfoDict;
+    if (!d.count && bundlePath.length) {
+      d = [self infoDictionaryForBundleDirectory:bundlePath];
     }
     if (d.count) {
       self.infoDict = d;

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -23,9 +23,18 @@
 static const uint32_t kFatTestSliceSize = 8192;
 
 @interface SNTFileInfoTest : XCTestCase
+@property NSString* scratchDirPath;
 @end
 
 @implementation SNTFileInfoTest
+
+- (void)tearDown {
+  if (self.scratchDirPath) {
+    [[NSFileManager defaultManager] removeItemAtPath:self.scratchDirPath error:NULL];
+    self.scratchDirPath = nil;
+  }
+  [super tearDown];
+}
 
 - (NSString*)directoryBundle {
   NSString* rp = [[NSBundle bundleForClass:[self class]] resourcePath];
@@ -35,6 +44,70 @@ static const uint32_t kFatTestSliceSize = 8192;
 - (NSString*)bundleExample {
   NSString* rp = [[NSBundle bundleForClass:[self class]] resourcePath];
   return [rp stringByAppendingPathComponent:@"testdata/BundleExample.app"];
+}
+
+///
+///  Root of a per-test temporary directory, removed in -tearDown.
+///
+- (NSString*)scratchDir {
+  if (!self.scratchDirPath) {
+    self.scratchDirPath = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:[NSString stringWithFormat:@"SNTFileInfoTest-%@",
+                                                                  NSUUID.UUID.UUIDString]];
+    XCTAssertTrue([[NSFileManager defaultManager] createDirectoryAtPath:self.scratchDirPath
+                                            withIntermediateDirectories:YES
+                                                             attributes:nil
+                                                                  error:NULL]);
+  }
+  return self.scratchDirPath;
+}
+
+///
+///  Write an Info.plist declaring `identifier` at `path`, creating parent directories.
+///
+- (void)writeInfoPlistAtPath:(NSString*)path identifier:(NSString*)identifier {
+  XCTAssertTrue([[NSFileManager defaultManager]
+            createDirectoryAtPath:[path stringByDeletingLastPathComponent]
+      withIntermediateDirectories:YES
+                       attributes:nil
+                            error:NULL]);
+  NSDictionary* plist = @{
+    @"CFBundleIdentifier" : identifier,
+    @"CFBundleName" : identifier,
+    @"CFBundleExecutable" : @"exe",
+  };
+  XCTAssertTrue([plist writeToFile:path atomically:YES]);
+}
+
+///
+///  Create a non-empty regular file at `path`, creating parent directories.
+///
+- (void)writeExecutableAtPath:(NSString*)path {
+  XCTAssertTrue([[NSFileManager defaultManager]
+            createDirectoryAtPath:[path stringByDeletingLastPathComponent]
+      withIntermediateDirectories:YES
+                       attributes:nil
+                            error:NULL]);
+  XCTAssertTrue([@"#!/bin/sh\nexit 0\n" writeToFile:path
+                                         atomically:YES
+                                           encoding:NSUTF8StringEncoding
+                                              error:NULL]);
+}
+
+///
+///  Build a bundle at `<scratch>/<name>` whose Info.plist sits at `relPlistPath`, containing an
+///  executable at `relExecPath`. Returns the path of the executable.
+///
+- (NSString*)bundleAtName:(NSString*)name
+             plistRelPath:(NSString*)relPlistPath
+              execRelPath:(NSString*)relExecPath
+               identifier:(NSString*)identifier {
+  NSString* bundlePath = [[self scratchDir] stringByAppendingPathComponent:name];
+  [self writeInfoPlistAtPath:[bundlePath stringByAppendingPathComponent:relPlistPath]
+                  identifier:identifier];
+  NSString* execPath = [bundlePath stringByAppendingPathComponent:relExecPath];
+  [self writeExecutableAtPath:execPath];
+  return execPath;
 }
 
 - (void)testPathStandardizing {
@@ -425,6 +498,199 @@ static const uint32_t kFatTestSliceSize = 8192;
   sut.useAncestorBundle = YES;
 
   XCTAssertNil([sut bundle]);
+}
+
+///
+///  CFBundle recognizes several Info.plist layouts. All of them must be found.
+///
+- (void)testBundleLayouts {
+  NSArray<NSArray<NSString*>*>* layouts = @[
+    @[ @"Contents.app", @"Contents/Info.plist", @"Contents/MacOS/exe" ],
+    @[ @"Flat.app", @"Info.plist", @"exe" ],
+    @[ @"Resources.app", @"Resources/Info.plist", @"exe" ],
+    @[ @"SupportFiles.app", @"Support Files/Info.plist", @"Support Files/exe" ],
+  ];
+
+  for (NSArray<NSString*>* layout in layouts) {
+    NSString* identifier = [@"com.northpolesec.santa.test." stringByAppendingString:layout[0]];
+    NSString* execPath = [self bundleAtName:layout[0]
+                               plistRelPath:layout[1]
+                                execRelPath:layout[2]
+                                 identifier:identifier];
+    SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:execPath];
+
+    XCTAssertEqualObjects([sut bundleIdentifier], identifier, @"layout %@", layout[0]);
+    XCTAssertEqualObjects([sut bundlePath],
+                          [[self scratchDir] stringByAppendingPathComponent:layout[0]],
+                          @"layout %@", layout[0]);
+  }
+}
+
+///
+///  Without useAncestorBundle any extension is accepted, not just the known bundle extensions.
+///
+- (void)testNonAncestorAcceptsAnyExtension {
+  NSString* execPath = [self bundleAtName:@"Odd.someext"
+                             plistRelPath:@"Contents/Info.plist"
+                              execRelPath:@"Contents/MacOS/exe"
+                               identifier:@"com.northpolesec.santa.test.Odd"];
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:execPath];
+
+  XCTAssertEqualObjects([sut bundleIdentifier], @"com.northpolesec.santa.test.Odd");
+
+  // With useAncestorBundle only the known bundle extensions are considered, so this one is not.
+  sut.useAncestorBundle = YES;
+  XCTAssertNil([sut bundle]);
+  XCTAssertNil([sut bundlePath]);
+}
+
+///
+///  An extension-less directory can hold a valid Info.plist, but is never treated as the bundle.
+///  The search passes over it and keeps going, rather than stopping there and reporting nothing.
+///
+- (void)testExtensionlessBundleIsSkipped {
+  NSString* outer = [[self scratchDir] stringByAppendingPathComponent:@"Outer.app"];
+  [self writeInfoPlistAtPath:[outer stringByAppendingPathComponent:@"Contents/Info.plist"]
+                  identifier:@"com.northpolesec.santa.test.Outer"];
+
+  NSString* inner = [outer stringByAppendingPathComponent:@"Contents/Resources/Payload"];
+  [self writeInfoPlistAtPath:[inner stringByAppendingPathComponent:@"Contents/Info.plist"]
+                  identifier:@"com.northpolesec.santa.test.Payload"];
+
+  NSString* execPath = [inner stringByAppendingPathComponent:@"bin/exe"];
+  [self writeExecutableAtPath:execPath];
+
+  // Guard against this test passing for the wrong reason: the platform really does consider the
+  // extension-less directory a bundle, so skipping it has to be a decision, not an accident.
+  XCTAssertEqualObjects(
+      [[NSBundle bundleWithPath:inner] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
+      @"com.northpolesec.santa.test.Payload");
+
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:execPath];
+  XCTAssertEqualObjects([sut bundleIdentifier], @"com.northpolesec.santa.test.Outer");
+  XCTAssertEqualObjects([sut bundlePath], outer);
+}
+
+///
+///  Bundle extensions are matched case insensitively, as macOS volumes usually are.
+///
+- (void)testAncestorExtensionIsCaseInsensitive {
+  NSString* execPath = [self bundleAtName:@"Upper.APP"
+                             plistRelPath:@"Contents/Info.plist"
+                              execRelPath:@"Contents/MacOS/exe"
+                               identifier:@"com.northpolesec.santa.test.Upper"];
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:execPath];
+  sut.useAncestorBundle = YES;
+
+  XCTAssertEqualObjects([sut bundleIdentifier], @"com.northpolesec.santa.test.Upper");
+  XCTAssertEqualObjects([sut bundlePath],
+                        [[self scratchDir] stringByAppendingPathComponent:@"Upper.APP"]);
+}
+
+///
+///  With nested bundles, useAncestorBundle selects the outermost and the default the innermost.
+///
+- (void)testNestedBundles {
+  NSString* outer = [[self scratchDir] stringByAppendingPathComponent:@"Outer.app"];
+  [self writeInfoPlistAtPath:[outer stringByAppendingPathComponent:@"Contents/Info.plist"]
+                  identifier:@"com.northpolesec.santa.test.Outer"];
+
+  NSString* inner = [outer stringByAppendingPathComponent:@"Contents/Library/LoginItems/Inner.app"];
+  [self writeInfoPlistAtPath:[inner stringByAppendingPathComponent:@"Contents/Info.plist"]
+                  identifier:@"com.northpolesec.santa.test.Inner"];
+
+  NSString* execPath = [inner stringByAppendingPathComponent:@"Contents/MacOS/exe"];
+  [self writeExecutableAtPath:execPath];
+
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:execPath];
+  XCTAssertEqualObjects([sut bundlePath], inner);
+  XCTAssertEqualObjects([sut bundleIdentifier], @"com.northpolesec.santa.test.Inner");
+
+  sut.useAncestorBundle = YES;
+  XCTAssertEqualObjects([sut bundlePath], outer);
+  XCTAssertEqualObjects([sut bundleIdentifier], @"com.northpolesec.santa.test.Outer");
+}
+
+///
+///  bundlePath is always a prefix of path, and doesn't change depending on whether the NSBundle
+///  has been materialized. Callers do string arithmetic against these two, so they must agree.
+///
+- (void)testBundlePathIsStablePrefixOfPath {
+  NSArray<NSString*>* paths = @[
+    [self bundleAtName:@"Prefix.app"
+          plistRelPath:@"Contents/Info.plist"
+           execRelPath:@"Contents/MacOS/exe"
+            identifier:@"com.northpolesec.santa.test.Prefix"],
+    [self bundleExample],
+  ];
+
+  for (NSString* path in paths) {
+    for (NSNumber* ancestor in @[ @NO, @YES ]) {
+      SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:path];
+      sut.useAncestorBundle = ancestor.boolValue;
+
+      // Read the path first, then materialize the NSBundle, then read it again.
+      NSString* before = [sut bundlePath];
+      XCTAssertNotNil([sut bundle], @"%@", path);
+      NSString* after = [sut bundlePath];
+
+      XCTAssertEqualObjects(before, after, @"%@ ancestor=%@", path, ancestor);
+      XCTAssertTrue([sut.path hasPrefix:before], @"%@ is not a prefix of %@", before, sut.path);
+      XCTAssertEqualObjects([sut bundle].bundlePath, before, @"%@ ancestor=%@", path, ancestor);
+    }
+  }
+}
+
+///
+///  The prefix relationship holds even when the path given to the class contains a symlink.
+///  NSBundle resolves symlinks in the paths it hands back, so deriving bundlePath from an
+///  NSBundle would break the relationship that callers depend on.
+///
+- (void)testBundlePathIsPrefixOfPathThroughSymlink {
+  NSString* execPath = [self bundleAtName:@"Symlinked.app"
+                             plistRelPath:@"Contents/Info.plist"
+                              execRelPath:@"Contents/MacOS/exe"
+                               identifier:@"com.northpolesec.santa.test.Symlinked"];
+
+  // <scratch>/link -> <scratch>, so <scratch>/link/Symlinked.app/... names the same file by a
+  // path that is not fully resolved.
+  NSString* link = [[self scratchDir] stringByAppendingPathComponent:@"link"];
+  XCTAssertTrue([[NSFileManager defaultManager] createSymbolicLinkAtPath:link
+                                                     withDestinationPath:[self scratchDir]
+                                                                   error:NULL]);
+  NSString* linkedExecPath = [link
+      stringByAppendingPathComponent:[execPath substringFromIndex:[self scratchDir].length + 1]];
+
+  // initWithResolvedPath: takes the path as-is, so self.path keeps the symlink in it.
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithResolvedPath:linkedExecPath error:NULL];
+  XCTAssertNotNil(sut);
+  XCTAssertEqualObjects(sut.path, linkedExecPath);
+
+  NSString* before = [sut bundlePath];
+  XCTAssertNotNil([sut bundle]);
+  NSString* after = [sut bundlePath];
+
+  XCTAssertEqualObjects(before, after);
+  XCTAssertTrue([sut.path hasPrefix:before], @"%@ is not a prefix of %@", before, sut.path);
+  XCTAssertEqualObjects(before, [link stringByAppendingPathComponent:@"Symlinked.app"]);
+}
+
+///
+///  A deep path with no bundle anywhere in it resolves to nothing.
+///
+- (void)testDeepNonBundlePath {
+  NSString* execPath =
+      [[self scratchDir] stringByAppendingPathComponent:@"one/two/three/four/five/six/seven/exe"];
+  [self writeExecutableAtPath:execPath];
+
+  SNTFileInfo* sut = [[SNTFileInfo alloc] initWithPath:execPath];
+  XCTAssertNil([sut bundle]);
+  XCTAssertNil([sut bundlePath]);
+  XCTAssertNil([sut bundleIdentifier]);
+
+  sut.useAncestorBundle = YES;
+  XCTAssertNil([sut bundle]);
+  XCTAssertNil([sut bundlePath]);
 }
 
 - (void)testEmbeddedInfoPlist {


### PR DESCRIPTION
`findBundleWithAncestor:` built an `NSBundle` for every ancestor directory of every file, so paths with no bundle in them — most executables — still did a full walk with real filesystem work.

- Filter the path with a string pass first; only components that could be a bundle are touched on disk
- Probe candidates with `CFBundleCopyInfoDictionaryInDirectory` instead of `NSBundle`, and reuse the Info.plist read during the search in `infoPlist` rather than parsing it twice
- Defer building the `NSBundle` until `bundle` is called, so `bundlePath` no longer materializes one
- Stop the ancestor search at the first match instead of always walking to `/`
- Make `bundlePath` the single source of truth for the bundle location: it is always a prefix of `path` and no longer depends on whether `bundle` has been called
- Match bundle extensions case insensitively

Total CPU for `santactl fileinfo --key "Bundle Name"`, before → after:

| workload | before | after |
|---|---|---|
| 298 `.app` executables | 0.62–0.71s | 0.37s |
| 1000 non-bundle paths | 0.64–0.70s | 0.42–0.47s |

Caveat on those numbers: each run is a fresh process, so the old code never gets to reuse `NSBundle`'s process-wide cache. A repeat lookup of the same bundle is slower than before (~93µs vs ~20µs); the win comes from the first lookup and from non-bundle paths being rejected without I/O. A bounded cross-instance cache would recover it and is left for a follow-up.

Two behavior changes:
- An extension-less directory holding an `Info.plist` no longer terminates a non-ancestor search. Previously the walk stopped there and returned nothing; now it continues and reports the enclosing bundle. This affects `fileBundleID`/`fileBundlePath`, so such a binary can now match a bundle rule and gets bundle-hashed where it previously did not.
- Uppercase bundle extensions (`.APP`) now match.