### PR TITLE
santad: timed rule kills quit only the recorded process

### DIFF
--- a/Source/santad/KillEnvTestSupport.h
+++ b/Source/santad/KillEnvTestSupport.h
@@ -75,7 +75,8 @@ struct FakeKillEnv {
   // pid -> the audit token read after which that pid is recycled: its live
   // pidversion changes, modeling a different process taking over the pid.
   // Reads are counted per pid across the whole call. Matching reads a pid's
-  // token twice, so 1 recycles mid-match and 2 recycles after it matched.
+  // token twice, so 1 recycles mid-match and 2 recycles after it matched;
+  // group targeting reads once more, before it signals the group.
   std::map<pid_t, int> recycleAfterNthRead;
   // errno both signal seams return for a delivery that reaches its target.
   int signalError = 0;

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -159,16 +159,6 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
   }
 
   if (request.targetProcessGroups) {
-    // The group is read here, immediately after the caller verified the audit
-    // token that brackets the match, so the raw syscall adjacency (token_after
-    // -> getpgid) matches the direct path's. The safety is NOT equivalent,
-    // though: the direct path's proc_signal_with_audittoken re-validates the
-    // token at delivery, so a pid recycled after matching yields ESRCH and its
-    // effective window is ~zero. kill(-pgid) cannot re-validate anything, so
-    // here the adjacency is the sole protection: a pid recycled in the narrow
-    // token_after -> getpgid window would put a stranger's group in scope. That
-    // residual is inherent to kill(-pgid) and is accepted; re-reading the token
-    // around this lookup would not remove it.
     pid_t targetPgid = env.pgid_for_pid(targetPid);
 
     // A group is only a legitimate target above pgid 1 and outside our own:
@@ -178,6 +168,21 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
     // signaling the one matched process, which is never broader than what was
     // asked for.
     if (targetPgid > 1 && targetPgid != getpgrp()) {
+      // Re-read the token so the lookup above sits between two matching reads:
+      // a (pid, pidversion) pair never recurs, so the group provably belongs to
+      // the process that matched. kill(-pgid) re-validates nothing at delivery
+      // the way the direct signal below does, so this is the only guard against
+      // a pid recycled since the match putting a stranger's group in scope.
+      audit_token_t current;
+      if (!env.token_for_pid(targetPid, &current) || Pidversion(current) != targetPidversion) {
+        LOGW(@"Not signaling (%d) process group %d: pid %d no longer holds the matched process "
+             @"(from kill command: %@)",
+             sig, targetPgid, targetPid, request.uuid);
+        return [[SNTKilledProcess alloc] initWithPid:targetPid
+                                          pidversion:targetPidversion
+                                               error:SNTKilledProcessErrorNoSuchProcess];
+      }
+
       // This request already tried this group, so its members all reuse that
       // one attempt's outcome. Reporting a failure for each of them keeps a
       // failed delivery visible for every process it left unsignaled.

--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -168,21 +168,6 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
     // signaling the one matched process, which is never broader than what was
     // asked for.
     if (targetPgid > 1 && targetPgid != getpgrp()) {
-      // Re-read the token so the lookup above sits between two matching reads:
-      // a (pid, pidversion) pair never recurs, so the group provably belongs to
-      // the process that matched. kill(-pgid) re-validates nothing at delivery
-      // the way the direct signal below does, so this is the only guard against
-      // a pid recycled since the match putting a stranger's group in scope.
-      audit_token_t current;
-      if (!env.token_for_pid(targetPid, &current) || Pidversion(current) != targetPidversion) {
-        LOGW(@"Not signaling (%d) process group %d: pid %d no longer holds the matched process "
-             @"(from kill command: %@)",
-             sig, targetPgid, targetPid, request.uuid);
-        return [[SNTKilledProcess alloc] initWithPid:targetPid
-                                          pidversion:targetPidversion
-                                               error:SNTKilledProcessErrorNoSuchProcess];
-      }
-
       // This request already tried this group, so its members all reuse that
       // one attempt's outcome. Reporting a failure for each of them keeps a
       // failed delivery visible for every process it left unsignaled.
@@ -201,22 +186,35 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
                                                error:SNTKilledProcessErrorNone];
       }
 
-      int error = env.signal_group(targetPgid, sig);
-      (*requestAttempts)[targetPgid] = error;
-      if (error == 0) {
-        // Only a landed delivery covers the pass: a failure must leave another
-        // request free to try the group itself.
-        passSignaledPgids->insert(targetPgid);
-        LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
-             request.uuid);
-      } else {
-        LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
-             targetPgid, error, request.uuid);
+      // Re-read the token just before delivering, so the pgid lookup above sits
+      // between two matching reads: kill(-pgid) re-validates nothing at
+      // delivery the way the direct signal does. The dedupe returns above
+      // deliver nothing, so only this delivery needs the re-read. A failed
+      // re-read falls through to the direct signal like every other lookup
+      // failure in this branch; that path validates its token at delivery.
+      audit_token_t current;
+      if (env.token_for_pid(targetPid, &current) && Pidversion(current) == targetPidversion) {
+        int error = env.signal_group(targetPgid, sig);
+        (*requestAttempts)[targetPgid] = error;
+        if (error == 0) {
+          // Only a landed delivery covers the pass: a failure must leave
+          // another request free to try the group itself.
+          passSignaledPgids->insert(targetPgid);
+          LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
+               request.uuid);
+        } else {
+          LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
+               targetPgid, error, request.uuid);
+        }
+
+        return [[SNTKilledProcess alloc] initWithPid:targetPid
+                                          pidversion:targetPidversion
+                                               error:LibprocSignalErrorToKilledProcessError(error)];
       }
 
-      return [[SNTKilledProcess alloc] initWithPid:targetPid
-                                        pidversion:targetPidversion
-                                             error:LibprocSignalErrorToKilledProcessError(error)];
+      LOGW(@"Not signaling (%d) process group %d: pid %d no longer holds the matched process, "
+           @"falling back to the direct signal (from kill command: %@)",
+           sig, targetPgid, targetPid, request.uuid);
     }
   }
 

--- a/Source/santad/KillingMachineTest.mm
+++ b/Source/santad/KillingMachineTest.mm
@@ -477,6 +477,31 @@ void TwoMatchesInOneGroup(FakeEnv* fake, pid_t pgid) {
   XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
 }
 
+// The pgid lookup is bracketed by two token reads, so a pid recycled between the
+// match and the lookup never puts a stranger's group in scope: nothing is
+// signaled at all.
+- (void)testGroupTargetingSkipsAGroupWhosePidWasRecycledDuringTheLookup {
+  FakeEnv fake;
+  fake.pidversions = {{10, 7}};
+  fake.pgids = {{10, getpgrp() + 1}};
+  // The match reads pidversion 7; the re-read after the pgid lookup sees 8.
+  fake.recycleAfterNthRead = {{10, 1}};
+
+  SNTKillRequest* request =
+      [[SNTKillRequestRunningProcess alloc] initWithUUID:@"uuid"
+                                                     pid:10
+                                              pidversion:7
+                                         bootSessionUUID:[SNTSystemInfo bootSessionUUID]
+                                                  signal:SIGKILL
+                                     targetProcessGroups:YES];
+
+  SNTKillResponse* response = santa::KillingMachine(request, MakeKillEnv(&fake));
+
+  XCTAssertTrue(fake.signals.empty());
+  XCTAssertEqual(response.killedProcesses.count, 1);
+  XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+}
+
 - (void)testRunningProcessRequestHonorsSignalAndGroupTargeting {
   pid_t pgid = getpgrp() + 3;
 

--- a/Source/santad/KillingMachineTest.mm
+++ b/Source/santad/KillingMachineTest.mm
@@ -477,10 +477,9 @@ void TwoMatchesInOneGroup(FakeEnv* fake, pid_t pgid) {
   XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
 }
 
-// The pgid lookup is bracketed by two token reads, so a pid recycled between the
-// match and the lookup never puts a stranger's group in scope: nothing is
-// signaled at all.
-- (void)testGroupTargetingSkipsAGroupWhosePidWasRecycledDuringTheLookup {
+// A pid recycled between the match and the pgid lookup is never delivered a
+// group signal: the kill falls back to the direct signal, which lands nowhere.
+- (void)testGroupTargetingFallsBackWhenPidRecycledDuringTheLookup {
   FakeEnv fake;
   fake.pidversions = {{10, 7}};
   fake.pgids = {{10, getpgrp() + 1}};
@@ -497,9 +496,39 @@ void TwoMatchesInOneGroup(FakeEnv* fake, pid_t pgid) {
 
   SNTKillResponse* response = santa::KillingMachine(request, MakeKillEnv(&fake));
 
-  XCTAssertTrue(fake.signals.empty());
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[ @"pid:10:9" ]));
   XCTAssertEqual(response.killedProcesses.count, 1);
   XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+}
+
+// The same recycle on the matcher path: only the recycled match falls back to
+// the direct signal; a live match in the same group still delivers to the group.
+- (void)testGroupTargetingFallsBackOnlyForTheRecycledMatch {
+  pid_t pgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  fake.matching = {10, 11};
+  fake.pgids = {{10, pgid}, {11, pgid}};
+  // Reads one and two bracket pid 10's match; the re-read before the group
+  // delivery sees the change.
+  fake.recycleAfterNthRead = {{10, 2}};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID
+                                                                signal:SIGKILL
+                                                   targetProcessGroups:YES];
+
+  SNTKillResponse* response = santa::KillingMachine(request, MakeKillEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals),
+                        (@[ @"pid:10:9", [NSString stringWithFormat:@"group:%d:9", pgid] ]));
+  XCTAssertEqual(response.killedProcesses.count, 2);
+  XCTAssertEqual(response.killedProcesses[0].pid, 10);
+  XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+  XCTAssertEqual(response.killedProcesses[1].pid, 11);
+  XCTAssertEqual(response.killedProcesses[1].error, SNTKilledProcessErrorNone);
 }
 
 - (void)testRunningProcessRequestHonorsSignalAndGroupTargeting {

--- a/Source/santad/SNTTimedRuleKills.mm
+++ b/Source/santad/SNTTimedRuleKills.mm
@@ -18,7 +18,6 @@
 #include <Kernel/kern/cs_blobs.h>
 #include <libproc.h>
 #include <mach/mach_time.h>
-#include <signal.h>
 #include <sys/param.h>
 
 #include <algorithm>
@@ -936,11 +935,13 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
 }
 
 /// The kill at a deadline: one running-process request per recorded pair of every
-/// due entry, all sent in one pass so they share the grace period. The rule and
-/// the window have already been re-checked; a dead pair fails its lookup inside
-/// the KillingMachine, so the entries are not pruned first. One summary per
-/// entry at info, one line per request at debug carrying the uuid every
-/// KillingMachine outcome logs.
+/// due entry, all sent in one pass so they share the grace period. Each request
+/// names the recorded execution alone; its process group is deliberately not
+/// taken, so a child it spawned survives unless it was recorded in its own
+/// right. The rule and the window have already been re-checked; a dead pair
+/// fails its lookup inside the KillingMachine, so the entries are not pruned
+/// first. One summary per entry at info, one line per request at debug carrying
+/// the uuid every KillingMachine outcome logs.
 - (void)killEntriesSerialized:(NSArray<SNTTimedRuleKillEntry*>*)entries {
   NSString* bootSession = [SNTSystemInfo bootSessionUUID];
   NSMutableArray<SNTKillRequest*>* requests = [NSMutableArray array];
@@ -953,9 +954,7 @@ class DeadlineTimer : public santa::Timer<DeadlineTimer> {
           [[SNTKillRequestRunningProcess alloc] initWithUUID:uuid
                                                          pid:[proc[kProcessPidKey] intValue]
                                                   pidversion:[proc[kProcessPidversionKey] intValue]
-                                             bootSessionUUID:bootSession
-                                                      signal:SIGKILL
-                                         targetProcessGroups:YES];
+                                             bootSessionUUID:bootSession];
       if (!request) {
         // Only when the boot session reads empty at fire time; the pair itself
         // passed validation. Rare enough to be worth a line when it happens.

--- a/Source/santad/SNTTimedRuleKillsTest.mm
+++ b/Source/santad/SNTTimedRuleKillsTest.mm
@@ -332,12 +332,13 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
   return [self makeSUTWithClock:clock];
 }
 
-/// The two deliveries a kill makes to the matching process's group: SIGTERM,
-/// then SIGKILL to whatever survived the grace period.
-- (NSArray<NSString*>*)termThenKillOfTheProcessGroup {
+/// The two deliveries a kill makes to the recorded process: SIGTERM, then
+/// SIGKILL if it survived the grace period. Its process group is deliberately
+/// not taken, so nothing else is signaled.
+- (NSArray<NSString*>*)termThenKillOfTheRecordedProcess {
   return @[
-    [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid, SIGTERM],
-    [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid, SIGKILL],
+    [NSString stringWithFormat:@"pid:%d:%d", getppid(), SIGTERM],
+    [NSString stringWithFormat:@"pid:%d:%d", getppid(), SIGKILL],
   ];
 }
 
@@ -964,12 +965,12 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
 #pragma mark The kill
 
-// Every execution rule type quits the process group of the execution recorded
-// under it: SIGTERM, five seconds, then SIGKILL to whatever is still there. The
-// five types take one path; the only per-type code left is the fire-time rule
-// lookup through IdentifiersForEntry, which each row exercises by its own
-// identifier, the `platform:` SIGNINGID form included.
-- (void)testEveryRuleTypeTermsThenKillsTheRecordedProcessGroup {
+// Every execution rule type quits the execution recorded under it: SIGTERM,
+// five seconds, then SIGKILL if it is still there. The five types take one
+// path; the only per-type code left is the fire-time rule lookup through
+// IdentifiersForEntry, which each row exercises by its own identifier, the
+// `platform:` SIGNINGID form included.
+- (void)testEveryRuleTypeTermsThenKillsTheRecordedProcess {
   NSArray<NSArray*>* rows = @[
     @[ @(SNTRuleTypeTeamID), kMatchingTeamID ],
     @[ @(SNTRuleTypeSigningID), [NSString stringWithFormat:@"platform:%@", kMatchingSigningID] ],
@@ -993,8 +994,8 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
     [self waitForEntriesToClear:sut];
     [self drain:sut];
 
-    XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup],
-                          @"%@", identifier);
+    XCTAssertEqualObjects(SignalDescriptions(_fake.signals),
+                          [self termThenKillOfTheRecordedProcess], @"%@", identifier);
     XCTAssertEqual(_fake.waits.size(), 1u, @"%@", identifier);
     XCTAssertEqualWithAccuracy(_fake.waits.front(), 5.0, 0.001);
     // The clear reached disk, not just the configurator's in-memory state.
@@ -1002,9 +1003,9 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
   }
 }
 
-// Two deadlines landing in one pass share one grace period: every due entry
-// is collected into a single kill call. Both rules cover the one process, so
-// the shared group is also signaled once per pass.
+// Two deadlines landing in one pass share one grace period: every due entry is
+// collected into a single kill call. Both rules cover the one process, and each
+// entry is its own request, so it is signaled once per entry per pass.
 - (void)testDeadlinesInOnePassShareTheGracePeriod {
   [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID ruleId:kRuleID];
   [self addRuleOfType:SNTRuleTypeCDHash identifier:kMatchingCDHash ruleId:kRuleID];
@@ -1018,15 +1019,18 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
   [self drain:sut];
 
   XCTAssertEqual(_fake.waits.size(), 1u);
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), (@[
+                          [NSString stringWithFormat:@"pid:%d:%d", getppid(), SIGTERM],
+                          [NSString stringWithFormat:@"pid:%d:%d", getppid(), SIGTERM],
+                          [NSString stringWithFormat:@"pid:%d:%d", getppid(), SIGKILL],
+                          [NSString stringWithFormat:@"pid:%d:%d", getppid(), SIGKILL],
+                        ]));
 }
 
 - (void)testFireBuildsOneRequestPerRecordedPairAndSharesOneGrace {
   [self addRuleOfType:SNTRuleTypeTeamID identifier:kMatchingTeamID ruleId:kRuleID];
   _fake.pidversions[6001] = 1;
-  _fake.pgids[6001] = self.matchingPgid;
   _fake.pidversions[6002] = 1;
-  _fake.pgids[6002] = self.matchingPgid + 1;
 
   SNTTimedRuleKills* sut = [self makeSUT];
   NSDate* due = [NSDate dateWithTimeIntervalSinceNow:0.5];
@@ -1048,15 +1052,14 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
   [self waitForEntriesToClear:sut];
   [self drain:sut];
 
-  // Both groups are termed, one grace period passes, both are killed.
+  // Both processes are termed, one grace period passes, both are killed.
   XCTAssertEqual(_fake.waits.size(), 1u);
-  XCTAssertEqualObjects(
-      SignalDescriptions(_fake.signals), (@[
-        [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid, SIGTERM],
-        [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid + 1, SIGTERM],
-        [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid, SIGKILL],
-        [NSString stringWithFormat:@"group:%d:%d", self.matchingPgid + 1, SIGKILL],
-      ]));
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), (@[
+                          [NSString stringWithFormat:@"pid:%d:%d", 6001, SIGTERM],
+                          [NSString stringWithFormat:@"pid:%d:%d", 6002, SIGTERM],
+                          [NSString stringWithFormat:@"pid:%d:%d", 6001, SIGKILL],
+                          [NSString stringWithFormat:@"pid:%d:%d", 6002, SIGKILL],
+                        ]));
 }
 
 - (void)testAnEntryWhosePairsAreAllDeadKillsNothingAndIsSpent {
@@ -1440,7 +1443,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
   // the process snapshot behind the warning never held the kill up.
   XCTAssertEqual(banners.count, 1u);
   XCTAssertEqualObjects(banners.firstObject[@"signals"], @2);
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 }
 
 #pragma mark Restart
@@ -1523,7 +1526,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
   XCTAssertNil(self.savedEntries);
 }
 
@@ -1544,7 +1547,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 }
 
 - (void)testRestartDropsMalformedEntries {
@@ -1714,7 +1717,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   // One rule's worth of deliveries: the row whose window had ended. The
   // rescheduled row covers the same process and would have doubled them.
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 
   // The other moved to 17:00 in its own zone, five hours on from the clock, and
   // kept the shape so the next pass can ask again.
@@ -1777,8 +1780,8 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
     [sut resumeFromSavedState];
     [self drain:sut];
 
-    XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup],
-                          @"%@", defect);
+    XCTAssertEqualObjects(SignalDescriptions(_fake.signals),
+                          [self termThenKillOfTheRecordedProcess], @"%@", defect);
     XCTAssertNil(self.savedEntries, @"%@", defect);
   }
 }
@@ -1986,7 +1989,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 }
 
 #pragma mark A moved clock
@@ -2042,7 +2045,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 }
 
 // The same rollback with less mach time behind it leaves the deadline in the
@@ -2103,7 +2106,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 }
 
 // The same entry from an earlier boot session. Its mach value belongs to a
@@ -2250,7 +2253,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
   [self waitForEntriesToClear:sut];
   [self drain:sut];
 
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
   XCTAssertEqual(banners.count, 0u);
 }
 
@@ -2284,7 +2287,7 @@ static NSString* const kOtherBootSessionUUID = @"6A2B4C8E-0000-0000-0000-0000000
 
   [self waitForEntriesToClear:sut];
   [self drain:sut];
-  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheProcessGroup]);
+  XCTAssertEqualObjects(SignalDescriptions(_fake.signals), [self termThenKillOfTheRecordedProcess]);
 }
 
 - (void)testAnEntryLoadedFromAForeignBootGetsItsMachDeadlineBackOnTheNextRecord {


### PR DESCRIPTION
Timed rule kills no longer signal the recorded process's group, and KillProcess re-verifies the pidversion after the pgid lookup so a recycled pid cannot put a stranger's group in scope.