### PR TITLE
santad: fix group kill reporting and harden kill request signal decode

### DIFF
--- a/Source/common/SNTKillCommand.mm
+++ b/Source/common/SNTKillCommand.mm
@@ -63,11 +63,26 @@
 
 - (instancetype)initWithCoder:(NSCoder*)decoder {
   // An archive written before the signal field existed has no signal key at
-  // all; keep such a request meaning what it meant when it was written. An
-  // archive that does carry a signal is held to the same range the
-  // initializers enforce.
-  NSNumber* encodedSignal = [decoder decodeObjectOfClass:[NSNumber class] forKey:@"signal"];
-  int decodedSignal = encodedSignal ? encodedSignal.intValue : SIGKILL;
+  // all; keep such a request meaning what it meant when it was written. The
+  // absence of the key is the only thing that means that, so test for it
+  // directly rather than inferring it from a nil decode: -decodeObjectOfClass:
+  // also returns nil for a key that is present but holds a class secure coding
+  // rejects, and reading a malformed archive as SIGKILL is not the same
+  // decision as reading a pre-signal one that way.
+  int decodedSignal = SIGKILL;
+  if ([decoder containsValueForKey:@"signal"]) {
+    // The declared class is not enough on its own either: an NSString stored
+    // under this key comes back from -decodeObjectOfClass:[NSNumber class]
+    // without an error, and its -intValue would quietly become the signal.
+    NSNumber* encodedSignal = [decoder decodeObjectOfClass:[NSNumber class] forKey:@"signal"];
+    if (![encodedSignal isKindOfClass:[NSNumber class]]) {
+      return nil;
+    }
+    decodedSignal = encodedSignal.intValue;
+  }
+
+  // A signal that is present is held to the same range the initializers
+  // enforce.
   if (decodedSignal <= 0 || decodedSignal >= NSIG) {
     return nil;
   }

--- a/Source/common/SNTKillCommandTest.mm
+++ b/Source/common/SNTKillCommandTest.mm
@@ -424,6 +424,39 @@
   }
 }
 
+// NSKeyedUnarchiver hands back an NSString for a key declared as NSNumber
+// without reporting an error, and -intValue would quietly turn it into the
+// signal to deliver. A signal key must hold an actual number.
+- (void)testSNTKillRequestDecodeRejectsSignalEncodedAsString {
+  NSKeyedArchiver* archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
+  [archiver encodeObject:[[NSUUID UUID] UUIDString] forKey:@"uuid"];
+  [archiver encodeObject:@"17" forKey:@"signal"];
+  [archiver finishEncoding];
+
+  NSKeyedUnarchiver* unarchiver =
+      [[NSKeyedUnarchiver alloc] initForReadingFromData:archiver.encodedData error:nil];
+  unarchiver.requiresSecureCoding = YES;
+
+  XCTAssertNil([[SNTKillRequest alloc] initWithCoder:unarchiver]);
+}
+
+// When the signal key holds a class secure coding rejects, the decode yields
+// nil — the same thing an archive predating the field yields. Only the absence
+// of the key means "predates the field", so a key that is present but unusable
+// is treated as a malformed archive and rejected, not read as SIGKILL.
+- (void)testSNTKillRequestDecodeRejectsSignalOfRejectedClass {
+  NSKeyedArchiver* archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
+  [archiver encodeObject:[[NSUUID UUID] UUIDString] forKey:@"uuid"];
+  [archiver encodeObject:@[ @9 ] forKey:@"signal"];
+  [archiver finishEncoding];
+
+  NSKeyedUnarchiver* unarchiver =
+      [[NSKeyedUnarchiver alloc] initForReadingFromData:archiver.encodedData error:nil];
+  unarchiver.requiresSecureCoding = YES;
+
+  XCTAssertNil([[SNTKillRequest alloc] initWithCoder:unarchiver]);
+}
+
 // The base class rejects the bad signal; subclasses reach that check through
 // [super initWithCoder:], so a concrete subclass carrying an invalid signal
 // must also decode to nil.

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1152,7 +1152,7 @@ objc_library(
         "//Source/common:String",
         "//Source/common:SystemResources",
         "@abseil-cpp//absl/cleanup:cleanup",
-        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/container:flat_hash_map",
     ],
 )
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1151,7 +1151,6 @@ objc_library(
         "//Source/common:SNTSystemInfo",
         "//Source/common:String",
         "//Source/common:SystemResources",
-        "@abseil-cpp//absl/cleanup:cleanup",
         "@abseil-cpp//absl/container:flat_hash_map",
     ],
 )

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -34,7 +34,7 @@
 #include "Source/common/String.h"
 #include "Source/common/SystemResources.h"
 #include "absl/cleanup/cleanup.h"
-#include "absl/container/flat_hash_set.h"
+#include "absl/container/flat_hash_map.h"
 
 namespace santa {
 
@@ -133,12 +133,13 @@ SNTKilledProcessError LibprocSignalErrorToKilledProcessError(int error) {
 // Delivers `sig` to the process `token` identifies, or to that process's group
 // when the request targets process groups. `sig` is passed in rather than read
 // from the request so the term-then-kill path can drive two passes at different
-// signals through the same request. `signaledPgids` holds the groups this pass
-// has already signaled, so each group is signaled exactly once no matter how
-// many of its members matched: the first member signals the group and later
-// members return nil, having already been reached by that one signal.
+// signals through the same request. `signaledGroups` maps each group this pass
+// has already signaled to the errno that delivery returned, so a group is
+// signaled exactly once no matter how many of its members matched, while every
+// member is still reported: the one delivery reached all of them, so they all
+// share its outcome.
 SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* token,
-                              const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
+                              const KillEnv& env, absl::flat_hash_map<pid_t, int>* signaledGroups) {
   static pid_t myPid = getpid();
   pid_t targetPid = Pid(*token);
   pid_t targetPidversion = Pidversion(*token);
@@ -170,23 +171,27 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
     // signaling the one matched process, which is never broader than what was
     // asked for.
     if (targetPgid > 1 && targetPgid != getpgrp()) {
-      if (!signaledPgids->insert(targetPgid).second) {
-        // Signaled earlier in this pass, which reached this process too.
-        return nil;
+      // Only the first member of a group delivers; the rest reuse that
+      // delivery's outcome. Reporting it for every member keeps a failed
+      // delivery visible for each process it left unsignaled, and keeps a
+      // successful one from understating what a single kill(-pgid) reached.
+      auto [group, delivered] = signaledGroups->try_emplace(targetPgid, 0);
+      if (delivered) {
+        int error = env.signal_group(targetPgid, sig);
+        if (error == 0) {
+          LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
+               request.uuid);
+        } else {
+          LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
+               targetPgid, error, request.uuid);
+        }
+        group->second = error;
       }
 
-      int error = env.signal_group(targetPgid, sig);
-      if (error == 0) {
-        LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
-             request.uuid);
-      } else {
-        LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
-             targetPgid, error, request.uuid);
-      }
-
-      return [[SNTKilledProcess alloc] initWithPid:targetPid
-                                        pidversion:targetPidversion
-                                             error:LibprocSignalErrorToKilledProcessError(error)];
+      return [[SNTKilledProcess alloc]
+          initWithPid:targetPid
+           pidversion:targetPidversion
+                error:LibprocSignalErrorToKilledProcessError(group->second)];
     }
   }
 
@@ -205,7 +210,7 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
 
 SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, int sig,
                                        const KillEnv& env,
-                                       absl::flat_hash_set<pid_t>* signaledPgids) {
+                                       absl::flat_hash_map<pid_t, int>* signaledGroups) {
   if (![[SNTSystemInfo bootSessionUUID] isEqualToString:request.bootSessionUUID]) {
     LOGW(@"Request to kill running process with non-matching boot session UUID");
     return [[SNTKilledProcess alloc] initWithPid:request.pid
@@ -216,7 +221,7 @@ SNTKilledProcess* KillByRunningProcess(SNTKillRequestRunningProcess* request, in
   audit_token_t token;
   if (env.token_for_pid(request.pid, &token)) {
     if (Pidversion(token) == request.pidversion) {
-      return KillProcess(request, sig, &token, env, signaledPgids);
+      return KillProcess(request, sig, &token, env, signaledGroups);
     } else {
       LOGW(@"Rejecting request to kill pid (%d) due to pidversion mismatch (got: %d, want: %d)",
            request.pid, Pidversion(token), request.pidversion);
@@ -267,12 +272,13 @@ std::optional<audit_token_t> MatchProcess(
 
 SNTKilledProcess* KillByMatchers(SNTKillRequest* request, int sig, pid_t pid,
                                  const std::vector<std::unique_ptr<ProcessMatcher>>& matchers,
-                                 const KillEnv& env, absl::flat_hash_set<pid_t>* signaledPgids) {
+                                 const KillEnv& env,
+                                 absl::flat_hash_map<pid_t, int>* signaledGroups) {
   std::optional<audit_token_t> token = MatchProcess(pid, matchers, env);
   if (!token) {
     return nil;
   }
-  return KillProcess(request, sig, &token.value(), env, signaledPgids);
+  return KillProcess(request, sig, &token.value(), env, signaledGroups);
 }
 
 // The matchers a request's criteria come down to, or nullopt when the request
@@ -312,13 +318,15 @@ std::optional<std::vector<std::unique_ptr<ProcessMatcher>>> BuildMatchers(SNTKil
 SNTKillResponse* RunKillPass(SNTKillRequest* request, int sig, const KillEnv& env) {
   NSMutableArray<SNTKilledProcess*>* killedProcs = [NSMutableArray array];
 
-  // Groups already signaled by this pass, so a group with several matching
-  // members is signaled once. Empty unless the request targets groups.
-  absl::flat_hash_set<pid_t> signaledPgids;
+  // Groups already signaled by this pass, mapped to the errno their one
+  // delivery returned, so a group with several matching members is signaled
+  // once and every member reports that outcome. Empty unless the request
+  // targets groups.
+  absl::flat_hash_map<pid_t, int> signaledGroups;
 
   if ([request isKindOfClass:[SNTKillRequestRunningProcess class]]) {
     SNTKilledProcess* killed =
-        KillByRunningProcess((SNTKillRequestRunningProcess*)request, sig, env, &signaledPgids);
+        KillByRunningProcess((SNTKillRequestRunningProcess*)request, sig, env, &signaledGroups);
     if (killed) {
       [killedProcs addObject:killed];
     }
@@ -340,7 +348,7 @@ SNTKillResponse* RunKillPass(SNTKillRequest* request, int sig, const KillEnv& en
         continue;
       }
 
-      SNTKilledProcess* killed = KillByMatchers(request, sig, pid, *matchers, env, &signaledPgids);
+      SNTKilledProcess* killed = KillByMatchers(request, sig, pid, *matchers, env, &signaledGroups);
       if (killed) {
         [killedProcs addObject:killed];
       }

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -33,7 +33,6 @@
 #import "Source/common/SNTSystemInfo.h"
 #include "Source/common/String.h"
 #include "Source/common/SystemResources.h"
-#include "absl/cleanup/cleanup.h"
 #include "absl/container/flat_hash_map.h"
 
 namespace santa {

--- a/Source/santad/KillingMachineTest.mm
+++ b/Source/santad/KillingMachineTest.mm
@@ -352,10 +352,9 @@ NSArray<NSString*>* SignalDescriptions(const std::vector<FakeSignal>& signals) {
   XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[ @"pid:10:15" ]));
 }
 
-// Three pids share a process group, so that group is signaled once and the
-// later members are skipped. A fourth pid in another group gets its own signal.
-// Reporting follows delivery: one record per signal sent, attributed to the pid
-// that triggered it.
+// Three pids share a process group, so that group is signaled once no matter
+// how many of its members matched. A fourth pid in another group gets its own
+// signal. What each pass reports is covered by the two tests below.
 - (void)testGroupTargetingSignalsEachGroupOnce {
   pid_t pgidA = getpgrp() + 1;
   pid_t pgidB = getpgrp() + 2;
@@ -372,18 +371,80 @@ NSArray<NSString*>* SignalDescriptions(const std::vector<FakeSignal>& signals) {
                                                                 signal:SIGTERM
                                                    targetProcessGroups:YES];
 
-  SNTKillResponse* response = santa::KillingMachine(request, MakeEnv(&fake));
+  santa::KillingMachine(request, MakeEnv(&fake));
 
   XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[
                           [NSString stringWithFormat:@"group:%d:15", pgidA],
                           [NSString stringWithFormat:@"group:%d:15", pgidB]
                         ]));
+}
 
-  XCTAssertEqual(response.killedProcesses.count, 2);
+// One kill(-pgid) reaches every member of the group, so every matched member is
+// reported, not just the one that triggered the delivery. Deduplication is
+// about how many signals are sent, not about how much of the match is
+// disclosed: a caller that sees one record where three processes matched cannot
+// tell that the other two were affected.
+- (void)testGroupTargetingReportsEveryMatchedMemberOfSignaledGroup {
+  pid_t pgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11, 12};
+  fake.pidversions = {{10, 1}, {11, 2}, {12, 3}};
+  fake.matching = {10, 11, 12};
+  fake.pgids = {{10, pgid}, {11, pgid}, {12, pgid}};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID
+                                                                signal:SIGTERM
+                                                   targetProcessGroups:YES];
+
+  SNTKillResponse* response = santa::KillingMachine(request, MakeEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals),
+                        (@[ [NSString stringWithFormat:@"group:%d:15", pgid] ]));
+
+  XCTAssertEqual(response.killedProcesses.count, 3);
   XCTAssertEqual(response.killedProcesses[0].pid, 10);
-  XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNotPermitted);
-  XCTAssertEqual(response.killedProcesses[1].pid, 20);
-  XCTAssertEqual(response.killedProcesses[1].error, SNTKilledProcessErrorNotPermitted);
+  XCTAssertEqual(response.killedProcesses[0].pidversion, 1);
+  XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNone);
+  XCTAssertEqual(response.killedProcesses[1].pid, 11);
+  XCTAssertEqual(response.killedProcesses[1].pidversion, 2);
+  XCTAssertEqual(response.killedProcesses[1].error, SNTKilledProcessErrorNone);
+  XCTAssertEqual(response.killedProcesses[2].pid, 12);
+  XCTAssertEqual(response.killedProcesses[2].pidversion, 3);
+  XCTAssertEqual(response.killedProcesses[2].error, SNTKilledProcessErrorNone);
+}
+
+// A failed kill(-pgid) signaled nothing, so none of the group's matched members
+// were reached. Every one of them is reported with that failure: dropping them
+// would leave the caller unable to distinguish a group it could not signal from
+// a group with a single member.
+- (void)testGroupTargetingReportsEveryMatchedMemberWhenGroupSignalFails {
+  pid_t pgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11, 12};
+  fake.pidversions = {{10, 1}, {11, 2}, {12, 3}};
+  fake.matching = {10, 11, 12};
+  fake.pgids = {{10, pgid}, {11, pgid}, {12, pgid}};
+  fake.signalError = EPERM;
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID
+                                                                signal:SIGTERM
+                                                   targetProcessGroups:YES];
+
+  SNTKillResponse* response = santa::KillingMachine(request, MakeEnv(&fake));
+
+  // Still one attempt: a group that could not be signaled is not retried once
+  // per member.
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals),
+                        (@[ [NSString stringWithFormat:@"group:%d:15", pgid] ]));
+
+  XCTAssertEqual(response.killedProcesses.count, 3);
+  for (SNTKilledProcess* killed in response.killedProcesses) {
+    XCTAssertEqual(killed.error, SNTKilledProcessErrorNotPermitted, @"pid %d", killed.pid);
+  }
 }
 
 // kill(2) reads a pgid of 1 as every process on the machine and a pgid of 0 as
@@ -586,9 +647,13 @@ NSArray<NSString*>* SignalDescriptions(const std::vector<FakeSignal>& signals) {
                         ]));
   XCTAssertEqual(fake.waits.size(), 1);
   XCTAssertEqual(fake.waits[0], 1.5);
-  // One result per group per pass, not per matched pid: the SIGTERM pass reports
-  // the group once and the SIGKILL pass reports the survivor's group once.
-  XCTAssertEqual(response.killedProcesses.count, 2);
+  // One result per matched pid per pass, even though each pass delivered one
+  // signal: the SIGTERM pass reports both members of the group it signaled, and
+  // the SIGKILL pass reports the survivor.
+  XCTAssertEqual(response.killedProcesses.count, 3);
+  XCTAssertEqual(response.killedProcesses[0].pid, 10);
+  XCTAssertEqual(response.killedProcesses[1].pid, 11);
+  XCTAssertEqual(response.killedProcesses[2].pid, 11);
 }
 
 // Nothing matched the SIGTERM pass, so nothing can survive it. The caller's


### PR DESCRIPTION
Follow-ups to #1149.

- `KillProcess` recorded a pgid in the dedup set before attempting delivery and returned nil for later members, so a failed `kill(-pgid)` dropped every other matched member of that group from the response. Now tracks pgid -> delivery errno and reports that outcome for every matched member. Still one delivery per group.
- `initWithCoder:` inferred "archive predates the signal field" from a nil decode, but `-decodeObjectOfClass:` also returns nil for a key holding a class secure coding rejects, so a malformed archive was read as SIGKILL. Now uses `-containsValueForKey:` to test for the key directly, and requires the value to actually be an NSNumber.
- Drops the unused `absl/cleanup` include and dep from KillingMachine.

`killedProcesses` is now one record per matched process per pass rather than one per signal delivery. #1153 logs that count in `killForEntrySerialized` and describes it as a delivery count; that wording needs updating on merge.

Note: `//Source/santad:SNTRuleTableTest` fails on `main` at b3503fdb (#1162, negative rule cache) independently of this branch.