### PR TITLE
gui: Fix beachball rendering block messages, throttle bundleservice updates and drop main-queue drops

### DIFF
--- a/Source/common/SNTBlockMessage.mm
+++ b/Source/common/SNTBlockMessage.mm
@@ -67,12 +67,35 @@ static id EncodedValueOrNull(id value) {
   NSString* fullHTML = [NSString stringWithFormat:@"%@%@%@", htmlHeader, message, htmlFooter];
 
 #ifdef SANTAGUI
+  // NSHTMLTextDocumentType is the WebKit-backed importer: ~2.3s on first use in a process and
+  // 10-140ms on every use after, always on the main thread. Every message window asks for its
+  // block message from inside a SwiftUI `body`, which is re-evaluated on each state change --
+  // bundle-hash progress alone ticks many times a second -- so parsing per render pins the main
+  // thread and beachballs the whole GUI, menu bar item included.
+  //
+  // Cache on the exact HTML instead. The message is a pure function of the event and config, so
+  // a re-render is always a hit and only a genuinely new message pays for a parse.
+  // ponytail: NSCache, which is already thread-safe; no lock of our own.
+  static NSCache<NSString*, NSAttributedString*>* cache;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    cache = [[NSCache alloc] init];
+    cache.countLimit = 32;
+  });
+
+  NSAttributedString* cached = [cache objectForKey:fullHTML];
+  if (cached) return cached;
+
   NSData* htmlData = [fullHTML dataUsingEncoding:NSUTF8StringEncoding];
   NSDictionary* options = @{
     NSDocumentTypeDocumentAttribute : NSHTMLTextDocumentType,
     NSCharacterEncodingDocumentAttribute : @(NSUTF8StringEncoding),
   };
-  return [[NSAttributedString alloc] initWithHTML:htmlData options:options documentAttributes:NULL];
+  NSAttributedString* formatted = [[NSAttributedString alloc] initWithHTML:htmlData
+                                                                   options:options
+                                                        documentAttributes:NULL];
+  if (formatted) [cache setObject:formatted forKey:fullHTML];
+  return formatted;
 #else
   NSString* strippedHTML = [self stringFromHTML:fullHTML];
   if (!strippedHTML) {

--- a/Source/common/SNTBlockMessageTest.mm
+++ b/Source/common/SNTBlockMessageTest.mm
@@ -47,6 +47,21 @@
   XCTAssertEqualObjects([got string], input);
 }
 
+// The GUI asks for the block message from inside a SwiftUI `body`, which re-runs on every state
+// change. The HTML importer behind it is main-thread-only and costs 10-140ms a call, so repeated
+// formatting of one message must not re-parse.
+- (void)testFormatMessageCachesRepeatedMessages {
+  NSString* input = @"Repeated message";
+  NSAttributedString* first = [SNTBlockMessage formatMessage:input withFallback:@""];
+  NSAttributedString* second = [SNTBlockMessage formatMessage:input withFallback:@""];
+  XCTAssertIdentical(first, second);
+
+  NSAttributedString* other = [SNTBlockMessage formatMessage:@"A different message"
+                                                withFallback:@""];
+  XCTAssertNotIdentical(first, other);
+  XCTAssertEqualObjects([other string], @"A different message");
+}
+
 - (void)testEventDetailURLForEvent {
   SNTStoredExecutionEvent* se = [[SNTStoredExecutionEvent alloc] init];
 

--- a/Source/gui/SNTAppDelegate.mm
+++ b/Source/gui/SNTAppDelegate.mm
@@ -18,6 +18,7 @@
 #import <UserNotifications/UserNotifications.h>
 
 #import "Source/common/MOLXPCConnection.h"
+#import "Source/common/SNTBlockMessage.h"
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTKVOManager.h"
@@ -86,6 +87,14 @@
   // Connection setup runs off the main thread because it blocks on the handshake and then waits
   // up to 5s for the daemon to connect back.
   [self attemptDaemonReconnection];
+
+  // +formatMessage: is backed by the main-thread-only WebKit HTML importer, which costs ~2s the
+  // first time it runs in a process and ~10ms after. Pay that once here, as the first block of
+  // the running main queue, so the first block dialog is not preceded by a beachball. Deferred
+  // rather than called inline so launch finishes and the status bar item is live first.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    (void)[SNTBlockMessage formatMessage:@"" withFallback:@"warm up the HTML importer"];
+  });
 }
 
 // Any visible window other than those backing the status bar item. The status bar windows should

--- a/Source/gui/SNTNotificationManager.mm
+++ b/Source/gui/SNTNotificationManager.mm
@@ -258,7 +258,12 @@ static NSString* const silencedNotificationsKey = @"SilencedNotifications";
 
 - (void)hashBundleBinariesForEvent:(SNTStoredExecutionEvent*)event
                     withController:(SNTBinaryMessageWindowController*)withController {
-  withController.bundleProgress.label = @"Searching for files...";
+  // bundleProgress is an ObservableObject driving SwiftUI; this runs on hashBundleBinariesQueue,
+  // and publishing a change off the main thread mutates the view graph from under the renderer.
+  // Every other writer (-updateCountsForEvent:..., -updateBlockNotification:...) already hops.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    withController.bundleProgress.label = @"Searching for files...";
+  });
 
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
   MOLXPCConnection* bc = [SNTXPCBundleServiceInterface configuredConnection];

--- a/Source/santabundleservice/SNTBundleService.mm
+++ b/Source/santabundleservice/SNTBundleService.mm
@@ -46,7 +46,8 @@
   if (self) {
     _queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
     _stateQueue =
-        dispatch_queue_create("com.northpolesec.santa.bundleservice.state", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_create_with_target("com.northpolesec.santa.bundleservice.state",
+                                          DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL, _queue);
   }
   return self;
 }
@@ -228,7 +229,8 @@
   // Counts used as additional progress information in SantaGUI
   std::atomic<int64_t> binaryCount{0};
   std::atomic<int64_t> completedUnits{0};
-  // Highest count already reported to the GUI. Only ever moves forward, via the CAS below.
+  // Highest count already reported to the GUI. Only ever written on stateQueue, and only ever
+  // forward; atomic so the per-file fast path below can read it without taking that queue.
   std::atomic<int64_t> reportedUnits{0};
   auto* binaryCountPtr = &binaryCount;
   auto* completedUnitsPtr = &completedUnits;
@@ -257,20 +259,29 @@
       // This used to hop to the main queue for every file, purely to serialize the throttle
       // check. For Xcode.app that is ~120k blocking round trips through the main thread, which
       // serialized this otherwise-concurrent dispatch_apply and made the main thread the
-      // bottleneck for the whole scan. Nothing here needs a queue: completedUnits is already
-      // atomic, and NSProgress and NSXPCConnection are both documented thread-safe. Claim each
-      // 1% boundary with a compare-exchange so exactly one worker reports it.
+      // bottleneck for the whole scan. The per-file cost is now a lock-free atomic read; only a
+      // worker that actually crosses a boundary takes a queue, and never the main one.
       int64_t done = completedUnitsPtr->fetch_add(1) + 1;
-      int64_t reported = reportedUnitsPtr->load();
-      if (done - reported >= reportInterval &&
-          reportedUnitsPtr->compare_exchange_strong(reported, done)) {
-        p.completedUnitCount = done;
-        // fileCount is how many have been scanned, not `i`: dispatch_apply does not hand out
-        // indices in order, so `i` made the displayed count jump around.
-        [[clientListener remoteObjectProxy] updateCountsForEvent:event
-                                                     binaryCount:binaryCountPtr->load()
-                                                       fileCount:done
-                                                     hashedCount:0];
+      if (done - reportedUnitsPtr->load() >= reportInterval) {
+        // Claim and publish together. An atomic compare-exchange would pick one reporter per
+        // boundary but would not order the publish that follows it: a worker preempted between
+        // claiming 5000 and sending it lands after a worker that already sent 10000, and both
+        // the progress bar and the GUI's file count jump backwards -- a visible flicker on
+        // exactly the large bundles this throttle exists for. Serializing the pair keeps both
+        // monotonic. Reached ~100 times, not once per file.
+        dispatch_sync(self.stateQueue, ^{
+          // Re-check under serialization: a larger claim may have landed while this worker was
+          // waiting, in which case this one is stale and must not publish.
+          if (done - reportedUnitsPtr->load() < reportInterval) return;
+          reportedUnitsPtr->store(done);
+          p.completedUnitCount = done;
+          // fileCount is how many have been scanned, not `i`: dispatch_apply does not hand out
+          // indices in order, so `i` made the displayed count jump around.
+          [[clientListener remoteObjectProxy] updateCountsForEvent:event
+                                                       binaryCount:binaryCountPtr->load()
+                                                         fileCount:done
+                                                       hashedCount:0];
+        });
       }
 
       NSString* subpath = subpaths[i];

--- a/Source/santabundleservice/SNTBundleService.mm
+++ b/Source/santabundleservice/SNTBundleService.mm
@@ -18,8 +18,8 @@
 #import <CommonCrypto/CommonDigest.h>
 #import <pthread/pthread.h>
 
+#import <algorithm>
 #import <atomic>
-#import <memory>
 #import <vector>
 
 #include "Source/common/Glob.h"
@@ -33,6 +33,10 @@
 
 @interface SNTBundleService ()
 @property(nonatomic) dispatch_queue_t queue;
+// Serializes the shared mutable state the concurrent bundle scan writes to. Previously the main
+// queue was used for this, which made bundle hashing contend with -- and stall -- this process's
+// UI thread for no reason. A private serial queue gives the same mutual exclusion off it.
+@property(nonatomic) dispatch_queue_t stateQueue;
 @end
 
 @implementation SNTBundleService
@@ -41,6 +45,8 @@
   self = [super init];
   if (self) {
     _queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+    _stateQueue =
+        dispatch_queue_create("com.northpolesec.santa.bundleservice.state", DISPATCH_QUEUE_SERIAL);
   }
   return self;
 }
@@ -210,12 +216,29 @@
   //
   // Xcode.app has roughly 500k files, 8bytes per pointer is ~4MB for this array. This size to space
   // ratio seems appropriate as Xcode.app is in the upper bounds of bundle size.
-  // Using a shared pointer to make block capture easy.
-  __block auto fis = std::make_shared<std::vector<SNTFileInfo*>>(subpaths.count);
+  //
+  // dispatch_apply is synchronous, so the block cannot outlive this scope: these are plain locals
+  // captured by pointer rather than __block shared_ptrs. The vector still keeps its elements on the
+  // heap, so nothing large lands on the stack. (Removing the per-file main-queue hop below also
+  // removed the synchronization edge that was hiding the __block/shared_ptr capture from
+  // ThreadSanitizer; capturing by pointer needs no such edge to be obviously correct.)
+  std::vector<SNTFileInfo*> fis(subpaths.count);
+  auto* fisPtr = &fis;
 
   // Counts used as additional progress information in SantaGUI
-  __block auto binaryCount = std::make_shared<std::atomic<int64_t>>(0);
-  __block auto completedUnits = std::make_shared<std::atomic<int64_t>>(0);
+  std::atomic<int64_t> binaryCount{0};
+  std::atomic<int64_t> completedUnits{0};
+  // Highest count already reported to the GUI. Only ever moves forward, via the CAS below.
+  std::atomic<int64_t> reportedUnits{0};
+  auto* binaryCountPtr = &binaryCount;
+  auto* completedUnitsPtr = &completedUnits;
+  auto* reportedUnitsPtr = &reportedUnits;
+
+  // Report every 1% of work, as before, but derived once rather than recomputed per file. Also
+  // makes the throttle independent of `p`, which fixes a flood when `progress` is nil: the old
+  // condition compared against `p.completedUnitCount`, and messaging nil always returns 0, so
+  // past the 1% mark it reported on every single file.
+  const int64_t reportInterval = std::max<int64_t>(1, (int64_t)subpaths.count / 100);
 
   // Account for 80% of the work
   NSProgress* p;
@@ -229,18 +252,26 @@
     @autoreleasepool {
       if (progress.isCancelled) return;
 
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        // Update the UI for every 1% of work completed.
-        completedUnits->fetch_add(1);
-        if ((((double)completedUnits->load() / subpaths.count) -
-             ((double)p.completedUnitCount / subpaths.count)) > 0.01) {
-          p.completedUnitCount = completedUnits->load();
-          [[clientListener remoteObjectProxy] updateCountsForEvent:event
-                                                       binaryCount:binaryCount->load()
-                                                         fileCount:i
-                                                       hashedCount:0];
-        }
-      });
+      // Update the UI for every 1% of work completed.
+      //
+      // This used to hop to the main queue for every file, purely to serialize the throttle
+      // check. For Xcode.app that is ~120k blocking round trips through the main thread, which
+      // serialized this otherwise-concurrent dispatch_apply and made the main thread the
+      // bottleneck for the whole scan. Nothing here needs a queue: completedUnits is already
+      // atomic, and NSProgress and NSXPCConnection are both documented thread-safe. Claim each
+      // 1% boundary with a compare-exchange so exactly one worker reports it.
+      int64_t done = completedUnitsPtr->fetch_add(1) + 1;
+      int64_t reported = reportedUnitsPtr->load();
+      if (done - reported >= reportInterval &&
+          reportedUnitsPtr->compare_exchange_strong(reported, done)) {
+        p.completedUnitCount = done;
+        // fileCount is how many have been scanned, not `i`: dispatch_apply does not hand out
+        // indices in order, so `i` made the displayed count jump around.
+        [[clientListener remoteObjectProxy] updateCountsForEvent:event
+                                                     binaryCount:binaryCountPtr->load()
+                                                       fileCount:done
+                                                     hashedCount:0];
+      }
 
       NSString* subpath = subpaths[i];
 
@@ -249,16 +280,16 @@
       SNTFileInfo* fi = [[SNTFileInfo alloc] initWithResolvedPath:file error:NULL];
       if (!fi.isExecutable) return;
 
-      fis->at(i) = fi;
-      binaryCount->fetch_add(1);
+      fisPtr->at(i) = fi;
+      binaryCountPtr->fetch_add(1);
     }
   });
 
   [progress resignCurrent];
 
-  NSMutableArray* fileInfos = [NSMutableArray arrayWithCapacity:binaryCount->load()];
+  NSMutableArray* fileInfos = [NSMutableArray arrayWithCapacity:binaryCount.load()];
   for (NSUInteger i = 0; i < subpaths.count; i++) {
-    if (fis->at(i)) [fileInfos addObject:fis->at(i)];
+    if (fis.at(i)) [fileInfos addObject:fis.at(i)];
   }
 
   return [self generateEventsFromBinaries:fileInfos
@@ -282,6 +313,14 @@
     p = [NSProgress progressWithTotalUnitCount:fis.count * 100];
   }
 
+  // Throttle GUI updates to every 1% of work, matching -findRelatedBinaries: above. Unthrottled,
+  // this sent one XPC message per binary -- 1822 of them for Xcode.app -- and each one lands on
+  // the GUI's main thread and re-renders the notification window, pinning that main thread for
+  // tens of seconds (beachball, unresponsive status item) while a large bundle is hashed.
+  // Both counters are only ever touched on stateQueue below, so no atomics needed.
+  __block int64_t completedBinaries = 0;
+  __block int64_t reportedBinaries = 0;
+
   dispatch_apply(fis.count, self.queue, ^(size_t i) {
     @autoreleasepool {
       if (progress.isCancelled) return;
@@ -297,14 +336,21 @@
       se.fileBundleVersion = event.fileBundleVersion;
       se.fileBundleVersionString = event.fileBundleVersionString;
 
-      dispatch_sync(dispatch_get_main_queue(), ^{
+      // stateQueue, not the main queue: this only needs mutual exclusion for the dictionary
+      // write and the two counters, which is no reason to involve the UI thread.
+      dispatch_sync(self.stateQueue, ^{
         relatedEvents[se.fileSHA256] = se;
         p.completedUnitCount++;
-        if (progress) {
+        completedBinaries++;
+        // hashedCount reports how many are done, not `i`: dispatch_apply does not hand out
+        // indices in order, so `i` made the displayed count jump around.
+        if (progress &&
+            ((double)(completedBinaries - reportedBinaries) / (double)fis.count) > 0.01) {
+          reportedBinaries = completedBinaries;
           [[clientListener remoteObjectProxy] updateCountsForEvent:event
                                                        binaryCount:fis.count
                                                          fileCount:0
-                                                       hashedCount:i];
+                                                       hashedCount:completedBinaries];
         }
       });
     }


### PR DESCRIPTION
In the GUI, prime the WebKit HTML importer so that the first displayed notification is not delayed by initialization (which can cost ~2s), ensure bundle progress labels are only changed on main thread, and cache generated attributed string values so that re-renders of the notification window don't pay the generation cost repeatedly.

In bundleservice, only message the GUI when the percentage has changed, avoiding potentially hundreds of XPC messages for little value. The bundleservice also previously pushed every processed file onto the main queue, slowing down hashing but the values being updated are atomic so it isn't necessary.