### PR TITLE
santad: stop SNTRuleTableTest inheriting the machine's static rules

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -629,9 +629,6 @@
                        errors:&err];
   XCTAssertNil(err);
 
-  // This test is only concerned about sqlite's behavior. Ensure static rules are ignored.
-  [self.sut updateStaticRules:nil];
-
   // This test verifies that rule precedence ordering is correct.
   // The query uses UNION ALL with ORDER BY type ASC to guarantee the highest-priority
   // rule is returned. See the comment in SNTRuleTable#executionRuleForIdentifiers:
@@ -737,9 +734,6 @@
                        errors:&err];
   XCTAssertNil(err);
 
-  // Only sqlite's behavior is under test here. Ensure static rules are ignored.
-  [self.sut updateStaticRules:nil];
-
   NSString* transitiveID = [self _exampleTransitiveRule].identifier;
 
   // Each case pairs the transitive Binary rule with exactly one configured rule. The configured
@@ -829,7 +823,6 @@
                   ruleCleanup:SNTRuleCleanupNone
                        errors:&err];
   XCTAssertNil(err);
-  [self.sut updateStaticRules:nil];
 
   SNTRule* r = [self.sut
       executionRuleForIdentifiers:(struct RuleIdentifiers){
@@ -865,7 +858,6 @@
                   ruleCleanup:SNTRuleCleanupNone
                        errors:&err];
   XCTAssertNil(err);
-  [self.sut updateStaticRules:nil];
 
   NSString* transitiveID = [self _exampleTransitiveRule].identifier;
 
@@ -924,7 +916,6 @@
                   ruleCleanup:SNTRuleCleanupNone
                        errors:&err];
   XCTAssertNil(err);
-  [self.sut updateStaticRules:nil];
 
   SNTRule* r = [self.sut
       executionRuleForIdentifiers:
@@ -979,7 +970,6 @@
                   ruleCleanup:SNTRuleCleanupNone
                        errors:&err];
   XCTAssertNil(err);
-  [self.sut updateStaticRules:nil];
 
   SNTRule* r = [self.sut executionRuleForIdentifiers:(struct RuleIdentifiers){
                                                          .signingID = @"ABCDEFGHIJ:signingID",

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -57,6 +57,13 @@
   self.dbq = [[FMDatabaseQueue alloc] init];
   self.sut = [[SNTRuleTable alloc] initWithDatabaseQueue:self.dbq];
 
+  // -initializeDatabase:fromVersion: primes the static rule cache from the real SNTConfigurator,
+  // which happens before the mock below is installed. On a machine with a Santa configuration
+  // profile that sets StaticRules, those rules leak into every test in this class -- and static
+  // rules are consulted ahead of both the miss cache and the database in
+  // -executionRuleForIdentifiers:. Drop them so tests only ever see rules they set up themselves.
+  [self.sut updateStaticRules:nil];
+
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
 }

--- a/Source/santad/DataLayer/SNTRuleTableTest.mm
+++ b/Source/santad/DataLayer/SNTRuleTableTest.mm
@@ -54,18 +54,14 @@
 - (void)setUp {
   [super setUp];
 
-  self.dbq = [[FMDatabaseQueue alloc] init];
-  self.sut = [[SNTRuleTable alloc] initWithDatabaseQueue:self.dbq];
-
-  // -initializeDatabase:fromVersion: primes the static rule cache from the real SNTConfigurator,
-  // which happens before the mock below is installed. On a machine with a Santa configuration
-  // profile that sets StaticRules, those rules leak into every test in this class -- and static
-  // rules are consulted ahead of both the miss cache and the database in
-  // -executionRuleForIdentifiers:. Drop them so tests only ever see rules they set up themselves.
-  [self.sut updateStaticRules:nil];
-
+  // Mock the configurator before the rule table is created: -initializeDatabase:fromVersion:
+  // reads the configurator, so a real one there would prime the static rule cache from the
+  // machine's own StaticRules and call -setSyncTypeRequired: on the real singleton.
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+
+  self.dbq = [[FMDatabaseQueue alloc] init];
+  self.sut = [[SNTRuleTable alloc] initWithDatabaseQueue:self.dbq];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
`SNTRuleTableTest.setUp` constructed the `SNTRuleTable` *before* installing the `SNTConfigurator` class mock, so `-initializeDatabase:fromVersion:` ran against the **real** configurator. Two things leaked as a result:

- `[self updateStaticRules:[[SNTConfigurator configurator] staticRules]]` primed the static rule cache from the machine's own `StaticRules`. Static rules are consulted ahead of both the negative cache and the database in `-executionRuleForIdentifiers:`, so any test asserting a *nil* lookup for a colliding identifier failed.
- The `version < 1` upgrade branch called `-setSyncTypeRequired:SNTSyncTypeCleanAll` on the real singleton. Every test hits this, since each one starts from a fresh in-memory database.

Concretely, a configuration profile containing

```
identifier => b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670
policy     => BLOCKLIST
rule_type  => BINARY
```

collides with `_exampleBinaryRule`, and `testExecutionRuleMissCacheClearedByRuleAdd` / `testExecutionRuleMissCacheIgnoresQueryFailures` fail on their setup `XCTAssertNil` — the lookup returns the machine's static rule. Verified by instrumentation: the first test reports `executionRuleCount=0`, and in the second the SQL genuinely fails (`no such table: execution_rules`, after the test renames it away) yet a rule still comes back.

Moving the mock ahead of the rule table closes both leaks at the source.

- Pre-existing, not from #1162 — six older tests in the file already call `[self.sut updateStaticRules:nil]` as a per-test workaround. The two tests added in #1162 are simply the first to assert nil on a colliding identifier.
- CI has no configuration profile, which is why this passes there and only reproduces on machines running Santa.

The six per-test `updateStaticRules:nil` calls that worked around this are now redundant and are removed.

`bazel test //Source/santad:SNTRuleTableTest` — 69/69 pass on a machine that previously saw the 2 failures.

