### PR TITLE
config: Normalize sync-configured regexes, reject empty pattern

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -98,8 +98,9 @@
 
 ///
 ///  Set the regex of allowed paths as received from a sync server.
+///  The pattern is normalized (anchored with ^) before being stored.
 ///
-- (void)setSyncServerAllowedPathRegex:(nonnull NSRegularExpression*)re;
+- (void)setSyncServerAllowedPathRegex:(nonnull NSString*)pattern;
 
 ///
 ///  The regex of blocked paths. Regexes are specified in ICU format.
@@ -112,8 +113,9 @@
 
 ///
 ///  Set the regex of blocked paths as received from a sync server.
+///  The pattern is normalized (anchored with ^) before being stored.
 ///
-- (void)setSyncServerBlockedPathRegex:(nonnull NSRegularExpression*)re;
+- (void)setSyncServerBlockedPathRegex:(nonnull NSString*)pattern;
 
 ///
 ///  The regex of paths to log file changes for. Regexes are specified in ICU format.

--- a/Source/common/SNTConfigurator.mm
+++ b/Source/common/SNTConfigurator.mm
@@ -1125,8 +1125,8 @@ static SNTConfigurator* sharedConfigurator = nil;
   return self.configState[kAllowedPathRegexKeyDeprecated];
 }
 
-- (void)setSyncServerAllowedPathRegex:(NSRegularExpression*)re {
-  [self updateSyncStateForKey:kAllowedPathRegexKey value:re];
+- (void)setSyncServerAllowedPathRegex:(NSString*)pattern {
+  [self updateSyncStateForKey:kAllowedPathRegexKey value:[self expressionForPattern:pattern]];
 }
 
 - (NSRegularExpression*)blockedPathRegex {
@@ -1142,8 +1142,8 @@ static SNTConfigurator* sharedConfigurator = nil;
   return self.configState[kBlockedPathRegexKeyDeprecated];
 }
 
-- (void)setSyncServerBlockedPathRegex:(NSRegularExpression*)re {
-  [self updateSyncStateForKey:kBlockedPathRegexKey value:re];
+- (void)setSyncServerBlockedPathRegex:(NSString*)pattern {
+  [self updateSyncStateForKey:kBlockedPathRegexKey value:[self expressionForPattern:pattern]];
 }
 
 - (NSRegularExpression*)fileChangesRegex {
@@ -2278,7 +2278,9 @@ static SNTConfigurator* sharedConfigurator = nil;
 #pragma mark - Private Defaults Methods
 
 - (NSRegularExpression*)expressionForPattern:(NSString*)pattern {
-  if (!pattern) return nil;
+  // An empty pattern must clear the regex, not become "^", which matches every
+  // path. Sync servers send "" to mean "no regex managed here".
+  if (!pattern.length) return nil;
   if (![pattern hasPrefix:@"^"]) pattern = [@"^" stringByAppendingString:pattern];
   return [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:NULL];
 }

--- a/Source/common/SNTConfiguratorTest.mm
+++ b/Source/common/SNTConfiguratorTest.mm
@@ -605,6 +605,31 @@ typedef BOOL (^StateFileAccessAuthorizer)(void);
   }
 }
 
+// Patterns from a sync server must be normalized the same way as ones from the
+// config profile: anchored with ^ if not already, so the stored expression is a
+// prefix match rather than a substring match.
+- (void)testSyncServerPathRegexesAreAnchored {
+  SNTConfigurator* sut = [[SNTConfigurator alloc] init];
+
+  [sut setSyncServerAllowedPathRegex:@"/usr/bin/.*"];
+  [sut setSyncServerBlockedPathRegex:@"^/tmp/.*"];
+
+  XCTAssertEqualObjects(sut.allowedPathRegex.pattern, @"^/usr/bin/.*");
+  XCTAssertEqualObjects(sut.blockedPathRegex.pattern, @"^/tmp/.*");
+
+  // "" means "no regex managed here". It must clear the key, not anchor into
+  // "^", which matches every path (i.e. allow everything under Lockdown).
+  [sut setSyncServerAllowedPathRegex:@""];
+  [sut setSyncServerBlockedPathRegex:@""];
+
+  XCTAssertNil(sut.allowedPathRegex);
+  XCTAssertNil(sut.blockedPathRegex);
+
+  // An uncompilable pattern also clears rather than storing a bogus expression.
+  [sut setSyncServerAllowedPathRegex:@"/usr/["];
+  XCTAssertNil(sut.allowedPathRegex);
+}
+
 - (void)testDNSUpstreamTimeoutSecsForcedConfig {
   SNTConfigurator* sut = [[SNTConfigurator alloc] init];
   // Unset -> 0, the "use built-in default" sentinel. The default + [1,60]s clamp live downstream

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -674,17 +674,11 @@ static NSString* TAMUsernameForUID(uid_t uid) {
     }];
 
     [result allowlistRegex:^(NSString* val) {
-      [configurator
-          setSyncServerAllowedPathRegex:[NSRegularExpression regularExpressionWithPattern:val
-                                                                                  options:0
-                                                                                    error:NULL]];
+      [configurator setSyncServerAllowedPathRegex:val];
     }];
 
     [result blocklistRegex:^(NSString* val) {
-      [configurator
-          setSyncServerBlockedPathRegex:[NSRegularExpression regularExpressionWithPattern:val
-                                                                                  options:0
-                                                                                    error:NULL]];
+      [configurator setSyncServerBlockedPathRegex:val];
     }];
 
     [result removableMediaAction:^(NSString* val) {


### PR DESCRIPTION
Prior to this change, regexes sent by a sync server would not have a ^ prefixed to anchor the regex for absolute matches, but on restart the regex would have the anchor added, as it is when loaded from a mobileconfig.

This change fixes that issue, ensuring that all regexes are anchored. Additionally, it ensures that every top-level alternation branch is anchored.