### PR TITLE
santactl/status: Report sync-server provided telemetry filters

### DIFF
--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -88,6 +88,7 @@ struct RuleCounts {
 // Whether the daemon holds a (non-revoked) sync-server export config. Sync state is root-only, so
 // unprivileged callers can't read it directly and must ask the daemon.
 - (void)telemetryExportConfigured:(void (^)(BOOL))reply;
+- (void)telemetryFilterCount:(void (^)(uint64_t))reply;
 
 ///
 /// FAA Retrieval ops

--- a/Source/santactl/Commands/SNTCommandStatus.mm
+++ b/Source/santactl/Commands/SNTCommandStatus.mm
@@ -361,6 +361,10 @@ REGISTER_COMMAND_NAME(@"status")
                                                 ? @"disabled by config"
                                                 : @"disabled by sync server";
   NSUInteger telemetryExportInterval = configurator.telemetryExportIntervalSec;
+  __block uint64_t telemetryFilterCount = 0;
+  [rop telemetryFilterCount:^(uint64_t count) {
+    telemetryFilterCount = count;
+  }];
 
   NSArray<NSString*>* allowedCommands = configurator.allowedSantaCommands;
   NSString* allowedStr = !allowedCommands ? @"All"
@@ -502,7 +506,7 @@ REGISTER_COMMAND_NAME(@"status")
 
     stats[@"telemetry"] = [@{
       @"signal_rules" : @(ruleCounts.signals),
-      @"filters" : @(configurator.telemetryFilterExpressions.count),
+      @"filters" : @(telemetryFilterCount),
       @"export_enabled" : @(telemetryExportEnabled),
     } mutableCopy];
     if (telemetryExportEnabled) {
@@ -624,8 +628,7 @@ REGISTER_COMMAND_NAME(@"status")
              [FormatInterval(telemetryExportInterval) UTF8String]);
     }
     printf("  %-40s | %lld\n", "Signal Rules", ruleCounts.signals);
-    printf("  %-40s | %lu\n", "Filters",
-           (unsigned long)configurator.telemetryFilterExpressions.count);
+    printf("  %-40s | %llu\n", "Filters", telemetryFilterCount);
 
     printf(">>> Sync\n");
     printf("  %-40s | %s\n", "Enabled", syncURLStr.length ? "Yes" : "No");

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -628,6 +628,10 @@ static NSString* TAMUsernameForUID(uid_t uid) {
   reply([SNTConfigurator configurator].exportConfig != nil);
 }
 
+- (void)telemetryFilterCount:(void (^)(uint64_t))reply {
+  reply([SNTConfigurator configurator].telemetryFilterExpressions.count);
+}
+
 - (void)enableBundles:(void (^)(BOOL))reply {
   reply([SNTConfigurator configurator].enableBundles);
 }


### PR DESCRIPTION
`santactl status` reports the number of telemetry filter expressions configured but it directly uses SNTConfigurator to provide this count, which doesn't include sync-server provided filters because `santactl` can't access sync-state. Instead, ask santad for the number of filters and return that.