### PR TITLE
santad: run the group kill guard just before delivery, falling back to the direct signal

### DIFF
--- a/Source/santad/KillingMachine.mm
+++ b/Source/santad/KillingMachine.mm
@@ -168,21 +168,6 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
     // signaling the one matched process, which is never broader than what was
     // asked for.
     if (targetPgid > 1 && targetPgid != getpgrp()) {
-      // Re-read the token so the lookup above sits between two matching reads:
-      // a (pid, pidversion) pair never recurs, so the group provably belongs to
-      // the process that matched. kill(-pgid) re-validates nothing at delivery
-      // the way the direct signal below does, so this is the only guard against
-      // a pid recycled since the match putting a stranger's group in scope.
-      audit_token_t current;
-      if (!env.token_for_pid(targetPid, &current) || Pidversion(current) != targetPidversion) {
-        LOGW(@"Not signaling (%d) process group %d: pid %d no longer holds the matched process "
-             @"(from kill command: %@)",
-             sig, targetPgid, targetPid, request.uuid);
-        return [[SNTKilledProcess alloc] initWithPid:targetPid
-                                          pidversion:targetPidversion
-                                               error:SNTKilledProcessErrorNoSuchProcess];
-      }
-
       // This request already tried this group, so its members all reuse that
       // one attempt's outcome. Reporting a failure for each of them keeps a
       // failed delivery visible for every process it left unsignaled.
@@ -201,22 +186,35 @@ SNTKilledProcess* KillProcess(SNTKillRequest* request, int sig, audit_token_t* t
                                                error:SNTKilledProcessErrorNone];
       }
 
-      int error = env.signal_group(targetPgid, sig);
-      (*requestAttempts)[targetPgid] = error;
-      if (error == 0) {
-        // Only a landed delivery covers the pass: a failure must leave another
-        // request free to try the group itself.
-        passSignaledPgids->insert(targetPgid);
-        LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
-             request.uuid);
-      } else {
-        LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
-             targetPgid, error, request.uuid);
+      // Re-read the token just before delivering, so the pgid lookup above sits
+      // between two matching reads: kill(-pgid) re-validates nothing at
+      // delivery the way the direct signal does. The dedupe returns above
+      // deliver nothing, so only this delivery needs the re-read. A failed
+      // re-read falls through to the direct signal like every other lookup
+      // failure in this branch; that path validates its token at delivery.
+      audit_token_t current;
+      if (env.token_for_pid(targetPid, &current) && Pidversion(current) == targetPidversion) {
+        int error = env.signal_group(targetPgid, sig);
+        (*requestAttempts)[targetPgid] = error;
+        if (error == 0) {
+          // Only a landed delivery covers the pass: a failure must leave
+          // another request free to try the group itself.
+          passSignaledPgids->insert(targetPgid);
+          LOGI(@"Signaled (%d) process group: %d (from kill command: %@)", sig, targetPgid,
+               request.uuid);
+        } else {
+          LOGW(@"Failed to signal (%d) process group: %d, error: %d (from kill command: %@)", sig,
+               targetPgid, error, request.uuid);
+        }
+
+        return [[SNTKilledProcess alloc] initWithPid:targetPid
+                                          pidversion:targetPidversion
+                                               error:LibprocSignalErrorToKilledProcessError(error)];
       }
 
-      return [[SNTKilledProcess alloc] initWithPid:targetPid
-                                        pidversion:targetPidversion
-                                             error:LibprocSignalErrorToKilledProcessError(error)];
+      LOGW(@"Not signaling (%d) process group %d: pid %d no longer holds the matched process, "
+           @"falling back to the direct signal (from kill command: %@)",
+           sig, targetPgid, targetPid, request.uuid);
     }
   }
 

--- a/Source/santad/KillingMachineTest.mm
+++ b/Source/santad/KillingMachineTest.mm
@@ -477,10 +477,9 @@ void TwoMatchesInOneGroup(FakeEnv* fake, pid_t pgid) {
   XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
 }
 
-// The pgid lookup is bracketed by two token reads, so a pid recycled between the
-// match and the lookup never puts a stranger's group in scope: nothing is
-// signaled at all.
-- (void)testGroupTargetingSkipsAGroupWhosePidWasRecycledDuringTheLookup {
+// A pid recycled between the match and the pgid lookup is never delivered a
+// group signal: the kill falls back to the direct signal, which lands nowhere.
+- (void)testGroupTargetingFallsBackWhenPidRecycledDuringTheLookup {
   FakeEnv fake;
   fake.pidversions = {{10, 7}};
   fake.pgids = {{10, getpgrp() + 1}};
@@ -497,9 +496,39 @@ void TwoMatchesInOneGroup(FakeEnv* fake, pid_t pgid) {
 
   SNTKillResponse* response = santa::KillingMachine(request, MakeKillEnv(&fake));
 
-  XCTAssertTrue(fake.signals.empty());
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals), (@[ @"pid:10:9" ]));
   XCTAssertEqual(response.killedProcesses.count, 1);
   XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+}
+
+// The same recycle on the matcher path: only the recycled match falls back to
+// the direct signal; a live match in the same group still delivers to the group.
+- (void)testGroupTargetingFallsBackOnlyForTheRecycledMatch {
+  pid_t pgid = getpgrp() + 1;
+
+  FakeEnv fake;
+  fake.pids = std::vector<pid_t>{10, 11};
+  fake.pidversions = {{10, 1}, {11, 2}};
+  fake.matching = {10, 11};
+  fake.pgids = {{10, pgid}, {11, pgid}};
+  // Reads one and two bracket pid 10's match; the re-read before the group
+  // delivery sees the change.
+  fake.recycleAfterNthRead = {{10, 2}};
+
+  SNTKillRequest* request = [[SNTKillRequestTeamID alloc] initWithUUID:@"uuid"
+                                                                teamID:kMatchingTeamID
+                                                                signal:SIGKILL
+                                                   targetProcessGroups:YES];
+
+  SNTKillResponse* response = santa::KillingMachine(request, MakeKillEnv(&fake));
+
+  XCTAssertEqualObjects(SignalDescriptions(fake.signals),
+                        (@[ @"pid:10:9", [NSString stringWithFormat:@"group:%d:9", pgid] ]));
+  XCTAssertEqual(response.killedProcesses.count, 2);
+  XCTAssertEqual(response.killedProcesses[0].pid, 10);
+  XCTAssertEqual(response.killedProcesses[0].error, SNTKilledProcessErrorNoSuchProcess);
+  XCTAssertEqual(response.killedProcesses[1].pid, 11);
+  XCTAssertEqual(response.killedProcesses[1].error, SNTKilledProcessErrorNone);
 }
 
 - (void)testRunningProcessRequestHonorsSignalAndGroupTargeting {


### PR DESCRIPTION
# Stacked on #1176

Two adjustments to the pid-recycle guard added in #1176:

- A failed or mismatched token re-read now falls through to the direct signal — the discipline every other lookup failure in the branch already follows — instead of returning early with `NoSuchProcess`. The direct path validates its token at delivery, so a genuinely recycled pid still lands nowhere, while a live process whose re-read transiently failed is still killed (and the SIGKILL escalation pass still runs).
- The re-read moved below the `requestAttempts`/`passSignaledPgids` dedupe checks, immediately before `signal_group` — the only call it protects. A group member that a landed delivery already reached (and likely killed) now reports the recorded outcome instead of a false `NoSuchProcess`, and deduped members skip the extra token read.
- Updated the recycled-pid test for the fall-back behavior and added a matcher-path test pinning that only the recycled match degrades while a live match in the same group still delivers to the group.